### PR TITLE
feat(app): opt-in DAG instrument view via ?engine=dag (M3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,8 @@
         "react-dom": "^19.0.0",
         "tonal": "^6.4.0",
         "vite": "^6.2.0",
-        "zod": "^3.24.1"
+        "zod": "^3.24.1",
+        "zustand": "^5.0.14"
       },
       "devDependencies": {
         "@types/express": "^4.17.21",
@@ -6219,6 +6220,35 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
+      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -19,8 +19,6 @@
     "@google/genai": "^1.29.0",
     "@mediapipe/hands": "^0.4.1675469240",
     "@tailwindcss/vite": "^4.1.14",
-    "zod": "^3.24.1",
-    "tonal": "^6.4.0",
     "@tensorflow-models/hand-pose-detection": "^2.0.1",
     "@tensorflow/tfjs-backend-webgl": "^4.22.0",
     "@tensorflow/tfjs-converter": "^4.22.0",
@@ -33,7 +31,10 @@
     "motion": "^12.23.24",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "vite": "^6.2.0"
+    "tonal": "^6.4.0",
+    "vite": "^6.2.0",
+    "zod": "^3.24.1",
+    "zustand": "^5.0.14"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,0 +1,78 @@
+/**
+ * App — the Thoremin instrument view. Hosts the hidden webcam <video>, the
+ * overlay <canvas> the DAG draws to, the audio-start gesture button, and the
+ * live controls panel. All signal processing happens in the DAG engine via
+ * {@link useThoreminEngine}; this component is purely presentational + lifecycle.
+ */
+import { useThoreminEngine } from './useEngine';
+import ControlsPanel from './ControlsPanel';
+
+export default function App() {
+  const { videoRef, canvasRef, status, error, audioOn, startAudio } = useThoreminEngine();
+
+  return (
+    <div className="min-h-screen bg-[#0a0a0a] font-mono text-white">
+      <header className="flex items-center gap-3 border-b border-white/5 px-6 py-4">
+        <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-emerald-500 text-black font-black">θ</div>
+        <div>
+          <h1 className="text-base font-bold uppercase italic tracking-tighter">Thoremin</h1>
+          <p className="text-[10px] uppercase tracking-widest text-emerald-500/70">
+            DAG sonification · from anything to music
+          </p>
+        </div>
+        <span className="ml-auto text-[10px] uppercase tracking-widest text-white/40">
+          {status === 'loading' && 'loading neural engine…'}
+          {status === 'ready' && (audioOn ? 'live' : 'ready — start audio')}
+          {status === 'error' && 'error'}
+        </span>
+      </header>
+
+      <main className="flex flex-col items-start gap-6 p-6 lg:flex-row">
+        <div className="relative">
+          <video ref={videoRef} autoPlay playsInline muted className="hidden" />
+          <canvas
+            ref={canvasRef}
+            width={640}
+            height={480}
+            className="rounded-3xl border border-white/10 bg-black/40 shadow-2xl"
+          />
+
+          {status === 'loading' && (
+            <div className="absolute inset-0 flex items-center justify-center rounded-3xl bg-black/60 backdrop-blur-sm">
+              <div className="text-center">
+                <div className="mx-auto mb-3 h-12 w-12 animate-spin rounded-full border-4 border-emerald-500/30 border-t-emerald-500" />
+                <p className="text-xs uppercase tracking-widest text-emerald-500">Loading neural engine</p>
+              </div>
+            </div>
+          )}
+
+          {error && (
+            <div className="absolute inset-0 flex items-center justify-center rounded-3xl bg-red-500/10 p-6 text-center backdrop-blur">
+              <div>
+                <p className="mb-3 text-red-400">{error}</p>
+                <button
+                  onClick={() => window.location.reload()}
+                  className="rounded-full bg-red-500 px-5 py-2 text-xs font-bold uppercase tracking-widest"
+                >
+                  Retry
+                </button>
+              </div>
+            </div>
+          )}
+
+          <button
+            onClick={startAudio}
+            disabled={status !== 'ready' || audioOn}
+            className={`mt-4 w-full rounded-xl px-6 py-3 text-xs font-bold uppercase tracking-widest transition ${
+              audioOn ? 'bg-emerald-500/20 text-emerald-400' : 'bg-emerald-500 text-black hover:brightness-110'
+            } disabled:opacity-40`}
+          >
+            {audioOn ? '♪ audio engine active' : 'initialize audio engine'}
+          </button>
+        </div>
+
+        <ControlsPanel />
+      </main>
+    </div>
+  );
+}

--- a/src/app/ControlsPanel.tsx
+++ b/src/app/ControlsPanel.tsx
@@ -1,0 +1,104 @@
+/**
+ * ControlsPanel — schema-light UI bound to the Zustand control store. Changing
+ * any value updates the store; the `store-controls` DAG node reads it on the
+ * next tick, so edits take effect live without rebuilding the graph.
+ */
+import { NOTES, SCALE_TYPES, type ScaleTypeId } from '@/music/theory';
+import { useControls, type VoiceControl } from './store';
+
+const INSTRUMENTS: VoiceControl['instrument'][] = ['sine', 'square', 'sawtooth', 'triangle'];
+
+function VoiceControls({ side }: { side: 'right' | 'left' }) {
+  const voice = useControls((s) => s[side]);
+  const setVoice = useControls((s) => s.setVoice);
+  const color = side === 'right' ? 'text-emerald-400' : 'text-blue-400';
+
+  return (
+    <div className="space-y-2">
+      <h3 className={`text-xs font-bold uppercase tracking-widest ${color}`}>{side} hand</h3>
+      <label className="flex items-center justify-between gap-2 text-xs">
+        Root
+        <select
+          className="bg-white/10 rounded px-2 py-1"
+          value={voice.root}
+          onChange={(e) => setVoice(side, { root: Number(e.target.value) })}
+        >
+          {NOTES.map((n, i) => (
+            <option key={n} value={i}>{n}</option>
+          ))}
+        </select>
+      </label>
+      <label className="flex items-center justify-between gap-2 text-xs">
+        Scale
+        <select
+          className="bg-white/10 rounded px-2 py-1"
+          value={voice.type}
+          onChange={(e) => setVoice(side, { type: e.target.value as ScaleTypeId })}
+        >
+          {Object.entries(SCALE_TYPES).map(([id, s]) => (
+            <option key={id} value={id}>{s.name}</option>
+          ))}
+        </select>
+      </label>
+      <label className="flex items-center justify-between gap-2 text-xs">
+        Octaves
+        <input
+          type="range" min={1} max={4} step={1} value={voice.octaves}
+          onChange={(e) => setVoice(side, { octaves: Number(e.target.value) })}
+        />
+      </label>
+      <label className="flex items-center justify-between gap-2 text-xs">
+        Base octave
+        <input
+          type="range" min={1} max={5} step={1} value={voice.baseOctave}
+          onChange={(e) => setVoice(side, { baseOctave: Number(e.target.value) })}
+        />
+      </label>
+      <label className="flex items-center justify-between gap-2 text-xs">
+        Wave
+        <select
+          className="bg-white/10 rounded px-2 py-1"
+          value={voice.instrument}
+          onChange={(e) => setVoice(side, { instrument: e.target.value as VoiceControl['instrument'] })}
+        >
+          {INSTRUMENTS.map((i) => (
+            <option key={i} value={i}>{i}</option>
+          ))}
+        </select>
+      </label>
+    </div>
+  );
+}
+
+export default function ControlsPanel() {
+  const syncHands = useControls((s) => s.syncHands);
+  const setSync = useControls((s) => s.setSync);
+  const masterVolume = useControls((s) => s.masterVolume);
+  const setMasterVolume = useControls((s) => s.setMasterVolume);
+
+  return (
+    <div className="w-64 shrink-0 space-y-4 rounded-2xl border border-white/10 bg-black/40 p-4 backdrop-blur">
+      <div>
+        <label className="flex items-center justify-between gap-2 text-xs">
+          Master volume
+          <input
+            type="range" min={0} max={1} step={0.01} value={masterVolume}
+            onChange={(e) => setMasterVolume(Number(e.target.value))}
+          />
+        </label>
+        <label className="mt-2 flex items-center gap-2 text-xs">
+          <input type="checkbox" checked={syncHands} onChange={(e) => setSync(e.target.checked)} />
+          Sync both hands
+        </label>
+      </div>
+      <VoiceControls side="right" />
+      {!syncHands && <VoiceControls side="left" />}
+      <div className="border-t border-white/10 pt-3 text-[10px] leading-relaxed text-white/50">
+        <p className="mb-1 font-bold uppercase tracking-widest text-white/70">Keyboard</p>
+        <p>↑ / ↓ — octave shift</p>
+        <p>← / → — less / more scale-snap</p>
+        <p>m — mute</p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -1,0 +1,60 @@
+/**
+ * Zustand control store — the single source of truth for live UI controls.
+ * The React control panel writes here; the `store-controls` DAG node reads
+ * `getState()` each tick and emits the values onto the graph as port values.
+ * This keeps UI state out of the graph spec, so changing scale/instrument
+ * never rebuilds the engine or reloads the ML model.
+ */
+import { create } from 'zustand';
+import type { ScaleTypeId } from '@/music/theory';
+import type { VoiceParams } from '@/nodes';
+
+export interface VoiceControl {
+  root: number; // 0..11
+  type: ScaleTypeId;
+  octaves: number;
+  baseOctave: number;
+  instrument: VoiceParams['instrument'];
+}
+
+export interface ControlState {
+  right: VoiceControl;
+  left: VoiceControl;
+  syncHands: boolean;
+  masterVolume: number; // 0..1
+  setVoice(side: 'right' | 'left', patch: Partial<VoiceControl>): void;
+  setSync(v: boolean): void;
+  setMasterVolume(v: number): void;
+}
+
+const defaultVoice = (instrument: VoiceParams['instrument']): VoiceControl => ({
+  root: 0,
+  type: 'major',
+  octaves: 2,
+  baseOctave: 3,
+  instrument,
+});
+
+export const useControls = create<ControlState>((set) => ({
+  right: defaultVoice('sine'),
+  left: defaultVoice('triangle'),
+  syncHands: true,
+  masterVolume: 0.2,
+  setVoice: (side, patch) =>
+    set((s) => {
+      const next = { ...s[side], ...patch };
+      if (s.syncHands) {
+        // When synced, both hands share settings — including the patched
+        // instrument on the *addressed* hand — but each hand keeps its OWN
+        // instrument otherwise, so the two voices stay timbrally distinct.
+        const other = side === 'right' ? 'left' : 'right';
+        return {
+          [side]: next,
+          [other]: { ...next, instrument: s[other].instrument },
+        } as Pick<ControlState, 'right' | 'left'>;
+      }
+      return { [side]: next } as Pick<ControlState, 'right' | 'left'>;
+    }),
+  setSync: (v) => set({ syncHands: v }),
+  setMasterVolume: (v) => set({ masterVolume: v }),
+}));

--- a/src/app/useEngine.ts
+++ b/src/app/useEngine.ts
@@ -1,0 +1,126 @@
+/**
+ * useThoreminEngine — the React ↔ DAG bridge. Owns the webcam, the AudioContext
+ * (created lazily on a user gesture, as browsers require), builds the default
+ * graph against the browser registry, runs `engine.init()` (loads the ML model)
+ * and drives `engine.tick()` from a requestAnimationFrame loop. The engine and
+ * its nodes do the real work; this hook just supplies host resources and timing.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Engine } from '@/dag';
+import { createAppRegistry } from '@/nodes/browser';
+import { defaultGraph } from './graph';
+import { useControls } from './store';
+
+export type EngineStatus = 'idle' | 'loading' | 'ready' | 'error';
+
+export function useThoreminEngine() {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const engineRef = useRef<Engine | null>(null);
+  const resourcesRef = useRef<Record<string, unknown>>({});
+  const masterGainRef = useRef<GainNode | null>(null);
+  const rafRef = useRef<number | null>(null);
+
+  const [status, setStatus] = useState<EngineStatus>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [audioOn, setAudioOn] = useState(false);
+
+  const masterVolume = useControls((s) => s.masterVolume);
+
+  useEffect(() => {
+    let disposed = false;
+    // The acquired stream is held here (not read back off video.srcObject) so
+    // cleanup can always stop the exact stream this run acquired. Under React
+    // StrictMode the effect runs mount→cleanup→mount; an aborted run must stop
+    // its own stream and bail *before* building an engine (no leaked camera, no
+    // double model load, no clobbered engineRef).
+    let stream: MediaStream | null = null;
+    (async () => {
+      try {
+        setStatus('loading');
+        const video = videoRef.current!;
+        stream = await navigator.mediaDevices.getUserMedia({
+          video: { width: 640, height: 480 },
+          audio: false,
+        });
+        if (disposed) {
+          // Cleanup already ran (it saw stream === null), so stop it here.
+          stream.getTracks().forEach((t) => t.stop());
+          return;
+        }
+        video.srcObject = stream;
+        await new Promise<void>((resolve) => {
+          video.onloadedmetadata = () => {
+            void video.play();
+            resolve();
+          };
+        });
+        if (disposed) return; // cleanup stops the now-assigned stream
+
+        const resources = resourcesRef.current;
+        resources.video = video;
+        resources.canvas = canvasRef.current;
+        resources.window = window;
+        resources.controls = () => useControls.getState();
+
+        const engine = new Engine(defaultGraph(), createAppRegistry(), { resources });
+        await engine.init(); // loads the MediaPipe model
+        if (disposed) {
+          engine.dispose();
+          return;
+        }
+        engineRef.current = engine;
+        setStatus('ready');
+
+        const loop = () => {
+          engine.tick(performance.now() / 1000);
+          rafRef.current = requestAnimationFrame(loop);
+        };
+        rafRef.current = requestAnimationFrame(loop);
+      } catch (e) {
+        if (disposed) return;
+        console.error('[thoremin] engine setup failed', e);
+        setError(e instanceof Error ? e.message : String(e));
+        setStatus('error');
+      }
+    })();
+
+    return () => {
+      disposed = true;
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+      engineRef.current?.dispose();
+      engineRef.current = null;
+      stream?.getTracks().forEach((t) => t.stop());
+    };
+  }, []);
+
+  // Keep master gain synced to the UI volume.
+  useEffect(() => {
+    const ac = resourcesRef.current.audioContext as AudioContext | undefined;
+    if (masterGainRef.current && ac) {
+      masterGainRef.current.gain.setTargetAtTime(masterVolume, ac.currentTime, 0.05);
+    }
+  }, [masterVolume]);
+
+  const startAudio = useCallback(async () => {
+    const resources = resourcesRef.current;
+    let ac = resources.audioContext as AudioContext | undefined;
+    if (!ac) {
+      const Ctor = window.AudioContext || (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext;
+      ac = new Ctor({ latencyHint: 'interactive' });
+      const master = ac.createGain();
+      master.gain.setValueAtTime(useControls.getState().masterVolume, ac.currentTime);
+      master.connect(ac.destination);
+      resources.audioContext = ac;
+      resources.masterGain = master;
+      masterGainRef.current = master;
+    }
+    if (ac.state === 'suspended') await ac.resume();
+    setAudioOn(true);
+  }, []);
+
+  return { videoRef, canvasRef, status, error, audioOn, startAudio };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,31 @@
-import {StrictMode} from 'react';
+/**
+ * App entry — selects which front-end to mount.
+ *
+ * By default mounts the current production hand-theremin app (`./App`), exactly
+ * as before: a static import that paints synchronously from the entry bundle —
+ * the deployed default is untouched. Append `?engine=dag` to the URL to mount
+ * the DAG-driven instrument view (`./app/App`) instead — an opt-in alternate
+ * that runs the same gesture→audio path through the typed DAG engine. Only the
+ * DAG view is code-split (lazy), so it never weighs on the default path.
+ */
+import {StrictMode, Suspense, lazy} from 'react';
 import {createRoot} from 'react-dom/client';
-import App from './App.tsx';
+import DefaultApp from './App.tsx';
 import './index.css';
+
+const useDagEngine =
+  new URLSearchParams(window.location.search).get('engine') === 'dag';
+
+const DagApp = lazy(() => import('./app/App.tsx'));
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    {useDagEngine ? (
+      <Suspense fallback={null}>
+        <DagApp />
+      </Suspense>
+    ) : (
+      <DefaultApp />
+    )}
   </StrictMode>,
 );

--- a/test/app_store.test.ts
+++ b/test/app_store.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for the DAG app's control store and its bridge into the graph via the
+ * `store-controls` node — the only genuinely-new logic the opt-in `?engine=dag`
+ * view adds. Covers the Zustand store's reducers (sync behaviour, per-hand
+ * instruments) and the store → store-controls → (scale arrays + instruments)
+ * path the graph reads each tick. Pure + headless: no React render, camera, or
+ * audio. (The full graph's topology + clean tick are covered by app_graph.test.)
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useControls } from '@/app/store';
+import { storeControlsNode } from '@/nodes/browser';
+import { generateScale } from '@/music/theory';
+import type { NodeContext } from '@/dag';
+
+beforeEach(() => {
+  // The store is a module singleton; reset to its initial state per test.
+  useControls.setState(useControls.getInitialState(), true);
+});
+
+describe('control store', () => {
+  it('has sensible defaults', () => {
+    const s = useControls.getState();
+    expect(s.right.instrument).toBe('sine');
+    expect(s.left.instrument).toBe('triangle');
+    expect(s.syncHands).toBe(true);
+    expect(s.masterVolume).toBeCloseTo(0.2, 6);
+  });
+
+  it('setVoice with sync ON mirrors both hands but keeps instruments distinct', () => {
+    useControls.getState().setVoice('right', { root: 7, octaves: 4 });
+    const s = useControls.getState();
+    expect(s.right.root).toBe(7);
+    expect(s.left.root).toBe(7);
+    expect(s.right.octaves).toBe(4);
+    expect(s.left.octaves).toBe(4);
+    // Instruments stay per-hand even when synced.
+    expect(s.right.instrument).toBe('sine');
+    expect(s.left.instrument).toBe('triangle');
+  });
+
+  it('setVoice with sync ON applies the patched instrument to the addressed hand only', () => {
+    // Regression guard: changing the Wave (instrument) while synced — the only
+    // instrument control visible in the default (synced) state — must take
+    // effect on the addressed hand while the other hand keeps its own timbre.
+    useControls.getState().setVoice('right', { instrument: 'square' });
+    const s = useControls.getState();
+    expect(s.right.instrument).toBe('square');
+    expect(s.left.instrument).toBe('triangle');
+  });
+
+  it('setSync only flips the flag; it does not re-converge already-diverged hands', () => {
+    useControls.getState().setSync(false);
+    useControls.getState().setVoice('left', { root: 9 });
+    useControls.getState().setSync(true);
+    const s = useControls.getState();
+    // Re-enabling sync leaves the divergence in place until the next setVoice.
+    expect(s.syncHands).toBe(true);
+    expect(s.right.root).toBe(0);
+    expect(s.left.root).toBe(9);
+    // The next synced edit re-converges shared fields (instruments stay distinct).
+    useControls.getState().setVoice('right', { root: 4 });
+    const s2 = useControls.getState();
+    expect(s2.right.root).toBe(4);
+    expect(s2.left.root).toBe(4);
+    expect(s2.right.instrument).toBe('sine');
+    expect(s2.left.instrument).toBe('triangle');
+  });
+
+  it('setVoice with sync OFF changes only the addressed hand', () => {
+    useControls.getState().setSync(false);
+    useControls.getState().setVoice('right', { root: 5 });
+    const s = useControls.getState();
+    expect(s.right.root).toBe(5);
+    expect(s.left.root).toBe(0); // untouched default
+  });
+
+  it('setMasterVolume updates the master volume', () => {
+    useControls.getState().setMasterVolume(0.75);
+    expect(useControls.getState().masterVolume).toBeCloseTo(0.75, 6);
+  });
+});
+
+describe('store-controls node reads the store', () => {
+  const ctxWith = (resources: Record<string, unknown>): NodeContext => ({
+    tick: 0,
+    time: 0,
+    dt: 0,
+    resources,
+  });
+
+  it('emits scale arrays + instruments derived from the store snapshot', () => {
+    useControls.getState().setSync(false);
+    useControls.getState().setVoice('right', { root: 2, type: 'minor', instrument: 'square' });
+    useControls.getState().setVoice('left', { root: 9, instrument: 'sawtooth' });
+
+    const node = storeControlsNode.make(storeControlsNode.params.parse({}));
+    const out = node.process({}, ctxWith({ controls: () => useControls.getState() }));
+
+    const s = useControls.getState();
+    expect(out.instrumentRight).toBe('square');
+    expect(out.instrumentLeft).toBe('sawtooth');
+    expect(out.scaleRight).toEqual(generateScale(s.right));
+    expect(out.scaleLeft).toEqual(generateScale(s.left));
+    expect((out.scaleRight as number[]).length).toBeGreaterThan(0);
+  });
+
+  it('emits nothing when no controls getter is injected (safe before host wires it)', () => {
+    const node = storeControlsNode.make(storeControlsNode.params.parse({}));
+    expect(node.process({}, ctxWith({}))).toEqual({});
+  });
+});

--- a/tsconfig.dag.json
+++ b/tsconfig.dag.json
@@ -1,5 +1,5 @@
 {
-  "//": "Scoped strict typecheck for the DAG engine, node library, music helpers, tests and scripts. The deployable React app is built (and type-erased) by Vite; this config keeps the DAG layer honest without coupling to the app's looser config.",
+  "//": "Scoped strict typecheck for the DAG engine, node library, music helpers, the non-React DAG app glue (src/app/graph.ts; src/app/store.ts is pulled in transitively by tests), tests and scripts. The React layer (src/main.tsx, src/app/{App,ControlsPanel,useEngine}.tsx and the legacy wips app) is built and type-erased by Vite/esbuild — the project ships no @types/react — so it stays out of this config, which is Node-oriented (types: node + vitest).",
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "strict": true,


### PR DESCRIPTION
## M3 — wire the deployed app through the DAG, opt-in and risk-free

Visiting the app with **no query string** mounts the existing production app exactly as before (static import, synchronous mount — the deployed default is untouched). Visiting with **`?engine=dag`** lazily mounts a DAG-driven instrument view that runs the same gesture → audio path through the typed dataflow engine:

`webcam-hands → hand-features → voice-mapping → webaudio-synth` (+ `canvas-overlay`), steerable live by a zustand control store + keyboard.

### What's here
- `zustand` dep + the app shell (`src/app/{store,useEngine,App,ControlsPanel}.tsx`); `src/app/graph.ts` was already on main.
- `main.tsx`: default app static; only the DAG view is code-split (lazy).
- `tsconfig.dag.json` stays Node-oriented; `store.ts` gets strict coverage transitively via the new test. The React shell is built/type-erased by Vite (the project ships no `@types/react`), same as the existing app.

### Adversarial review (4 lenses → independent verification): 7 confirmed, 0 blockers
Three distinct issues, all fixed in this PR:
- **`useEngine` StrictMode/unmount-during-init race** — leaked the webcam `MediaStream` + clobbered `engineRef` + double-loaded the model. Now the stream is held in scope and stopped in cleanup; a disposed run stops its stream and bails before building the engine.
- **`store.setVoice` dead Wave selector while synced (the default)** — the patched instrument was silently dropped. Now it applies to the addressed hand; only the other hand keeps its own timbre. Regression test added.
- **`main.tsx`** — restored the old synchronous mount for the default; lazy only the DAG view.

### Gates
- Strict typecheck ✅ · **87 tests** ✅ · `vite build` ✅
- `test/app_store.test.ts` covers store reducers + the store-controls bridge; `app_graph.test.ts` covers headless graph topology.

### Not in scope
The Lyria generative path (the default graph has no `lyria` node) — that swap needs a browser + Gemini key and is a follow-up.

Refs #6.

https://claude.ai/code/session_01Gp5tDXPQZuM7WaetpZwxij