### PR TITLE
Fix confirmed findings from adversarial review #2

### DIFF
--- a/src/nodes/mapping/indirect_map.ts
+++ b/src/nodes/mapping/indirect_map.ts
@@ -24,7 +24,9 @@ const FeatureRef = z.object({
    * Feature name. hand: x | y | openness | pinch. face: smile | mouthOpen |
    * browRaise | browFurrow | eyeBlink.
    */
-  feature: z.string().default('openness'),
+  feature: z
+    .enum(['x', 'y', 'openness', 'pinch', 'smile', 'mouthOpen', 'browRaise', 'browFurrow', 'eyeBlink'])
+    .default('openness'),
   inMin: z.number().default(0),
   inMax: z.number().default(1),
 });

--- a/src/nodes/music/progression.ts
+++ b/src/nodes/music/progression.ts
@@ -11,12 +11,19 @@ import { z } from 'zod';
 import { Key } from 'tonal';
 import { defineNode } from '@/dag';
 
-const Params = z.object({
-  /** Tonic key for the Roman-numeral progression, e.g. "C", "G", "Eb". */
-  key: z.string().default('C'),
-  /** The progression as Roman numerals. */
-  romanNumerals: z.array(z.string()).default(['I', 'IV', 'V', 'vi']),
-});
+const Params = z
+  .object({
+    /** Tonic key for the Roman-numeral progression, e.g. "C", "G", "Eb". */
+    key: z.string().default('C'),
+    /** The progression as Roman numerals. */
+    romanNumerals: z.array(z.string()).default(['I', 'IV', 'V', 'vi']),
+  })
+  // Fail fast on a key Tonal can't resolve to 7 diatonic triads (e.g. 'H',
+  // 'Dm', '') — otherwise it would silently degrade to a single-chord loop.
+  .refine((p) => Key.majorKey(p.key).triads.length === 7, {
+    message: 'key must be a valid major key (e.g. "C", "G", "Eb")',
+    path: ['key'],
+  });
 type Params = z.infer<typeof Params>;
 
 function clamp01(v: number): number {

--- a/test/catalog.test.ts
+++ b/test/catalog.test.ts
@@ -40,12 +40,28 @@ describe('buildCatalog', () => {
     expect(names).toEqual(expect.arrayContaining(['mirrorX', 'opennessMin', 'pinchApart']));
     expect(hf.params.find((p) => p.name === 'opennessMin')).toMatchObject({ type: 'number', default: 1.3 });
 
-    // an enum param surfaces its options
-    const inst = byType['voice-mapping']; // has nested objects; ensure no throw + some params
-    expect(inst.params.length).toBeGreaterThan(0);
+    // voice-mapping has nested ZodObject params (right/left) — introspection
+    // must surface every top-level param name, not silently drop them.
+    const vm = byType['voice-mapping'];
+    expect(vm.params.map((p) => p.name)).toEqual(
+      expect.arrayContaining(['magnetism', 'maxGain', 'opennessGatesGain', 'right', 'left']),
+    );
   });
 
   it('is JSON-serializable (for the frontend manual)', () => {
     expect(() => JSON.stringify(catalog)).not.toThrow();
+  });
+
+  it('introspects the FULL app registry (incl. browser nodes) without dropping or throwing', async () => {
+    // Resilience: buildCatalog must never throw on any registered node's schema,
+    // and must cover every node — guards the try/catch fallback in paramsOf from
+    // silently hiding a broken introspection path.
+    const { createAppRegistry } = await import('@/nodes/browser');
+    const appReg = createAppRegistry();
+    const full = buildCatalog(appReg);
+    expect(full.length).toBe(appReg.list().length);
+    expect(full.every((e) => e.title.length > 0 && e.description.length > 0)).toBe(true);
+    // every entry has well-formed (array) port/param lists
+    expect(full.every((e) => Array.isArray(e.inputs) && Array.isArray(e.outputs) && Array.isArray(e.params))).toBe(true);
   });
 });

--- a/test/dag_core.test.ts
+++ b/test/dag_core.test.ts
@@ -159,7 +159,7 @@ describe('Recording & replay', () => {
   it('replays a recorded stream into a downstream node in isolation', async () => {
     // Pretend "c.n" was recorded earlier; replay it into a fresh affine node.
     const recordedA = [0, 2, 4, 6];
-    const outs = await replayNode(affine.make({ gain: 5 }), { a: recordedA });
+    const outs = await replayNode(affine.make(affine.params.parse({ gain: 5 })), { a: recordedA });
     expect(outs.map((o) => o.out)).toEqual([0, 10, 20, 30]);
   });
 });

