### PR TITLE
Conductor mode — transport + score + performance (M5)

### DIFF
--- a/docs/DAG_NODES.md
+++ b/docs/DAG_NODES.md
@@ -40,6 +40,14 @@ Build a registry with `createCoreRegistry()` (pure nodes) or `createAppRegistry(
 | `chord` | ✅ | `chord` (symbol, e.g. "Cmaj7"), `gain` | `params: SynthParams` | Voices a chord symbol into one synth voice per chord tone (stacked ascending from `baseOctave`), so it drives `webaudio-synth` directly. Lets you *express harmony*. |
 | `progression` | ✅ | `position` (0..1) | `chord` (symbol), `index` | Holds a diatonic progression (Roman numerals in a `key`, correct qualities via `Key.majorKey().triads`) and selects the current chord from a continuous position — keeps harmony in-key while the player moves freely. Pair with `chord`: gesture → position → chord → notes. |
 
+## Conductor mode (M5 — direct a fixed piece with gesture)
+
+| Node `type` | Pure? | Inputs | Outputs | Purpose |
+|-------------|-------|--------|---------|---------|
+| `transport` | ✅ | `bpm` | `beat` | Beat clock: integrates BPM over `ctx.dt` into a running beat position. |
+| `score` | ✅ | `beat`, `velocityScale` | `params: SynthParams` | An immutable piece (notes with beat timing) performed live — emits the notes sounding at the current beat as voices, scaled by velocity. Loops. |
+| `performance` | ✅ | `control` (0..1) | `bpm`, `velocityScale` | The conductor's hand: maps a control signal → tempo + dynamics, with optional deterministic *humanization* (jitter). Chain: control → performance → transport → score. |
+
 ## Synthesis / output
 
 | Node `type` | Pure? | Inputs | Outputs | Purpose |
@@ -59,7 +67,7 @@ Build a registry with `createCoreRegistry()` (pure nodes) or `createAppRegistry(
 ## Planned nodes (see ROADMAP)
 
 `webcam-face` (browser FaceLandmarker source), `pose-features`, `gesture-classifier`
-(discrete events), `voicing` (smarter voice-leading), `score` + `performance`
-(conductor mode), `midi-in`/`midi-out` (WEBMIDI.js), signal conditioners
+(discrete events), `voicing` (smarter voice-leading),
+`midi-in`/`midi-out` (WEBMIDI.js), signal conditioners
 (one-euro filter, hysteresis, debounce), and a small adapter to feed a scalar
 feature (e.g. hand x) into `progression.position`.

--- a/scripts/gen_conductor_demo.ts
+++ b/scripts/gen_conductor_demo.ts
@@ -1,0 +1,50 @@
+/**
+ * Generate a conductor-mode SynthParams stream for the audible demo: a control
+ * curve (triangle: rise then fall) drives `performance → transport → score`,
+ * so a fixed C-major scale speeds up + grows louder, then slows + softens —
+ * accelerando/crescendo then ritardando/decrescendo, "conducted" by the curve.
+ *
+ * Usage: vite-node scripts/gen_conductor_demo.ts <out.params.ndjson>
+ */
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { runHeadless, serializeRecords, type GraphSpec, type StreamRecord } from '@/dag';
+import { createCoreRegistry } from '@/nodes';
+
+async function main(): Promise<void> {
+  const out = process.argv[2] ?? 'media/conductor_demo.params.ndjson';
+  const fps = 30;
+  const ticks = fps * 12; // 12s
+
+  // Triangle control 0 → 1 → 0.
+  const ramp = Array.from({ length: ticks }, (_, i) => {
+    const t = i / (ticks - 1);
+    return t < 0.5 ? t * 2 : (1 - t) * 2;
+  });
+
+  const notes = [60, 62, 64, 65, 67, 69, 71, 72].map((midi, i) => ({ midi, start: i, duration: 0.9, velocity: 1 }));
+
+  const spec: GraphSpec = {
+    nodes: [
+      { id: 'ctrl', type: 'replay-source', params: { values: ramp } },
+      { id: 'perf', type: 'performance', params: { bpmMin: 50, bpmMax: 260, dynMin: 0.3, dynMax: 1, humanizeBpm: 3 } },
+      { id: 'xport', type: 'transport' },
+      { id: 'score', type: 'score', params: { notes, loopBeats: 8, baseGain: 0.4, instrument: 'triangle' } },
+    ],
+    edges: [
+      { from: { node: 'ctrl', port: 'value' }, to: { node: 'perf', port: 'control' } },
+      { from: { node: 'perf', port: 'bpm' }, to: { node: 'xport', port: 'bpm' } },
+      { from: { node: 'perf', port: 'velocityScale' }, to: { node: 'score', port: 'velocityScale' } },
+      { from: { node: 'xport', port: 'beat' }, to: { node: 'score', port: 'beat' } },
+    ],
+  };
+
+  const { recorder } = await runHeadless(spec, createCoreRegistry(), { ticks, nominalDt: 1 / fps, recordOnly: ['score.params'] });
+  const params = recorder.values('score.params');
+  const records: StreamRecord[] = params.map((value, i) => ({ tick: i, t: i / fps, value }));
+  mkdirSync(dirname(out), { recursive: true });
+  writeFileSync(out, serializeRecords(records));
+  console.log(`conductor demo: ${ticks} ticks (12s) -> ${out}`);
+}
+
+void main();

--- a/scripts/lib_audio.ts
+++ b/scripts/lib_audio.ts
@@ -1,0 +1,101 @@
+/**
+ * Offline synth DSP library (no side effects) — turn a `SynthParams` stream into
+ * PCM and write a 16-bit WAV. Imported by `render_audio.ts` (the CLI) and by
+ * `test/render_audio.test.ts`. Pure: importing this never runs anything.
+ */
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+import type { SynthParams, VoiceParams } from '@/nodes';
+
+export const SR = 44100;
+const MASTER = 0.25;
+
+function wave(phase: number, type: VoiceParams['instrument']): number {
+  const p = phase - Math.floor(phase); // 0..1
+  switch (type) {
+    case 'square':
+      return p < 0.5 ? 1 : -1;
+    case 'sawtooth':
+      return 2 * p - 1;
+    case 'triangle':
+      return 4 * Math.abs(p - 0.5) - 1;
+    default:
+      return Math.sin(2 * Math.PI * p);
+  }
+}
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+interface VoiceState {
+  phase: number;
+  gain: number;
+  freq: number;
+}
+
+/** Render a per-tick SynthParams stream to mono PCM (sum of oscillator voices). */
+export function render(frames: SynthParams[], dt: number): Float32Array {
+  const samplesPerTick = Math.max(1, Math.round(SR * dt));
+  const out = new Float32Array(frames.length * samplesPerTick);
+  const voices = new Map<number, VoiceState>();
+
+  let s = 0;
+  for (const frame of frames) {
+    const targets = new Map<number, VoiceParams>();
+    for (const v of frame.voices) targets.set(v.id, v);
+
+    for (let j = 0; j < samplesPerTick; j++) {
+      const frac = j / samplesPerTick;
+      let acc = 0;
+      for (const [id, target] of targets) {
+        let st = voices.get(id);
+        if (!st) {
+          st = { phase: 0, gain: 0, freq: target.freq };
+          voices.set(id, st);
+        }
+        const curGain = target.present ? target.gain : 0;
+        const g = lerp(st.gain, curGain, frac); // ramp within tick (declick)
+        const f = lerp(st.freq, target.freq, frac);
+        st.phase += f / SR;
+        acc += wave(st.phase, target.instrument) * g;
+      }
+      out[s++] = Math.max(-1, Math.min(1, acc * MASTER));
+    }
+    for (const [id, target] of targets) {
+      const st = voices.get(id)!;
+      st.gain = target.present ? target.gain : 0;
+      st.freq = target.freq;
+    }
+  }
+  return out;
+}
+
+export function rms(s: Float32Array): number {
+  let sum = 0;
+  for (let i = 0; i < s.length; i++) sum += s[i] * s[i];
+  return Math.sqrt(sum / s.length);
+}
+
+export function writeWav(path: string, samples: Float32Array): void {
+  const n = samples.length;
+  const buf = Buffer.alloc(44 + n * 2);
+  buf.write('RIFF', 0);
+  buf.writeUInt32LE(36 + n * 2, 4);
+  buf.write('WAVE', 8);
+  buf.write('fmt ', 12);
+  buf.writeUInt32LE(16, 16);
+  buf.writeUInt16LE(1, 20); // PCM
+  buf.writeUInt16LE(1, 22); // mono
+  buf.writeUInt32LE(SR, 24);
+  buf.writeUInt32LE(SR * 2, 28);
+  buf.writeUInt16LE(2, 32);
+  buf.writeUInt16LE(16, 34);
+  buf.write('data', 36);
+  buf.writeUInt32LE(n * 2, 40);
+  for (let i = 0; i < n; i++) {
+    buf.writeInt16LE(Math.round(Math.max(-1, Math.min(1, samples[i])) * 32767), 44 + i * 2);
+  }
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, buf);
+}

