### PR TITLE
pick adapter — wire gesture → harmony in a live graph

### DIFF
--- a/src/nodes/index.ts
+++ b/src/nodes/index.ts
@@ -15,6 +15,7 @@ import { faceFeaturesNode } from './features/face_features';
 import { voiceMappingNode } from './mapping/voice_mapping';
 import { keyboardControlNode } from './mapping/keyboard_control';
 import { indirectMapNode } from './mapping/indirect_map';
+import { pickNode } from './mapping/pick';
 import { lyriaNode } from './output/lyria';
 import { chordNode } from './music/chord';
 import { progressionNode } from './music/progression';
@@ -26,6 +27,7 @@ export { faceFeaturesNode } from './features/face_features';
 export { voiceMappingNode } from './mapping/voice_mapping';
 export { keyboardControlNode } from './mapping/keyboard_control';
 export { indirectMapNode } from './mapping/indirect_map';
+export { pickNode } from './mapping/pick';
 export { lyriaNode } from './output/lyria';
 export { chordNode, voiceChord } from './music/chord';
 export { progressionNode } from './music/progression';
@@ -41,6 +43,7 @@ export const CORE_NODES = [
   voiceMappingNode,
   keyboardControlNode,
   indirectMapNode,
+  pickNode,
   lyriaNode,
   chordNode,
   progressionNode,

--- a/src/nodes/mapping/pick.ts
+++ b/src/nodes/mapping/pick.ts
@@ -1,0 +1,37 @@
+/**
+ * `pick` node — a tiny adapter that extracts a scalar from a structured input
+ * via a dotted path (e.g. `right.x` from `HandFeatures`, or `smile` from
+ * `FaceFeatures`). Bridges nodes whose output is an object to nodes that want a
+ * bare number — e.g. `hand-features → pick('right.x') → progression.position`
+ * to drive harmony from a gesture. Pure + deterministic.
+ */
+import { z } from 'zod';
+import { defineNode } from '@/dag';
+
+const Params = z.object({
+  /** Dotted path into the input object, e.g. "right.x" or "smile". */
+  path: z.string().default(''),
+  /** Value emitted when the path is missing or not a number. */
+  default: z.number().default(0),
+});
+type Params = z.infer<typeof Params>;
+
+export const pickNode = defineNode<Params>({
+  type: 'pick',
+  title: 'Pick',
+  description: 'Extract a scalar from a structured input by dotted path (e.g. right.x).',
+  inputs: [{ name: 'in', kind: 'any' }],
+  outputs: [{ name: 'value', kind: 'number' }],
+  params: Params,
+  process(inputs, p) {
+    let v: unknown = inputs.in;
+    for (const seg of p.path.split('.').filter(Boolean)) {
+      if (v == null || typeof v !== 'object') {
+        v = undefined;
+        break;
+      }
+      v = (v as Record<string, unknown>)[seg];
+    }
+    return { value: typeof v === 'number' && Number.isFinite(v) ? v : p.default };
+  },
+});

--- a/test/pick.test.ts
+++ b/test/pick.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Tests the `pick` adapter and the full gesture→harmony DAG it unlocks:
+ *   synthetic-hands → hand-features → pick(right.x) → progression → chord
+ */
+import { describe, it, expect } from 'vitest';
+import { replayNode, runHeadless, type GraphSpec } from '@/dag';
+import { pickNode, createCoreRegistry, ABSENT_HAND, type HandFeatures, type SynthParams } from '@/nodes';
+
+function feat(rightX: number, present = true): HandFeatures {
+  return { left: { ...ABSENT_HAND }, right: { ...ABSENT_HAND, present, x: rightX } };
+}
+
+describe('pick node', () => {
+  it('extracts a scalar by dotted path', async () => {
+    const h = pickNode.make(pickNode.params.parse({ path: 'right.x', default: -1 }));
+    const outs = await replayNode(h, { in: [feat(0.25), feat(0.8)] });
+    expect(outs.map((o) => o.value)).toEqual([0.25, 0.8]);
+  });
+
+  it('returns the default for a missing path or non-number', async () => {
+    const h = pickNode.make(pickNode.params.parse({ path: 'right.nope', default: 0.5 }));
+    const [out] = await replayNode(h, { in: [feat(0.3)] });
+    expect(out.value).toBe(0.5);
+  });
+});
+
+describe('gesture → harmony DAG (via pick)', () => {
+  it('hand x sweep drives the progression → chord changes', async () => {
+    const spec: GraphSpec = {
+      nodes: [
+        { id: 'src', type: 'synthetic-hands', params: { hands: 'right', sweepPeriod: 2 } },
+        { id: 'feat', type: 'hand-features', params: { mirrorX: false, mirrorHandedness: false } },
+        { id: 'x', type: 'pick', params: { path: 'right.x' } },
+        { id: 'prog', type: 'progression', params: { key: 'C', romanNumerals: ['I', 'IV', 'V', 'vi'] } },
+        { id: 'chord', type: 'chord', params: { baseOctave: 4, maxVoices: 4 } },
+      ],
+      edges: [
+        { from: { node: 'src', port: 'hands' }, to: { node: 'feat', port: 'hands' } },
+        { from: { node: 'feat', port: 'features' }, to: { node: 'x', port: 'in' } },
+        { from: { node: 'x', port: 'value' }, to: { node: 'prog', port: 'position' } },
+        { from: { node: 'prog', port: 'chord' }, to: { node: 'chord', port: 'chord' } },
+      ],
+    };
+    const { recorder } = await runHeadless(spec, createCoreRegistry(), { ticks: 60, nominalDt: 1 / 30 });
+
+    const chords = recorder.values('prog.chord') as string[];
+    // The hand sweeps across the frame, so more than one chord is visited.
+    expect(new Set(chords).size).toBeGreaterThan(1);
+    // Every emitted chord renders to a non-empty voiced SynthParams.
+    const params = recorder.values('chord.params') as SynthParams[];
+    expect(params.every((p) => p.voices.length >= 3)).toBe(true);
+  });
+});


### PR DESCRIPTION
Refs #6. A tiny pure `pick` adapter extracts a scalar from a structured input by dotted path (e.g. `right.x` from HandFeatures, `smile` from FaceFeatures), bridging object-output nodes to scalar-input nodes.

Completes the **gesture → harmony** chain in a real DAG (previously only doable via direct replay): `hand-features → pick('right.x') → progression.position → chord`.

`test/pick.test.ts`: scalar extraction, missing-path default, and the full synthetic-hands→…→chord graph (x sweep visits multiple chords, each voiced). **58 tests total.** Pure, headlessly verified, additive.