### PR TITLE
Music-logic: chord + progression nodes (Tonal.js, M4)

### DIFF
--- a/docs/DAG_NODES.md
+++ b/docs/DAG_NODES.md
@@ -33,6 +33,13 @@ Build a registry with `createCoreRegistry()` (pure nodes) or `createAppRegistry(
 | `keyboard-control` | ✅ | `pressed: string[]` | `octaveShift`, `magnetism`, `mute` | Interprets key presses (arrows, `m`) into musical control values. |
 | `indirect-map` | ✅ | `features` (hand), `face` (expressions) | `steer: GenerativeSteer` | **Indirect** mapping: hand features AND/OR face expressions → weighted text prompts + config dials (density/brightness/bpm), with optional smoothing + throttle. Each strain/dial picks its `source` (`hand`/`face`) + `feature`. Steers a generative engine. |
 
+## Music-logic (tonal guidance — Tonal.js)
+
+| Node `type` | Pure? | Inputs | Outputs | Purpose |
+|-------------|-------|--------|---------|---------|
+| `chord` | ✅ | `chord` (symbol, e.g. "Cmaj7"), `gain` | `params: SynthParams` | Voices a chord symbol into one synth voice per chord tone (stacked ascending from `baseOctave`), so it drives `webaudio-synth` directly. Lets you *express harmony*. |
+| `progression` | ✅ | `position` (0..1) | `chord` (symbol), `index` | Holds a diatonic progression (Roman numerals in a `key`, correct qualities via `Key.majorKey().triads`) and selects the current chord from a continuous position — keeps harmony in-key while the player moves freely. Pair with `chord`: gesture → position → chord → notes. |
+
 ## Synthesis / output
 
 | Node `type` | Pure? | Inputs | Outputs | Purpose |
@@ -52,6 +59,7 @@ Build a registry with `createCoreRegistry()` (pure nodes) or `createAppRegistry(
 ## Planned nodes (see ROADMAP)
 
 `webcam-face` (browser FaceLandmarker source), `pose-features`, `gesture-classifier`
-(discrete events), `chord`/`voicing`/`progression` (Tonal.js), `score` +
-`performance` (conductor mode), `midi-in`/`midi-out` (WEBMIDI.js), signal
-conditioners (one-euro filter, hysteresis, debounce).
+(discrete events), `voicing` (smarter voice-leading), `score` + `performance`
+(conductor mode), `midi-in`/`midi-out` (WEBMIDI.js), signal conditioners
+(one-euro filter, hysteresis, debounce), and a small adapter to feed a scalar
+feature (e.g. hand x) into `progression.position`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "motion": "^12.23.24",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "tonal": "^6.4.0",
         "vite": "^6.2.0",
         "zod": "^3.24.1"
       },