--- a/scripts/render_audio.ts
+++ b/scripts/render_audio.ts
@@ -1,130 +1,28 @@
 /**
- * Offline synth renderer — turn a recorded `SynthParams` stream into an audible
- * WAV, no browser. Lets the DAG's audio output be *heard* (and spot-checked)
- * headlessly: render a fixture's `map.params.ndjson` (or any SynthParams stream)
- * to a .wav. Pure DSP + a tiny 16-bit PCM WAV writer (no deps).
+ * Offline synth renderer CLI — turn a recorded `SynthParams` stream into an
+ * audible WAV (no browser). The DSP lives in `lib_audio.ts` (imported by tests);
+ * this is the thin command-line entry.
  *
  * Usage: vite-node scripts/render_audio.ts <map.params.ndjson> <out.wav> [fps]
  */
-import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
-import { dirname } from 'node:path';
+import { readFileSync } from 'node:fs';
 import { parseRecords } from '@/dag';
-import type { SynthParams, VoiceParams } from '@/nodes';
+import type { SynthParams } from '@/nodes';
+import { render, writeWav, rms, SR } from './lib_audio';
 
-const SR = 44100;
-const MASTER = 0.25;
-
-function wave(phase: number, type: VoiceParams['instrument']): number {
-  const p = phase - Math.floor(phase); // 0..1
-  switch (type) {
-    case 'square':
-      return p < 0.5 ? 1 : -1;
-    case 'sawtooth':
-      return 2 * p - 1;
-    case 'triangle':
-      return 4 * Math.abs(p - 0.5) - 1;
-    default:
-      return Math.sin(2 * Math.PI * p);
-  }
+const [src, out, fpsArg] = process.argv.slice(2);
+if (!src || !out) {
+  console.error('usage: render_audio.ts <map.params.ndjson> <out.wav> [fps]');
+  process.exit(1);
 }
-
-function lerp(a: number, b: number, t: number): number {
-  return a + (b - a) * t;
-}
-
-interface VoiceState {
-  phase: number;
-  gain: number;
-  freq: number;
-  type: VoiceParams['instrument'];
-}
-
-export function render(frames: SynthParams[], dt: number): Float32Array {
-  const samplesPerTick = Math.max(1, Math.round(SR * dt));
-  const total = frames.length * samplesPerTick;
-  const out = new Float32Array(total);
-  const voices = new Map<number, VoiceState>();
-
-  let s = 0;
-  for (const frame of frames) {
-    // Snapshot targets for this tick.
-    const targets = new Map<number, VoiceParams>();
-    for (const v of frame.voices) targets.set(v.id, v);
-
-    for (let j = 0; j < samplesPerTick; j++) {
-      const frac = j / samplesPerTick;
-      let acc = 0;
-      for (const [id, target] of targets) {
-        let st = voices.get(id);
-        if (!st) {
-          st = { phase: 0, gain: 0, freq: target.freq, type: target.instrument };
-          voices.set(id, st);
-        }
-        const curGain = target.present ? target.gain : 0;
-        const g = lerp(st.gain, curGain, frac); // ramp within tick (declick)
-        const f = lerp(st.freq, target.freq, frac);
-        st.phase += f / SR;
-        acc += wave(st.phase, target.instrument) * g;
-      }
-      out[s++] = Math.max(-1, Math.min(1, acc * MASTER));
-    }
-    // Commit tick-end values as the next ramp start.
-    for (const [id, target] of targets) {
-      const st = voices.get(id)!;
-      st.gain = target.present ? target.gain : 0;
-      st.freq = target.freq;
-      st.type = target.instrument;
-    }
-  }
-  return out;
-}
-
-export function writeWav(path: string, samples: Float32Array): void {
-  const n = samples.length;
-  const buf = Buffer.alloc(44 + n * 2);
-  buf.write('RIFF', 0);
-  buf.writeUInt32LE(36 + n * 2, 4);
-  buf.write('WAVE', 8);
-  buf.write('fmt ', 12);
-  buf.writeUInt32LE(16, 16);
-  buf.writeUInt16LE(1, 20); // PCM
-  buf.writeUInt16LE(1, 22); // mono
-  buf.writeUInt32LE(SR, 24);
-  buf.writeUInt32LE(SR * 2, 28);
-  buf.writeUInt16LE(2, 32);
-  buf.writeUInt16LE(16, 34);
-  buf.write('data', 36);
-  buf.writeUInt32LE(n * 2, 40);
-  for (let i = 0; i < n; i++) {
-    buf.writeInt16LE(Math.round(Math.max(-1, Math.min(1, samples[i])) * 32767), 44 + i * 2);
-  }
-  mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, buf);
-}
-
-function rms(s: Float32Array): number {
-  let sum = 0;
-  for (let i = 0; i < s.length; i++) sum += s[i] * s[i];
-  return Math.sqrt(sum / s.length);
-}
-
-function main(): void {
-  const [src, out, fpsArg] = process.argv.slice(2);
-  if (!src || !out) {
-    console.error('usage: render_audio.ts <map.params.ndjson> <out.wav> [fps]');
-    process.exit(1);
-  }
-  const records = parseRecords(readFileSync(src, 'utf8'));
-  const frames = records.map((r) => r.value) as SynthParams[];
-  // Derive dt from record timestamps when available, else fps arg / 30.
-  const dt =
-    records.length > 1 && records[1].t > records[0].t
-      ? records[1].t - records[0].t
-      : 1 / (fpsArg ? Number(fpsArg) : 30);
-  const samples = render(frames, dt);
-  writeWav(out, samples);
-  console.log(`rendered ${frames.length} frames @ dt=${dt.toFixed(4)}s -> ${out} (${(samples.length / SR).toFixed(1)}s, rms=${rms(samples).toFixed(4)})`);
-}
-
-// Run the CLI only when invoked directly (not when imported by a test).
-if (process.argv[1] && process.argv[1].includes('render_audio')) main();
+const records = parseRecords(readFileSync(src, 'utf8'));
+const frames = records.map((r) => r.value) as SynthParams[];
+const dt =
+  records.length > 1 && records[1].t > records[0].t
+    ? records[1].t - records[0].t
+    : 1 / (fpsArg ? Number(fpsArg) : 30);
+const samples = render(frames, dt);
+writeWav(out, samples);
+console.log(
+  `rendered ${frames.length} frames @ dt=${dt.toFixed(4)}s -> ${out} (${(samples.length / SR).toFixed(1)}s, rms=${rms(samples).toFixed(4)})`,
+);

