### PR TITLE
Fix confirmed findings from the adversarial DAG review

### DIFF
--- a/src/nodes/features/hand_features.ts
+++ b/src/nodes/features/hand_features.ts
@@ -37,11 +37,31 @@ const Params = z.object({
   pinchTouch: z.number().default(0.25),
   /** pinchDist/handScale at/above which pinch=0 (apart). */
   pinchApart: z.number().default(1.2),
-});
+})
+  // Fail fast on degenerate ranges (the openness/pinch maps divide by these).
+  .refine((p) => p.opennessMax > p.opennessMin, {
+    message: 'opennessMax must be greater than opennessMin',
+    path: ['opennessMax'],
+  })
+  .refine((p) => p.pinchApart > p.pinchTouch, {
+    message: 'pinchApart must be greater than pinchTouch',
+    path: ['pinchApart'],
+  });
 type Params = z.infer<typeof Params>;
 
 function clamp01(v: number): number {
   return v < 0 ? 0 : v > 1 ? 1 : v;
+}
+
+/**
+ * Normalize `value` from [lo, hi] to [0, 1], clamped. Guards a zero range so a
+ * misconfigured param (lo === hi) can never produce NaN, even if params bypass
+ * Zod parsing (e.g. a direct node.make() call).
+ */
+function normRange(value: number, lo: number, hi: number): number {
+  const denom = hi - lo;
+  if (Math.abs(denom) < 1e-9) return 0;
+  return clamp01((value - lo) / denom);
 }
 
 function handScaleOf(hand: Hand): number {
@@ -71,7 +91,7 @@ function extractOne(hand: Hand, frame: HandsFrame, p: Params): SingleHandFeature
   if (tips.length) {
     const meanTipDist = tips.reduce((s, t) => s + dist2d(t, wrist), 0) / tips.length;
     const openRaw = meanTipDist / handScale;
-    openness = clamp01((openRaw - p.opennessMin) / (p.opennessMax - p.opennessMin));
+    openness = normRange(openRaw, p.opennessMin, p.opennessMax);
   }
 
   // Pinch: thumb-tip to index-tip distance, scaled by hand size, inverted.
@@ -79,7 +99,8 @@ function extractOne(hand: Hand, frame: HandsFrame, p: Params): SingleHandFeature
   let pinch = 0;
   if (thumbTip) {
     const pinchDist = dist2d(thumbTip, indexTip) / handScale;
-    pinch = clamp01((p.pinchApart - pinchDist) / (p.pinchApart - p.pinchTouch));
+    // Inverted range: pinchDist=pinchTouch → 1, pinchDist=pinchApart → 0.
+    pinch = normRange(pinchDist, p.pinchApart, p.pinchTouch);
   }
 
   return { present: true, x, y, openness, pinch };

--- a/src/nodes/output/lyria.ts
+++ b/src/nodes/output/lyria.ts
@@ -51,8 +51,12 @@ export const lyriaNode = defineNode<Params>({
         // ---- lifecycle ----
         if (playing && !started) {
           started = true;
-          // The engine is responsible for connect-once idempotency.
-          void Promise.resolve(engine.connect()).then(() => engine.play());
+          // The engine is responsible for connect-once idempotency. Guard play()
+          // with the *current* started state: if the transport was paused
+          // between connect() resolving and this microtask, don't start playing.
+          void Promise.resolve(engine.connect()).then(() => {
+            if (started) engine.play();
+          });
         } else if (!playing && started) {
           started = false;
           void engine.pause();

--- a/test/hand_pipeline.test.ts
+++ b/test/hand_pipeline.test.ts
@@ -35,6 +35,11 @@ const MAP_PARAMS = {
   left: { scale: { root: 0, type: 'major' as const, octaves: 2, baseOctave: 3 }, instrument: 'triangle' as const },
 };
 
+// Parse params through each node's Zod schema (as the engine does) before any
+// direct make() call — applies defaults/validation, not just the raw object.
+const FEAT_PARSED = handFeaturesNode.params.parse(FEAT_PARAMS);
+const MAP_PARSED = voiceMappingNode.params.parse(MAP_PARAMS);
+
 function rightHandFrame(spread: number, pinch: number): HandsFrame {
   return {
     width: 640,
@@ -51,7 +56,7 @@ function rightHandFrame(spread: number, pinch: number): HandsFrame {
 describe('hand-features node', () => {
   it('open hand has higher openness than a fist; pinch detects thumb-index contact', async () => {
     const run = (spread: number, pinch: number) =>
-      replayNode(handFeaturesNode.make(FEAT_PARAMS), { hands: [rightHandFrame(spread, pinch)] });
+      replayNode(handFeaturesNode.make(FEAT_PARSED), { hands: [rightHandFrame(spread, pinch)] });
 
     const [fist] = await run(0, 0);
     const [open] = await run(1, 0);
@@ -68,7 +73,7 @@ describe('hand-features node', () => {
   });
 
   it('reports both hands absent when no hands present', async () => {
-    const [out] = await replayNode(handFeaturesNode.make(FEAT_PARAMS), {
+    const [out] = await replayNode(handFeaturesNode.make(FEAT_PARSED), {
       hands: [{ width: 640, height: 480, hands: [] } as HandsFrame],
     });
     const f = out.features as HandFeatures;
@@ -111,9 +116,33 @@ describe('synthetic → features → mapping DAG', () => {
     const recordedFeatures = recorder.values('feat.features');
     const liveFreqs = (recorder.values('map.params') as SynthParams[]).map((p) => p.voices[0].freq);
 
-    const replayParams = await replayNode(voiceMappingNode.make(MAP_PARAMS), { features: recordedFeatures }, { dt: 1 / 30 });
+    const replayParams = await replayNode(voiceMappingNode.make(MAP_PARSED), { features: recordedFeatures }, { dt: 1 / 30 });
     const replayedFreqs = replayParams.map((p) => (p.params as SynthParams).voices[0].freq);
 
     expect(replayedFreqs).toEqual(liveFreqs);
+  });
+});
+
+describe('hand-features param robustness (review fix)', () => {
+  it('rejects degenerate openness/pinch ranges at parse time', () => {
+    expect(() => handFeaturesNode.params.parse({ opennessMin: 2, opennessMax: 2 })).toThrow();
+    expect(() => handFeaturesNode.params.parse({ pinchTouch: 1, pinchApart: 1 })).toThrow();
+  });
+
+  it('never emits NaN even if params bypass parsing (defensive guard)', async () => {
+    // Degenerate ranges (max === min) that Zod would reject; here we bypass parse
+    // to confirm the normRange guard still yields finite features, not NaN.
+    const degenerate = {
+      mirrorX: false,
+      mirrorHandedness: false,
+      opennessMin: 1.3,
+      opennessMax: 1.3,
+      pinchTouch: 1.2,
+      pinchApart: 1.2,
+    } as unknown as Parameters<typeof handFeaturesNode.make>[0];
+    const [out] = await replayNode(handFeaturesNode.make(degenerate), { hands: [rightHandFrame(0.5, 0.5)] });
+    const f = (out.features as HandFeatures).right;
+    expect(Number.isFinite(f.openness)).toBe(true);
+    expect(Number.isFinite(f.pinch)).toBe(true);
   });
 });

--- a/test/keyboard_control.test.ts
+++ b/test/keyboard_control.test.ts
@@ -15,7 +15,9 @@ describe('keyboard-control', () => {
       ['m'], // mute off
     ];
     const outs = await replayNode(
-      keyboardControlNode.make({ magnetismStep: 0.1, magnetismStart: 0.8, octaveMin: -2, octaveMax: 2 }),
+      keyboardControlNode.make(
+        keyboardControlNode.params.parse({ magnetismStep: 0.1, magnetismStart: 0.8, octaveMin: -2, octaveMax: 2 }),
+      ),
       { pressed: pressedFrames },
     );
 

--- a/test/lyria_node.test.ts
+++ b/test/lyria_node.test.ts
@@ -45,14 +45,14 @@ function steer(weight: number, bpm: number): GenerativeSteer {
 
 describe('lyria node (contract logic, mock engine)', () => {
   it('no-ops without an engine', () => {
-    const handlers = lyriaNode.make({ throttleSec: 0.2 });
+    const handlers = lyriaNode.make(lyriaNode.params.parse({ throttleSec: 0.2 }));
     const out = handlers.process({ playing: true, steer: steer(1, 120) }, { tick: 0, time: 0, dt: 0, resources: {} });
     expect(out.state).toBe('no-engine');
   });
 
   it('connects+plays once, throttles steer updates, resets context on bpm change', async () => {
     const engine = new MockEngine();
-    const handlers = lyriaNode.make({ throttleSec: 0.2 });
+    const handlers = lyriaNode.make(lyriaNode.params.parse({ throttleSec: 0.2 }));
     const resources = { generativeEngine: engine };
     const dt = 1 / 30;
 
@@ -85,7 +85,7 @@ describe('lyria node (contract logic, mock engine)', () => {
 
   it('pauses when transport stops', () => {
     const engine = new MockEngine();
-    const handlers = lyriaNode.make({ throttleSec: 0.2 });
+    const handlers = lyriaNode.make(lyriaNode.params.parse({ throttleSec: 0.2 }));
     const resources = { generativeEngine: engine };
     handlers.process({ playing: true, steer: steer(1, 120) }, { tick: 0, time: 0, dt: 0, resources });
     handlers.process({ playing: false }, { tick: 1, time: 0.1, dt: 0.1, resources });


### PR DESCRIPTION
A multi-agent adversarial review (5 dimension reviewers → 19 findings → **9 confirmed** after per-finding refutation) surfaced 3 real issues. All fixed + locked in with tests (**60 total**).

**A — hand-features division-by-zero → NaN (medium).** openness/pinch divided by a range that's zero if params are misconfigured (e.g. `opennessMax === opennessMin`); NaN then serializes to `null`, breaking replay. Fix: Zod `.refine()` (fail fast at parse) **plus** a defensive `normRange()` guard so no NaN escapes even if params bypass parsing. New tests cover both.

**B — tests call `make()` with raw params (low/med).** The known footgun (skips Zod defaults). Fixed in keyboard_control / hand_pipeline / lyria_node tests.

**C — `lyria` connect→play microtask race (low).** If paused between `connect()` resolving and the `.then()`, `play()` still fired. Now guarded by the current `started` state.

The other 10 findings were refuted (style/won't-happen-in-practice) and dropped. typecheck + 60 tests + `vite build` green.