@@ -1635,6 +1636,295 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@tonaljs/abc-notation": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@tonaljs/abc-notation/-/abc-notation-4.9.1.tgz",
+      "integrity": "sha512-2fDUdPsFDdgZgyIiZCTYGKy30QiwIQxSXCSN2thGrSMXbQKCp8iTC8haStYcrA+25MPWhWlmvC/pz3tGcTNAqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch-distance": "5.0.5",
+        "@tonaljs/pitch-note": "6.1.0"
+      }
+    },
+    "node_modules/@tonaljs/array": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/@tonaljs/array/-/array-4.8.4.tgz",
+      "integrity": "sha512-97HVdpZy82PqNBDMM9PRSbO2DUrnxNg3++N4xqLpfby70fKHAHhTWrMXWZK+Dzs76HDPQLd+qhd4cq28eBZzjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch-note": "6.1.0"
+      }
+    },
+    "node_modules/@tonaljs/chord": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/chord/-/chord-6.1.2.tgz",
+      "integrity": "sha512-39crsPVyBJxdGJ1DGl+4diM+6+mZ/ws6crkQMlqX4zTYHMUVfJOQrko4mPF1CD89AFhHJe1zCT9Js+nNp3Gffg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/chord-detect": "4.9.1",
+        "@tonaljs/chord-type": "5.1.1",
+        "@tonaljs/collection": "4.9.0",
+        "@tonaljs/interval": "^5.1.0",
+        "@tonaljs/pcset": "4.10.1",
+        "@tonaljs/pitch-distance": "5.0.5",
+        "@tonaljs/pitch-note": "6.1.0",
+        "@tonaljs/scale-type": "4.9.2"
+      }
+    },
+    "node_modules/@tonaljs/chord-detect": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@tonaljs/chord-detect/-/chord-detect-4.9.1.tgz",
+      "integrity": "sha512-rV/9+R7aZ9cQorQ3jdNMMMh63onosglYZM71Q0n7KKcWMAGrxF66MzxBG82xy+w1QDMJQslB3iHfDHUiS6wRjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/chord-type": "5.1.1",
+        "@tonaljs/pcset": "4.10.1",
+        "@tonaljs/pitch-note": "6.1.0"
+      }
+    },
+    "node_modules/@tonaljs/chord-type": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@tonaljs/chord-type/-/chord-type-5.1.1.tgz",
+      "integrity": "sha512-ti4WzRYvvjH7to0G3zlJFq7WsjHqmcqbk8Jv98aZSR5YumLdY/ua2yOPPyoPq82n6vfgjZsacnAZ3v8/SodOcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pcset": "4.10.1"
+      }
+    },
+    "node_modules/@tonaljs/collection": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/collection/-/collection-4.9.0.tgz",
+      "integrity": "sha512-Mk0h7O54nT6PgNVcUYauzxa5KOB23+0AOKudWzRH7JhJIN9vhVIC7PtwZXE+/G051UTbHSFIcN/afkgF4nB/8A==",
+      "license": "MIT"
+    },
+    "node_modules/@tonaljs/core": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/core/-/core-5.0.2.tgz",
+      "integrity": "sha512-v/fIRsB+lz93/yJnDEWvjDX6nDJ/Pz3cb0znm/UD8qKpN9BhN+v93iIaZG5LX0J2JNS35TtgIhwKFO10j6zieQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.2",
+        "@tonaljs/pitch-distance": "5.0.5",
+        "@tonaljs/pitch-interval": "6.1.0",
+        "@tonaljs/pitch-note": "6.1.0"
+      }
+    },
+    "node_modules/@tonaljs/duration-value": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/duration-value/-/duration-value-4.9.0.tgz",
+      "integrity": "sha512-Muz54HyIe0nMYKWx6wyTa4y17ma29DtpJF4/oqJphy6A124rAVDe/SKit8JGOvDYAQj71FUXqs17sXBxO/ExVw==",
+      "license": "MIT"
+    },
+    "node_modules/@tonaljs/interval": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/interval/-/interval-5.1.0.tgz",
+      "integrity": "sha512-GR9dUjn0j7yhjwjRh8HQxZYXOiVl05WfY3AFyMB9rfg807K4dSJmWfPTULPQXyHJ6NiZOPXcwRs8MxMLDxgdbg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "^5.0.2",
+        "@tonaljs/pitch-distance": "^5.0.4",
+        "@tonaljs/pitch-interval": "^6.0.0"
+      }
+    },
+    "node_modules/@tonaljs/key": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/key/-/key-4.11.2.tgz",
+      "integrity": "sha512-fc1y5+NwS4S3amirzYLLB324PxJDO00oIBbLJclAddc46UBeYnu4FNz+1nZboHCXRQ/06/ftuaWD/l7HrAoulw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/note": "4.12.1",
+        "@tonaljs/pitch-note": "6.1.0",
+        "@tonaljs/roman-numeral": "4.9.1"
+      }
+    },
+    "node_modules/@tonaljs/midi": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/midi/-/midi-4.10.2.tgz",
+      "integrity": "sha512-MPamXhEwPL7L1udLfYMm3Ft8mLYtHr62Zi2w5zYHM2P7YwIvNoiX0+dvAN5is1Wvq4iVRa8AjFHerjOW/SZhGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch-note": "6.1.0"
+      }
+    },
+    "node_modules/@tonaljs/mode": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/mode/-/mode-4.9.2.tgz",
+      "integrity": "sha512-Il48fWX9SnGMzwNFVbizkWkr/SJ+aCIIHhjWfSf1agrQAoq81536qBXEyEyvia6aqEXC4OaXAQ5rSoBcmQRj1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/collection": "4.9.0",
+        "@tonaljs/interval": "5.1.0",
+        "@tonaljs/pcset": "4.10.1",
+        "@tonaljs/pitch-distance": "5.0.5",
+        "@tonaljs/pitch-note": "6.1.0",
+        "@tonaljs/scale-type": "4.9.2"
+      }
+    },
+    "node_modules/@tonaljs/note": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@tonaljs/note/-/note-4.12.1.tgz",
+      "integrity": "sha512-yh6cnhu21bUb0VuIQWxObSbWBVp2cHIkJj4zZ4qsNOW4jSqn74+wHpSbOTDF8q+2hl6upz7TtBRavtqwPtLUCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/midi": "4.10.2",
+        "@tonaljs/pitch": "5.0.2",
+        "@tonaljs/pitch-distance": "5.0.5",
+        "@tonaljs/pitch-interval": "6.1.0",
+        "@tonaljs/pitch-note": "6.1.0"
+      }
+    },
+    "node_modules/@tonaljs/pcset": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pcset/-/pcset-4.10.1.tgz",
+      "integrity": "sha512-CZG1rpKc38yMfpEJsbDTvsTmQqsek9xxcuMgK64Tr6sP1lEiDuZJbQeKVWWRnreBF2FQ1cEGLmfOpvSO+40csA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/collection": "4.9.0",
+        "@tonaljs/pitch": "5.0.2",
+        "@tonaljs/pitch-distance": "5.0.5",
+        "@tonaljs/pitch-interval": "6.1.0",
+        "@tonaljs/pitch-note": "6.1.0"
+      }
+    },
+    "node_modules/@tonaljs/pitch": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch/-/pitch-5.0.2.tgz",
+      "integrity": "sha512-mxaXJPPe+LIJdjzpZEl8I8Wx3dEvlzkBbsr2Ltwc2dTAdnErAZ5R0TxVq2egF27lMvQN2QPQPWI9iDPPdVUmrg==",
+      "license": "MIT"
+    },
+    "node_modules/@tonaljs/pitch-distance": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch-distance/-/pitch-distance-5.0.5.tgz",
+      "integrity": "sha512-dTfjsU0zyrj5YmiFio5prPaD5w7sBmHp4nnmlEg70nHY+SerAH0KiO9HM9usttVgRFUaXl0Gc7OI8YMGfSFmug==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.2",
+        "@tonaljs/pitch-interval": "6.1.0",
+        "@tonaljs/pitch-note": "6.1.0"
+      }
+    },
+    "node_modules/@tonaljs/pitch-interval": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch-interval/-/pitch-interval-6.1.0.tgz",
+      "integrity": "sha512-9ZMxA7V4UgySnOKPIG6HECzhDb8mbiTCIdNNIzCIfz5XpjUmohku2YZpVVWMacLHgyeQicJzNoRiPel5oSAn4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.2"
+      }
+    },
+    "node_modules/@tonaljs/pitch-note": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch-note/-/pitch-note-6.1.0.tgz",
+      "integrity": "sha512-A4OSLo8DjM38u73862LnDmL4YInDDRBmg0fojXcvu4cyU3oOlqndyeHOra1OVoH/WW46uNIxNs1wJDZNPWL5KQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.2"
+      }
+    },
+    "node_modules/@tonaljs/progression": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/progression/-/progression-4.9.2.tgz",
+      "integrity": "sha512-1Pmau5tKoWmY2H/fp9WVJ5Qm4c+xlu7IEZb3R3uLbc26kJq97DbuSnfArIAQoZTum2V6lOEN/Dt34E9OrGKnoA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/chord": "6.1.2",
+        "@tonaljs/pitch-distance": "5.0.5",
+        "@tonaljs/pitch-interval": "6.1.0",
+        "@tonaljs/pitch-note": "6.1.0",
+        "@tonaljs/roman-numeral": "4.9.1"
+      }
+    },
+    "node_modules/@tonaljs/range": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/range/-/range-4.9.2.tgz",
+      "integrity": "sha512-XhFbCJCrEEIVz3MNmdVp9QUyiJA6eqnNnQeNqto8AuT5BYuffHDoMkBmvvjPuV5Lh8zfF9D0aqglvqPbZ+neKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/collection": "4.9.0",
+        "@tonaljs/midi": "4.10.2"
+      }
+    },
+    "node_modules/@tonaljs/rhythm-pattern": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/rhythm-pattern/-/rhythm-pattern-1.0.0.tgz",
+      "integrity": "sha512-3hp4Yw49e6BTWApRNb7arJ6HiICsHRFZYijuPE+vR93lIo9+lxcOMh0OPc4DyupTN7cvFTSB70Z7B/IeEJxhCQ==",
+      "license": "MIT"
+    },
+    "node_modules/@tonaljs/roman-numeral": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@tonaljs/roman-numeral/-/roman-numeral-4.9.1.tgz",
+      "integrity": "sha512-dJGKBNHdPrNTE97ZDk4t6wpNmgYcpHyLkAvWkRP9I/HsDkeTFFQqNXosYIvspPWrFySlRpeqqFwcqV74MYoOag==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.2",
+        "@tonaljs/pitch-interval": "6.1.0",
+        "@tonaljs/pitch-note": "6.1.0"
+      }
+    },
+    "node_modules/@tonaljs/scale": {
+      "version": "4.13.4",
+      "resolved": "https://registry.npmjs.org/@tonaljs/scale/-/scale-4.13.4.tgz",
+      "integrity": "sha512-hyilnmsCmoGQiRhYWKM1QPrqaNH3KGEfrSfxeXcicPnEh12yvrVRm4djKmTVw7Rc/5P4GniPAA51+CS0C5dbLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/chord-type": "5.1.1",
+        "@tonaljs/collection": "4.9.0",
+        "@tonaljs/note": "4.12.1",
+        "@tonaljs/pcset": "4.10.1",
+        "@tonaljs/pitch-distance": "5.0.5",
+        "@tonaljs/pitch-note": "6.1.0",
+        "@tonaljs/scale-type": "4.9.2"
+      }
+    },
+    "node_modules/@tonaljs/scale-type": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/scale-type/-/scale-type-4.9.2.tgz",
+      "integrity": "sha512-XDRPySg0X6owJ6AVzVRpS4ZpgleAUQakuq5VtfQ0JitnJKGRYo5Y0w7Fl/wEz/X9aEMk2lxcdF8VGGMIsQFo0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pcset": "4.10.1"
+      }
+    },
+    "node_modules/@tonaljs/time-signature": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/time-signature/-/time-signature-4.9.0.tgz",
+      "integrity": "sha512-zRo8CBqg/2guzTlF2vxyVIuB5gmwWQaxlknJPUSDII8CTdQ/x3a1LlNoMKkvTUnqwCihe3WrNPZ5XUfOOTthYA==",
+      "license": "MIT"
+    },
+    "node_modules/@tonaljs/voice-leading": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/voice-leading/-/voice-leading-5.1.2.tgz",
+      "integrity": "sha512-lV5hsDZC4ekhh465d2aVFFqyG9AOZvwKdxU1+dNB/P6ldefU1yHC10mKdY7FrdhVgKeGZG1MbJh8rETaKVg7vA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/note": "4.12.1"
+      }
+    },
+    "node_modules/@tonaljs/voicing": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@tonaljs/voicing/-/voicing-5.1.3.tgz",
+      "integrity": "sha512-OLNcaIA086/4gwoXVa736yW0yP9TADi95/5LAS8KxMtzYBWPYzxyC1IxcE9bGqXsdBnI99au57J8+G6wroluyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/chord": "6.1.2",
+        "@tonaljs/interval": "5.1.0",
+        "@tonaljs/note": "4.12.1",
+        "@tonaljs/range": "4.9.2",
+        "@tonaljs/voice-leading": "5.1.2",
+        "@tonaljs/voicing-dictionary": "5.1.3"
+      }
+    },
+    "node_modules/@tonaljs/voicing-dictionary": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@tonaljs/voicing-dictionary/-/voicing-dictionary-5.1.3.tgz",
+      "integrity": "sha512-kRM6IOHq+ULgZtJdbGNz5OmfUo+WyA3EeqKVrlA9Uj7QqrrfOkzeQdE3jXEBnjO1oGP5ql6NS5QUF3rST+SqUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/chord": "6.1.2",
+        "@tonaljs/note": "4.12.1",
+        "@tonaljs/voice-leading": "5.1.2"
       }
     },
     "node_modules/@types/babel__core": {
@@ -4941,6 +5231,37 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tonal": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/tonal/-/tonal-6.4.3.tgz",
+      "integrity": "sha512-p+0kwBBma3Ko2xtHVq8oYa+IAGRozkAkBk03swRvcEfxYa8Ktr0yrBYW1fsZlywaerEu346oebghrS8jDQmBsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/abc-notation": "4.9.1",
+        "@tonaljs/array": "4.8.4",
+        "@tonaljs/chord": "6.1.2",
+        "@tonaljs/chord-type": "5.1.1",
+        "@tonaljs/collection": "4.9.0",
+        "@tonaljs/core": "5.0.2",
+        "@tonaljs/duration-value": "4.9.0",
+        "@tonaljs/interval": "5.1.0",
+        "@tonaljs/key": "4.11.2",
+        "@tonaljs/midi": "4.10.2",
+        "@tonaljs/mode": "4.9.2",
+        "@tonaljs/note": "4.12.1",
+        "@tonaljs/pcset": "4.10.1",
+        "@tonaljs/progression": "4.9.2",
+        "@tonaljs/range": "4.9.2",
+        "@tonaljs/rhythm-pattern": "1.0.0",
+        "@tonaljs/roman-numeral": "4.9.1",
+        "@tonaljs/scale": "4.13.4",
+        "@tonaljs/scale-type": "4.9.2",
+        "@tonaljs/time-signature": "4.9.0",
+        "@tonaljs/voice-leading": "5.1.2",
+        "@tonaljs/voicing": "5.1.3",
+        "@tonaljs/voicing-dictionary": "5.1.3"
       }
     },
     "node_modules/tr46": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@mediapipe/hands": "^0.4.1675469240",
     "@tailwindcss/vite": "^4.1.14",
     "zod": "^3.24.1",
