### PR TITLE
gesture-classifier — discrete hand poses + edge events (M4)

### DIFF
--- a/docs/DAG_NODES.md
+++ b/docs/DAG_NODES.md
@@ -24,6 +24,7 @@ Build a registry with `createCoreRegistry()` (pure nodes) or `createAppRegistry(
 |-------------|-------|--------|---------|---------|
 | `hand-features` | ✅ | `hands: HandsFrame` | `features: HandFeatures` | Landmarks → per-hand normalized `{present, x, y, openness, pinch}`. openness/pinch are scaled by per-hand size for camera-distance invariance. |
 | `face-features` | ✅ | `face: FaceFrame` | `features: FaceFeatures` | 52 blendshapes → normalized expression controls `{present, smile, mouthOpen, browRaise, browFurrow, eyeBlink}`, with gain + smoothing. Tested against the `video_face_expressions` fixture. (Browser `webcam-face` source feeds it; M4 wiring.) |
+| `gesture-classifier` | ✅ | `features: HandFeatures` | `poses`, `events` | Continuous features → DISCRETE poses (fist/open/pinch/neutral) per hand + enter/exit edge events, with hysteresis. The discrete-gesture modality: a pose can trigger things (scale change, chord stab, mute) rather than continuously modulate. |
 
 ## Mapping (mapping layer — the direct↔indirect spectrum)
 
@@ -66,7 +67,7 @@ Build a registry with `createCoreRegistry()` (pure nodes) or `createAppRegistry(
 
 ## Planned nodes (see ROADMAP)
 
-`webcam-face` (browser FaceLandmarker source), `pose-features`, `gesture-classifier`
+`webcam-face` (browser FaceLandmarker source), `pose-features`
 (discrete events), `voicing` (smarter voice-leading),
 `midi-in`/`midi-out` (WEBMIDI.js), signal conditioners
 (one-euro filter, hysteresis, debounce), and a small adapter to feed a scalar

--- a/src/nodes/features/gesture_classifier.ts
+++ b/src/nodes/features/gesture_classifier.ts
@@ -1,0 +1,80 @@
+/**
+ * `gesture-classifier` node — turns continuous hand features into DISCRETE poses
+ * (fist / open / pinch / neutral) and emits edge events on transitions. This is
+ * the discrete-gesture modality: a recognized pose can trigger things (change
+ * scale, stab a chord, toggle a mode, mute) rather than continuously modulate.
+ *
+ * Pure; stateful only to detect enter/exit edges across ticks. Hysteresis avoids
+ * flicker at the thresholds. Classification priority: pinch > fist > open, since
+ * a pinch also lowers openness.
+ */
+import { z } from 'zod';
+import { defineNode } from '@/dag';
+import { ABSENT_HAND, type HandFeatures, type SingleHandFeatures } from '../domain';
+
+export type Pose = 'pinch' | 'fist' | 'open' | 'neutral' | 'absent';
+export interface GestureEvent {
+  hand: 'left' | 'right';
+  pose: Pose;
+  edge: 'enter' | 'exit';
+}
+
+const Params = z.object({
+  pinchOn: z.number().min(0).max(1).default(0.6),
+  pinchOff: z.number().min(0).max(1).default(0.45),
+  fistBelow: z.number().min(0).max(1).default(0.25),
+  openAbove: z.number().min(0).max(1).default(0.6),
+  /** Hysteresis margin applied to fist/open thresholds. */
+  hysteresis: z.number().min(0).max(0.5).default(0.05),
+});
+type Params = z.infer<typeof Params>;
+
+function classify(f: SingleHandFeatures, prev: Pose, p: Params): Pose {
+  if (!f.present) return 'absent';
+  // Pinch wins, with hysteresis so it doesn't chatter.
+  if (prev === 'pinch' ? f.pinch > p.pinchOff : f.pinch > p.pinchOn) return 'pinch';
+  const h = p.hysteresis;
+  if (prev === 'fist' ? f.openness < p.fistBelow + h : f.openness < p.fistBelow) return 'fist';
+  if (prev === 'open' ? f.openness > p.openAbove - h : f.openness > p.openAbove) return 'open';
+  return 'neutral';
+}
+
+export const gestureClassifierNode = defineNode<Params>({
+  type: 'gesture-classifier',
+  title: 'Gesture Classifier',
+  description: 'Hand features → discrete poses (fist/open/pinch) + enter/exit edge events.',
+  inputs: [{ name: 'features', kind: 'hand-features' }],
+  outputs: [
+    { name: 'poses', kind: 'poses' },
+    { name: 'events', kind: 'gesture-events' },
+  ],
+  params: Params,
+  make(p) {
+    const prev: Record<'left' | 'right', Pose> = { left: 'absent', right: 'absent' };
+    return {
+      process(inputs) {
+        const f = (inputs.features as HandFeatures | undefined) ?? {
+          left: { ...ABSENT_HAND },
+          right: { ...ABSENT_HAND },
+        };
+        const events: GestureEvent[] = [];
+        const poses: Record<'left' | 'right', Pose> = { left: 'absent', right: 'absent' };
+        for (const hand of ['left', 'right'] as const) {
+          const pose = classify(f[hand], prev[hand], p);
+          poses[hand] = pose;
+          if (pose !== prev[hand]) {
+            // Exiting the old meaningful pose, then entering the new one.
+            if (prev[hand] !== 'neutral' && prev[hand] !== 'absent') {
+              events.push({ hand, pose: prev[hand], edge: 'exit' });
+            }
+            if (pose !== 'neutral' && pose !== 'absent') {
+              events.push({ hand, pose, edge: 'enter' });
+            }
+            prev[hand] = pose;
+          }
+        }
+        return { poses, events };
+      },
+    };
+  },
+});

--- a/src/nodes/index.ts
+++ b/src/nodes/index.ts
@@ -12,6 +12,7 @@ import { syntheticHandsNode } from './sources/synthetic_hands';
 import { replaySourceNode } from './sources/replay';
 import { handFeaturesNode } from './features/hand_features';
 import { faceFeaturesNode } from './features/face_features';
+import { gestureClassifierNode } from './features/gesture_classifier';
 import { voiceMappingNode } from './mapping/voice_mapping';
 import { keyboardControlNode } from './mapping/keyboard_control';
 import { indirectMapNode } from './mapping/indirect_map';
@@ -27,6 +28,8 @@ export { syntheticHandsNode } from './sources/synthetic_hands';
 export { replaySourceNode } from './sources/replay';
 export { handFeaturesNode } from './features/hand_features';
 export { faceFeaturesNode } from './features/face_features';
+export { gestureClassifierNode } from './features/gesture_classifier';
+export type { Pose, GestureEvent } from './features/gesture_classifier';
 export { voiceMappingNode } from './mapping/voice_mapping';
 export { keyboardControlNode } from './mapping/keyboard_control';
 export { indirectMapNode } from './mapping/indirect_map';
@@ -46,6 +49,7 @@ export const CORE_NODES = [
   replaySourceNode,
   handFeaturesNode,
   faceFeaturesNode,
+  gestureClassifierNode,
   voiceMappingNode,
   keyboardControlNode,
   indirectMapNode,

--- a/test/gesture_classifier.test.ts
+++ b/test/gesture_classifier.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Tests `gesture-classifier`: discrete pose classification, enter/exit edge
+ * events, hysteresis, and a replay from the real hand fixtures (the open/close
+ * clip should produce fist↔open transitions; the pinch clip should detect pinch).
+ */
+import { readFileSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect } from 'vitest';
+import { replayNode, valuesFromNDJSON } from '@/dag';
+import { gestureClassifierNode, ABSENT_HAND, type HandFeatures, type GestureEvent, type Pose } from '@/nodes';
+
+const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), 'fixtures');
+
+function feat(right: Partial<typeof ABSENT_HAND>): HandFeatures {
+  return { left: { ...ABSENT_HAND }, right: { ...ABSENT_HAND, present: true, ...right } };
+}
+
+const params = () => gestureClassifierNode.params.parse({});
+
+describe('gesture-classifier (unit)', () => {
+  it('classifies fist / open / pinch and emits enter+exit edges on change', async () => {
+    const frames = [
+      feat({ openness: 0.1, pinch: 0 }), // fist
+      feat({ openness: 0.9, pinch: 0 }), // open
+      feat({ openness: 0.5, pinch: 0.9 }), // pinch (wins over openness)
+    ];
+    const outs = await replayNode(gestureClassifierNode.make(params()), { features: frames });
+    const poses = outs.map((o) => (o.poses as Record<string, Pose>).right);
+    expect(poses).toEqual(['fist', 'open', 'pinch']);
+
+    // tick0: enter fist; tick1: exit fist + enter open; tick2: exit open + enter pinch
+    const ev = outs.map((o) => o.events as GestureEvent[]);
+    expect(ev[0]).toEqual([{ hand: 'right', pose: 'fist', edge: 'enter' }]);
+    expect(ev[1]).toEqual([
+      { hand: 'right', pose: 'fist', edge: 'exit' },
+      { hand: 'right', pose: 'open', edge: 'enter' },
+    ]);
+    expect(ev[2][0]).toMatchObject({ pose: 'open', edge: 'exit' });
+    expect(ev[2][1]).toMatchObject({ pose: 'pinch', edge: 'enter' });
+  });
+
+  it('hysteresis prevents chatter near the open threshold', async () => {
+    // openAbove=0.6, hysteresis=0.05 → once open, stays open until openness < 0.55.
+    const frames = [feat({ openness: 0.62 }), feat({ openness: 0.57 }), feat({ openness: 0.5 })];
+    const outs = await replayNode(gestureClassifierNode.make(params()), { features: frames });
+    const poses = outs.map((o) => (o.poses as Record<string, Pose>).right);
+    expect(poses[0]).toBe('open');
+    expect(poses[1]).toBe('open'); // 0.57 still open thanks to hysteresis
+    expect(poses[2]).toBe('neutral'); // 0.5 drops out
+  });
+
+  it('absent hand → absent pose, no events', async () => {
+    const [out] = await replayNode(gestureClassifierNode.make(params()), {
+      features: [{ left: { ...ABSENT_HAND }, right: { ...ABSENT_HAND } } as HandFeatures],
+    });
+    expect((out.poses as Record<string, Pose>).right).toBe('absent');
+    expect(out.events as GestureEvent[]).toEqual([]);
+  });
+});
+
+describe('gesture-classifier from video fixtures', () => {
+  it('open/close clip yields fist and open poses; pinch clip detects pinch', async () => {
+    const load = (scn: string) => {
+      const path = join(FIXTURES, scn, 'feat.features.ndjson');
+      if (!existsSync(path)) throw new Error(`missing ${path}`);
+      return valuesFromNDJSON(readFileSync(path, 'utf8')) as HandFeatures[];
+    };
+
+    // This AI-generated clip's tracked openness peaks ~0.5, so use an openAbove
+    // the data supports (a real reminder that thresholds are camera/hand-tunable).
+    const tuned = gestureClassifierNode.params.parse({ openAbove: 0.4 });
+    const oc = await replayNode(gestureClassifierNode.make(tuned), { features: load('video_hand_open_close') });
+    const ocPoses = new Set(oc.flatMap((o) => Object.values(o.poses as Record<string, Pose>)));
+    expect(ocPoses.has('fist')).toBe(true);
+    expect(ocPoses.has('open')).toBe(true);
+
+    const pinch = await replayNode(gestureClassifierNode.make(params()), { features: load('video_hand_pinch') });
+    const pinchEvents = pinch.flatMap((o) => o.events as GestureEvent[]).filter((e) => e.pose === 'pinch');
+    expect(pinchEvents.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Refs #6 (M4). The **discrete-gesture** modality: continuous hand features → discrete poses (fist / open / pinch / neutral) per hand, with **enter/exit edge events** and hysteresis. A recognized pose can *trigger* things (scale change, chord stab, mute) instead of continuously modulating — complementing the continuous-control nodes.

- `gesture-classifier` (pure; stateful only to detect edges). Priority pinch > fist > open. Registered in CORE_NODES.
- `test/gesture_classifier.test.ts`: classification, enter/exit edges, hysteresis, absent-hand, and a replay from the real `video_hand_open_close` / `video_hand_pinch` fixtures. **69 tests total.**

Real-data note: the AI open/close clip's tracked openness peaks ~0.5, so the fixture test tunes `openAbove` to 0.4 — a reminder that pose thresholds are camera/hand-tunable. typecheck + build green; additive.