--- a/src/nodes/index.ts
+++ b/src/nodes/index.ts
@@ -19,6 +19,9 @@ import { pickNode } from './mapping/pick';
 import { lyriaNode } from './output/lyria';
 import { chordNode } from './music/chord';
 import { progressionNode } from './music/progression';
+import { transportNode } from './music/transport';
+import { scoreNode } from './music/score';
+import { performanceNode } from './music/performance';
 
 export { syntheticHandsNode } from './sources/synthetic_hands';
 export { replaySourceNode } from './sources/replay';
@@ -31,6 +34,9 @@ export { pickNode } from './mapping/pick';
 export { lyriaNode } from './output/lyria';
 export { chordNode, voiceChord } from './music/chord';
 export { progressionNode } from './music/progression';
+export { transportNode } from './music/transport';
+export { scoreNode } from './music/score';
+export { performanceNode } from './music/performance';
 export type { GenerativeEngine, GenerativeSteer, GenerativeConfig, WeightedPrompt } from './output/generative';
 export * from './domain';
 
@@ -47,6 +53,9 @@ export const CORE_NODES = [
   lyriaNode,
   chordNode,
   progressionNode,
+  transportNode,
+  scoreNode,
+  performanceNode,
 ];
 
 /** Build a registry pre-loaded with the pure node library. */

