### PR TITLE
indirect-map: facial expressions steer generation (M4)

### DIFF
--- a/docs/DAG_NODES.md
+++ b/docs/DAG_NODES.md
@@ -31,7 +31,7 @@ Build a registry with `createCoreRegistry()` (pure nodes) or `createAppRegistry(
 |-------------|-------|--------|---------|---------|
 | `voice-mapping` | ✅ | `features`; live overrides: `magnetism`, `octaveShift`, `mute`, `scaleRight`, `scaleLeft`, `instrumentRight`, `instrumentLeft` | `params: SynthParams` | **Direct** mapping: x→pitch (scale-snapped by magnetism), y→volume. Two voices (0=right, 1=left). |
 | `keyboard-control` | ✅ | `pressed: string[]` | `octaveShift`, `magnetism`, `mute` | Interprets key presses (arrows, `m`) into musical control values. |
-| `indirect-map` | ✅ | `features` | `steer: GenerativeSteer` | **Indirect** mapping: gesture features → weighted text prompts + config dials (density/brightness/bpm), with optional smoothing + throttle. Steers a generative engine. |
+| `indirect-map` | ✅ | `features` (hand), `face` (expressions) | `steer: GenerativeSteer` | **Indirect** mapping: hand features AND/OR face expressions → weighted text prompts + config dials (density/brightness/bpm), with optional smoothing + throttle. Each strain/dial picks its `source` (`hand`/`face`) + `feature`. Steers a generative engine. |
 
 ## Synthesis / output
 

--- a/src/nodes/mapping/indirect_map.ts
+++ b/src/nodes/mapping/indirect_map.ts
@@ -12,12 +12,19 @@
 import { z } from 'zod';
 import { defineNode } from '@/dag';
 import { rangeMap } from '@/music/theory';
-import { ABSENT_HAND, type HandFeatures, type SingleHandFeatures } from '../domain';
+import { ABSENT_FACE, ABSENT_HAND, type FaceFeatures, type HandFeatures, type SingleHandFeatures } from '../domain';
 import type { GenerativeSteer, WeightedPrompt } from '../output/generative';
 
 const FeatureRef = z.object({
+  /** Which input to read from: a hand feature or a face expression control. */
+  source: z.enum(['hand', 'face']).default('hand'),
+  /** For source='hand': which hand. */
   hand: z.enum(['left', 'right']).default('right'),
-  feature: z.enum(['x', 'y', 'openness', 'pinch']).default('openness'),
+  /**
+   * Feature name. hand: x | y | openness | pinch. face: smile | mouthOpen |
+   * browRaise | browFurrow | eyeBlink.
+   */
+  feature: z.string().default('openness'),
   inMin: z.number().default(0),
   inMax: z.number().default(1),
 });
@@ -44,16 +51,28 @@ const Params = z.object({
 });
 type Params = z.infer<typeof Params>;
 
-function readFeature(f: HandFeatures, hand: 'left' | 'right', key: 'x' | 'y' | 'openness' | 'pinch'): number {
-  const h: SingleHandFeatures = f[hand] ?? ABSENT_HAND;
-  return h.present ? h[key] : 0;
+type Ref = z.infer<typeof FeatureRef>;
+
+function readFeature(hands: HandFeatures, face: FaceFeatures, ref: Ref): number {
+  if (ref.source === 'face') {
+    if (!face.present) return 0;
+    const v = (face as unknown as Record<string, number>)[ref.feature];
+    return typeof v === 'number' ? v : 0;
+  }
+  const h: SingleHandFeatures = hands[ref.hand] ?? ABSENT_HAND;
+  if (!h.present) return 0;
+  const v = (h as unknown as Record<string, number>)[ref.feature];
+  return typeof v === 'number' ? v : 0;
 }
 
 export const indirectMapNode = defineNode<Params>({
   type: 'indirect-map',
   title: 'Indirect Map',
   description: 'Gesture features → weighted prompts + config dials (steers a generative engine).',
-  inputs: [{ name: 'features', kind: 'hand-features' }],
+  inputs: [
+    { name: 'features', kind: 'hand-features' },
+    { name: 'face', kind: 'face-features' },
+  ],
   outputs: [{ name: 'steer', kind: 'generative-steer' }],
   params: Params,
   make(p) {
@@ -72,10 +91,11 @@ export const indirectMapNode = defineNode<Params>({
     return {
       process(inputs, ctx) {
         const f = (inputs.features as HandFeatures | undefined) ?? { left: { ...ABSENT_HAND }, right: { ...ABSENT_HAND } };
+        const face = (inputs.face as FaceFeatures | undefined) ?? { ...ABSENT_FACE };
 
         // Always advance the smoothed state so it tracks even between emits.
         const prompts: WeightedPrompt[] = p.strains.map((s, i) => {
-          const raw = readFeature(f, s.hand, s.feature);
+          const raw = readFeature(f, face, s);
           const target = rangeMap(raw, s.inMin, s.inMax, s.weightMin, s.weightMax);
           const w = smooth(weights.get(i), target);
           weights.set(i, w);
@@ -83,7 +103,7 @@ export const indirectMapNode = defineNode<Params>({
         });
         const config: Record<string, number> = {};
         p.dials.forEach((d, i) => {
-          const raw = readFeature(f, d.hand, d.feature);
+          const raw = readFeature(f, face, d);
           const target = rangeMap(raw, d.inMin, d.inMax, d.outMin, d.outMax);
           const v = smooth(dialVals.get(i), target);
           dialVals.set(i, v);

--- a/test/indirect_map.test.ts
+++ b/test/indirect_map.test.ts
@@ -8,7 +8,7 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, it, expect } from 'vitest';
 import { replayNode, valuesFromNDJSON } from '@/dag';
-import { indirectMapNode, ABSENT_HAND, type GenerativeSteer, type HandFeatures } from '@/nodes';
+import { indirectMapNode, ABSENT_HAND, ABSENT_FACE, type GenerativeSteer, type HandFeatures, type FaceFeatures } from '@/nodes';
 
 const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), 'fixtures');
 
@@ -26,30 +26,34 @@ const PARAMS = {
   throttleSec: 0,
 };
 
+// Parse params through the node's Zod schema (applies defaults like `source`),
+// as the engine does — make() expects the parsed shape.
+const P = indirectMapNode.params.parse(PARAMS);
+
 describe('indirect-map', () => {
   it('maps openness → strain weight exactly (no smoothing)', async () => {
     const frames = [feat({ openness: 0 }), feat({ openness: 0.5 }), feat({ openness: 1 })];
-    const outs = (await replayNode(indirectMapNode.make(PARAMS), { features: frames })).map((o) => o.steer as GenerativeSteer);
+    const outs = (await replayNode(indirectMapNode.make(P), { features: frames })).map((o) => o.steer as GenerativeSteer);
     expect(outs[0].prompts[0]).toMatchObject({ text: 'ambient pads', weight: 0 });
     expect(outs[1].prompts[0].weight).toBeCloseTo(1, 3); // 0.5 of 0..2
     expect(outs[2].prompts[0].weight).toBeCloseTo(2, 3);
   });
 
   it('absent hand → zero weights', async () => {
-    const [out] = await replayNode(indirectMapNode.make(PARAMS), {
+    const [out] = await replayNode(indirectMapNode.make(P), {
       features: [{ left: { ...ABSENT_HAND }, right: { ...ABSENT_HAND } } as HandFeatures],
     });
     expect((out.steer as GenerativeSteer).prompts.every((p) => p.weight === 0)).toBe(true);
   });
 
   it('emits the configured dial value', async () => {
-    const [out] = await replayNode(indirectMapNode.make(PARAMS), { features: [feat({ x: 0.75 })] });
+    const [out] = await replayNode(indirectMapNode.make(P), { features: [feat({ x: 0.75 })] });
     expect((out.steer as GenerativeSteer).config.brightness).toBeCloseTo(0.75, 3);
   });
 
   it('smoothing eases the weight toward the target over ticks', async () => {
     const frames = Array.from({ length: 10 }, () => feat({ openness: 1 }));
-    const outs = (await replayNode(indirectMapNode.make({ ...PARAMS, smoothing: 0.6 }), { features: frames })).map(
+    const outs = (await replayNode(indirectMapNode.make(indirectMapNode.params.parse({ ...PARAMS, smoothing: 0.6 })), { features: frames })).map(
       (o) => (o.steer as GenerativeSteer).prompts[0].weight,
     );
     expect(outs[0]).toBeLessThan(outs[1]); // easing in
@@ -59,10 +63,30 @@ describe('indirect-map', () => {
 
   it('runs from a recorded hand-features fixture', async () => {
     const features = valuesFromNDJSON(readFileSync(join(FIXTURES, 'sweep_right', 'feat.features.ndjson'), 'utf8'));
-    const outs = await replayNode(indirectMapNode.make(PARAMS), { features });
+    const outs = await replayNode(indirectMapNode.make(P), { features });
     expect(outs.length).toBe(features.length);
     const steer = outs[20].steer as GenerativeSteer;
     expect(steer.prompts).toHaveLength(2);
     expect(steer.config).toHaveProperty('brightness');
+  });
+
+  it('steers from FACE features (smile → strain weight, mouthOpen → dial)', async () => {
+    const faceParams = indirectMapNode.params.parse({
+      strains: [{ text: 'euphoric choir', source: 'face', feature: 'smile', inMin: 0, inMax: 1, weightMin: 0, weightMax: 2 }],
+      dials: [{ name: 'density', source: 'face', feature: 'mouthOpen', inMin: 0, inMax: 1, outMin: 0, outMax: 1 }],
+    });
+    const face = (smile: number, mouthOpen: number): FaceFeatures => ({ ...ABSENT_FACE, present: true, smile, mouthOpen });
+    const outs = (
+      await replayNode(indirectMapNode.make(faceParams), {
+        face: [face(0, 0), face(0.5, 0.4), face(1, 0.8)],
+      })
+    ).map((o) => o.steer as GenerativeSteer);
+
+    expect(outs[0].prompts[0]).toMatchObject({ text: 'euphoric choir', weight: 0 });
+    expect(outs[2].prompts[0].weight).toBeCloseTo(2, 3); // full smile → max weight
+    expect(outs[1].config.density).toBeCloseTo(0.4, 3); // mouthOpen → density dial
+    // Absent face → zero.
+    const [absent] = await replayNode(indirectMapNode.make(faceParams), { face: [{ ...ABSENT_FACE }] });
+    expect((absent.steer as GenerativeSteer).prompts[0].weight).toBe(0);
   });
 });


### PR DESCRIPTION
Refs #6 (M4). Completes the *indirect* chain for the face modality: `face-features → indirect-map → lyria`.

`indirect-map` strains/dials now pick a `source` (`hand` | `face`), so a smile can drive a strain weight and an open mouth a density dial — the user's vision of facial expressions modifying/generating music, now real at the logic level and unit-tested. Adds a `face` input port; fully backward-compatible (source defaults to `hand`).

Also fixed the existing indirect-map test to parse params through Zod (the correct pattern; previously relied on passing fully-specified raw params).

46 tests pass · typecheck (strict) clean · `vite build` clean (additive; app bundle unchanged).