### PR TITLE
lyria generative node + GenerativeEngine facade (M3 groundwork)

### DIFF
--- a/docs/DAG_NODES.md
+++ b/docs/DAG_NODES.md
@@ -30,12 +30,14 @@ Build a registry with `createCoreRegistry()` (pure nodes) or `createAppRegistry(
 |-------------|-------|--------|---------|---------|
 | `voice-mapping` | ✅ | `features`; live overrides: `magnetism`, `octaveShift`, `mute`, `scaleRight`, `scaleLeft`, `instrumentRight`, `instrumentLeft` | `params: SynthParams` | **Direct** mapping: x→pitch (scale-snapped by magnetism), y→volume. Two voices (0=right, 1=left). |
 | `keyboard-control` | ✅ | `pressed: string[]` | `octaveShift`, `magnetism`, `mute` | Interprets key presses (arrows, `m`) into musical control values. |
+| `indirect-map` | ✅ | `features` | `steer: GenerativeSteer` | **Indirect** mapping: gesture features → weighted text prompts + config dials (density/brightness/bpm), with optional smoothing + throttle. Steers a generative engine. |
 
 ## Synthesis / output
 
 | Node `type` | Pure? | Inputs | Outputs | Purpose |
 |-------------|-------|--------|---------|---------|
 | `webaudio-synth` | browser | `params: SynthParams` | — | One oscillator+gain voice per `SynthParams` voice, smoothed ramps. Uses `ctx.resources.audioContext` + `masterGain`; silent no-op until the host wires audio. |
+| `lyria` | ✅ (node) | `steer: GenerativeSteer`, `playing: boolean` | `state: string` | Drives a generative engine (Lyria RealTime) — lifecycle + throttled/diffed steer + tempo-reset. The engine is injected via `ctx.resources.generativeEngine` (the browser-only `LyriaEngine` implements the `GenerativeEngine` facade in `src/nodes/output/`). The node logic is unit-tested with a mock engine. |
 | `canvas-overlay` | browser | `hands`, `features` | — | Draws mirrored video + landmark dots + control markers (openness=ring, pinch=fill) + feature HUD onto `ctx.resources.canvas`. |
 
 ## Domain types (`src/nodes/domain.ts`)
@@ -47,8 +49,7 @@ Build a registry with `createCoreRegistry()` (pure nodes) or `createAppRegistry(
 
 ## Planned nodes (see ROADMAP)
 
-`lyria` (steerable AI generation), `indirect-map` (gesture → weighted prompts +
-dials), `face-features` (52 blendshapes), `pose-features`, `gesture-classifier`
+`face-features` (52 blendshapes), `pose-features`, `gesture-classifier`
 (discrete events), `chord`/`voicing`/`progression` (Tonal.js), `score` +
 `performance` (conductor mode), `midi-in`/`midi-out` (WEBMIDI.js), signal
 conditioners (one-euro filter, hysteresis, debounce).

--- a/src/nodes/browser.ts
+++ b/src/nodes/browser.ts
@@ -17,6 +17,10 @@ export { keyboardSourceNode } from './sources/keyboard';
 export { storeControlsNode } from './sources/store_controls';
 export { webAudioSynthNode } from './output/webaudio_synth';
 export { canvasOverlayNode } from './output/canvas_overlay';
+// The browser-only Lyria engine (implements the GenerativeEngine facade the
+// `lyria` node drives). The node itself is Node-safe and lives in CORE_NODES.
+export { LyriaEngine } from './output/lyria_engine';
+export type { LyriaEngineOptions } from './output/lyria_engine';
 
 export const BROWSER_NODES = [
   webcamHandsNode,

--- a/src/nodes/index.ts
+++ b/src/nodes/index.ts
@@ -14,6 +14,7 @@ import { handFeaturesNode } from './features/hand_features';
 import { voiceMappingNode } from './mapping/voice_mapping';
 import { keyboardControlNode } from './mapping/keyboard_control';
 import { indirectMapNode } from './mapping/indirect_map';
+import { lyriaNode } from './output/lyria';
 
 export { syntheticHandsNode } from './sources/synthetic_hands';
 export { replaySourceNode } from './sources/replay';
@@ -21,6 +22,7 @@ export { handFeaturesNode } from './features/hand_features';
 export { voiceMappingNode } from './mapping/voice_mapping';
 export { keyboardControlNode } from './mapping/keyboard_control';
 export { indirectMapNode } from './mapping/indirect_map';
+export { lyriaNode } from './output/lyria';
 export type { GenerativeEngine, GenerativeSteer, GenerativeConfig, WeightedPrompt } from './output/generative';
 export * from './domain';
 
@@ -32,6 +34,7 @@ export const CORE_NODES = [
   voiceMappingNode,
   keyboardControlNode,
   indirectMapNode,
+  lyriaNode,
 ];
 
 /** Build a registry pre-loaded with the pure node library. */

--- a/src/nodes/output/lyria.ts
+++ b/src/nodes/output/lyria.ts
@@ -1,0 +1,97 @@
+/**
+ * `lyria` node — the generative-music sink for the *indirect* mapping path.
+ * Consumes a {@link GenerativeSteer} (weighted prompts + config dials, produced
+ * by `indirect-map`) plus a `playing` transport flag, and drives a
+ * {@link GenerativeEngine} (injected via `ctx.resources.generativeEngine`).
+ *
+ * The vendor websocket/audio lives behind the GenerativeEngine facade (the
+ * browser-only `LyriaEngine` is the first impl). This node owns the *contract
+ * logic* — lifecycle (connect/play/pause), throttling steer updates to a steady
+ * cadence (Lyria likes ~200ms), diffing so we only send real changes, and
+ * resetting the model context when tempo changes. That logic is pure enough to
+ * unit-test with a mock engine (no network, no audio), using `ctx.time` for a
+ * deterministic throttle clock.
+ */
+import { z } from 'zod';
+import { defineNode } from '@/dag';
+import type { NodeContext } from '@/dag';
+import type { GenerativeEngine, GenerativeSteer } from './generative';
+
+const Params = z.object({
+  /** Minimum seconds between pushed steer updates (Lyria likes ~0.2s). */
+  throttleSec: z.number().min(0).default(0.2),
+});
+type Params = z.infer<typeof Params>;
+
+export const lyriaNode = defineNode<Params>({
+  type: 'lyria',
+  title: 'Lyria Generative',
+  description: 'Steers a generative engine (Lyria RealTime) from weighted prompts + config dials.',
+  inputs: [
+    { name: 'steer', kind: 'generative-steer' },
+    { name: 'playing', kind: 'boolean', default: false },
+  ],
+  outputs: [{ name: 'state', kind: 'string' }],
+  params: Params,
+  make(p) {
+    let started = false;
+    let lastSentAt = -Infinity;
+    let lastPromptsKey = '';
+    let lastConfigKey = '';
+    let lastBpm: number | undefined;
+
+    return {
+      process(inputs, ctx: NodeContext) {
+        const engine = ctx.resources.generativeEngine as GenerativeEngine | undefined;
+        if (!engine) return { state: 'no-engine' };
+
+        const playing = inputs.playing === true;
+        const steer = inputs.steer as GenerativeSteer | undefined;
+
+        // ---- lifecycle ----
+        if (playing && !started) {
+          started = true;
+          // The engine is responsible for connect-once idempotency.
+          void Promise.resolve(engine.connect()).then(() => engine.play());
+        } else if (!playing && started) {
+          started = false;
+          void engine.pause();
+        }
+
+        // ---- steering (throttled + diffed) ----
+        if (started && steer && ctx.time - lastSentAt >= p.throttleSec) {
+          let sent = false;
+
+          const configKey = JSON.stringify(steer.config ?? {});
+          if (configKey !== lastConfigKey) {
+            const bpm = steer.config?.bpm;
+            if (bpm !== undefined && lastBpm !== undefined && bpm !== lastBpm) {
+              engine.resetContext(); // tempo change needs a fresh musical context
+            }
+            engine.setConfig(steer.config ?? {});
+            lastConfigKey = configKey;
+            lastBpm = bpm;
+            sent = true;
+          }
+
+          const promptsKey = JSON.stringify(steer.prompts ?? []);
+          if (promptsKey !== lastPromptsKey) {
+            engine.setWeightedPrompts(steer.prompts ?? []);
+            lastPromptsKey = promptsKey;
+            sent = true;
+          }
+
+          if (sent) lastSentAt = ctx.time;
+        }
+
+        return { state: started ? 'playing' : 'stopped' };
+      },
+      dispose() {
+        if (started) {
+          started = false;
+          // best-effort stop; engine may already be gone
+        }
+      },
+    };
+  },
+});

--- a/src/nodes/output/lyria_engine.ts
+++ b/src/nodes/output/lyria_engine.ts
@@ -1,0 +1,153 @@
+/**
+ * LyriaEngine (browser-only) — implements the {@link GenerativeEngine} facade
+ * against Google Lyria RealTime via `@google/genai`. Ported from the deployed
+ * app's `LyriaSession` (src/plugins/ai-dj): WebSocket session, 48 kHz stereo PCM
+ * decoded + scheduled ahead through Web Audio, weighted prompts + config.
+ *
+ * This is the host-injected engine the `lyria` node drives (via
+ * `ctx.resources.generativeEngine`). It is never imported by Node tests or by
+ * the node itself (the node depends only on the facade); it is type-checked but
+ * exercised only in the browser with a real API key.
+ */
+import { GoogleGenAI, type LiveMusicSession, type LiveMusicServerMessage } from '@google/genai';
+import type { GenerativeConfig, GenerativeEngine, WeightedPrompt } from './generative';
+
+function decodeBase64(base64: string): Uint8Array {
+  const bin = atob(base64);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return bytes;
+}
+
+function decodePcm(data: Uint8Array, ctx: AudioContext, sampleRate: number, channels: number): AudioBuffer {
+  const int16 = new Int16Array(data.buffer, data.byteOffset, data.byteLength / 2);
+  const frames = int16.length / channels;
+  const buffer = ctx.createBuffer(channels, frames, sampleRate);
+  for (let ch = 0; ch < channels; ch++) {
+    const out = buffer.getChannelData(ch);
+    for (let i = 0; i < frames; i++) out[i] = int16[i * channels + ch] / 32768;
+  }
+  return buffer;
+}
+
+export interface LyriaEngineOptions {
+  apiKey: string;
+  audioContext: AudioContext;
+  /** Lyria PCM is mixed into this node (typically the app's masterGain). */
+  destination: GainNode;
+  model?: string;
+  bufferSeconds?: number;
+}
+
+export class LyriaEngine implements GenerativeEngine {
+  private ai: GoogleGenAI;
+  private model: string;
+  private session: LiveMusicSession | null = null;
+  private connecting: Promise<LiveMusicSession> | null = null;
+  private ac: AudioContext;
+  private out: GainNode;
+  private dest: GainNode;
+  private nextStartTime = 0;
+  private bufferTime: number;
+  private playing = false;
+
+  constructor(opts: LyriaEngineOptions) {
+    this.ai = new GoogleGenAI({ apiKey: opts.apiKey, apiVersion: 'v1alpha' });
+    this.model = opts.model ?? 'lyria-realtime-exp';
+    this.ac = opts.audioContext;
+    this.dest = opts.destination;
+    this.out = this.ac.createGain();
+    this.bufferTime = opts.bufferSeconds ?? 2;
+  }
+
+  async connect(): Promise<void> {
+    if (this.session || this.connecting) {
+      await (this.connecting ?? Promise.resolve(this.session!));
+      return;
+    }
+    this.connecting = this.ai.live.music.connect({
+      model: this.model,
+      callbacks: {
+        onmessage: (e: LiveMusicServerMessage) => {
+          if (e.serverContent?.audioChunks) this.schedule(e.serverContent.audioChunks);
+        },
+        onerror: () => {
+          this.playing = false;
+        },
+        onclose: () => {
+          this.playing = false;
+        },
+      },
+    });
+    this.session = await this.connecting;
+  }
+
+  private schedule(chunks: { data?: string; mimeType?: string }[]): void {
+    if (!this.playing || !chunks[0]?.data) return;
+    const buffer = decodePcm(decodeBase64(chunks[0].data), this.ac, 48000, 2);
+    const src = this.ac.createBufferSource();
+    src.buffer = buffer;
+    src.connect(this.out);
+    if (this.nextStartTime === 0) this.nextStartTime = this.ac.currentTime + this.bufferTime;
+    if (this.nextStartTime < this.ac.currentTime) {
+      this.nextStartTime = 0; // underrun; resync next chunk
+      return;
+    }
+    src.start(this.nextStartTime);
+    this.nextStartTime += buffer.duration;
+  }
+
+  async play(): Promise<void> {
+    if (!this.session) await this.connect();
+    if (this.ac.state === 'suspended') await this.ac.resume();
+    this.out.connect(this.dest);
+    this.out.gain.setValueAtTime(0, this.ac.currentTime);
+    this.out.gain.linearRampToValueAtTime(1, this.ac.currentTime + 0.1);
+    this.playing = true;
+    this.session?.play();
+  }
+
+  async pause(): Promise<void> {
+    this.playing = false;
+    this.session?.pause();
+    this.out.gain.linearRampToValueAtTime(0, this.ac.currentTime + 0.1);
+    this.nextStartTime = 0;
+  }
+
+  async stop(): Promise<void> {
+    this.playing = false;
+    try {
+      this.session?.stop();
+    } catch {
+      /* ignore */
+    }
+    this.out.disconnect();
+    this.out = this.ac.createGain();
+    this.nextStartTime = 0;
+  }
+
+  setWeightedPrompts(prompts: WeightedPrompt[]): void {
+    const active = prompts.filter((p) => p.weight !== 0);
+    if (!this.session || active.length === 0) return;
+    void this.session.setWeightedPrompts({
+      weightedPrompts: active.map((p) => ({ text: p.text, weight: p.weight })),
+    });
+  }
+
+  setConfig(config: GenerativeConfig): void {
+    if (!this.session) return;
+    void this.session.setMusicGenerationConfig({
+      musicGenerationConfig: {
+        bpm: config.bpm,
+        density: config.density,
+        brightness: config.brightness,
+        guidance: config.guidance,
+        temperature: config.temperature,
+      },
+    });
+  }
+
+  resetContext(): void {
+    this.session?.resetContext();
+  }
+}

--- a/test/lyria_node.test.ts
+++ b/test/lyria_node.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Headless contract test for the `lyria` node — drives it with a MOCK
+ * GenerativeEngine (no network, no audio) and verifies the steering contract:
+ * lifecycle (connect/play/pause), throttled + diffed steer updates, and a
+ * context reset on tempo change. This is where the real bugs live, so it's the
+ * part worth testing without a live Lyria connection.
+ */
+import { describe, it, expect } from 'vitest';
+import { Engine, StreamRecorder } from '@/dag';
+import { createCoreRegistry, lyriaNode } from '@/nodes';
+import type { GenerativeConfig, GenerativeEngine, GenerativeSteer, WeightedPrompt } from '@/nodes';
+
+class MockEngine implements GenerativeEngine {
+  calls: string[] = [];
+  prompts: WeightedPrompt[][] = [];
+  configs: GenerativeConfig[] = [];
+  async connect() {
+    this.calls.push('connect');
+  }
+  async play() {
+    this.calls.push('play');
+  }
+  async pause() {
+    this.calls.push('pause');
+  }
+  async stop() {
+    this.calls.push('stop');
+  }
+  setWeightedPrompts(p: WeightedPrompt[]) {
+    this.calls.push('setWeightedPrompts');
+    this.prompts.push(p);
+  }
+  setConfig(c: GenerativeConfig) {
+    this.calls.push('setConfig');
+    this.configs.push(c);
+  }
+  resetContext() {
+    this.calls.push('resetContext');
+  }
+}
+
+function steer(weight: number, bpm: number): GenerativeSteer {
+  return { prompts: [{ text: 'ambient pads', weight }], config: { bpm, density: 0.5 } };
+}
+
+describe('lyria node (contract logic, mock engine)', () => {
+  it('no-ops without an engine', () => {
+    const handlers = lyriaNode.make({ throttleSec: 0.2 });
+    const out = handlers.process({ playing: true, steer: steer(1, 120) }, { tick: 0, time: 0, dt: 0, resources: {} });
+    expect(out.state).toBe('no-engine');
+  });
+
+  it('connects+plays once, throttles steer updates, resets context on bpm change', async () => {
+    const engine = new MockEngine();
+    const handlers = lyriaNode.make({ throttleSec: 0.2 });
+    const resources = { generativeEngine: engine };
+    const dt = 1 / 30;
+
+    // 30 ticks (~1s) of "playing" with prompt weight ramping every tick and a
+    // bpm change partway through.
+    for (let i = 0; i < 30; i++) {
+      const w = 0.5 + (i % 10) * 0.05; // changes every tick
+      const bpm = i < 15 ? 120 : 90; // tempo change at tick 15
+      handlers.process(
+        { playing: true, steer: steer(w, bpm) },
+        { tick: i, time: i * dt, dt, resources },
+      );
+    }
+    // play() is fire-and-forget after connect() resolves (a microtask), so flush.
+    await new Promise((r) => setTimeout(r, 0));
+
+    // connect + play exactly once.
+    expect(engine.calls.filter((c) => c === 'connect')).toHaveLength(1);
+    expect(engine.calls.filter((c) => c === 'play')).toHaveLength(1);
+
+    // Prompts change every tick, but pushes are throttled to ~0.2s over ~1s,
+    // so far fewer than 30 sends.
+    const promptSends = engine.calls.filter((c) => c === 'setWeightedPrompts').length;
+    expect(promptSends).toBeGreaterThan(2);
+    expect(promptSends).toBeLessThan(12);
+
+    // The tempo change triggered exactly one resetContext.
+    expect(engine.calls.filter((c) => c === 'resetContext')).toHaveLength(1);
+  });
+
+  it('pauses when transport stops', () => {
+    const engine = new MockEngine();
+    const handlers = lyriaNode.make({ throttleSec: 0.2 });
+    const resources = { generativeEngine: engine };
+    handlers.process({ playing: true, steer: steer(1, 120) }, { tick: 0, time: 0, dt: 0, resources });
+    handlers.process({ playing: false }, { tick: 1, time: 0.1, dt: 0.1, resources });
+    expect(engine.calls).toContain('pause');
+  });
+
+  it('is registered in the core registry and wires from indirect-map', () => {
+    const spec = {
+      nodes: [
+        { id: 'src', type: 'synthetic-hands', params: { hands: 'right' } },
+        { id: 'feat', type: 'hand-features', params: { mirrorX: false, mirrorHandedness: false } },
+        {
+          id: 'ind',
+          type: 'indirect-map',
+          params: {
+            strains: [{ text: 'pads', hand: 'right', feature: 'openness', inMin: 0, inMax: 1, weightMin: 0, weightMax: 2 }],
+            dials: [{ name: 'bpm', hand: 'right', feature: 'y', inMin: 0, inMax: 1, outMin: 80, outMax: 140 }],
+          },
+        },
+        { id: 'gen', type: 'lyria' },
+      ],
+      edges: [
+        { from: { node: 'src', port: 'hands' }, to: { node: 'feat', port: 'hands' } },
+        { from: { node: 'feat', port: 'features' }, to: { node: 'ind', port: 'features' } },
+        { from: { node: 'ind', port: 'steer' }, to: { node: 'gen', port: 'steer' } },
+      ],
+    };
+    const engine = new MockEngine();
+    const rec = new StreamRecorder();
+    const eng = new Engine(spec, createCoreRegistry(), { resources: { generativeEngine: engine }, taps: [rec], nominalDt: 1 / 30 });
+    // 'playing' is unconnected (defaults false) → lyria idles but the graph runs.
+    expect(() => {
+      for (let i = 0; i < 10; i++) eng.tick();
+    }).not.toThrow();
+    const steers = rec.values('ind.steer') as GenerativeSteer[];
+    expect(steers[5].prompts[0].text).toBe('pads');
+    expect(steers[5].config.bpm).toBeGreaterThanOrEqual(80);
+  });
+});


### PR DESCRIPTION
Refs #6 (M3). Adds the indirect/AI generative path behind the `GenerativeEngine` facade, **additively** (not yet wired into the deployed app).

- **`lyria` node** (`src/nodes/output/lyria.ts`, Node-safe): the steering *contract logic* — lifecycle (connect/play/pause), throttled + diffed steer updates (deterministic `ctx.time` clock), `resetContext` on tempo change. The engine is injected via `ctx.resources.generativeEngine`.
- **`LyriaEngine`** (`src/nodes/output/lyria_engine.ts`, browser-only): implements the facade against Lyria RealTime via `@google/genai` (ported from the deployed app's `LyriaSession` + `audioUtils` — WebSocket session + 48kHz PCM scheduled through Web Audio). Type-checked; runs only in-browser with an API key.
- **Test** (`test/lyria_node.test.ts`): headless contract test with a **mock** engine — connect/play once, throttling, `resetContext` on bpm change, pause on transport stop, and end-to-end wiring from `indirect-map`. **37 tests total.**
- **Docs**: `indirect-map` + `lyria` moved from 'planned' into the node catalog.

### Verification
typecheck (strict, incl. the engine) clean · 37/37 tests pass · `vite build` clean (deployed bundle unchanged — the app doesn't import these yet).

### Remaining for M3 (#6)
Wire the deployed app through the DAG: refactor `Theremin.tsx`'s detect loop onto `webcam-hands → hand-features → voice-mapping → webaudio-synth` + `canvas-overlay`, and replace the Lyria plugin's session with the `lyria` node + `LyriaEngine`. That step changes the running app, so it needs live-browser verification (camera + a Gemini key) before merging.