+    "tonal": "^6.4.0",
     "@tensorflow-models/hand-pose-detection": "^2.0.1",
     "@tensorflow/tfjs-backend-webgl": "^4.22.0",
     "@tensorflow/tfjs-converter": "^4.22.0",

--- a/src/nodes/index.ts
+++ b/src/nodes/index.ts
@@ -16,6 +16,8 @@ import { voiceMappingNode } from './mapping/voice_mapping';
 import { keyboardControlNode } from './mapping/keyboard_control';
 import { indirectMapNode } from './mapping/indirect_map';
 import { lyriaNode } from './output/lyria';
+import { chordNode } from './music/chord';
+import { progressionNode } from './music/progression';
 
 export { syntheticHandsNode } from './sources/synthetic_hands';
 export { replaySourceNode } from './sources/replay';
@@ -25,6 +27,8 @@ export { voiceMappingNode } from './mapping/voice_mapping';
 export { keyboardControlNode } from './mapping/keyboard_control';
 export { indirectMapNode } from './mapping/indirect_map';
 export { lyriaNode } from './output/lyria';
+export { chordNode, voiceChord } from './music/chord';
+export { progressionNode } from './music/progression';
 export type { GenerativeEngine, GenerativeSteer, GenerativeConfig, WeightedPrompt } from './output/generative';
 export * from './domain';
 
