### PR TITLE
face-features node — facial expressions → controls (M4)

### DIFF
--- a/docs/DAG_NODES.md
+++ b/docs/DAG_NODES.md
@@ -23,6 +23,7 @@ Build a registry with `createCoreRegistry()` (pure nodes) or `createAppRegistry(
 | Node `type` | Pure? | Inputs | Outputs | Purpose |
 |-------------|-------|--------|---------|---------|
 | `hand-features` | ✅ | `hands: HandsFrame` | `features: HandFeatures` | Landmarks → per-hand normalized `{present, x, y, openness, pinch}`. openness/pinch are scaled by per-hand size for camera-distance invariance. |
+| `face-features` | ✅ | `face: FaceFrame` | `features: FaceFeatures` | 52 blendshapes → normalized expression controls `{present, smile, mouthOpen, browRaise, browFurrow, eyeBlink}`, with gain + smoothing. Tested against the `video_face_expressions` fixture. (Browser `webcam-face` source feeds it; M4 wiring.) |
 
 ## Mapping (mapping layer — the direct↔indirect spectrum)
 
@@ -44,12 +45,13 @@ Build a registry with `createCoreRegistry()` (pure nodes) or `createAppRegistry(
 
 - `Keypoint {x,y,z?,name?}`, `Hand {handedness, keypoints[]}`, `HandsFrame {width,height,hands[]}` — MediaPipe Hands 21-landmark layout (indices in `LM`).
 - `SingleHandFeatures {present, x, y, openness, pinch}` (all 0..1); `HandFeatures {left, right}`.
+- `FaceFrame {present, blendshapes: Record<string,number>}` (52 MediaPipe blendshapes); `FaceFeatures {present, smile, mouthOpen, browRaise, browFurrow, eyeBlink}` (all 0..1).
 - `VoiceParams {id, present, freq, gain, instrument}`; `SynthParams {voices[]}`.
 - `makeHandKeypoints(spec)` builds a plausible 21-point hand for synthetic data/tests.
 
 ## Planned nodes (see ROADMAP)
 
-`face-features` (52 blendshapes), `pose-features`, `gesture-classifier`
+`webcam-face` (browser FaceLandmarker source), `pose-features`, `gesture-classifier`
 (discrete events), `chord`/`voicing`/`progression` (Tonal.js), `score` +
 `performance` (conductor mode), `midi-in`/`midi-out` (WEBMIDI.js), signal
 conditioners (one-euro filter, hysteresis, debounce).

--- a/src/nodes/domain.ts
+++ b/src/nodes/domain.ts
@@ -71,6 +71,42 @@ export interface SynthParams {
   voices: VoiceParams[];
 }
 
+// ---- Face (MediaPipe Face Landmarker blendshapes) ------------------------
+
+/**
+ * One frame of face data: the 52 MediaPipe blendshape scores (each 0..1),
+ * keyed by name (e.g. `mouthSmileLeft`, `jawOpen`, `browInnerUp`). Produced by
+ * the browser `webcam-face` node or by `scripts/video_to_face.py`.
+ */
+export interface FaceFrame {
+  present: boolean;
+  blendshapes: Record<string, number>;
+}
+
+/** Normalized expression controls derived from blendshapes, all 0..1. */
+export interface FaceFeatures {
+  present: boolean;
+  /** Smile amount (mouth corners up). */
+  smile: number;
+  /** Jaw drop / open mouth. */
+  mouthOpen: number;
+  /** Eyebrows raised. */
+  browRaise: number;
+  /** Eyebrows furrowed/lowered. */
+  browFurrow: number;
+  /** Both eyes closed (blink). */
+  eyeBlink: number;
+}
+
+export const ABSENT_FACE: FaceFeatures = {
+  present: false,
+  smile: 0,
+  mouthOpen: 0,
+  browRaise: 0,
+  browFurrow: 0,
+  eyeBlink: 0,
+};
+
 // ---- MediaPipe Hands landmark indices ------------------------------------
 
 export const LM = {

--- a/src/nodes/features/face_features.ts
+++ b/src/nodes/features/face_features.ts
@@ -1,0 +1,77 @@
+/**
+ * `face-features` node — turns a {@link FaceFrame} (52 MediaPipe blendshapes)
+ * into a small set of normalized expression controls (smile, mouthOpen,
+ * browRaise, browFurrow, eyeBlink), each 0..1, with optional gain + smoothing.
+ *
+ * The face analogue of `hand-features`: pure and deterministic, so it is the
+ * first face edge we record and test from a replay (e.g. the
+ * `video_face_expressions` fixture). These controls are the *direct* facial
+ * mapping surface — e.g. smile→brightness, mouthOpen→amplitude — wired in the
+ * mapping layer. The browser `webcam-face` node produces the input.
+ */
+import { z } from 'zod';
+import { defineNode } from '@/dag';
+import { ABSENT_FACE, type FaceFeatures, type FaceFrame } from '../domain';
+
+const Params = z.object({
+  /** Global multiplier applied to each control before clamping (expressiveness). */
+  gain: z.number().min(0).default(1),
+  /** Exponential smoothing 0..1 per tick (0 = instant, higher = smoother/slower). */
+  smoothing: z.number().min(0).max(0.999).default(0),
+});
+type Params = z.infer<typeof Params>;
+
+function clamp01(v: number): number {
+  return v < 0 ? 0 : v > 1 ? 1 : v;
+}
+
+export const faceFeaturesNode = defineNode<Params>({
+  type: 'face-features',
+  title: 'Face Features',
+  description: 'Face blendshapes → normalized expression controls (smile, mouthOpen, brow, blink).',
+  inputs: [{ name: 'face', kind: 'face-frame' }],
+  outputs: [{ name: 'features', kind: 'face-features' }],
+  params: Params,
+  make(p) {
+    // Smoothed state per control, so expressions ease rather than jump.
+    const prev: Record<keyof Omit<FaceFeatures, 'present'>, number> = {
+      smile: 0,
+      mouthOpen: 0,
+      browRaise: 0,
+      browFurrow: 0,
+      eyeBlink: 0,
+    };
+
+    return {
+      process(inputs) {
+        const face = inputs.face as FaceFrame | undefined;
+        if (!face || !face.present) {
+          // Decay toward rest so a lost face doesn't freeze the last expression.
+          for (const k of Object.keys(prev) as (keyof typeof prev)[]) {
+            prev[k] = p.smoothing * prev[k];
+          }
+          return { features: { ...ABSENT_FACE } };
+        }
+
+        const bs = (name: string): number => face.blendshapes[name] ?? 0;
+        const avg = (...xs: number[]): number => (xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0);
+
+        const targets: Record<keyof typeof prev, number> = {
+          smile: avg(bs('mouthSmileLeft'), bs('mouthSmileRight')),
+          mouthOpen: bs('jawOpen'),
+          browRaise: avg(bs('browInnerUp'), bs('browOuterUpLeft'), bs('browOuterUpRight')),
+          browFurrow: avg(bs('browDownLeft'), bs('browDownRight')),
+          eyeBlink: avg(bs('eyeBlinkLeft'), bs('eyeBlinkRight')),
+        };
+
+        const out: FaceFeatures = { ...ABSENT_FACE, present: true };
+        for (const k of Object.keys(targets) as (keyof typeof prev)[]) {
+          const target = clamp01(targets[k] * p.gain);
+          prev[k] = prev[k] + (1 - p.smoothing) * (target - prev[k]);
+          out[k] = prev[k];
+        }
+        return { features: out };
+      },
+    };
+  },
+});

--- a/src/nodes/index.ts
+++ b/src/nodes/index.ts
@@ -11,6 +11,7 @@ import { createRegistry, type NodeRegistry } from '@/dag';
 import { syntheticHandsNode } from './sources/synthetic_hands';
 import { replaySourceNode } from './sources/replay';
 import { handFeaturesNode } from './features/hand_features';
+import { faceFeaturesNode } from './features/face_features';
 import { voiceMappingNode } from './mapping/voice_mapping';
 import { keyboardControlNode } from './mapping/keyboard_control';
 import { indirectMapNode } from './mapping/indirect_map';
@@ -19,6 +20,7 @@ import { lyriaNode } from './output/lyria';
 export { syntheticHandsNode } from './sources/synthetic_hands';
 export { replaySourceNode } from './sources/replay';
 export { handFeaturesNode } from './features/hand_features';
+export { faceFeaturesNode } from './features/face_features';
 export { voiceMappingNode } from './mapping/voice_mapping';
 export { keyboardControlNode } from './mapping/keyboard_control';
 export { indirectMapNode } from './mapping/indirect_map';
@@ -31,6 +33,7 @@ export const CORE_NODES = [
   syntheticHandsNode,
   replaySourceNode,
   handFeaturesNode,
+  faceFeaturesNode,
   voiceMappingNode,
   keyboardControlNode,
   indirectMapNode,

--- a/test/face_features.test.ts
+++ b/test/face_features.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Tests the `face-features` node: blendshapes → normalized expression controls.
+ * Unit cases (synthetic blendshapes) + a replay against the real
+ * `video_face_expressions` fixture (decoded once via MediaPipe FaceLandmarker).
+ */
+import { readFileSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect } from 'vitest';
+import { replayNode, valuesFromNDJSON } from '@/dag';
+import { faceFeaturesNode, type FaceFeatures, type FaceFrame } from '@/nodes';
+
+const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), 'fixtures');
+const span = (xs: number[]) => Math.max(...xs) - Math.min(...xs);
+
+function frame(blendshapes: Record<string, number>): FaceFrame {
+  return { present: true, blendshapes };
+}
+
+describe('face-features node (unit)', () => {
+  const params = faceFeaturesNode.params.parse({});
+
+  it('maps blendshapes to expression controls', async () => {
+    const [out] = await replayNode(faceFeaturesNode.make(params), {
+      face: [frame({ mouthSmileLeft: 0.8, mouthSmileRight: 0.6, jawOpen: 0.5, browInnerUp: 0.9 })],
+    });
+    const f = out.features as FaceFeatures;
+    expect(f.present).toBe(true);
+    expect(f.smile).toBeCloseTo(0.7, 5); // avg(0.8, 0.6)
+    expect(f.mouthOpen).toBeCloseTo(0.5, 5); // jawOpen
+    expect(f.browRaise).toBeCloseTo(0.3, 5); // avg(0.9, 0, 0)
+  });
+
+  it('absent face → all controls zero', async () => {
+    const [out] = await replayNode(faceFeaturesNode.make(params), {
+      face: [{ present: false, blendshapes: {} } as FaceFrame],
+    });
+    const f = out.features as FaceFeatures;
+    expect(f.present).toBe(false);
+    expect(f.smile).toBe(0);
+    expect(f.mouthOpen).toBe(0);
+  });
+
+  it('clamps with gain and eases with smoothing', async () => {
+    // gain pushes a small smile to full; smoothing eases in over ticks.
+    const handlers = faceFeaturesNode.make(faceFeaturesNode.params.parse({ gain: 3, smoothing: 0.6 }));
+    const frames = Array.from({ length: 8 }, () => frame({ mouthSmileLeft: 0.5, mouthSmileRight: 0.5 }));
+    const outs = (await replayNode(handlers, { face: frames })).map((o) => (o.features as FaceFeatures).smile);
+    expect(outs[0]).toBeLessThan(outs[1]); // easing in
+    expect(outs[7]).toBeGreaterThan(outs[0]);
+    expect(outs[7]).toBeLessThanOrEqual(1); // clamped (0.5*3 would be 1.5)
+  });
+});
+
+describe('face-features from the video_face_expressions fixture', () => {
+  it('detects a face and smile/mouthOpen/browRaise vary through the expression sweep', async () => {
+    const path = join(FIXTURES, 'video_face_expressions', 'face.blendshapes.ndjson');
+    if (!existsSync(path)) throw new Error(`missing ${path} — regenerate (see docs/TESTING.md)`);
+    const faces = valuesFromNDJSON(readFileSync(path, 'utf8')) as FaceFrame[];
+
+    const outs = (await replayNode(faceFeaturesNode.make(faceFeaturesNode.params.parse({})), { face: faces })).map(
+      (o) => o.features as FaceFeatures,
+    );
+    const present = outs.filter((f) => f.present);
+    expect(present.length / outs.length).toBeGreaterThan(0.8);
+    expect(span(present.map((f) => f.smile))).toBeGreaterThan(0.3);
+    expect(span(present.map((f) => f.mouthOpen))).toBeGreaterThan(0.2);
+    expect(span(present.map((f) => f.browRaise))).toBeGreaterThan(0.2);
+    // All controls stay in range.
+    expect(present.every((f) => f.smile >= 0 && f.smile <= 1 && f.mouthOpen >= 0 && f.mouthOpen <= 1)).toBe(true);
+  });
+});


### PR DESCRIPTION
Refs #6 (M4). The face analogue of `hand-features` — the first facial-expression node, fully verifiable headlessly against the `video_face_expressions` fixture from #19.

- **Domain** (`src/nodes/domain.ts`): `FaceFrame {present, blendshapes}` (52 MediaPipe blendshapes) + `FaceFeatures {present, smile, mouthOpen, browRaise, browFurrow, eyeBlink}` (all 0..1).
- **`face-features` node** (`src/nodes/features/face_features.ts`, pure): blendshapes → normalized expression controls, with `gain` + `smoothing`. Registered in CORE_NODES.
- **Tests** (`test/face_features.test.ts`): unit cases (mapping, absent-face, gain+smoothing) + a replay against the real face fixture (smile/mouthOpen/browRaise vary through the prompted expression sweep). **45 tests total** (was 41).
- **Docs**: catalog + domain types updated.

### Verification
typecheck (strict) clean · 45/45 tests pass · additive (not imported by the app).

### Remaining M4 (browser/wiring)
`webcam-face` source (in-browser FaceLandmarker, like `webcam-hands`) + a face→sound mapping (e.g. smile→brightness, mouthOpen→amplitude/density). Pairs naturally with the M3 live-app verification (camera).