--- a/src/nodes/music/performance.ts
+++ b/src/nodes/music/performance.ts
@@ -1,0 +1,51 @@
+/**
+ * `performance` node — the conductor's hand. Maps a continuous control signal
+ * (0..1, e.g. hand height via `pick`) into a tempo (`bpm`) and a `velocityScale`
+ * (dynamics) that drive `transport` + `score`. Optional *humanization* adds a
+ * small deterministic jitter to tempo/velocity so a fixed piece breathes — the
+ * same overlay mechanism, driven by noise instead of a gesture.
+ *
+ * Pure + deterministic: the jitter is a hash of `ctx.time` (no Math.random), so
+ * runs replay exactly.
+ */
+import { z } from 'zod';
+import { defineNode } from '@/dag';
+import type { NodeContext } from '@/dag';
+import { clamp01, rangeMap } from '@/music/theory';
+
+const Params = z.object({
+  bpmMin: z.number().default(60),
+  bpmMax: z.number().default(160),
+  dynMin: z.number().min(0).max(1).default(0.4),
+  dynMax: z.number().min(0).max(1).default(1),
+  /** Tempo jitter amplitude in BPM (humanization). */
+  humanizeBpm: z.number().min(0).default(0),
+  /** Velocity jitter amplitude 0..1 (humanization). */
+  humanizeVel: z.number().min(0).default(0),
+});
+type Params = z.infer<typeof Params>;
+
+/** Deterministic pseudo-noise in [-0.5, 0.5] from a scalar seed (classic hash). */
+function hashNoise(t: number): number {
+  const x = Math.sin(t * 12.9898) * 43758.5453;
+  return (x - Math.floor(x)) - 0.5;
+}
+
+export const performanceNode = defineNode<Params>({
+  type: 'performance',
+  title: 'Performance',
+  description: 'Control signal → tempo (bpm) + dynamics (velocityScale), with optional humanization.',
+  inputs: [{ name: 'control', kind: 'number', default: 0.5 }],
+  outputs: [
+    { name: 'bpm', kind: 'number' },
+    { name: 'velocityScale', kind: 'number' },
+  ],
+  params: Params,
+  process(inputs, p, ctx: NodeContext) {
+    const c = clamp01(typeof inputs.control === 'number' ? inputs.control : 0.5);
+    const n = hashNoise(ctx.time);
+    const bpm = Math.max(1, rangeMap(c, 0, 1, p.bpmMin, p.bpmMax) + p.humanizeBpm * n);
+    const velocityScale = clamp01(rangeMap(c, 0, 1, p.dynMin, p.dynMax) + p.humanizeVel * n);
+    return { bpm, velocityScale };
+  },
+});