@@ -38,6 +42,8 @@ export const CORE_NODES = [
   keyboardControlNode,
   indirectMapNode,
   lyriaNode,
+  chordNode,
+  progressionNode,
 ];
 
 /** Build a registry pre-loaded with the pure node library. */

--- a/src/nodes/music/chord.ts
+++ b/src/nodes/music/chord.ts
@@ -1,0 +1,71 @@
+/**
+ * `chord` node — music-logic layer (tonal guidance for harmony). Turns a chord
+ * symbol (e.g. "Cmaj7", "Am7") into voiced {@link SynthParams} — one voice per
+ * chord tone, stacked ascending from a base octave — so it drives the existing
+ * `webaudio-synth` directly (each chord tone is a synth voice; chord changes
+ * glide via the synth's per-voice smoothing = simple voice-leading).
+ *
+ * Pure + deterministic (uses Tonal.js, no DOM/audio), so it's unit-testable.
+ * Lets you *express harmony* directly; pair with `progression` to drive chord
+ * selection from a gesture.
+ */
+import { z } from 'zod';
+import { Chord, Note } from 'tonal';
+import { defineNode } from '@/dag';
+import { midiToFreq } from '@/music/theory';
+import type { SynthParams, VoiceParams } from '../domain';
+
+const Params = z.object({
+  /** Octave of the lowest chord tone. */
+  baseOctave: z.number().int().min(0).max(7).default(4),
+  /** Cap the number of voices (chord tones) emitted. */
+  maxVoices: z.number().int().min(1).max(8).default(4),
+  instrument: z.enum(['sine', 'square', 'sawtooth', 'triangle']).default('sine'),
+});
+type Params = z.infer<typeof Params>;
+
+/** Stack chord pitch-classes ascending from `baseOctave` into MIDI notes. */
+export function voiceChord(symbol: string, baseOctave: number, maxVoices: number): number[] {
+  const chord = Chord.get(symbol);
+  if (chord.empty || chord.notes.length === 0) return [];
+  const out: number[] = [];
+  let octave = baseOctave;
+  let prev = -Infinity;
+  for (const pc of chord.notes.slice(0, maxVoices)) {
+    let midi = Note.midi(`${pc}${octave}`);
+    if (midi !== null && midi <= prev) {
+      octave += 1;
+      midi = Note.midi(`${pc}${octave}`);
+    }
+    if (midi === null) continue; // unparseable note name — skip
+    prev = midi;
+    out.push(midi);
+  }
+  return out;
+}
+
+export const chordNode = defineNode<Params>({
+  type: 'chord',
+  title: 'Chord',
+  description: 'Chord symbol (e.g. Cmaj7) → voiced synth params (one voice per chord tone).',
+  inputs: [
+    { name: 'chord', kind: 'chord-symbol', default: 'C' },
+    { name: 'gain', kind: 'number', default: 0.3 },
+  ],
+  outputs: [{ name: 'params', kind: 'synth-params' }],
+  params: Params,
+  process(inputs, p) {
+    const symbol = typeof inputs.chord === 'string' && inputs.chord ? inputs.chord : 'C';
+    const gain = typeof inputs.gain === 'number' ? inputs.gain : 0.3;
+    const midis = voiceChord(symbol, p.baseOctave, p.maxVoices);
+    const voices: VoiceParams[] = midis.map((midi, id) => ({
+      id,
+      present: true,
+      freq: midiToFreq(midi),
+      gain,
+      instrument: p.instrument,
+    }));
+    const out: SynthParams = { voices };
+    return { params: out };
+  },
+});

