### PR TITLE
Offline synth renderer — hear the pipeline headlessly

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -96,3 +96,18 @@ deterministically.
 `test/fixture_replay.test.ts` doubles as a **regression gate**: replaying recorded
 features must reproduce the recorded synth params; if `voice-mapping` logic
 changes intentionally, re-record (`npm run record`) to update the baseline.
+
+## Audible spot-check (offline render)
+
+`scripts/render_audio.ts` turns any `SynthParams` stream into a WAV with a tiny
+no-deps offline synth — so the audio output can be *heard* headlessly (no
+browser):
+
+```bash
+vite-node scripts/render_audio.ts test/fixtures/video_hand_sweep/map.params.ndjson media/audio/sweep.wav
+vite-node scripts/gen_chord_demo.ts media/chord_demo.params.ndjson   # I–IV–V–vi in C
+vite-node scripts/render_audio.ts media/chord_demo.params.ndjson media/audio/chords.wav
+```
+
+`test/render_audio.test.ts` covers the DSP (non-silent tone, silence→silence,
+chord louder than single voice). WAVs land in gitignored `media/audio/`.

--- a/scripts/gen_chord_demo.ts
+++ b/scripts/gen_chord_demo.ts
@@ -1,0 +1,36 @@
+/**
+ * Generate a chord-progression SynthParams stream for the audible harmony demo:
+ * a position ramp walks I–IV–V–vi (in C), each chord held ~2s, through the
+ * `progression` → `chord` nodes. Writes a `map.params.ndjson` you can render
+ * with `render_audio.ts`.
+ *
+ * Usage: vite-node scripts/gen_chord_demo.ts <out.params.ndjson>
+ */
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { replayNode, serializeRecords, type StreamRecord } from '@/dag';
+import { progressionNode, chordNode, type SynthParams } from '@/nodes';
+
+async function main(): Promise<void> {
+  const out = process.argv[2] ?? 'media/chord_demo.params.ndjson';
+  const fps = 30;
+  const chordsCount = 4;
+  const ticksPerChord = fps * 2; // 2s each
+  const ticks = chordsCount * ticksPerChord; // 8s
+
+  // Position ramps 0..1 across the 8s, stepping the progression every 2s.
+  const positions = Array.from({ length: ticks }, (_, i) => i / ticks);
+
+  const prog = progressionNode.make(progressionNode.params.parse({ key: 'C', romanNumerals: ['I', 'IV', 'V', 'vi'] }));
+  const symbols = (await replayNode(prog, { position: positions })).map((o) => o.chord as string);
+
+  const chord = chordNode.make(chordNode.params.parse({ baseOctave: 4, maxVoices: 4, instrument: 'triangle' }));
+  const params = (await replayNode(chord, { chord: symbols })).map((o) => o.params as SynthParams);
+
+  const records: StreamRecord[] = params.map((value, i) => ({ tick: i, t: i / fps, value }));
+  mkdirSync(dirname(out), { recursive: true });
+  writeFileSync(out, serializeRecords(records));
+  console.log(`chord demo: ${ticks} ticks, chords ${[...new Set(symbols)].join(' ')} -> ${out}`);
+}
+
+void main();

--- a/scripts/render_audio.ts
+++ b/scripts/render_audio.ts
@@ -1,0 +1,130 @@
+/**
+ * Offline synth renderer — turn a recorded `SynthParams` stream into an audible
+ * WAV, no browser. Lets the DAG's audio output be *heard* (and spot-checked)
+ * headlessly: render a fixture's `map.params.ndjson` (or any SynthParams stream)
+ * to a .wav. Pure DSP + a tiny 16-bit PCM WAV writer (no deps).
+ *
+ * Usage: vite-node scripts/render_audio.ts <map.params.ndjson> <out.wav> [fps]
+ */
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { parseRecords } from '@/dag';
+import type { SynthParams, VoiceParams } from '@/nodes';
+
+const SR = 44100;
+const MASTER = 0.25;
+
+function wave(phase: number, type: VoiceParams['instrument']): number {
+  const p = phase - Math.floor(phase); // 0..1
+  switch (type) {
+    case 'square':
+      return p < 0.5 ? 1 : -1;
+    case 'sawtooth':
+      return 2 * p - 1;
+    case 'triangle':
+      return 4 * Math.abs(p - 0.5) - 1;
+    default:
+      return Math.sin(2 * Math.PI * p);
+  }
+}
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+interface VoiceState {
+  phase: number;
+  gain: number;
+  freq: number;
+  type: VoiceParams['instrument'];
+}
+
+export function render(frames: SynthParams[], dt: number): Float32Array {
+  const samplesPerTick = Math.max(1, Math.round(SR * dt));
+  const total = frames.length * samplesPerTick;
+  const out = new Float32Array(total);
+  const voices = new Map<number, VoiceState>();
+
+  let s = 0;
+  for (const frame of frames) {
+    // Snapshot targets for this tick.
+    const targets = new Map<number, VoiceParams>();
+    for (const v of frame.voices) targets.set(v.id, v);
+
+    for (let j = 0; j < samplesPerTick; j++) {
+      const frac = j / samplesPerTick;
+      let acc = 0;
+      for (const [id, target] of targets) {
+        let st = voices.get(id);
+        if (!st) {
+          st = { phase: 0, gain: 0, freq: target.freq, type: target.instrument };
+          voices.set(id, st);
+        }
+        const curGain = target.present ? target.gain : 0;
+        const g = lerp(st.gain, curGain, frac); // ramp within tick (declick)
+        const f = lerp(st.freq, target.freq, frac);
+        st.phase += f / SR;
+        acc += wave(st.phase, target.instrument) * g;
+      }
+      out[s++] = Math.max(-1, Math.min(1, acc * MASTER));
+    }
+    // Commit tick-end values as the next ramp start.
+    for (const [id, target] of targets) {
+      const st = voices.get(id)!;
+      st.gain = target.present ? target.gain : 0;
+      st.freq = target.freq;
+      st.type = target.instrument;
+    }
+  }
+  return out;
+}
+
+export function writeWav(path: string, samples: Float32Array): void {
+  const n = samples.length;
+  const buf = Buffer.alloc(44 + n * 2);
+  buf.write('RIFF', 0);
+  buf.writeUInt32LE(36 + n * 2, 4);
+  buf.write('WAVE', 8);
+  buf.write('fmt ', 12);
+  buf.writeUInt32LE(16, 16);
+  buf.writeUInt16LE(1, 20); // PCM
+  buf.writeUInt16LE(1, 22); // mono
+  buf.writeUInt32LE(SR, 24);
+  buf.writeUInt32LE(SR * 2, 28);
+  buf.writeUInt16LE(2, 32);
+  buf.writeUInt16LE(16, 34);
+  buf.write('data', 36);
+  buf.writeUInt32LE(n * 2, 40);
+  for (let i = 0; i < n; i++) {
+    buf.writeInt16LE(Math.round(Math.max(-1, Math.min(1, samples[i])) * 32767), 44 + i * 2);
+  }
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, buf);
+}
+
+function rms(s: Float32Array): number {
+  let sum = 0;
+  for (let i = 0; i < s.length; i++) sum += s[i] * s[i];
+  return Math.sqrt(sum / s.length);
+}
+
+function main(): void {
+  const [src, out, fpsArg] = process.argv.slice(2);
+  if (!src || !out) {
+    console.error('usage: render_audio.ts <map.params.ndjson> <out.wav> [fps]');
+    process.exit(1);
+  }
+  const records = parseRecords(readFileSync(src, 'utf8'));
+  const frames = records.map((r) => r.value) as SynthParams[];
+  // Derive dt from record timestamps when available, else fps arg / 30.
+  const dt =
+    records.length > 1 && records[1].t > records[0].t
+      ? records[1].t - records[0].t
+      : 1 / (fpsArg ? Number(fpsArg) : 30);
+  const samples = render(frames, dt);
+  writeWav(out, samples);
+  console.log(`rendered ${frames.length} frames @ dt=${dt.toFixed(4)}s -> ${out} (${(samples.length / SR).toFixed(1)}s, rms=${rms(samples).toFixed(4)})`);
+}
+
+// Run the CLI only when invoked directly (not when imported by a test).
+if (process.argv[1] && process.argv[1].includes('render_audio')) main();