--- a/src/nodes/music/score.ts
+++ b/src/nodes/music/score.ts
@@ -1,0 +1,65 @@
+/**
+ * `score` node — an immutable piece (notes with musical timing). Given the
+ * current `beat` (from `transport`) and a `velocityScale` (from `performance`),
+ * it emits the notes sounding right now as {@link SynthParams} voices — so a
+ * fixed piece is *performed* live, its tempo and dynamics directed by gesture
+ * (conductor mode). Pure + deterministic.
+ *
+ * Each score note maps to a stable voice id (its index), so the synth manages
+ * each note's voice across ticks; notes not currently sounding are emitted as
+ * silent (present:false) voices so they are released.
+ */
+import { z } from 'zod';
+import { defineNode } from '@/dag';
+import { midiToFreq } from '@/music/theory';
+import type { SynthParams, VoiceParams } from '../domain';
+
+const Note = z.object({
+  midi: z.number(),
+  /** Start time in beats (from the loop start). */
+  start: z.number(),
+  /** Duration in beats. */
+  duration: z.number(),
+  /** 0..1. */
+  velocity: z.number().min(0).max(1).default(1),
+});
+
+const Params = z.object({
+  notes: z.array(Note).default([]),
+  /** Loop length in beats; the beat position wraps modulo this. 0 = no loop. */
+  loopBeats: z.number().min(0).default(8),
+  /** Base output gain multiplier. */
+  baseGain: z.number().min(0).max(1).default(0.4),
+  instrument: z.enum(['sine', 'square', 'sawtooth', 'triangle']).default('triangle'),
+});
+type Params = z.infer<typeof Params>;
+
+export const scoreNode = defineNode<Params>({
+  type: 'score',
+  title: 'Score',
+  description: 'An immutable piece performed live: beat + velocityScale → sounding synth voices.',
+  inputs: [
+    { name: 'beat', kind: 'number', default: 0 },
+    { name: 'velocityScale', kind: 'number', default: 1 },
+  ],
+  outputs: [{ name: 'params', kind: 'synth-params' }],
+  params: Params,
+  process(inputs, p) {
+    const rawBeat = typeof inputs.beat === 'number' ? inputs.beat : 0;
+    const vScale = typeof inputs.velocityScale === 'number' ? inputs.velocityScale : 1;
+    const pos = p.loopBeats > 0 ? ((rawBeat % p.loopBeats) + p.loopBeats) % p.loopBeats : rawBeat;
+
+    const voices: VoiceParams[] = p.notes.map((n, id) => {
+      const sounding = pos >= n.start && pos < n.start + n.duration;
+      return {
+        id,
+        present: sounding,
+        freq: midiToFreq(n.midi),
+        gain: sounding ? Math.max(0, Math.min(1, n.velocity * vScale)) * p.baseGain : 0,
+        instrument: p.instrument,
+      };
+    });
+    const out: SynthParams = { voices };
+    return { params: out };
+  },
+});

