### PR TITLE
Generated capabilities manual (schema-derived, frontend-accessible)

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -1,0 +1,186 @@
+# Thoremin — Capabilities Manual
+
+_Auto-generated from the node registry (`scripts/gen_catalog.ts`). Do not edit by hand._
+
+Thoremin turns live sensor streams (webcam hand gestures, facial expressions, computer keyboard, later MIDI) into a live audiovisual stream — musical audio plus the captured video with overlaid guides. You build instruments by wiring small, typed **nodes** into a dataflow graph (DAG): inputs → features → mapping → music-logic → synthesis/generation → output. Every edge can be recorded and replayed.
+
+The mapping layer spans a spectrum: **direct** (a gesture *is* a note/parameter — e.g. hand position → scale-snapped pitch) through **indirect** (a gesture expresses a high-level idea — e.g. openness → musical density steering an AI model), including **conductor** mode (direct a fixed piece's tempo and dynamics).
+
+This page catalogs the engine's building blocks — every node and how they connect. Some already run in the deployed app; wiring the full graph into the live instrument is in progress.
+
+## Example pipelines
+
+- **Theremin (direct)** — `webcam-hands → hand-features → voice-mapping → webaudio-synth ( + canvas-overlay)`  
+  Hand x → scale-snapped pitch, y → volume. Two hands = two voices.
+- **Gesture → harmony** — `hand-features → pick('right.x') → progression → chord → webaudio-synth`  
+  Hand position walks an in-key chord progression.
+- **Conductor** — `control → performance → transport → score → webaudio-synth`  
+  A control signal directs a fixed piece's tempo + dynamics (accelerando/crescendo…).
+- **Indirect / AI (gesture or expression)** — `hand-features / face-features → indirect-map → lyria`  
+  Openness/smile/etc. steer weighted prompts + dials of Google Lyria RealTime.
+- **Discrete triggers** — `hand-features → gesture-classifier → (events)`  
+  Fist/open/pinch poses emit enter/exit events to trigger scale changes, stabs, mutes.
+
+## Nodes (20)
+
+### Inputs (sources)
+_Where signals enter the graph._
+
+#### `webcam-hands` — Webcam Hands
+MediaPipe hand landmark detection from a webcam video element.
+
+- **in:** —
+- **out:** hands:hands-frame
+- **params:** modelType (enum(lite | full)="full"), maxHands (number=2)
+
+#### `keyboard-source` — Keyboard Source
+Global keyboard input → held / pressed / released key events.
+
+- **in:** —
+- **out:** held:string[], pressed:string[], released:string[]
+- **params:** preventDefaultKeys (array=["ArrowUp","ArrowDown","ArrowLeft","ArrowRight"," "])
+
+#### `store-controls` — UI Controls
+Reads the live UI control store → scale + instrument port values.
+
+- **in:** —
+- **out:** scaleRight:number[], scaleLeft:number[], instrumentRight:instrument, instrumentLeft:instrument
+- **params:** —
+
+#### `synthetic-hands` — Synthetic Hands
+Camera-free animated hand landmark source for tests & demos.
+
+- **in:** —
+- **out:** hands:hands-frame
+- **params:** width (number=640), height (number=480), sweepPeriod (number=4), opennessPeriod (number=3), pinchPeriod (number=2.5), hands (enum(right | left | both)="right"), yNorm (number=0.5), scale (number=80)
+
+#### `replay-source` — Replay Source
+Emits a recorded value stream, one value per tick.
+
+- **in:** —
+- **out:** value
+- **params:** values (array=[]), loop (boolean=false)
+
+### Features
+_Raw sensor data → normalized control signals._
+
+#### `hand-features` — Hand Features
+Landmarks → normalized per-hand position, openness, pinch.
+
+- **in:** hands:hands-frame
+- **out:** features:hand-features
+- **params:** mirrorX (boolean=true), mirrorHandedness (boolean=true), opennessMin (number=1.3), opennessMax (number=2.3), pinchTouch (number=0.25), pinchApart (number=1.2)
+
+#### `face-features` — Face Features
+Face blendshapes → normalized expression controls (smile, mouthOpen, brow, blink).
+
+- **in:** face:face-frame
+- **out:** features:face-features
+- **params:** gain (number=1), smoothing (number=0)
+
+#### `gesture-classifier` — Gesture Classifier
+Hand features → discrete poses (fist/open/pinch) + enter/exit edge events.
+
+- **in:** features:hand-features
+- **out:** poses:poses, events:gesture-events
+- **params:** pinchOn (number=0.6), pinchOff (number=0.45), fistBelow (number=0.25), openAbove (number=0.6), hysteresis (number=0.05)
+
+### Mapping (direct ↔ indirect)
+_Features → engine parameters, across the expression spectrum._
+
+#### `voice-mapping` — Voice Mapping
+Hand features → tonal synth parameters (x→pitch w/ scale snap, y→volume).
+
+- **in:** features:hand-features, magnetism:number, octaveShift:number, mute:boolean, scaleRight:number[], scaleLeft:number[], instrumentRight:instrument, instrumentLeft:instrument
+- **out:** params:synth-params
+- **params:** magnetism (number=0.8), maxGain (number=0.5), opennessGatesGain (boolean=false), right (object={"scale":{"root":0,"type":"major","octaves":2,"baseOctave":3},"instrument":"sine"}), left (object={"scale":{"root":0,"type":"major","octaves":2,"baseOctave":3},"instrument":"triangle"})
+
+#### `indirect-map` — Indirect Map
+Gesture features → weighted prompts + config dials (steers a generative engine).
+
+- **in:** features:hand-features, face:face-features
+- **out:** steer:generative-steer
+- **params:** strains (array=[]), dials (array=[]), smoothing (number=0), throttleSec (number=0)
+
+#### `keyboard-control` — Keyboard Control
+Keyboard key-press events → octave shift, magnetism, mute.
+
+- **in:** pressed:string[]
+- **out:** octaveShift:number, magnetism:number, mute:boolean
+- **params:** magnetismStep (number=0.1), magnetismStart (number=0.8), octaveMin (number=-2), octaveMax (number=2)
+
+#### `pick` — Pick
+Extract a scalar from a structured input by dotted path (e.g. right.x).
+
+- **in:** in:any
+- **out:** value:number
+- **params:** path (string=""), default (number=0)
+
+### Music logic (tonal guidance)
+_Harmony kept in-key._
+
+#### `chord` — Chord
+Chord symbol (e.g. Cmaj7) → voiced synth params (one voice per chord tone).
+
+- **in:** chord:chord-symbol, gain:number
+- **out:** params:synth-params
+- **params:** baseOctave (number=4), maxVoices (number=4), instrument (enum(sine | square | sawtooth | triangle)="sine")
+
+#### `progression` — Progression
+Roman-numeral progression in a key + position (0..1) → current chord symbol.
+
+- **in:** position:number
+- **out:** chord:chord-symbol, index:number
+- **params:** key (string="C"), romanNumerals (array=["I","IV","V","vi"])
+
+### Conductor mode
+_Direct a fixed piece with gesture (tempo + dynamics)._
+
+#### `transport` — Transport
+Beat clock: integrates BPM over time into a running beat position.
+
+- **in:** bpm:number
+- **out:** beat:number
+- **params:** startBeat (number=0)
+
+#### `score` — Score
+An immutable piece performed live: beat + velocityScale → sounding synth voices.
+
+- **in:** beat:number, velocityScale:number
+- **out:** params:synth-params
+- **params:** notes (array=[]), loopBeats (number=8), baseGain (number=0.4), instrument (enum(sine | square | sawtooth | triangle)="triangle")
+
+#### `performance` — Performance
+Control signal → tempo (bpm) + dynamics (velocityScale), with optional humanization.
+
+- **in:** control:number
+- **out:** bpm:number, velocityScale:number
+- **params:** bpmMin (number=60), bpmMax (number=160), dynMin (number=0.4), dynMax (number=1), humanizeBpm (number=0), humanizeVel (number=0)
+
+### Synthesis & generation
+_Make sound — direct synthesis or steered AI music._
+
+#### `webaudio-synth` — Web Audio Synth
+Renders synth params to oscillator voices (browser only).
+
+- **in:** params:synth-params
+- **out:** —
+- **params:** freqGlide (number=0.03), gainGlide (number=0.08)
+
+#### `lyria` — Lyria Generative
+Steers a generative engine (Lyria RealTime) from weighted prompts + config dials.
+
+- **in:** steer:generative-steer, playing:boolean
+- **out:** state:string
+- **params:** throttleSec (number=0.2)
+
+### Output
+_Audio + the captured video with overlaid guides._
+
+#### `canvas-overlay` — Canvas Overlay
+Draws mirrored video + landmarks + control markers + HUD.
+
+- **in:** hands:hands-frame, features:hand-features
+- **out:** —
+- **params:** showLandmarks (boolean=true), showVideo (boolean=true), videoAlpha (number=0.35)
+

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc -p tsconfig.dag.json --noEmit",
-    "record": "vite-node scripts/record_stream.ts"
+    "record": "vite-node scripts/record_stream.ts",
+    "catalog": "vite-node scripts/gen_catalog.ts"
   },
   "dependencies": {
     "@google/genai": "^1.29.0",

--- a/public/catalog.json
+++ b/public/catalog.json
@@ -1,0 +1,788 @@
+[
+  {
+    "type": "canvas-overlay",
+    "title": "Canvas Overlay",
+    "description": "Draws mirrored video + landmarks + control markers + HUD.",
+    "inputs": [
+      {
+        "name": "hands",
+        "kind": "hands-frame"
+      },
+      {
+        "name": "features",
+        "kind": "hand-features"
+      }
+    ],
+    "outputs": [],
+    "params": [
+      {
+        "name": "showLandmarks",
+        "type": "boolean",
+        "default": true
+      },
+      {
+        "name": "showVideo",
+        "type": "boolean",
+        "default": true
+      },
+      {
+        "name": "videoAlpha",
+        "type": "number",
+        "default": 0.35
+      }
+    ]
+  },
+  {
+    "type": "chord",
+    "title": "Chord",
+    "description": "Chord symbol (e.g. Cmaj7) → voiced synth params (one voice per chord tone).",
+    "inputs": [
+      {
+        "name": "chord",
+        "kind": "chord-symbol",
+        "default": "C"
+      },
+      {
+        "name": "gain",
+        "kind": "number",
+        "default": 0.3
+      }
+    ],
+    "outputs": [
+      {
+        "name": "params",
+        "kind": "synth-params"
+      }
+    ],
+    "params": [
+      {
+        "name": "baseOctave",
+        "type": "number",
+        "default": 4
+      },
+      {
+        "name": "maxVoices",
+        "type": "number",
+        "default": 4
+      },
+      {
+        "name": "instrument",
+        "type": "enum(sine | square | sawtooth | triangle)",
+        "default": "sine"
+      }
+    ]
+  },
+  {
+    "type": "face-features",
+    "title": "Face Features",
+    "description": "Face blendshapes → normalized expression controls (smile, mouthOpen, brow, blink).",
+    "inputs": [
+      {
+        "name": "face",
+        "kind": "face-frame"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "features",
+        "kind": "face-features"
+      }
+    ],
+    "params": [
+      {
+        "name": "gain",
+        "type": "number",
+        "default": 1
+      },
+      {
+        "name": "smoothing",
+        "type": "number",
+        "default": 0
+      }
+    ]
+  },
+  {
+    "type": "gesture-classifier",
+    "title": "Gesture Classifier",
+    "description": "Hand features → discrete poses (fist/open/pinch) + enter/exit edge events.",
+    "inputs": [
+      {
+        "name": "features",
+        "kind": "hand-features"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "poses",
+        "kind": "poses"
+      },
+      {
+        "name": "events",
+        "kind": "gesture-events"
+      }
+    ],
+    "params": [
+      {
+        "name": "pinchOn",
+        "type": "number",
+        "default": 0.6
+      },
+      {
+        "name": "pinchOff",
+        "type": "number",
+        "default": 0.45
+      },
+      {
+        "name": "fistBelow",
+        "type": "number",
+        "default": 0.25
+      },
+      {
+        "name": "openAbove",
+        "type": "number",
+        "default": 0.6
+      },
+      {
+        "name": "hysteresis",
+        "type": "number",
+        "default": 0.05
+      }
+    ]
+  },
+  {
+    "type": "hand-features",
+    "title": "Hand Features",
+    "description": "Landmarks → normalized per-hand position, openness, pinch.",
+    "inputs": [
+      {
+        "name": "hands",
+        "kind": "hands-frame"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "features",
+        "kind": "hand-features"
+      }
+    ],
+    "params": [
+      {
+        "name": "mirrorX",
+        "type": "boolean",
+        "default": true
+      },
+      {
+        "name": "mirrorHandedness",
+        "type": "boolean",
+        "default": true
+      },
+      {
+        "name": "opennessMin",
+        "type": "number",
+        "default": 1.3
+      },
+      {
+        "name": "opennessMax",
+        "type": "number",
+        "default": 2.3
+      },
+      {
+        "name": "pinchTouch",
+        "type": "number",
+        "default": 0.25
+      },
+      {
+        "name": "pinchApart",
+        "type": "number",
+        "default": 1.2
+      }
+    ]
+  },
+  {
+    "type": "indirect-map",
+    "title": "Indirect Map",
+    "description": "Gesture features → weighted prompts + config dials (steers a generative engine).",
+    "inputs": [
+      {
+        "name": "features",
+        "kind": "hand-features"
+      },
+      {
+        "name": "face",
+        "kind": "face-features"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "steer",
+        "kind": "generative-steer"
+      }
+    ],
+    "params": [
+      {
+        "name": "strains",
+        "type": "array",
+        "default": []
+      },
+      {
+        "name": "dials",
+        "type": "array",
+        "default": []
+      },
+      {
+        "name": "smoothing",
+        "type": "number",
+        "default": 0
+      },
+      {
+        "name": "throttleSec",
+        "type": "number",
+        "default": 0
+      }
+    ]
+  },
+  {
+    "type": "keyboard-control",
+    "title": "Keyboard Control",
+    "description": "Keyboard key-press events → octave shift, magnetism, mute.",
+    "inputs": [
+      {
+        "name": "pressed",
+        "kind": "string[]",
+        "default": []
+      }
+    ],
+    "outputs": [
+      {
+        "name": "octaveShift",
+        "kind": "number"
+      },
+      {
+        "name": "magnetism",
+        "kind": "number"
+      },
+      {
+        "name": "mute",
+        "kind": "boolean"
+      }
+    ],
+    "params": [
+      {
+        "name": "magnetismStep",
+        "type": "number",
+        "default": 0.1
+      },
+      {
+        "name": "magnetismStart",
+        "type": "number",
+        "default": 0.8
+      },
+      {
+        "name": "octaveMin",
+        "type": "number",
+        "default": -2
+      },
+      {
+        "name": "octaveMax",
+        "type": "number",
+        "default": 2
+      }
+    ]
+  },
+  {
+    "type": "keyboard-source",
+    "title": "Keyboard Source",
+    "description": "Global keyboard input → held / pressed / released key events.",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "held",
+        "kind": "string[]"
+      },
+      {
+        "name": "pressed",
+        "kind": "string[]"
+      },
+      {
+        "name": "released",
+        "kind": "string[]"
+      }
+    ],
+    "params": [
+      {
+        "name": "preventDefaultKeys",
+        "type": "array",
+        "default": [
+          "ArrowUp",
+          "ArrowDown",
+          "ArrowLeft",
+          "ArrowRight",
+          " "
+        ]
+      }
+    ]
+  },
+  {
+    "type": "lyria",
+    "title": "Lyria Generative",
+    "description": "Steers a generative engine (Lyria RealTime) from weighted prompts + config dials.",
+    "inputs": [
+      {
+        "name": "steer",
+        "kind": "generative-steer"
+      },
+      {
+        "name": "playing",
+        "kind": "boolean",
+        "default": false
+      }
+    ],
+    "outputs": [
+      {
+        "name": "state",
+        "kind": "string"
+      }
+    ],
+    "params": [
+      {
+        "name": "throttleSec",
+        "type": "number",
+        "default": 0.2
+      }
+    ]
+  },
+  {
+    "type": "performance",
+    "title": "Performance",
+    "description": "Control signal → tempo (bpm) + dynamics (velocityScale), with optional humanization.",
+    "inputs": [
+      {
+        "name": "control",
+        "kind": "number",
+        "default": 0.5
+      }
+    ],
+    "outputs": [
+      {
+        "name": "bpm",
+        "kind": "number"
+      },
+      {
+        "name": "velocityScale",
+        "kind": "number"
+      }
+    ],
+    "params": [
+      {
+        "name": "bpmMin",
+        "type": "number",
+        "default": 60
+      },
+      {
+        "name": "bpmMax",
+        "type": "number",
+        "default": 160
+      },
+      {
+        "name": "dynMin",
+        "type": "number",
+        "default": 0.4
+      },
+      {
+        "name": "dynMax",
+        "type": "number",
+        "default": 1
+      },
+      {
+        "name": "humanizeBpm",
+        "type": "number",
+        "default": 0
+      },
+      {
+        "name": "humanizeVel",
+        "type": "number",
+        "default": 0
+      }
+    ]
+  },
+  {
+    "type": "pick",
+    "title": "Pick",
+    "description": "Extract a scalar from a structured input by dotted path (e.g. right.x).",
+    "inputs": [
+      {
+        "name": "in",
+        "kind": "any"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "value",
+        "kind": "number"
+      }
+    ],
+    "params": [
+      {
+        "name": "path",
+        "type": "string",
+        "default": ""
+      },
+      {
+        "name": "default",
+        "type": "number",
+        "default": 0
+      }
+    ]
+  },
+  {
+    "type": "progression",
+    "title": "Progression",
+    "description": "Roman-numeral progression in a key + position (0..1) → current chord symbol.",
+    "inputs": [
+      {
+        "name": "position",
+        "kind": "number",
+        "default": 0
+      }
+    ],
+    "outputs": [
+      {
+        "name": "chord",
+        "kind": "chord-symbol"
+      },
+      {
+        "name": "index",
+        "kind": "number"
+      }
+    ],
+    "params": [
+      {
+        "name": "key",
+        "type": "string",
+        "default": "C"
+      },
+      {
+        "name": "romanNumerals",
+        "type": "array",
+        "default": [
+          "I",
+          "IV",
+          "V",
+          "vi"
+        ]
+      }
+    ]
+  },
+  {
+    "type": "replay-source",
+    "title": "Replay Source",
+    "description": "Emits a recorded value stream, one value per tick.",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "value"
+      }
+    ],
+    "params": [
+      {
+        "name": "values",
+        "type": "array",
+        "default": []
+      },
+      {
+        "name": "loop",
+        "type": "boolean",
+        "default": false
+      }
+    ]
+  },
+  {
+    "type": "score",
+    "title": "Score",
+    "description": "An immutable piece performed live: beat + velocityScale → sounding synth voices.",
+    "inputs": [
+      {
+        "name": "beat",
+        "kind": "number",
+        "default": 0
+      },
+      {
+        "name": "velocityScale",
+        "kind": "number",
+        "default": 1
+      }
+    ],
+    "outputs": [
+      {
+        "name": "params",
+        "kind": "synth-params"
+      }
+    ],
+    "params": [
+      {
+        "name": "notes",
+        "type": "array",
+        "default": []
+      },
+      {
+        "name": "loopBeats",
+        "type": "number",
+        "default": 8
+      },
+      {
+        "name": "baseGain",
+        "type": "number",
+        "default": 0.4
+      },
+      {
+        "name": "instrument",
+        "type": "enum(sine | square | sawtooth | triangle)",
+        "default": "triangle"
+      }
+    ]
+  },
+  {
+    "type": "store-controls",
+    "title": "UI Controls",
+    "description": "Reads the live UI control store → scale + instrument port values.",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "scaleRight",
+        "kind": "number[]"
+      },
+      {
+        "name": "scaleLeft",
+        "kind": "number[]"
+      },
+      {
+        "name": "instrumentRight",
+        "kind": "instrument"
+      },
+      {
+        "name": "instrumentLeft",
+        "kind": "instrument"
+      }
+    ],
+    "params": []
+  },
+  {
+    "type": "synthetic-hands",
+    "title": "Synthetic Hands",
+    "description": "Camera-free animated hand landmark source for tests & demos.",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "hands",
+        "kind": "hands-frame"
+      }
+    ],
+    "params": [
+      {
+        "name": "width",
+        "type": "number",
+        "default": 640
+      },
+      {
+        "name": "height",
+        "type": "number",
+        "default": 480
+      },
+      {
+        "name": "sweepPeriod",
+        "type": "number",
+        "default": 4
+      },
+      {
+        "name": "opennessPeriod",
+        "type": "number",
+        "default": 3
+      },
+      {
+        "name": "pinchPeriod",
+        "type": "number",
+        "default": 2.5
+      },
+      {
+        "name": "hands",
+        "type": "enum(right | left | both)",
+        "default": "right"
+      },
+      {
+        "name": "yNorm",
+        "type": "number",
+        "default": 0.5
+      },
+      {
+        "name": "scale",
+        "type": "number",
+        "default": 80
+      }
+    ]
+  },
+  {
+    "type": "transport",
+    "title": "Transport",
+    "description": "Beat clock: integrates BPM over time into a running beat position.",
+    "inputs": [
+      {
+        "name": "bpm",
+        "kind": "number",
+        "default": 120
+      }
+    ],
+    "outputs": [
+      {
+        "name": "beat",
+        "kind": "number"
+      }
+    ],
+    "params": [
+      {
+        "name": "startBeat",
+        "type": "number",
+        "default": 0
+      }
+    ]
+  },
+  {
+    "type": "voice-mapping",
+    "title": "Voice Mapping",
+    "description": "Hand features → tonal synth parameters (x→pitch w/ scale snap, y→volume).",
+    "inputs": [
+      {
+        "name": "features",
+        "kind": "hand-features"
+      },
+      {
+        "name": "magnetism",
+        "kind": "number",
+        "description": "Override magnetism 0..1"
+      },
+      {
+        "name": "octaveShift",
+        "kind": "number",
+        "description": "Transpose by N octaves",
+        "default": 0
+      },
+      {
+        "name": "mute",
+        "kind": "boolean",
+        "default": false
+      },
+      {
+        "name": "scaleRight",
+        "kind": "number[]"
+      },
+      {
+        "name": "scaleLeft",
+        "kind": "number[]"
+      },
+      {
+        "name": "instrumentRight",
+        "kind": "instrument"
+      },
+      {
+        "name": "instrumentLeft",
+        "kind": "instrument"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "params",
+        "kind": "synth-params"
+      }
+    ],
+    "params": [
+      {
+        "name": "magnetism",
+        "type": "number",
+        "default": 0.8
+      },
+      {
+        "name": "maxGain",
+        "type": "number",
+        "default": 0.5
+      },
+      {
+        "name": "opennessGatesGain",
+        "type": "boolean",
+        "default": false
+      },
+      {
+        "name": "right",
+        "type": "object",
+        "default": {
+          "scale": {
+            "root": 0,
+            "type": "major",
+            "octaves": 2,
+            "baseOctave": 3
+          },
+          "instrument": "sine"
+        }
+      },
+      {
+        "name": "left",
+        "type": "object",
+        "default": {
+          "scale": {
+            "root": 0,
+            "type": "major",
+            "octaves": 2,
+            "baseOctave": 3
+          },
+          "instrument": "triangle"
+        }
+      }
+    ]
+  },
+  {
+    "type": "webaudio-synth",
+    "title": "Web Audio Synth",
+    "description": "Renders synth params to oscillator voices (browser only).",
+    "inputs": [
+      {
+        "name": "params",
+        "kind": "synth-params"
+      }
+    ],
+    "outputs": [],
+    "params": [
+      {
+        "name": "freqGlide",
+        "type": "number",
+        "default": 0.03
+      },
+      {
+        "name": "gainGlide",
+        "type": "number",
+        "default": 0.08
+      }
+    ]
+  },
+  {
+    "type": "webcam-hands",
+    "title": "Webcam Hands",
+    "description": "MediaPipe hand landmark detection from a webcam video element.",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "hands",
+        "kind": "hands-frame"
+      }
+    ],
+    "params": [
+      {
+        "name": "modelType",
+        "type": "enum(lite | full)",
+        "default": "full"
+      },
+      {
+        "name": "maxHands",
+        "type": "number",
+        "default": 2
+      }
+    ]
+  }
+]