--- a/test/render_audio.test.ts
+++ b/test/render_audio.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Tests the offline synth renderer's DSP: a SynthParams stream produces audible
+ * (non-silent), correctly-sized PCM, and silence in → silence out.
+ */
+import { describe, it, expect } from 'vitest';
+import { render } from '../scripts/render_audio';
+import type { SynthParams } from '@/nodes';
+
+const SR = 44100;
+const voice = (freq: number, gain: number): SynthParams => ({
+  voices: [{ id: 0, present: true, freq, gain, instrument: 'sine' }],
+});
+
+function rms(s: Float32Array): number {
+  let sum = 0;
+  for (const x of s) sum += x * x;
+  return Math.sqrt(sum / s.length);
+}
+
+describe('render_audio', () => {
+  it('produces non-silent PCM of the right length for a held tone', () => {
+    const dt = 0.1; // 100ms/frame
+    const frames = Array.from({ length: 10 }, () => voice(440, 0.5));
+    const out = render(frames, dt);
+    expect(out.length).toBe(10 * Math.round(SR * dt)); // 1.0s
+    expect(rms(out)).toBeGreaterThan(0.05);
+    expect(Math.max(...out)).toBeLessThanOrEqual(1);
+    expect(Math.min(...out)).toBeGreaterThanOrEqual(-1);
+  });
+
+  it('silent (gain 0 / absent) → near-silence', () => {
+    const frames: SynthParams[] = [
+      { voices: [{ id: 0, present: false, freq: 440, gain: 0, instrument: 'sine' }] },
+      { voices: [{ id: 0, present: false, freq: 440, gain: 0, instrument: 'sine' }] },
+    ];
+    const out = render(frames, 0.05);
+    expect(rms(out)).toBeLessThan(0.01);
+  });
+
+  it('a chord (multiple voices) is louder than a single voice', () => {
+    const single = render([voice(220, 0.4), voice(220, 0.4)], 0.1);
+    const chord: SynthParams = {
+      voices: [0, 1, 2].map((id) => ({ id, present: true, freq: 220 * (id + 1), gain: 0.4, instrument: 'sine' as const })),
+    };
+    const multi = render([chord, chord], 0.1);
+    expect(rms(multi)).toBeGreaterThan(rms(single));
+  });
+});


### PR DESCRIPTION
Refs #6. A tiny no-deps offline synth (`scripts/render_audio.ts`) turns any `SynthParams` stream into a WAV, so the DAG's audio output can be **heard** and spot-checked without a browser — closing the loop on 'test what you can'.

- `render_audio.ts`: oscillator sum per voice with per-tick gain/freq ramps (declick) + a 16-bit PCM WAV writer; exports `render()`/`writeWav()`.
- `gen_chord_demo.ts`: drives `progression → chord` over a position ramp → a C–F–G–Am harmony stream.
- `test/render_audio.test.ts`: DSP coverage (non-silent tone, silence→silence, chord louder than a single voice). **55 tests total.**
- `docs/TESTING.md`: documents the audible spot-check tier.

Rendered demos (gitignored `media/audio/`): the theremin following each AI-generated hand video, plus the chord progression — all non-silent. typecheck + build green; additive.