--- a/src/nodes/music/transport.ts
+++ b/src/nodes/music/transport.ts
@@ -1,0 +1,34 @@
+/**
+ * `transport` node — a beat clock. Integrates a (possibly time-varying) BPM into
+ * a running beat position using the per-tick `ctx.dt`. The conductor chain's
+ * timebase: `performance` sets `bpm`, `transport` turns it into a `beat`, and
+ * `score` reads `beat` to decide which notes sound. Deterministic given the
+ * tick timing, so it replays exactly.
+ */
+import { z } from 'zod';
+import { defineNode } from '@/dag';
+import type { NodeContext } from '@/dag';
+
+const Params = z.object({
+  startBeat: z.number().default(0),
+});
+type Params = z.infer<typeof Params>;
+
+export const transportNode = defineNode<Params>({
+  type: 'transport',
+  title: 'Transport',
+  description: 'Beat clock: integrates BPM over time into a running beat position.',
+  inputs: [{ name: 'bpm', kind: 'number', default: 120 }],
+  outputs: [{ name: 'beat', kind: 'number' }],
+  params: Params,
+  make(p) {
+    let beat = p.startBeat;
+    return {
+      process(inputs, ctx: NodeContext) {
+        const bpm = typeof inputs.bpm === 'number' && inputs.bpm > 0 ? inputs.bpm : 120;
+        beat += (bpm / 60) * ctx.dt; // dt is 0 on the first tick, so beat starts at startBeat
+        return { beat };
+      },
+    };
+  },
+});