--- a/src/nodes/music/progression.ts
+++ b/src/nodes/music/progression.ts
@@ -1,0 +1,63 @@
+/**
+ * `progression` node — music-logic layer. Holds a diatonic chord progression
+ * (Roman numerals in a key, e.g. I–IV–V–vi in C) and selects the current chord
+ * from a continuous `position` input (0..1). Pair with `chord` to drive harmony
+ * from a gesture: hand x → position → chord symbol → voiced synth params.
+ *
+ * This is the "guide toward tonal patterns" piece — the player moves freely, but
+ * the harmony stays in-key. Pure + deterministic (Tonal.js), unit-testable.
+ */
+import { z } from 'zod';
+import { Key } from 'tonal';
+import { defineNode } from '@/dag';
+
+const Params = z.object({
+  /** Tonic key for the Roman-numeral progression, e.g. "C", "G", "Eb". */
+  key: z.string().default('C'),
+  /** The progression as Roman numerals. */
+  romanNumerals: z.array(z.string()).default(['I', 'IV', 'V', 'vi']),
+});
+type Params = z.infer<typeof Params>;
+
+function clamp01(v: number): number {
+  return v < 0 ? 0 : v > 1 ? 1 : v;
+}
+
+const ROMAN_TO_DEGREE: Record<string, number> = {
+  i: 1, ii: 2, iii: 3, iv: 4, v: 5, vi: 6, vii: 7,
+};
+
+/** Roman numeral → scale degree (1..7); case is ignored (key sets quality). */
+function romanToDegree(rn: string): number {
+  const key = rn.replace(/[^ivxIVX]/g, '').toLowerCase();
+  return ROMAN_TO_DEGREE[key] ?? 1;
+}
+
+export const progressionNode = defineNode<Params>({
+  type: 'progression',
+  title: 'Progression',
+  description: 'Roman-numeral progression in a key + position (0..1) → current chord symbol.',
+  inputs: [{ name: 'position', kind: 'number', default: 0 }],
+  outputs: [
+    { name: 'chord', kind: 'chord-symbol' },
+    { name: 'index', kind: 'number' },
+  ],
+  params: Params,
+  make(p) {
+    // Resolve Roman numerals → diatonic chord symbols once. Using the key's
+    // diatonic triads gives correct qualities (vi in C → "Am", not "A").
+    const triads = Key.majorKey(p.key).triads;
+    const chords =
+      triads.length === 7 ? p.romanNumerals.map((rn) => triads[romanToDegree(rn) - 1]) : [p.key];
+    const n = chords.length;
+    return {
+      process(inputs) {
+        if (n === 0) return { chord: p.key, index: 0 };
+        const pos = typeof inputs.position === 'number' ? clamp01(inputs.position) : 0;
+        // Map 0..1 across the chords; the top edge maps to the last chord.
+        const index = Math.min(n - 1, Math.floor(pos * n));
+        return { chord: chords[index], index };
+      },
+    };
+  },
+});

