### PR TITLE
one-euro filter — adaptive jitter smoothing

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -21,7 +21,7 @@ This page catalogs the engine's building blocks — every node and how they conn
 - **Discrete triggers** — `hand-features → gesture-classifier → (events)`  
   Fist/open/pinch poses emit enter/exit events to trigger scale changes, stabs, mutes.
 
-## Nodes (20)
+## Nodes (21)
 
 ### Inputs (sources)
 _Where signals enter the graph._
@@ -115,6 +115,13 @@ Extract a scalar from a structured input by dotted path (e.g. right.x).
 - **in:** in:any
 - **out:** value:number
 - **params:** path (string=""), default (number=0)
+
+#### `one-euro` — One-Euro Filter
+Adaptive jitter smoothing for a noisy control value (smooth at rest, responsive when fast).
+
+- **in:** value:number
+- **out:** value:number
+- **params:** minCutoff (number=1), beta (number=0.01), dCutoff (number=1), fallbackDt (number=0.016666666666666666)
 
 ### Music logic (tonal guidance)
 _Harmony kept in-key._

--- a/docs/DAG_NODES.md
+++ b/docs/DAG_NODES.md
@@ -32,7 +32,9 @@ Build a registry with `createCoreRegistry()` (pure nodes) or `createAppRegistry(
 |-------------|-------|--------|---------|---------|
 | `voice-mapping` | ✅ | `features`; live overrides: `magnetism`, `octaveShift`, `mute`, `scaleRight`, `scaleLeft`, `instrumentRight`, `instrumentLeft` | `params: SynthParams` | **Direct** mapping: x→pitch (scale-snapped by magnetism), y→volume. Two voices (0=right, 1=left). |
 | `keyboard-control` | ✅ | `pressed: string[]` | `octaveShift`, `magnetism`, `mute` | Interprets key presses (arrows, `m`) into musical control values. |
-| `indirect-map` | ✅ | `features` (hand), `face` (expressions) | `steer: GenerativeSteer` | **Indirect** mapping: hand features AND/OR face expressions → weighted text prompts + config dials (density/brightness/bpm), with optional smoothing + throttle. Each strain/dial picks its `source` (`hand`/`face`) + `feature`. Steers a generative engine. |
+| `indirect-map` | ✅ | `features` (hand), `face` (expressions) | `steer: GenerativeSteer` | **Indirect** mapping: hand features AND/OR face expressions → weighted text prompts + config dials (density/brightness/bpm), with optional smoothing + throttle. Each strain/dial picks its `source` (`hand`/`face`) + `feature` (enum-validated). Steers a generative engine. |
+| `pick` | ✅ | `in` (any) | `value: number` | Adapter: extract a scalar from a structured input by dotted path (e.g. `right.x` from HandFeatures). Bridges object-output nodes to scalar-input nodes. |
+| `one-euro` | ✅ | `value: number` | `value: number` | The 1€ filter — adaptive jitter smoothing (smooth at rest, responsive on fast moves). Drop between a feature and a mapping to de-noise gesture input. |
 
 ## Music-logic (tonal guidance — Tonal.js)
 
@@ -67,8 +69,8 @@ Build a registry with `createCoreRegistry()` (pure nodes) or `createAppRegistry(
 
 ## Planned nodes (see ROADMAP)
 
-`webcam-face` (browser FaceLandmarker source), `pose-features`
-(discrete events), `voicing` (smarter voice-leading),
-`midi-in`/`midi-out` (WEBMIDI.js), signal conditioners
-(one-euro filter, hysteresis, debounce), and a small adapter to feed a scalar
-feature (e.g. hand x) into `progression.position`.
+`webcam-face` (browser FaceLandmarker source), `pose-features` (body pose),
+`voicing` (smarter voice-leading), `midi-in`/`midi-out` (WEBMIDI.js), and other
+signal conditioners (hysteresis, debounce). The biggest remaining piece is the
+**M3 live-app wiring** — running the deployed app through the DAG (needs a
+browser session: camera + Gemini key).

--- a/public/catalog.json
+++ b/public/catalog.json
@@ -352,6 +352,46 @@
     ]
   },
   {
+    "type": "one-euro",
+    "title": "One-Euro Filter",
+    "description": "Adaptive jitter smoothing for a noisy control value (smooth at rest, responsive when fast).",
+    "inputs": [
+      {
+        "name": "value",
+        "kind": "number",
+        "default": 0
+      }
+    ],
+    "outputs": [
+      {
+        "name": "value",
+        "kind": "number"
+      }
+    ],
+    "params": [
+      {
+        "name": "minCutoff",
+        "type": "number",
+        "default": 1
+      },
+      {
+        "name": "beta",
+        "type": "number",
+        "default": 0.01
+      },
+      {
+        "name": "dCutoff",
+        "type": "number",
+        "default": 1
+      },
+      {
+        "name": "fallbackDt",
+        "type": "number",
+        "default": 0.016666666666666666
+      }
+    ]
+  },
+  {
     "type": "performance",
     "title": "Performance",
     "description": "Control signal → tempo (bpm) + dynamics (velocityScale), with optional humanization.",

--- a/public/manual.html
+++ b/public/manual.html
@@ -23,7 +23,7 @@
   .examples code { color: #7dd3fc; } .note { color: #9aa; font-size: 13px; }
 </style></head><body><div class="wrap">
   <h1>θ Thoremin — Capabilities Manual</h1>
-  <p class="gen">Auto-generated from the node registry. 20 nodes.</p>
+  <p class="gen">Auto-generated from the node registry. 21 nodes.</p>
   <p>Thoremin turns live sensor streams (webcam hand gestures, facial expressions, computer keyboard, later MIDI) into a live audiovisual stream — musical audio plus the captured video with overlaid guides. You build instruments by wiring small, typed <b>nodes</b> into a dataflow graph (DAG): inputs → features → mapping → music-logic → synthesis/generation → output. Every edge can be recorded and replayed.</p><p>The mapping layer spans a spectrum: <b>direct</b> (a gesture *is* a note/parameter — e.g. hand position → scale-snapped pitch) through <b>indirect</b> (a gesture expresses a high-level idea — e.g. openness → musical density steering an AI model), including <b>conductor</b> mode (direct a fixed piece's tempo and dynamics).</p><p>This page catalogs the engine's building blocks — every node and how they connect. Some already run in the deployed app; wiring the full graph into the live instrument is in progress.</p>
   <h3>Example pipelines</h3>
   <ul class="examples"><li><b>Theremin (direct)</b> — <code>webcam-hands → hand-features → voice-mapping → webaudio-synth ( + canvas-overlay)</code><br/><span class="note">Hand x → scale-snapped pitch, y → volume. Two hands = two voices.</span></li><li><b>Gesture → harmony</b> — <code>hand-features → pick('right.x') → progression → chord → webaudio-synth</code><br/><span class="note">Hand position walks an in-key chord progression.</span></li><li><b>Conductor</b> — <code>control → performance → transport → score → webaudio-synth</code><br/><span class="note">A control signal directs a fixed piece's tempo + dynamics (accelerando/crescendo…).</span></li><li><b>Indirect / AI (gesture or expression)</b> — <code>hand-features / face-features → indirect-map → lyria</code><br/><span class="note">Openness/smile/etc. steer weighted prompts + dials of Google Lyria RealTime.</span></li><li><b>Discrete triggers</b> — <code>hand-features → gesture-classifier → (events)</code><br/><span class="note">Fist/open/pinch poses emit enter/exit events to trigger scale changes, stabs, mutes.</span></li></ul>
@@ -136,6 +136,15 @@
         <dt>in</dt><dd>in:any</dd>
         <dt>out</dt><dd>value:number</dd>
         <dt>params</dt><dd>path (string=""), default (number=0)</dd>
+      </dl>
+    </div>
+    <div class="node">
+      <h4><code>one-euro</code> <span class="title">One-Euro Filter</span></h4>
+      <p>Adaptive jitter smoothing for a noisy control value (smooth at rest, responsive when fast).</p>
+      <dl>
+        <dt>in</dt><dd>value:number</dd>
+        <dt>out</dt><dd>value:number</dd>
+        <dt>params</dt><dd>minCutoff (number=1), beta (number=0.01), dCutoff (number=1), fallbackDt (number=0.016666666666666666)</dd>
       </dl>
     </div></div></section>
 <section><h3>Music logic (tonal guidance)</h3><p class="blurb">Harmony kept in-key.</p><div class="grid">

--- a/scripts/gen_catalog.ts
+++ b/scripts/gen_catalog.ts
@@ -20,7 +20,7 @@ const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const CATEGORIES: Array<{ name: string; blurb: string; types: string[] }> = [
   { name: 'Inputs (sources)', blurb: 'Where signals enter the graph.', types: ['webcam-hands', 'keyboard-source', 'store-controls', 'synthetic-hands', 'replay-source'] },
   { name: 'Features', blurb: 'Raw sensor data → normalized control signals.', types: ['hand-features', 'face-features', 'gesture-classifier'] },
-  { name: 'Mapping (direct ↔ indirect)', blurb: 'Features → engine parameters, across the expression spectrum.', types: ['voice-mapping', 'indirect-map', 'keyboard-control', 'pick'] },
+  { name: 'Mapping (direct ↔ indirect)', blurb: 'Features → engine parameters, across the expression spectrum.', types: ['voice-mapping', 'indirect-map', 'keyboard-control', 'pick', 'one-euro'] },
   { name: 'Music logic (tonal guidance)', blurb: 'Harmony kept in-key.', types: ['chord', 'progression'] },
   { name: 'Conductor mode', blurb: 'Direct a fixed piece with gesture (tempo + dynamics).', types: ['transport', 'score', 'performance'] },
   { name: 'Synthesis & generation', blurb: 'Make sound — direct synthesis or steered AI music.', types: ['webaudio-synth', 'lyria'] },

--- a/src/nodes/index.ts
+++ b/src/nodes/index.ts
@@ -17,6 +17,7 @@ import { voiceMappingNode } from './mapping/voice_mapping';
 import { keyboardControlNode } from './mapping/keyboard_control';
 import { indirectMapNode } from './mapping/indirect_map';
 import { pickNode } from './mapping/pick';
+import { oneEuroNode } from './mapping/one_euro';
 import { lyriaNode } from './output/lyria';
 import { chordNode } from './music/chord';
 import { progressionNode } from './music/progression';
@@ -34,6 +35,7 @@ export { voiceMappingNode } from './mapping/voice_mapping';
 export { keyboardControlNode } from './mapping/keyboard_control';
 export { indirectMapNode } from './mapping/indirect_map';
 export { pickNode } from './mapping/pick';
+export { oneEuroNode } from './mapping/one_euro';
 export { lyriaNode } from './output/lyria';
 export { chordNode, voiceChord } from './music/chord';
 export { progressionNode } from './music/progression';
@@ -54,6 +56,7 @@ export const CORE_NODES = [
   keyboardControlNode,
   indirectMapNode,
   pickNode,
+  oneEuroNode,
   lyriaNode,
   chordNode,
   progressionNode,

--- a/src/nodes/mapping/one_euro.ts
+++ b/src/nodes/mapping/one_euro.ts
@@ -1,0 +1,62 @@
+/**
+ * `one-euro` node — the 1€ filter (Casiez et al. 2012) for smoothing a noisy
+ * real-time control signal. Landmark trackers jitter; naive low-pass smoothing
+ * adds lag. The 1€ filter adapts its cutoff to signal speed: heavy smoothing
+ * when the hand is still (kills jitter), light smoothing when moving fast (stays
+ * responsive). Drop it between a feature and a mapping, e.g.
+ * `pick('right.x') → one-euro → progression.position`.
+ *
+ * Pure + deterministic (uses ctx.dt as the timestep), so it replays exactly.
+ */
+import { z } from 'zod';
+import { defineNode } from '@/dag';
+import type { NodeContext } from '@/dag';
+
+const Params = z.object({
+  /** Cutoff (Hz) at rest. Lower = smoother (more lag) when the signal is still. */
+  minCutoff: z.number().min(0).default(1.0),
+  /** Speed coefficient. Higher = more responsive on fast moves (less lag). */
+  beta: z.number().min(0).default(0.01),
+  /** Cutoff (Hz) for the derivative estimate. */
+  dCutoff: z.number().min(0).default(1.0),
+  /** Fallback dt (seconds) when ctx.dt is 0 (e.g. the first tick). */
+  fallbackDt: z.number().min(1e-6).default(1 / 60),
+});
+type Params = z.infer<typeof Params>;
+
+/** Smoothing factor for a low-pass with the given cutoff and timestep. */
+function smoothingAlpha(cutoffHz: number, dt: number): number {
+  const tau = 1 / (2 * Math.PI * cutoffHz);
+  return 1 / (1 + tau / dt);
+}
+
+export const oneEuroNode = defineNode<Params>({
+  type: 'one-euro',
+  title: 'One-Euro Filter',
+  description: 'Adaptive jitter smoothing for a noisy control value (smooth at rest, responsive when fast).',
+  inputs: [{ name: 'value', kind: 'number', default: 0 }],
+  outputs: [{ name: 'value', kind: 'number' }],
+  params: Params,
+  make(p) {
+    let xPrev: number | undefined;
+    let dxPrev = 0;
+    return {
+      process(inputs, ctx: NodeContext) {
+        const x = typeof inputs.value === 'number' && Number.isFinite(inputs.value) ? inputs.value : 0;
+        const dt = ctx.dt > 0 ? ctx.dt : p.fallbackDt;
+        if (xPrev === undefined) {
+          xPrev = x;
+          dxPrev = 0;
+          return { value: x };
+        }
+        const dx = (x - xPrev) / dt;
+        const dxHat = dxPrev + smoothingAlpha(p.dCutoff, dt) * (dx - dxPrev);
+        const cutoff = p.minCutoff + p.beta * Math.abs(dxHat);
+        const xHat = xPrev + smoothingAlpha(cutoff, dt) * (x - xPrev);
+        xPrev = xHat;
+        dxPrev = dxHat;
+        return { value: xHat };
+      },
+    };
+  },
+});

--- a/test/one_euro.test.ts
+++ b/test/one_euro.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Tests the one-euro filter: passes the first sample through, holds a constant,
+ * reduces jitter (variance) while still tracking a step change, and is
+ * deterministic given the tick timing.
+ */
+import { describe, it, expect } from 'vitest';
+import { replayNode } from '@/dag';
+import { oneEuroNode } from '@/nodes';
+
+const variance = (xs: number[]) => {
+  const m = xs.reduce((a, b) => a + b, 0) / xs.length;
+  return xs.reduce((a, b) => a + (b - m) ** 2, 0) / xs.length;
+};
+
+const run = (values: number[], dt = 1 / 60) =>
+  replayNode(oneEuroNode.make(oneEuroNode.params.parse({})), { value: values }, { dt }).then((o) =>
+    o.map((r) => r.value as number),
+  );
+
+describe('one-euro filter', () => {
+  it('passes the first sample through and holds a constant', async () => {
+    const out = await run(Array(20).fill(0.7));
+    expect(out[0]).toBe(0.7);
+    expect(out.every((v) => Math.abs(v - 0.7) < 1e-9)).toBe(true);
+  });
+
+  it('reduces jitter: output variance << input variance', async () => {
+    const noisy = Array.from({ length: 80 }, (_, i) => 0.5 + (i % 2 === 0 ? 0.12 : -0.12)); // ±0.12 chatter
+    const out = await run(noisy);
+    // ignore the warm-up; compare steady-state variance
+    expect(variance(out.slice(20))).toBeLessThan(variance(noisy.slice(20)) * 0.25);
+    // still centered around the mean
+    expect(Math.abs(out[60] - 0.5)).toBeLessThan(0.1);
+  });
+
+  it('still tracks a step change (responsive, not stuck)', async () => {
+    const step = [...Array(30).fill(0), ...Array(90).fill(1)];
+    const out = await run(step);
+    expect(out[20]).toBeLessThan(0.1); // settled low before the step
+    expect(out[out.length - 1]).toBeGreaterThan(0.9); // reached the new level
+    // a higher beta tracks faster than a lower one
+    const slow = (await replayNode(oneEuroNode.make(oneEuroNode.params.parse({ beta: 0 })), { value: step })).map((r) => r.value as number);
+    const fast = (await replayNode(oneEuroNode.make(oneEuroNode.params.parse({ beta: 2 })), { value: step })).map((r) => r.value as number);
+    expect(fast[45]).toBeGreaterThan(slow[45]);
+  });
+
+  it('is deterministic', async () => {
+    const sig = Array.from({ length: 40 }, (_, i) => Math.sin(i / 5) + (i % 3 ? 0.05 : -0.05));
+    expect(await run(sig)).toEqual(await run(sig));
+  });
+});


### PR DESCRIPTION
The 1€ filter (Casiez et al. 2012) for de-noising a noisy real-time control signal — heavy smoothing at rest (kills tracker jitter), light when moving fast (stays responsive). Drop between a feature and a mapping, e.g. `pick('right.x') → one-euro → progression.position`. Materially improves the live-instrument feel.

- `one-euro` node (pure, deterministic via `ctx.dt`). Registered.
- `test/one_euro.test.ts`: pass-through first sample, hold constant, variance reduction vs input, tracks a step (higher beta tracks faster), deterministic.
- Regenerated the manual (now **21 nodes**; one-euro under Mapping) + updated `docs/DAG_NODES.md` (added the missing `pick` + `one-euro` rows, pruned the planned list).

**79 tests**, typecheck + build green; additive.