--- a/test/conductor.test.ts
+++ b/test/conductor.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests conductor mode (M5): `transport` (beat clock), `score` (immutable piece
+ * performed live), `performance` (control → tempo + dynamics), and the full DAG:
+ *   control → performance → transport → score
+ * A rising control speeds up the piece and raises its dynamics.
+ */
+import { describe, it, expect } from 'vitest';
+import { replayNode, runHeadless, type GraphSpec } from '@/dag';
+import { transportNode, scoreNode, performanceNode, createCoreRegistry } from '@/nodes';
+import { freqToMidi } from '@/music/theory';
+import type { SynthParams } from '@/nodes';
+
+const SCALE_NOTES = [60, 62, 64, 65, 67, 69, 71, 72].map((midi, i) => ({
+  midi,
+  start: i,
+  duration: 1,
+  velocity: 1,
+}));
+
+const presentVoice = (p: SynthParams) => p.voices.find((v) => v.present);
+
+describe('transport node', () => {
+  it('advances beats proportional to bpm and elapsed time', async () => {
+    const dt = 1 / 30;
+    const at120 = await replayNode(transportNode.make(transportNode.params.parse({})), { bpm: Array(31).fill(120) }, { dt });
+    const at240 = await replayNode(transportNode.make(transportNode.params.parse({})), { bpm: Array(31).fill(240) }, { dt });
+    // 30 increments * (1/30)s = 1.0s; 120bpm = 2 beats/s, 240bpm = 4 beats/s.
+    expect(at120[at120.length - 1].beat as number).toBeCloseTo(2.0, 1);
+    expect(at240[at240.length - 1].beat as number).toBeCloseTo(4.0, 1);
+  });
+});
+
+describe('score node', () => {
+  it('sounds the note at the current beat, scaled by velocityScale, and loops', async () => {
+    const h = scoreNode.make(scoreNode.params.parse({ notes: SCALE_NOTES, loopBeats: 8, baseGain: 0.4 }));
+    const outs = await replayNode(h, { beat: [0, 1, 7.5, 8.0], velocityScale: [1, 0.5, 1, 1] });
+    const v = outs.map((o) => presentVoice(o.params as SynthParams)!);
+    expect(Math.round(freqToMidi(v[0].freq))).toBe(60); // beat 0 → first note
+    expect(Math.round(freqToMidi(v[1].freq))).toBe(62); // beat 1 → second note
+    expect(v[1].gain).toBeCloseTo(0.5 * 0.4, 5); // velocityScale 0.5
+    expect(Math.round(freqToMidi(v[2].freq))).toBe(72); // beat 7.5 → last note
+    expect(Math.round(freqToMidi(v[3].freq))).toBe(60); // beat 8.0 wraps → first note
+  });
+});
+
+describe('performance node', () => {
+  it('maps control 0..1 to bpm and velocityScale (no humanization = exact)', async () => {
+    const h = performanceNode.make(performanceNode.params.parse({ bpmMin: 60, bpmMax: 160, dynMin: 0.4, dynMax: 1 }));
+    const outs = await replayNode(h, { control: [0, 0.5, 1] });
+    expect(outs[0]).toMatchObject({ bpm: 60, velocityScale: 0.4 });
+    expect(outs[1].bpm).toBeCloseTo(110, 5);
+    expect(outs[2]).toMatchObject({ bpm: 160, velocityScale: 1 });
+  });
+
+  it('humanization adds bounded, deterministic jitter', async () => {
+    const h = performanceNode.make(performanceNode.params.parse({ humanizeBpm: 5, bpmMin: 120, bpmMax: 120 }));
+    const a = (await replayNode(h, { control: [0.5, 0.5, 0.5] }, { dt: 1 / 30 })).map((o) => o.bpm as number);
+    const b = (await replayNode(h, { control: [0.5, 0.5, 0.5] }, { dt: 1 / 30 })).map((o) => o.bpm as number);
+    expect(a).toEqual(b); // deterministic
+    expect(a.every((x) => Math.abs(x - 120) <= 5.001)).toBe(true); // bounded by amplitude
+  });
+});
+
+describe('conductor chain (DAG): rising control speeds up the piece', () => {
+  it('beat accelerates and the score keeps sounding notes', async () => {
+    const ticks = 90;
+    const ramp = Array.from({ length: ticks }, (_, i) => i / (ticks - 1)); // 0 → 1
+    const spec: GraphSpec = {
+      nodes: [
+        { id: 'ctrl', type: 'replay-source', params: { values: ramp } },
+        { id: 'perf', type: 'performance', params: { bpmMin: 40, bpmMax: 200 } },
+        { id: 'xport', type: 'transport' },
+        { id: 'score', type: 'score', params: { notes: SCALE_NOTES, loopBeats: 8 } },
+      ],
+      edges: [
+        { from: { node: 'ctrl', port: 'value' }, to: { node: 'perf', port: 'control' } },
+        { from: { node: 'perf', port: 'bpm' }, to: { node: 'xport', port: 'bpm' } },
+        { from: { node: 'perf', port: 'velocityScale' }, to: { node: 'score', port: 'velocityScale' } },
+        { from: { node: 'xport', port: 'beat' }, to: { node: 'score', port: 'beat' } },
+      ],
+    };
+    const { recorder } = await runHeadless(spec, createCoreRegistry(), { ticks, nominalDt: 1 / 30 });
+
+    const beats = recorder.values('xport.beat') as number[];
+    // Monotonic non-decreasing.
+    for (let i = 1; i < beats.length; i++) expect(beats[i]).toBeGreaterThanOrEqual(beats[i - 1]);
+    // Late (fast) beat deltas exceed early (slow) ones — the piece accelerates.
+    const earlyDelta = beats[10] - beats[5];
+    const lateDelta = beats[beats.length - 1] - beats[beats.length - 6];
+    expect(lateDelta).toBeGreaterThan(earlyDelta * 1.5);
+    // The score is performing: a note sounds on most ticks.
+    const params = recorder.values('score.params') as SynthParams[];
+    const sounding = params.filter((p) => p.voices.some((v) => v.present)).length;
+    expect(sounding).toBeGreaterThan(ticks * 0.6);
+  });
+});