--- a/test/music_logic.test.ts
+++ b/test/music_logic.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests the music-logic layer: `chord` (chord symbol → voiced synth params) and
+ * `progression` (Roman numerals in a key + position → chord symbol), plus the
+ * full gesture→harmony chain wired as a DAG:
+ *   synthetic-hands → hand-features → (x→position) → progression → chord
+ */
+import { describe, it, expect } from 'vitest';
+import { replayNode, runHeadless, type GraphSpec } from '@/dag';
+import { chordNode, progressionNode, voiceChord, createCoreRegistry } from '@/nodes';
+import { freqToMidi } from '@/music/theory';
+import type { SynthParams } from '@/nodes';
+
+describe('chord node', () => {
+  it('voices a chord ascending into MIDI', () => {
+    expect(voiceChord('Cmaj7', 4, 4)).toEqual([60, 64, 67, 71]); // C4 E4 G4 B4
+    // Am7 = A C E G; C wraps up an octave to stay ascending.
+    expect(voiceChord('Am7', 4, 4)).toEqual([69, 72, 76, 79]); // A4 C5 E5 G5
+  });
+
+  it('emits a synth voice per chord tone at the right pitch', async () => {
+    const [out] = await replayNode(chordNode.make(chordNode.params.parse({ baseOctave: 4, maxVoices: 4 })), {
+      chord: ['Cmaj7'],
+      gain: [0.3],
+    });
+    const sp = out.params as SynthParams;
+    expect(sp.voices).toHaveLength(4);
+    expect(sp.voices.every((v) => v.present && v.gain === 0.3)).toBe(true);
+    const midis = sp.voices.map((v) => Math.round(freqToMidi(v.freq)));
+    expect(midis).toEqual([60, 64, 67, 71]);
+  });
+
+  it('an unparseable chord yields no voices (silent)', async () => {
+    const [out] = await replayNode(chordNode.make(chordNode.params.parse({})), { chord: ['nonsense'] });
+    expect((out.params as SynthParams).voices).toHaveLength(0);
+  });
+});
+
+describe('progression node', () => {
+  it('maps position 0..1 across the diatonic chords of a key', async () => {
+    const handlers = progressionNode.make(progressionNode.params.parse({ key: 'C', romanNumerals: ['I', 'IV', 'V', 'vi'] }));
+    const outs = await replayNode(handlers, { position: [0, 0.3, 0.6, 0.99] });
+    expect(outs.map((o) => o.chord)).toEqual(['C', 'F', 'G', 'Am']);
+    expect(outs.map((o) => o.index)).toEqual([0, 1, 2, 3]);
+  });
+});
+
+describe('gesture → harmony chain (DAG)', () => {
+  it('hand x sweep walks the progression and the chord notes change', async () => {
+    const spec: GraphSpec = {
+      nodes: [
+        { id: 'src', type: 'synthetic-hands', params: { hands: 'right', sweepPeriod: 4 } },
+        { id: 'feat', type: 'hand-features', params: { mirrorX: false, mirrorHandedness: false } },
+        // pull the right-hand x out of features into a bare number for `position`
+        { id: 'prog', type: 'progression', params: { key: 'C', romanNumerals: ['I', 'IV', 'V', 'vi'] } },
+        { id: 'chord', type: 'chord', params: { baseOctave: 4, maxVoices: 4 } },
+      ],
+      edges: [
+        { from: { node: 'src', port: 'hands' }, to: { node: 'feat', port: 'hands' } },
+        // feat.features → prog.position needs the scalar x; an adapter node would
+        // normally do this, but here we drive progression directly in a focused
+        // unit test below. This DAG asserts the chord stage runs end-to-end.
+        { from: { node: 'prog', port: 'chord' }, to: { node: 'chord', port: 'chord' } },
+      ],
+    };
+    const { recorder } = await runHeadless(spec, createCoreRegistry(), { ticks: 30, nominalDt: 1 / 30 });
+    // progression with no position input holds index 0 → chord "C" → 3 voices.
+    const params = recorder.values('chord.params') as SynthParams[];
+    expect(params.length).toBe(30);
+    expect(params[10].voices.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('driving progression position directly walks chords → distinct chord note sets', async () => {
+    const prog = progressionNode.make(progressionNode.params.parse({ key: 'C', romanNumerals: ['I', 'IV', 'V', 'vi'] }));
+    const chordH = chordNode.make(chordNode.params.parse({ baseOctave: 4 }));
+    const positions = [0.0, 0.3, 0.6, 0.95];
+    const symbols = (await replayNode(prog, { position: positions })).map((o) => o.chord as string);
+    const noteSets = (await replayNode(chordH, { chord: symbols })).map((o) =>
+      (o.params as SynthParams).voices.map((v) => Math.round(freqToMidi(v.freq))),
+    );
+    expect(symbols).toEqual(['C', 'F', 'G', 'Am']);
+    // Each chord produces a distinct, non-empty note set.
+    expect(noteSets.every((s) => s.length >= 3)).toBe(true);
+    expect(new Set(noteSets.map((s) => s.join(','))).size).toBe(4);
+  });
+});


### PR DESCRIPTION
Refs #6 (M4). The music-logic layer — tonal guidance for **harmony**, a core part of the vision ("express chords, guided toward tonal patterns").

- **`chord` node**: a chord symbol (e.g. `Cmaj7`, `Am7`) → voiced `SynthParams`, one voice per chord tone stacked ascending — so it drives the existing `webaudio-synth` directly (chord changes glide via per-voice smoothing = simple voice-leading).
- **`progression` node**: a diatonic progression (Roman numerals in a `key`) resolved via `Key.majorKey().triads` for correct qualities (vi in C → `Am`, not `A`); a continuous `position` (0..1) selects the current chord — keeps harmony **in-key** while the player moves freely. Chain: gesture → position → chord → notes.

Adds the `tonal` dependency (pure JS; nodes are Node-safe).

### Tests (`test/music_logic.test.ts`)
chord voicing (`Cmaj7`→[60,64,67,71]; `Am7` wraps ascending), progression (`I IV V vi` in C → C F G Am), bad-chord→silent, and a position-sweep producing 4 distinct chord note sets. **52 tests total** (was 46).

### Verification
typecheck (strict) clean · 52/52 pass · `vite build` clean (additive; app bundle unchanged).

A tiny scalar-pick adapter (feature → `progression.position`) is the small remaining piece to wire this from a gesture in a live graph (noted in docs).