--- a/public/manual.html
+++ b/public/manual.html
@@ -1,0 +1,217 @@
+<!doctype html><html lang="en"><head><meta charset="UTF-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Thoremin — Capabilities Manual</title>
+<style>
+  :root { color-scheme: dark; }
+  body { margin: 0; background: #0a0a0a; color: #e5e5e5; font: 15px/1.55 -apple-system, system-ui, sans-serif; }
+  .wrap { max-width: 980px; margin: 0 auto; padding: 2rem 1.25rem 4rem; }
+  h1 { color: #10b981; letter-spacing: -.02em; }
+  h3 { margin-top: 2.2rem; border-bottom: 1px solid #1f1f1f; padding-bottom: .35rem; color: #fff; }
+  .gen { color: #666; font-size: 12px; }
+  .blurb { color: #9aa; margin-top: -.3rem; }
+  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: .9rem; }
+  .node { background: #111; border: 1px solid #1f1f1f; border-radius: 12px; padding: .85rem 1rem; }
+  .node h4 { margin: 0 0 .35rem; font-size: 14px; }
+  .node code { color: #10b981; }
+  .node .title { color: #888; font-weight: 500; }
+  .node p { margin: .3rem 0 .6rem; color: #cfcfcf; font-size: 13px; }
+  dl { display: grid; grid-template-columns: auto 1fr; gap: 2px 10px; margin: 0; font-size: 12px; }
+  dt { color: #10b981; text-transform: uppercase; font-size: 10px; letter-spacing: .08em; padding-top: 2px; }
+  dd { margin: 0; color: #aab; font-family: ui-monospace, monospace; }
+  ul.examples { padding-left: 1.1rem; } ul.examples li { margin-bottom: .6rem; }
+  code { font-family: ui-monospace, SFMono-Regular, monospace; }
+  .examples code { color: #7dd3fc; } .note { color: #9aa; font-size: 13px; }
+</style></head><body><div class="wrap">
+  <h1>θ Thoremin — Capabilities Manual</h1>
+  <p class="gen">Auto-generated from the node registry. 20 nodes.</p>
+  <p>Thoremin turns live sensor streams (webcam hand gestures, facial expressions, computer keyboard, later MIDI) into a live audiovisual stream — musical audio plus the captured video with overlaid guides. You build instruments by wiring small, typed <b>nodes</b> into a dataflow graph (DAG): inputs → features → mapping → music-logic → synthesis/generation → output. Every edge can be recorded and replayed.</p><p>The mapping layer spans a spectrum: <b>direct</b> (a gesture *is* a note/parameter — e.g. hand position → scale-snapped pitch) through <b>indirect</b> (a gesture expresses a high-level idea — e.g. openness → musical density steering an AI model), including <b>conductor</b> mode (direct a fixed piece's tempo and dynamics).</p><p>This page catalogs the engine's building blocks — every node and how they connect. Some already run in the deployed app; wiring the full graph into the live instrument is in progress.</p>
+  <h3>Example pipelines</h3>
+  <ul class="examples"><li><b>Theremin (direct)</b> — <code>webcam-hands → hand-features → voice-mapping → webaudio-synth ( + canvas-overlay)</code><br/><span class="note">Hand x → scale-snapped pitch, y → volume. Two hands = two voices.</span></li><li><b>Gesture → harmony</b> — <code>hand-features → pick('right.x') → progression → chord → webaudio-synth</code><br/><span class="note">Hand position walks an in-key chord progression.</span></li><li><b>Conductor</b> — <code>control → performance → transport → score → webaudio-synth</code><br/><span class="note">A control signal directs a fixed piece's tempo + dynamics (accelerando/crescendo…).</span></li><li><b>Indirect / AI (gesture or expression)</b> — <code>hand-features / face-features → indirect-map → lyria</code><br/><span class="note">Openness/smile/etc. steer weighted prompts + dials of Google Lyria RealTime.</span></li><li><b>Discrete triggers</b> — <code>hand-features → gesture-classifier → (events)</code><br/><span class="note">Fist/open/pinch poses emit enter/exit events to trigger scale changes, stabs, mutes.</span></li></ul>
+  <section><h3>Inputs (sources)</h3><p class="blurb">Where signals enter the graph.</p><div class="grid">
+    <div class="node">
+      <h4><code>webcam-hands</code> <span class="title">Webcam Hands</span></h4>
+      <p>MediaPipe hand landmark detection from a webcam video element.</p>
+      <dl>
+        <dt>in</dt><dd>—</dd>
+        <dt>out</dt><dd>hands:hands-frame</dd>
+        <dt>params</dt><dd>modelType (enum(lite | full)="full"), maxHands (number=2)</dd>
+      </dl>
+    </div>
+    <div class="node">
+      <h4><code>keyboard-source</code> <span class="title">Keyboard Source</span></h4>
+      <p>Global keyboard input → held / pressed / released key events.</p>
+      <dl>
+        <dt>in</dt><dd>—</dd>
+        <dt>out</dt><dd>held:string[], pressed:string[], released:string[]</dd>
+        <dt>params</dt><dd>preventDefaultKeys (array=["ArrowUp","ArrowDown","ArrowLeft","ArrowRight"," "])</dd>
+      </dl>
+    </div>
+    <div class="node">
+      <h4><code>store-controls</code> <span class="title">UI Controls</span></h4>
+      <p>Reads the live UI control store → scale + instrument port values.</p>
+      <dl>
+        <dt>in</dt><dd>—</dd>
+        <dt>out</dt><dd>scaleRight:number[], scaleLeft:number[], instrumentRight:instrument, instrumentLeft:instrument</dd>
+        <dt>params</dt><dd>—</dd>
+      </dl>
+    </div>
+    <div class="node">
+      <h4><code>synthetic-hands</code> <span class="title">Synthetic Hands</span></h4>
+      <p>Camera-free animated hand landmark source for tests &amp; demos.</p>
+      <dl>
+        <dt>in</dt><dd>—</dd>
+        <dt>out</dt><dd>hands:hands-frame</dd>
+        <dt>params</dt><dd>width (number=640), height (number=480), sweepPeriod (number=4), opennessPeriod (number=3), pinchPeriod (number=2.5), hands (enum(right | left | both)="right"), yNorm (number=0.5), scale (number=80)</dd>
+      </dl>
+    </div>
+    <div class="node">
+      <h4><code>replay-source</code> <span class="title">Replay Source</span></h4>
+      <p>Emits a recorded value stream, one value per tick.</p>
+      <dl>
+        <dt>in</dt><dd>—</dd>
+        <dt>out</dt><dd>value</dd>
+        <dt>params</dt><dd>values (array=[]), loop (boolean=false)</dd>
+      </dl>
+    </div></div></section>
+<section><h3>Features</h3><p class="blurb">Raw sensor data → normalized control signals.</p><div class="grid">
+    <div class="node">
+      <h4><code>hand-features</code> <span class="title">Hand Features</span></h4>
+      <p>Landmarks → normalized per-hand position, openness, pinch.</p>
+      <dl>
+        <dt>in</dt><dd>hands:hands-frame</dd>
+        <dt>out</dt><dd>features:hand-features</dd>
+        <dt>params</dt><dd>mirrorX (boolean=true), mirrorHandedness (boolean=true), opennessMin (number=1.3), opennessMax (number=2.3), pinchTouch (number=0.25), pinchApart (number=1.2)</dd>
+      </dl>
+    </div>
+    <div class="node">
+      <h4><code>face-features</code> <span class="title">Face Features</span></h4>
+      <p>Face blendshapes → normalized expression controls (smile, mouthOpen, brow, blink).</p>
+      <dl>
+        <dt>in</dt><dd>face:face-frame</dd>
+        <dt>out</dt><dd>features:face-features</dd>
+        <dt>params</dt><dd>gain (number=1), smoothing (number=0)</dd>
+      </dl>
+    </div>
+    <div class="node">
+      <h4><code>gesture-classifier</code> <span class="title">Gesture Classifier</span></h4>
+      <p>Hand features → discrete poses (fist/open/pinch) + enter/exit edge events.</p>
+      <dl>
+        <dt>in</dt><dd>features:hand-features</dd>
+        <dt>out</dt><dd>poses:poses, events:gesture-events</dd>
+        <dt>params</dt><dd>pinchOn (number=0.6), pinchOff (number=0.45), fistBelow (number=0.25), openAbove (number=0.6), hysteresis (number=0.05)</dd>
+      </dl>
+    </div></div></section>
+<section><h3>Mapping (direct ↔ indirect)</h3><p class="blurb">Features → engine parameters, across the expression spectrum.</p><div class="grid">
+    <div class="node">
+      <h4><code>voice-mapping</code> <span class="title">Voice Mapping</span></h4>
+      <p>Hand features → tonal synth parameters (x→pitch w/ scale snap, y→volume).</p>
+      <dl>
+        <dt>in</dt><dd>features:hand-features, magnetism:number, octaveShift:number, mute:boolean, scaleRight:number[], scaleLeft:number[], instrumentRight:instrument, instrumentLeft:instrument</dd>
+        <dt>out</dt><dd>params:synth-params</dd>
+        <dt>params</dt><dd>magnetism (number=0.8), maxGain (number=0.5), opennessGatesGain (boolean=false), right (object={"scale":{"root":0,"type":"major","octaves":2,"baseOctave":3},"instrument":"sine"}), left (object={"scale":{"root":0,"type":"major","octaves":2,"baseOctave":3},"instrument":"triangle"})</dd>
+      </dl>
+    </div>
+    <div class="node">
+      <h4><code>indirect-map</code> <span class="title">Indirect Map</span></h4>
+      <p>Gesture features → weighted prompts + config dials (steers a generative engine).</p>
+      <dl>
+        <dt>in</dt><dd>features:hand-features, face:face-features</dd>
+        <dt>out</dt><dd>steer:generative-steer</dd>
+        <dt>params</dt><dd>strains (array=[]), dials (array=[]), smoothing (number=0), throttleSec (number=0)</dd>
+      </dl>
+    </div>
+    <div class="node">
+      <h4><code>keyboard-control</code> <span class="title">Keyboard Control</span></h4>
+      <p>Keyboard key-press events → octave shift, magnetism, mute.</p>
+      <dl>
+        <dt>in</dt><dd>pressed:string[]</dd>
+        <dt>out</dt><dd>octaveShift:number, magnetism:number, mute:boolean</dd>
+        <dt>params</dt><dd>magnetismStep (number=0.1), magnetismStart (number=0.8), octaveMin (number=-2), octaveMax (number=2)</dd>
+      </dl>
+    </div>
+    <div class="node">
+      <h4><code>pick</code> <span class="title">Pick</span></h4>
+      <p>Extract a scalar from a structured input by dotted path (e.g. right.x).</p>
+      <dl>
+        <dt>in</dt><dd>in:any</dd>
+        <dt>out</dt><dd>value:number</dd>
+        <dt>params</dt><dd>path (string=""), default (number=0)</dd>
+      </dl>
+    </div></div></section>
+<section><h3>Music logic (tonal guidance)</h3><p class="blurb">Harmony kept in-key.</p><div class="grid">
+    <div class="node">
+      <h4><code>chord</code> <span class="title">Chord</span></h4>
+      <p>Chord symbol (e.g. Cmaj7) → voiced synth params (one voice per chord tone).</p>
+      <dl>
+        <dt>in</dt><dd>chord:chord-symbol, gain:number</dd>
+        <dt>out</dt><dd>params:synth-params</dd>
+        <dt>params</dt><dd>baseOctave (number=4), maxVoices (number=4), instrument (enum(sine | square | sawtooth | triangle)="sine")</dd>
+      </dl>
+    </div>
+    <div class="node">
+      <h4><code>progression</code> <span class="title">Progression</span></h4>
+      <p>Roman-numeral progression in a key + position (0..1) → current chord symbol.</p>
+      <dl>
+        <dt>in</dt><dd>position:number</dd>
+        <dt>out</dt><dd>chord:chord-symbol, index:number</dd>
+        <dt>params</dt><dd>key (string="C"), romanNumerals (array=["I","IV","V","vi"])</dd>
+      </dl>
+    </div></div></section>
+<section><h3>Conductor mode</h3><p class="blurb">Direct a fixed piece with gesture (tempo + dynamics).</p><div class="grid">
+    <div class="node">
+      <h4><code>transport</code> <span class="title">Transport</span></h4>
+      <p>Beat clock: integrates BPM over time into a running beat position.</p>
+      <dl>
+        <dt>in</dt><dd>bpm:number</dd>
+        <dt>out</dt><dd>beat:number</dd>
+        <dt>params</dt><dd>startBeat (number=0)</dd>
+      </dl>
+    </div>
+    <div class="node">
+      <h4><code>score</code> <span class="title">Score</span></h4>
+      <p>An immutable piece performed live: beat + velocityScale → sounding synth voices.</p>
+      <dl>
+        <dt>in</dt><dd>beat:number, velocityScale:number</dd>
+        <dt>out</dt><dd>params:synth-params</dd>
+        <dt>params</dt><dd>notes (array=[]), loopBeats (number=8), baseGain (number=0.4), instrument (enum(sine | square | sawtooth | triangle)="triangle")</dd>
+      </dl>
+    </div>
+    <div class="node">
+      <h4><code>performance</code> <span class="title">Performance</span></h4>
+      <p>Control signal → tempo (bpm) + dynamics (velocityScale), with optional humanization.</p>
+      <dl>
+        <dt>in</dt><dd>control:number</dd>
+        <dt>out</dt><dd>bpm:number, velocityScale:number</dd>
+        <dt>params</dt><dd>bpmMin (number=60), bpmMax (number=160), dynMin (number=0.4), dynMax (number=1), humanizeBpm (number=0), humanizeVel (number=0)</dd>
+      </dl>
+    </div></div></section>
+<section><h3>Synthesis &amp; generation</h3><p class="blurb">Make sound — direct synthesis or steered AI music.</p><div class="grid">
+    <div class="node">
+      <h4><code>webaudio-synth</code> <span class="title">Web Audio Synth</span></h4>
+      <p>Renders synth params to oscillator voices (browser only).</p>
+      <dl>
+        <dt>in</dt><dd>params:synth-params</dd>
+        <dt>out</dt><dd>—</dd>
+        <dt>params</dt><dd>freqGlide (number=0.03), gainGlide (number=0.08)</dd>
+      </dl>
+    </div>
+    <div class="node">
+      <h4><code>lyria</code> <span class="title">Lyria Generative</span></h4>
+      <p>Steers a generative engine (Lyria RealTime) from weighted prompts + config dials.</p>
+      <dl>
+        <dt>in</dt><dd>steer:generative-steer, playing:boolean</dd>
+        <dt>out</dt><dd>state:string</dd>
+        <dt>params</dt><dd>throttleSec (number=0.2)</dd>
+      </dl>
+    </div></div></section>
+<section><h3>Output</h3><p class="blurb">Audio + the captured video with overlaid guides.</p><div class="grid">
+    <div class="node">
+      <h4><code>canvas-overlay</code> <span class="title">Canvas Overlay</span></h4>
+      <p>Draws mirrored video + landmarks + control markers + HUD.</p>
+      <dl>
+        <dt>in</dt><dd>hands:hands-frame, features:hand-features</dd>
+        <dt>out</dt><dd>—</dd>
+        <dt>params</dt><dd>showLandmarks (boolean=true), showVideo (boolean=true), videoAlpha (number=0.35)</dd>
+      </dl>
+    </div></div></section>
+</div></body></html>

--- a/scripts/gen_catalog.ts
+++ b/scripts/gen_catalog.ts
@@ -1,0 +1,137 @@
+/**
+ * Generate the user-facing manual from the node registry (the SSOT), so it can
+ * never drift from the code. Emits:
+ *   - docs/CATALOG.md     — human-readable markdown manual (repo browsing)
+ *   - public/manual.html  — self-contained styled manual; Vite copies public/
+ *     into the build, so the deployed app serves it at /thoremin/manual.html
+ *   - public/catalog.json — machine catalog for a future in-app node browser
+ *
+ * Usage: vite-node scripts/gen_catalog.ts
+ */
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { buildCatalog, type CatalogEntry, type ParamInfo, type PortInfo } from '@/catalog';
+import { createAppRegistry } from '@/nodes/browser';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+// Layer grouping for the manual (type → category, in display order).
+const CATEGORIES: Array<{ name: string; blurb: string; types: string[] }> = [
+  { name: 'Inputs (sources)', blurb: 'Where signals enter the graph.', types: ['webcam-hands', 'keyboard-source', 'store-controls', 'synthetic-hands', 'replay-source'] },
+  { name: 'Features', blurb: 'Raw sensor data → normalized control signals.', types: ['hand-features', 'face-features', 'gesture-classifier'] },
+  { name: 'Mapping (direct ↔ indirect)', blurb: 'Features → engine parameters, across the expression spectrum.', types: ['voice-mapping', 'indirect-map', 'keyboard-control', 'pick'] },
+  { name: 'Music logic (tonal guidance)', blurb: 'Harmony kept in-key.', types: ['chord', 'progression'] },
+  { name: 'Conductor mode', blurb: 'Direct a fixed piece with gesture (tempo + dynamics).', types: ['transport', 'score', 'performance'] },
+  { name: 'Synthesis & generation', blurb: 'Make sound — direct synthesis or steered AI music.', types: ['webaudio-synth', 'lyria'] },
+  { name: 'Output', blurb: 'Audio + the captured video with overlaid guides.', types: ['canvas-overlay'] },
+];
+
+const OVERVIEW = `Thoremin turns live sensor streams (webcam hand gestures, facial expressions, computer keyboard, later MIDI) into a live audiovisual stream — musical audio plus the captured video with overlaid guides. You build instruments by wiring small, typed **nodes** into a dataflow graph (DAG): inputs → features → mapping → music-logic → synthesis/generation → output. Every edge can be recorded and replayed.
+
+The mapping layer spans a spectrum: **direct** (a gesture *is* a note/parameter — e.g. hand position → scale-snapped pitch) through **indirect** (a gesture expresses a high-level idea — e.g. openness → musical density steering an AI model), including **conductor** mode (direct a fixed piece's tempo and dynamics).
+
+This page catalogs the engine's building blocks — every node and how they connect. Some already run in the deployed app; wiring the full graph into the live instrument is in progress.`;
+
+const EXAMPLES: Array<{ title: string; chain: string; note: string }> = [
+  { title: 'Theremin (direct)', chain: 'webcam-hands → hand-features → voice-mapping → webaudio-synth ( + canvas-overlay)', note: 'Hand x → scale-snapped pitch, y → volume. Two hands = two voices.' },
+  { title: 'Gesture → harmony', chain: "hand-features → pick('right.x') → progression → chord → webaudio-synth", note: 'Hand position walks an in-key chord progression.' },
+  { title: 'Conductor', chain: 'control → performance → transport → score → webaudio-synth', note: 'A control signal directs a fixed piece\'s tempo + dynamics (accelerando/crescendo…).' },
+  { title: 'Indirect / AI (gesture or expression)', chain: 'hand-features / face-features → indirect-map → lyria', note: 'Openness/smile/etc. steer weighted prompts + dials of Google Lyria RealTime.' },
+  { title: 'Discrete triggers', chain: 'hand-features → gesture-classifier → (events)', note: 'Fist/open/pinch poses emit enter/exit events to trigger scale changes, stabs, mutes.' },
+];
+
+function ports(ps: PortInfo[]): string {
+  if (!ps.length) return '—';
+  return ps.map((p) => `${p.name}${p.kind ? `:${p.kind}` : ''}`).join(', ');
+}
+function params(ps: ParamInfo[]): string {
+  if (!ps.length) return '—';
+  return ps.map((p) => `${p.name} (${p.type}${p.default !== undefined ? `=${JSON.stringify(p.default)}` : ''})`).join(', ');
+}
+function grouped(catalog: CatalogEntry[]): Array<{ name: string; blurb: string; entries: CatalogEntry[] }> {
+  const byType = Object.fromEntries(catalog.map((e) => [e.type, e]));
+  const used = new Set<string>();
+  const groups = CATEGORIES.map((c) => {
+    const entries = c.types.map((t) => byType[t]).filter(Boolean) as CatalogEntry[];
+    entries.forEach((e) => used.add(e.type));
+    return { name: c.name, blurb: c.blurb, entries };
+  });
+  const rest = catalog.filter((e) => !used.has(e.type));
+  if (rest.length) groups.push({ name: 'Other', blurb: '', entries: rest });
+  return groups.filter((g) => g.entries.length);
+}
+
+function toMarkdown(catalog: CatalogEntry[]): string {
+  const L: string[] = ['# Thoremin — Capabilities Manual', '', '_Auto-generated from the node registry (`scripts/gen_catalog.ts`). Do not edit by hand._', '', OVERVIEW, '', '## Example pipelines', ''];
+  for (const ex of EXAMPLES) L.push(`- **${ex.title}** — \`${ex.chain}\`  \n  ${ex.note}`);
+  L.push('', `## Nodes (${catalog.length})`, '');
+  for (const g of grouped(catalog)) {
+    L.push(`### ${g.name}`, g.blurb ? `_${g.blurb}_` : '', '');
+    for (const e of g.entries) {
+      L.push(`#### \`${e.type}\` — ${e.title}`, e.description, '', `- **in:** ${ports(e.inputs)}`, `- **out:** ${ports(e.outputs)}`, `- **params:** ${params(e.params)}`, '');
+    }
+  }
+  return L.join('\n');
+}
+
+const esc = (s: string): string => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+function toHtml(catalog: CatalogEntry[]): string {
+  const card = (e: CatalogEntry): string => `
+    <div class="node">
+      <h4><code>${esc(e.type)}</code> <span class="title">${esc(e.title)}</span></h4>
+      <p>${esc(e.description)}</p>
+      <dl>
+        <dt>in</dt><dd>${esc(ports(e.inputs))}</dd>
+        <dt>out</dt><dd>${esc(ports(e.outputs))}</dd>
+        <dt>params</dt><dd>${esc(params(e.params))}</dd>
+      </dl>
+    </div>`;
+  const sections = grouped(catalog)
+    .map((g) => `<section><h3>${esc(g.name)}</h3>${g.blurb ? `<p class="blurb">${esc(g.blurb)}</p>` : ''}<div class="grid">${g.entries.map(card).join('')}</div></section>`)
+    .join('\n');
+  const examples = EXAMPLES.map((ex) => `<li><b>${esc(ex.title)}</b> — <code>${esc(ex.chain)}</code><br/><span class="note">${esc(ex.note)}</span></li>`).join('');
+  return `<!doctype html><html lang="en"><head><meta charset="UTF-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Thoremin — Capabilities Manual</title>
+<style>
+  :root { color-scheme: dark; }
+  body { margin: 0; background: #0a0a0a; color: #e5e5e5; font: 15px/1.55 -apple-system, system-ui, sans-serif; }
+  .wrap { max-width: 980px; margin: 0 auto; padding: 2rem 1.25rem 4rem; }
+  h1 { color: #10b981; letter-spacing: -.02em; }
+  h3 { margin-top: 2.2rem; border-bottom: 1px solid #1f1f1f; padding-bottom: .35rem; color: #fff; }
+  .gen { color: #666; font-size: 12px; }
+  .blurb { color: #9aa; margin-top: -.3rem; }
+  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: .9rem; }
+  .node { background: #111; border: 1px solid #1f1f1f; border-radius: 12px; padding: .85rem 1rem; }
+  .node h4 { margin: 0 0 .35rem; font-size: 14px; }
+  .node code { color: #10b981; }
+  .node .title { color: #888; font-weight: 500; }
+  .node p { margin: .3rem 0 .6rem; color: #cfcfcf; font-size: 13px; }
+  dl { display: grid; grid-template-columns: auto 1fr; gap: 2px 10px; margin: 0; font-size: 12px; }
+  dt { color: #10b981; text-transform: uppercase; font-size: 10px; letter-spacing: .08em; padding-top: 2px; }
+  dd { margin: 0; color: #aab; font-family: ui-monospace, monospace; }
+  ul.examples { padding-left: 1.1rem; } ul.examples li { margin-bottom: .6rem; }
+  code { font-family: ui-monospace, SFMono-Regular, monospace; }
+  .examples code { color: #7dd3fc; } .note { color: #9aa; font-size: 13px; }
+</style></head><body><div class="wrap">
+  <h1>θ Thoremin — Capabilities Manual</h1>
+  <p class="gen">Auto-generated from the node registry. ${catalog.length} nodes.</p>
+  <p>${esc(OVERVIEW).replace(/\n\n/g, '</p><p>').replace(/\*\*(.+?)\*\*/g, '<b>$1</b>')}</p>
+  <h3>Example pipelines</h3>
+  <ul class="examples">${examples}</ul>
+  ${sections}
+</div></body></html>`;
+}
+
+function main(): void {
+  const catalog = buildCatalog(createAppRegistry());
+  mkdirSync(join(ROOT, 'public'), { recursive: true });
+  writeFileSync(join(ROOT, 'docs', 'CATALOG.md'), toMarkdown(catalog) + '\n');
+  writeFileSync(join(ROOT, 'public', 'manual.html'), toHtml(catalog) + '\n');
+  writeFileSync(join(ROOT, 'public', 'catalog.json'), JSON.stringify(catalog, null, 2) + '\n');
+  console.log(`catalog: ${catalog.length} nodes -> docs/CATALOG.md, public/manual.html, public/catalog.json`);
+}
+
+main();

--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -1,0 +1,118 @@
+/**
+ * Catalog — introspect a {@link NodeRegistry} into a structured, serializable
+ * description of every node: its purpose, ports, and params. This is the SSOT
+ * for the user-facing manual (rendered to markdown / a standalone HTML page /
+ * a future in-app "node browser"), so the manual can never drift from the code.
+ *
+ * Pure + Node-safe (just reads node metadata + introspects Zod schemas), so it
+ * is unit-testable headlessly.
+ */
+import type { NodeRegistry } from '@/dag';
+import type { NodeDef, PortSpec } from '@/dag';
+
+export interface PortInfo {
+  name: string;
+  kind?: string;
+  description?: string;
+  default?: unknown;
+}
+
+export interface ParamInfo {
+  name: string;
+  type: string;
+  default?: unknown;
+}
+
+export interface CatalogEntry {
+  type: string;
+  title: string;
+  description: string;
+  inputs: PortInfo[];
+  outputs: PortInfo[];
+  params: ParamInfo[];
+}
+
+const portInfo = (p: PortSpec): PortInfo => ({
+  name: p.name,
+  kind: p.kind,
+  description: p.description,
+  default: p.default,
+});
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const TYPE_NAMES: Record<string, string> = {
+  ZodNumber: 'number',
+  ZodString: 'string',
+  ZodBoolean: 'boolean',
+  ZodArray: 'array',
+  ZodObject: 'object',
+  ZodAny: 'any',
+  ZodUnknown: 'unknown',
+};
+
+/** Unwrap wrapper Zod types (effects/optional/default/nullable) to the inner ZodObject. */
+function unwrapToObject(schema: any): any | null {
+  let s = schema;
+  for (let i = 0; i < 6 && s && s._def; i++) {
+    const tn = s._def.typeName;
+    if (tn === 'ZodObject') return s;
+    if (tn === 'ZodEffects') s = s._def.schema;
+    else if (tn === 'ZodDefault' || tn === 'ZodOptional' || tn === 'ZodNullable') s = s._def.innerType;
+    else break;
+  }
+  return s && s._def && s._def.typeName === 'ZodObject' ? s : null;
+}
+
+function paramInfo(name: string, field: any): ParamInfo {
+  let f = field;
+  let def: unknown;
+  for (let i = 0; i < 6 && f && f._def; i++) {
+    const tn = f._def.typeName;
+    if (tn === 'ZodDefault') {
+      try {
+        def = f._def.defaultValue();
+      } catch {
+        /* ignore */
+      }
+      f = f._def.innerType;
+    } else if (tn === 'ZodOptional' || tn === 'ZodNullable') {
+      f = f._def.innerType;
+    } else {
+      break;
+    }
+  }
+  const tn = f && f._def ? f._def.typeName : 'unknown';
+  let type = TYPE_NAMES[tn] ?? String(tn).replace(/^Zod/, '').toLowerCase();
+  if (tn === 'ZodEnum') {
+    const values = (f._def.values as string[]) ?? [];
+    type = `enum(${values.join(' | ')})`;
+  }
+  return { name, type, default: def };
+}
+
+function paramsOf(def: NodeDef): ParamInfo[] {
+  try {
+    const obj = unwrapToObject(def.params as any);
+    if (!obj) return [];
+    const shape = typeof obj._def.shape === 'function' ? obj._def.shape() : obj.shape;
+    return Object.entries(shape).map(([name, field]) => paramInfo(name, field));
+  } catch {
+    return [];
+  }
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+/** Build the catalog from a registry (sorted by node type for stable output). */
+export function buildCatalog(registry: NodeRegistry): CatalogEntry[] {
+  return registry
+    .list()
+    .map((def) => ({
+      type: def.type,
+      title: def.title ?? def.type,
+      description: def.description ?? '',
+      inputs: def.inputs.map(portInfo),
+      outputs: def.outputs.map(portInfo),
+      params: paramsOf(def),
+    }))
+    .sort((a, b) => a.type.localeCompare(b.type));
+}

--- a/test/catalog.test.ts
+++ b/test/catalog.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Tests the catalog generator: it introspects the node registry into accurate,
+ * serializable node descriptions (ports + params), which the user-facing manual
+ * is generated from. Guards that the manual can't drift from the code.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildCatalog } from '@/catalog';
+import { createCoreRegistry } from '@/nodes';
+
+const catalog = buildCatalog(createCoreRegistry());
+const byType = Object.fromEntries(catalog.map((e) => [e.type, e]));
+
+describe('buildCatalog', () => {
+  it('covers every registered node with title + description', () => {
+    expect(catalog.length).toBe(createCoreRegistry().list().length);
+    expect(catalog.every((e) => e.title.length > 0 && e.description.length > 0)).toBe(true);
+    // a few expected members
+    for (const t of ['voice-mapping', 'chord', 'progression', 'face-features', 'gesture-classifier', 'transport']) {
+      expect(byType[t]).toBeTruthy();
+    }
+  });
+
+  it('captures ports with names/kinds/descriptions', () => {
+    const vm = byType['voice-mapping'];
+    expect(vm.inputs.map((p) => p.name)).toContain('features');
+    expect(vm.outputs.map((p) => p.name)).toContain('params');
+    const ind = byType['indirect-map'];
+    expect(ind.inputs.map((p) => p.name)).toEqual(expect.arrayContaining(['features', 'face']));
+  });
+
+  it('extracts params with types + defaults (incl. refined schemas)', () => {
+    // chord: plain ZodObject with defaults
+    const chord = byType['chord'];
+    const baseOctave = chord.params.find((p) => p.name === 'baseOctave');
+    expect(baseOctave).toMatchObject({ type: 'number', default: 4 });
+
+    // hand-features: a refined (ZodEffects) schema — unwrap must still find params
+    const hf = byType['hand-features'];
+    const names = hf.params.map((p) => p.name);
+    expect(names).toEqual(expect.arrayContaining(['mirrorX', 'opennessMin', 'pinchApart']));
+    expect(hf.params.find((p) => p.name === 'opennessMin')).toMatchObject({ type: 'number', default: 1.3 });
+
+    // an enum param surfaces its options
+    const inst = byType['voice-mapping']; // has nested objects; ensure no throw + some params
+    expect(inst.params.length).toBeGreaterThan(0);
+  });
+
+  it('is JSON-serializable (for the frontend manual)', () => {
+    expect(() => JSON.stringify(catalog)).not.toThrow();
+  });
+});


### PR DESCRIPTION
Answers *'is there a manual accessible from the frontend so we know all the possibilities?'* — yes, and **generated from the node registry (SSOT)** so it never drifts from the code.

- **`src/catalog.ts`** `buildCatalog(registry)` introspects every node → serializable {type, title, description, inputs, outputs, params} (unwraps Zod effects/defaults to read param types + defaults). Pure + tested.
- **`npm run catalog`** (`scripts/gen_catalog.ts`) emits:
  - `docs/CATALOG.md` — markdown manual (repo browsing)
  - `public/manual.html` — **self-contained styled manual**; Vite copies `public/` into the build, so the deployed app serves it at **`/thoremin/manual.html`**
  - `public/catalog.json` — machine catalog for a future in-app node browser
- Includes a capabilities overview + **example pipelines** (theremin, gesture→harmony, conductor, indirect/AI, discrete triggers) + all 20 nodes grouped by layer (ports + params).
- `test/catalog.test.ts`: coverage, ports, param/default extraction (incl. the refined `hand-features` schema), JSON-serializability. **73 tests total.**

typecheck + build green; `manual.html`/`catalog.json` land in `frontend/` on build. Will be live at `/thoremin/manual.html` after a deploy.