--- a/test/render_audio.test.ts
+++ b/test/render_audio.test.ts
@@ -3,7 +3,7 @@
  * (non-silent), correctly-sized PCM, and silence in → silence out.
  */
 import { describe, it, expect } from 'vitest';
-import { render } from '../scripts/render_audio';
+import { render } from '../scripts/lib_audio';
 import type { SynthParams } from '@/nodes';
 
 const SR = 44100;


### PR DESCRIPTION
Refs #6 (M5). Direct a fixed piece's tempo + dynamics with a control signal — the conductor idea from the project vision ('direct a piece's rendition via visual cues, like a conductor').

Three pure, deterministic nodes:
- **`transport`**: beat clock (integrates BPM over `ctx.dt` → beat).
- **`score`**: an immutable piece performed live — `beat` + `velocityScale` → the notes sounding now as `SynthParams` voices (loops).
- **`performance`**: `control` (0..1) → `bpm` + `velocityScale`, with optional deterministic humanization (hash-of-time jitter, no `Math.random`).

Chain: **control → performance → transport → score → synth**. A rising control accelerates + crescendos the piece; the same overlay driven by noise = humanization.

Also fixes the `render_audio` CLI (broke under `vite-node`, whose `process.argv` omits the script path so the import-guard never fired): split the DSP into a side-effect-free `scripts/lib_audio.ts` + a thin CLI. Added `scripts/gen_conductor_demo.ts`.

`test/conductor.test.ts` covers transport timing, score sounding/loop/velocity, performance mapping + bounded humanize, and the full accelerating-DAG. **65 tests total.** typecheck + build green; additive.

Rendered an audible 12s demo (accelerando/crescendo → ritardando) — sending it over.