--- a/test/music_logic.test.ts
+++ b/test/music_logic.test.ts
@@ -42,31 +42,39 @@ describe('progression node', () => {
     expect(outs.map((o) => o.chord)).toEqual(['C', 'F', 'G', 'Am']);
     expect(outs.map((o) => o.index)).toEqual([0, 1, 2, 3]);
   });
+
+  it('validates the key — rejects non-major / invalid keys at parse', () => {
+    expect(() => progressionNode.params.parse({ key: 'Eb' })).not.toThrow();
+    for (const bad of ['H', 'Dm', '', 'nonsense']) {
+      expect(() => progressionNode.params.parse({ key: bad })).toThrow();
+    }
+  });
 });
 
 describe('gesture → harmony chain (DAG)', () => {
-  it('hand x sweep walks the progression and the chord notes change', async () => {
+  it('hand x sweep (via pick) walks the progression so the chord changes', async () => {
     const spec: GraphSpec = {
       nodes: [
         { id: 'src', type: 'synthetic-hands', params: { hands: 'right', sweepPeriod: 4 } },
         { id: 'feat', type: 'hand-features', params: { mirrorX: false, mirrorHandedness: false } },
-        // pull the right-hand x out of features into a bare number for `position`
+        { id: 'x', type: 'pick', params: { path: 'right.x' } }, // scalar adapter: features → position
         { id: 'prog', type: 'progression', params: { key: 'C', romanNumerals: ['I', 'IV', 'V', 'vi'] } },
         { id: 'chord', type: 'chord', params: { baseOctave: 4, maxVoices: 4 } },
       ],
       edges: [
         { from: { node: 'src', port: 'hands' }, to: { node: 'feat', port: 'hands' } },
-        // feat.features → prog.position needs the scalar x; an adapter node would
-        // normally do this, but here we drive progression directly in a focused
-        // unit test below. This DAG asserts the chord stage runs end-to-end.
+        { from: { node: 'feat', port: 'features' }, to: { node: 'x', port: 'in' } },
+        { from: { node: 'x', port: 'value' }, to: { node: 'prog', port: 'position' } },
         { from: { node: 'prog', port: 'chord' }, to: { node: 'chord', port: 'chord' } },
       ],
     };
-    const { recorder } = await runHeadless(spec, createCoreRegistry(), { ticks: 30, nominalDt: 1 / 30 });
-    // progression with no position input holds index 0 → chord "C" → 3 voices.
+    const { recorder } = await runHeadless(spec, createCoreRegistry(), { ticks: 60, nominalDt: 1 / 30 });
+
+    const chords = recorder.values('prog.chord') as string[];
+    expect(new Set(chords).size).toBeGreaterThan(1); // the sweep actually changes chords
+    expect(chords.every((c) => ['C', 'F', 'G', 'Am'].includes(c))).toBe(true); // stays in-key
     const params = recorder.values('chord.params') as SynthParams[];
-    expect(params.length).toBe(30);
-    expect(params[10].voices.length).toBeGreaterThanOrEqual(3);
+    expect(params.every((p) => p.voices.length >= 3)).toBe(true); // each chord is voiced
   });
 
   it('driving progression position directly walks chords → distinct chord note sets', async () => {


### PR DESCRIPTION
Second multi-agent adversarial review (5 dimensions → **14 findings → 7 confirmed** after per-finding refutation) of everything added since #25. Fixes:

- **[high]** `music_logic` gesture→harmony DAG test was misleading — it never connected `feat.features → progression.position`, so the progression stayed on chord 'C' and the test would pass even if progression were broken. Now wired through the `pick` adapter; asserts the chord actually changes + stays in-key.
- **[med]** `progression` silently degraded on an invalid/non-major key. Added a Zod `.refine()` (rejects keys that don't yield 7 diatonic triads) + a key-validation test.
- **[med]** `indirect-map` `feature` was an unconstrained string — a typo silently mapped to 0. Now a `z.enum` of the valid hand+face feature names.
- **[med]** catalog tests strengthened: assert voice-mapping's nested-object params by name + a resilience test (buildCatalog over the full app registry, no drops/throws).
- **[low]** `dag_core` test `make()` without `params.parse()` — fixed.

Removed a stray demonstration test a verify-agent left behind. The other 7 findings were refuted. **75 tests, typecheck + build green.**