### PR TITLE
feat(dag-view): video-first UX, instrument presets, pentatonic default

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -131,7 +131,7 @@ Chord symbol (e.g. Cmaj7) → voiced synth params (one voice per chord tone).
 
 - **in:** chord:chord-symbol, gain:number
 - **out:** params:synth-params
-- **params:** baseOctave (number=4), maxVoices (number=4), instrument (enum(sine | square | sawtooth | triangle)="sine")
+- **params:** baseOctave (number=4), maxVoices (number=4), instrument (enum(sine | triangle | square | sawtooth | warmPad | glass | bell | organ | voice | softLead)="sine")
 
 #### `progression` — Progression
 Roman-numeral progression in a key + position (0..1) → current chord symbol.
@@ -155,7 +155,7 @@ An immutable piece performed live: beat + velocityScale → sounding synth voice
 
 - **in:** beat:number, velocityScale:number
 - **out:** params:synth-params
-- **params:** notes (array=[]), loopBeats (number=8), baseGain (number=0.4), instrument (enum(sine | square | sawtooth | triangle)="triangle")
+- **params:** notes (array=[]), loopBeats (number=8), baseGain (number=0.4), instrument (enum(sine | triangle | square | sawtooth | warmPad | glass | bell | organ | voice | softLead)="triangle")
 
 #### `performance` — Performance
 Control signal → tempo (bpm) + dynamics (velocityScale), with optional humanization.
@@ -168,7 +168,7 @@ Control signal → tempo (bpm) + dynamics (velocityScale), with optional humaniz
 _Make sound — direct synthesis or steered AI music._
 
 #### `webaudio-synth` — Web Audio Synth
-Renders synth params to oscillator voices (browser only).
+Renders synth params to instrument-preset voices (browser only).
 
 - **in:** params:synth-params
 - **out:** —

--- a/public/catalog.json
+++ b/public/catalog.json
@@ -67,7 +67,7 @@
       },
       {
         "name": "instrument",
-        "type": "enum(sine | square | sawtooth | triangle)",
+        "type": "enum(sine | triangle | square | sawtooth | warmPad | glass | bell | organ | voice | softLead)",
         "default": "sine"
       }
     ]
@@ -576,7 +576,7 @@
       },
       {
         "name": "instrument",
-        "type": "enum(sine | square | sawtooth | triangle)",
+        "type": "enum(sine | triangle | square | sawtooth | warmPad | glass | bell | organ | voice | softLead)",
         "default": "triangle"
       }
     ]
@@ -780,7 +780,7 @@
   {
     "type": "webaudio-synth",
     "title": "Web Audio Synth",
-    "description": "Renders synth params to oscillator voices (browser only).",
+    "description": "Renders synth params to instrument-preset voices (browser only).",
     "inputs": [
       {
         "name": "params",

--- a/public/manual.html
+++ b/public/manual.html
@@ -154,7 +154,7 @@
       <dl>
         <dt>in</dt><dd>chord:chord-symbol, gain:number</dd>
         <dt>out</dt><dd>params:synth-params</dd>
-        <dt>params</dt><dd>baseOctave (number=4), maxVoices (number=4), instrument (enum(sine | square | sawtooth | triangle)="sine")</dd>
+        <dt>params</dt><dd>baseOctave (number=4), maxVoices (number=4), instrument (enum(sine | triangle | square | sawtooth | warmPad | glass | bell | organ | voice | softLead)="sine")</dd>
       </dl>
     </div>
     <div class="node">
@@ -182,7 +182,7 @@
       <dl>
         <dt>in</dt><dd>beat:number, velocityScale:number</dd>
         <dt>out</dt><dd>params:synth-params</dd>
-        <dt>params</dt><dd>notes (array=[]), loopBeats (number=8), baseGain (number=0.4), instrument (enum(sine | square | sawtooth | triangle)="triangle")</dd>
+        <dt>params</dt><dd>notes (array=[]), loopBeats (number=8), baseGain (number=0.4), instrument (enum(sine | triangle | square | sawtooth | warmPad | glass | bell | organ | voice | softLead)="triangle")</dd>
       </dl>
     </div>
     <div class="node">
@@ -197,7 +197,7 @@
 <section><h3>Synthesis &amp; generation</h3><p class="blurb">Make sound — direct synthesis or steered AI music.</p><div class="grid">
     <div class="node">
       <h4><code>webaudio-synth</code> <span class="title">Web Audio Synth</span></h4>
-      <p>Renders synth params to oscillator voices (browser only).</p>
+      <p>Renders synth params to instrument-preset voices (browser only).</p>
       <dl>
         <dt>in</dt><dd>params:synth-params</dd>
         <dt>out</dt><dd>—</dd>

--- a/scripts/lib_audio.ts
+++ b/scripts/lib_audio.ts
@@ -5,12 +5,16 @@
  */
 import { writeFileSync, mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
+import { getInstrument, type OscType } from '@/music/instruments';
 import type { SynthParams, VoiceParams } from '@/nodes';
 
 export const SR = 44100;
 const MASTER = 0.25;
 
-function wave(phase: number, type: VoiceParams['instrument']): number {
+// Offline rendering is a simple single-oscillator approximation of each preset:
+// it plays the preset's primary partial waveform (no filter/vibrato/reverb),
+// which is enough for headless WAV demos and tests.
+function wave(phase: number, type: OscType): number {
   const p = phase - Math.floor(phase); // 0..1
   switch (type) {
     case 'square':
@@ -58,7 +62,7 @@ export function render(frames: SynthParams[], dt: number): Float32Array {
         const g = lerp(st.gain, curGain, frac); // ramp within tick (declick)
         const f = lerp(st.freq, target.freq, frac);
         st.phase += f / SR;
-        acc += wave(st.phase, target.instrument) * g;
+        acc += wave(st.phase, getInstrument(target.instrument).partials[0].type) * g;
       }
       out[s++] = Math.max(-1, Math.min(1, acc * MASTER));
     }

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,78 +1,125 @@
 /**
- * App — the Thoremin instrument view. Hosts the hidden webcam <video>, the
- * overlay <canvas> the DAG draws to, the audio-start gesture button, and the
- * live controls panel. All signal processing happens in the DAG engine via
- * {@link useThoreminEngine}; this component is purely presentational + lifecycle.
+ * App — the Thoremin instrument view. The webcam video (with hand-tracking
+ * overlays) fills the whole screen as the primary visual cue; everything else
+ * is a light, dismissible overlay so the instrument stays the focus:
+ *  - a minimal brand/status badge (never blocks pointer events),
+ *  - a collapsible controls panel (minimize to a single gear button),
+ *  - a prominent "tap to play" call-to-action until audio is running.
+ *
+ * All signal processing happens in the DAG engine via {@link useThoreminEngine};
+ * this component is purely presentational + lifecycle.
  */
+import { useState } from 'react';
+import { Settings, X, Play, BookOpen } from 'lucide-react';
 import { useThoreminEngine } from './useEngine';
 import ControlsPanel from './ControlsPanel';
 
 export default function App() {
   const { videoRef, canvasRef, status, error, audioOn, startAudio } = useThoreminEngine();
+  const [panelOpen, setPanelOpen] = useState(true);
 
   return (
-    <div className="min-h-screen bg-[#0a0a0a] font-mono text-white">
-      <header className="flex items-center gap-3 border-b border-white/5 px-6 py-4">
-        <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-emerald-500 text-black font-black">θ</div>
-        <div>
-          <h1 className="text-base font-bold uppercase italic tracking-tighter">Thoremin</h1>
-          <p className="text-[10px] uppercase tracking-widest text-emerald-500/70">
-            DAG sonification · from anything to music
-          </p>
+    <div className="relative h-screen w-screen overflow-hidden bg-black font-mono text-white">
+      {/* Hidden webcam feed; the DAG draws the mirrored video + overlays to the
+          canvas. object-cover fills the whole viewport (the video is the primary
+          cue) by scaling uniformly and cropping the overflow edges — overlay and
+          landmarks scale with it, and hand tracking still runs on the full frame
+          even where edges are cropped from view. */}
+      <video ref={videoRef} autoPlay playsInline muted className="hidden" />
+      <canvas
+        ref={canvasRef}
+        width={640}
+        height={480}
+        className="absolute inset-0 h-full w-full object-cover"
+      />
+
+      {/* Top-left: minimal brand + status. pointer-events-none so it never
+          intercepts clicks over the video. */}
+      <div className="pointer-events-none absolute left-3 top-3 flex items-center gap-2">
+        <div className="flex h-7 w-7 items-center justify-center rounded-md bg-emerald-500 font-black text-black">θ</div>
+        <div className="leading-tight">
+          <div className="text-xs font-bold uppercase italic tracking-tighter">Thoremin</div>
+          <div className="text-[9px] uppercase tracking-widest text-emerald-500/70">
+            {status === 'loading' && 'loading…'}
+            {status === 'ready' && (audioOn ? 'live' : 'ready')}
+            {status === 'error' && 'error'}
+          </div>
         </div>
-        <span className="ml-auto text-[10px] uppercase tracking-widest text-white/40">
-          {status === 'loading' && 'loading neural engine…'}
-          {status === 'ready' && (audioOn ? 'live' : 'ready — start audio')}
-          {status === 'error' && 'error'}
-        </span>
-      </header>
+      </div>
 
-      <main className="flex flex-col items-start gap-6 p-6 lg:flex-row">
-        <div className="relative">
-          <video ref={videoRef} autoPlay playsInline muted className="hidden" />
-          <canvas
-            ref={canvasRef}
-            width={640}
-            height={480}
-            className="rounded-3xl border border-white/10 bg-black/40 shadow-2xl"
-          />
+      {/* Bottom-left: link to the generated capabilities manual. */}
+      <a
+        href="manual.html"
+        className="absolute bottom-3 left-3 flex items-center gap-1 rounded-full bg-black/40 px-3 py-1 text-[10px] uppercase tracking-widest text-white/60 backdrop-blur transition hover:text-white"
+      >
+        <BookOpen className="h-3 w-3" /> manual
+      </a>
 
-          {status === 'loading' && (
-            <div className="absolute inset-0 flex items-center justify-center rounded-3xl bg-black/60 backdrop-blur-sm">
-              <div className="text-center">
-                <div className="mx-auto mb-3 h-12 w-12 animate-spin rounded-full border-4 border-emerald-500/30 border-t-emerald-500" />
-                <p className="text-xs uppercase tracking-widest text-emerald-500">Loading neural engine</p>
-              </div>
-            </div>
-          )}
+      {/* Top-right: collapsible controls — open by default (available), minimize
+          to a single gear once you've set things up. */}
+      {panelOpen ? (
+        <div className="absolute right-3 top-3 flex max-h-[calc(100vh-1.5rem)] w-72 flex-col overflow-hidden rounded-2xl border border-white/10 bg-black/60 backdrop-blur">
+          <div className="flex items-center justify-between border-b border-white/10 px-4 py-2">
+            <span className="text-[11px] font-bold uppercase tracking-widest text-white/70">Controls</span>
+            <button
+              onClick={() => setPanelOpen(false)}
+              aria-label="Minimize controls"
+              className="rounded p-1 text-white/60 transition hover:bg-white/10 hover:text-white"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+          <div className="overflow-auto p-4">
+            <ControlsPanel />
+          </div>
+        </div>
+      ) : (
+        <button
+          onClick={() => setPanelOpen(true)}
+          aria-label="Open controls"
+          className="absolute right-3 top-3 rounded-full border border-white/10 bg-black/50 p-2.5 text-white/80 backdrop-blur transition hover:text-white"
+        >
+          <Settings className="h-5 w-5" />
+        </button>
+      )}
 
-          {error && (
-            <div className="absolute inset-0 flex items-center justify-center rounded-3xl bg-red-500/10 p-6 text-center backdrop-blur">
-              <div>
-                <p className="mb-3 text-red-400">{error}</p>
-                <button
-                  onClick={() => window.location.reload()}
-                  className="rounded-full bg-red-500 px-5 py-2 text-xs font-bold uppercase tracking-widest"
-                >
-                  Retry
-                </button>
-              </div>
-            </div>
-          )}
-
+      {/* Center: prominent call-to-action until audio is running (the browser
+          requires a user gesture to start audio). */}
+      {status === 'ready' && !audioOn && (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
           <button
             onClick={startAudio}
-            disabled={status !== 'ready' || audioOn}
-            className={`mt-4 w-full rounded-xl px-6 py-3 text-xs font-bold uppercase tracking-widest transition ${
-              audioOn ? 'bg-emerald-500/20 text-emerald-400' : 'bg-emerald-500 text-black hover:brightness-110'
-            } disabled:opacity-40`}
+            className="pointer-events-auto flex items-center gap-3 rounded-full bg-emerald-500 px-8 py-4 text-sm font-bold uppercase tracking-widest text-black shadow-2xl transition hover:brightness-110"
           >
-            {audioOn ? '♪ audio engine active' : 'initialize audio engine'}
+            <Play className="h-5 w-5" /> Tap to play
           </button>
         </div>
+      )}
 
-        <ControlsPanel />
-      </main>
+      {/* Full-screen loading + error states. */}
+      {status === 'loading' && (
+        <div className="absolute inset-0 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+          <div className="text-center">
+            <div className="mx-auto mb-3 h-12 w-12 animate-spin rounded-full border-4 border-emerald-500/30 border-t-emerald-500" />
+            <p className="text-xs uppercase tracking-widest text-emerald-500">Loading neural engine</p>
+            <p className="mt-1 text-[10px] uppercase tracking-widest text-white/40">allow camera access</p>
+          </div>
+        </div>
+      )}
+
+      {error && (
+        <div className="absolute inset-0 flex items-center justify-center bg-red-500/10 p-6 text-center backdrop-blur">
+          <div>
+            <p className="mb-3 max-w-sm text-red-400">{error}</p>
+            <button
+              onClick={() => window.location.reload()}
+              className="rounded-full bg-red-500 px-5 py-2 text-xs font-bold uppercase tracking-widest"
+            >
+              Retry
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/ControlsPanel.tsx
+++ b/src/app/ControlsPanel.tsx
@@ -2,11 +2,15 @@
  * ControlsPanel — schema-light UI bound to the Zustand control store. Changing
  * any value updates the store; the `store-controls` DAG node reads it on the
  * next tick, so edits take effect live without rebuilding the graph.
+ *
+ * Renders just the controls *content* (no outer card); the host (App) wraps it
+ * in a collapsible translucent overlay so the video stays the focus.
  */
 import { NOTES, SCALE_TYPES, type ScaleTypeId } from '@/music/theory';
+import { INSTRUMENTS, INSTRUMENT_IDS } from '@/music/instruments';
 import { useControls, type VoiceControl } from './store';
 
-const INSTRUMENTS: VoiceControl['instrument'][] = ['sine', 'square', 'sawtooth', 'triangle'];
+const selectCls = 'rounded bg-white/10 px-2 py-1 text-xs outline-none focus:bg-white/20';
 
 function VoiceControls({ side }: { side: 'right' | 'left' }) {
   const voice = useControls((s) => s[side]);
@@ -15,11 +19,23 @@ function VoiceControls({ side }: { side: 'right' | 'left' }) {
 
   return (
     <div className="space-y-2">
-      <h3 className={`text-xs font-bold uppercase tracking-widest ${color}`}>{side} hand</h3>
+      <h3 className={`text-[11px] font-bold uppercase tracking-widest ${color}`}>{side} hand</h3>
+      <label className="flex items-center justify-between gap-2 text-xs">
+        Instrument
+        <select
+          className={selectCls}
+          value={voice.instrument}
+          onChange={(e) => setVoice(side, { instrument: e.target.value as VoiceControl['instrument'] })}
+        >
+          {INSTRUMENT_IDS.map((id) => (
+            <option key={id} value={id}>{INSTRUMENTS[id].name}</option>
+          ))}
+        </select>
+      </label>
       <label className="flex items-center justify-between gap-2 text-xs">
         Root
         <select
-          className="bg-white/10 rounded px-2 py-1"
+          className={selectCls}
           value={voice.root}
           onChange={(e) => setVoice(side, { root: Number(e.target.value) })}
         >
@@ -31,7 +47,7 @@ function VoiceControls({ side }: { side: 'right' | 'left' }) {
       <label className="flex items-center justify-between gap-2 text-xs">
         Scale
         <select
-          className="bg-white/10 rounded px-2 py-1"
+          className={selectCls}
           value={voice.type}
           onChange={(e) => setVoice(side, { type: e.target.value as ScaleTypeId })}
         >
@@ -54,18 +70,6 @@ function VoiceControls({ side }: { side: 'right' | 'left' }) {
           onChange={(e) => setVoice(side, { baseOctave: Number(e.target.value) })}
         />
       </label>
-      <label className="flex items-center justify-between gap-2 text-xs">
-        Wave
-        <select
-          className="bg-white/10 rounded px-2 py-1"
-          value={voice.instrument}
-          onChange={(e) => setVoice(side, { instrument: e.target.value as VoiceControl['instrument'] })}
-        >
-          {INSTRUMENTS.map((i) => (
-            <option key={i} value={i}>{i}</option>
-          ))}
-        </select>
-      </label>
     </div>
   );
 }
@@ -77,7 +81,7 @@ export default function ControlsPanel() {
   const setMasterVolume = useControls((s) => s.setMasterVolume);
 
   return (
-    <div className="w-64 shrink-0 space-y-4 rounded-2xl border border-white/10 bg-black/40 p-4 backdrop-blur">
+    <div className="space-y-4">
       <div>
         <label className="flex items-center justify-between gap-2 text-xs">
           Master volume

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -7,6 +7,7 @@
  */
 import { create } from 'zustand';
 import type { ScaleTypeId } from '@/music/theory';
+import { DEFAULT_INSTRUMENT_RIGHT, DEFAULT_INSTRUMENT_LEFT } from '@/music/instruments';
 import type { VoiceParams } from '@/nodes';
 
 export interface VoiceControl {
@@ -29,17 +30,19 @@ export interface ControlState {
 
 const defaultVoice = (instrument: VoiceParams['instrument']): VoiceControl => ({
   root: 0,
-  type: 'major',
+  // Pentatonic by default: every snapped note sounds consonant, so the
+  // instrument is forgiving and musical out of the box.
+  type: 'pentatonic',
   octaves: 2,
   baseOctave: 3,
   instrument,
 });
 
 export const useControls = create<ControlState>((set) => ({
-  right: defaultVoice('sine'),
-  left: defaultVoice('triangle'),
+  right: defaultVoice(DEFAULT_INSTRUMENT_RIGHT),
+  left: defaultVoice(DEFAULT_INSTRUMENT_LEFT),
   syncHands: true,
-  masterVolume: 0.2,
+  masterVolume: 0.4,
   setVoice: (side, patch) =>
     set((s) => {
       const next = { ...s[side], ...patch };

--- a/src/app/useEngine.ts
+++ b/src/app/useEngine.ts
@@ -73,7 +73,14 @@ export function useThoreminEngine() {
         setStatus('ready');
 
         const loop = () => {
-          engine.tick(performance.now() / 1000);
+          // Guard the tick: one node throwing on a frame (e.g. a degenerate
+          // value) must never stop the loop — drop that frame and keep going,
+          // so audio + video recover instead of freezing permanently.
+          try {
+            engine.tick(performance.now() / 1000);
+          } catch (err) {
+            console.error('[thoremin] engine tick error (frame dropped)', err);
+          }
           rafRef.current = requestAnimationFrame(loop);
         };
         rafRef.current = requestAnimationFrame(loop);

--- a/src/music/instruments.ts
+++ b/src/music/instruments.ts
@@ -1,0 +1,165 @@
+/**
+ * Instrument presets — the single source of truth for the sounds Thoremin can
+ * play. Each preset is a declarative recipe (additive oscillator partials +
+ * optional filter, vibrato, amplitude envelope and reverb send) that the
+ * browser `webaudio-synth` node realizes into a Web Audio voice graph, and that
+ * the UI lists by `name`. The `instrument` field on a synth voice is one of
+ * these ids ({@link InstrumentId}); adding a richer sound means adding an entry
+ * here (open/closed) — no other module needs to change.
+ *
+ * The four raw oscillator waveforms (sine/triangle/square/sawtooth) are kept as
+ * presets so existing graphs/tests that name them still resolve.
+ */
+import { z } from 'zod';
+
+/** The Web Audio oscillator shapes a partial can use. */
+export type OscType = 'sine' | 'square' | 'sawtooth' | 'triangle';
+
+/** One additive oscillator within a preset, tuned relative to the fundamental. */
+export interface Partial {
+  readonly type: OscType;
+  /** Frequency multiple of the fundamental (1 = unison, 2 = octave up). Default 1. */
+  readonly ratio?: number;
+  /** Detune in cents (for chorus/width). Default 0. */
+  readonly detuneCents?: number;
+  /** Relative level of this partial, 0..1. Default 1. */
+  readonly gain?: number;
+}
+
+/** A complete, declarative instrument timbre. */
+export interface InstrumentPreset {
+  /** Human label for the UI. */
+  readonly name: string;
+  /** Additive oscillators summed to form the tone — non-empty by construction,
+   * so `as const satisfies` rejects a partial-less preset at authoring time. */
+  readonly partials: readonly [Partial, ...Partial[]];
+  /** Optional tone-shaping filter applied to the summed partials. */
+  readonly filter?: { readonly type: 'lowpass' | 'highpass' | 'bandpass'; readonly cutoff: number; readonly q?: number };
+  /** Optional pitch vibrato (LFO on detune). */
+  readonly vibrato?: { readonly rateHz: number; readonly depthCents: number };
+  /** Amplitude glide-up time constant when a note starts (s). Default 0.02. */
+  readonly attack?: number;
+  /** Amplitude glide-down time constant when a note ends (s). Default 0.08. */
+  readonly release?: number;
+  /** Dry/wet send to the shared reverb, 0..1. Default 0 (dry). */
+  readonly reverbSend?: number;
+  /** Overall level trim for the preset, 0..1. Default 1. */
+  readonly gain?: number;
+}
+
+/**
+ * The preset registry. Keys are the stable instrument ids; values are the
+ * recipes. Declared with `satisfies` (not an annotation) so {@link InstrumentId}
+ * stays a literal union of the keys.
+ */
+export const INSTRUMENTS = {
+  // --- Raw waveforms (classic, also the backward-compatible ids) -----------
+  sine: { name: 'Sine', partials: [{ type: 'sine' }] },
+  triangle: { name: 'Triangle', partials: [{ type: 'triangle' }] },
+  square: {
+    name: 'Square',
+    partials: [{ type: 'square' }],
+    filter: { type: 'lowpass', cutoff: 3500, q: 0.7 },
+    gain: 0.85,
+  },
+  sawtooth: {
+    name: 'Sawtooth',
+    partials: [{ type: 'sawtooth' }],
+    filter: { type: 'lowpass', cutoff: 4000, q: 0.7 },
+    gain: 0.85,
+  },
+
+  // --- Richer, "nice" instruments ------------------------------------------
+  warmPad: {
+    name: 'Warm Pad',
+    partials: [
+      { type: 'sawtooth', detuneCents: -7 },
+      { type: 'sawtooth', detuneCents: 7 },
+      { type: 'sine', ratio: 0.5, gain: 0.3 },
+    ],
+    filter: { type: 'lowpass', cutoff: 2200, q: 0.6 },
+    attack: 0.18,
+    release: 0.28,
+    reverbSend: 0.35,
+    gain: 0.8,
+  },
+  glass: {
+    name: 'Glass',
+    partials: [
+      { type: 'sine' },
+      { type: 'sine', ratio: 2, gain: 0.35 },
+      { type: 'sine', ratio: 3, gain: 0.12 },
+    ],
+    attack: 0.01,
+    release: 0.4,
+    reverbSend: 0.4,
+    gain: 0.9,
+  },
+  bell: {
+    name: 'Bell',
+    partials: [
+      { type: 'sine' },
+      { type: 'sine', ratio: 2.0, gain: 0.5 },
+      { type: 'sine', ratio: 3.01, gain: 0.28 },
+      { type: 'sine', ratio: 4.2, gain: 0.12 },
+    ],
+    attack: 0.005,
+    release: 0.5,
+    reverbSend: 0.3,
+    gain: 0.8,
+  },
+  organ: {
+    name: 'Organ',
+    partials: [
+      { type: 'sine' },
+      { type: 'sine', ratio: 2, gain: 0.5 },
+      { type: 'sine', ratio: 3, gain: 0.33 },
+      { type: 'sine', ratio: 4, gain: 0.2 },
+    ],
+    attack: 0.02,
+    release: 0.06,
+    reverbSend: 0.15,
+    gain: 0.7,
+  },
+  voice: {
+    name: 'Voice',
+    partials: [{ type: 'sawtooth' }],
+    filter: { type: 'lowpass', cutoff: 1300, q: 3 },
+    vibrato: { rateHz: 5.5, depthCents: 14 },
+    attack: 0.08,
+    release: 0.15,
+    reverbSend: 0.3,
+    gain: 0.85,
+  },
+  softLead: {
+    name: 'Soft Lead',
+    partials: [
+      { type: 'triangle' },
+      { type: 'square', gain: 0.25, detuneCents: 5 },
+    ],
+    filter: { type: 'lowpass', cutoff: 3000, q: 0.8 },
+    vibrato: { rateHz: 5, depthCents: 6 },
+    attack: 0.03,
+    release: 0.12,
+    reverbSend: 0.18,
+    gain: 0.8,
+  },
+} as const satisfies Record<string, InstrumentPreset>;
+
+/** A valid instrument id (literal union of {@link INSTRUMENTS} keys). */
+export type InstrumentId = keyof typeof INSTRUMENTS;
+
+/** All instrument ids, registry order (UI lists them in this order). */
+export const INSTRUMENT_IDS = Object.keys(INSTRUMENTS) as InstrumentId[];
+
+/** Default timbres — pleasant, forgiving, and distinct per hand. */
+export const DEFAULT_INSTRUMENT_RIGHT: InstrumentId = 'warmPad';
+export const DEFAULT_INSTRUMENT_LEFT: InstrumentId = 'glass';
+
+/** Resolve an id to its preset, falling back to a pure sine for unknown ids. */
+export function getInstrument(id: string): InstrumentPreset {
+  return (INSTRUMENTS as Record<string, InstrumentPreset>)[id] ?? INSTRUMENTS.sine;
+}
+
+/** Zod schema accepting any registered instrument id. */
+export const InstrumentSchema = z.enum(INSTRUMENT_IDS as [InstrumentId, ...InstrumentId[]]);

--- a/src/nodes/domain.ts
+++ b/src/nodes/domain.ts
@@ -6,6 +6,7 @@
  * Landmark indices follow MediaPipe Hands (21 points). We also tolerate named
  * keypoints (as emitted by @tensorflow-models/hand-pose-detection).
  */
+import type { InstrumentId } from '@/music/instruments';
 
 export interface Keypoint {
   x: number;
@@ -64,7 +65,8 @@ export interface VoiceParams {
   present: boolean;
   freq: number;
   gain: number;
-  instrument: 'sine' | 'square' | 'sawtooth' | 'triangle';
+  /** Instrument timbre — an id from the {@link InstrumentId} registry. */
+  instrument: InstrumentId;
 }
 
 export interface SynthParams {

--- a/src/nodes/mapping/voice_mapping.ts
+++ b/src/nodes/mapping/voice_mapping.ts
@@ -19,6 +19,7 @@ import {
   midiToFreq,
   type ScaleTypeId,
 } from '@/music/theory';
+import { InstrumentSchema, INSTRUMENT_IDS } from '@/music/instruments';
 import { ABSENT_HAND, type HandFeatures, type SynthParams, type VoiceParams } from '../domain';
 
 const ScaleParams = z.object({
@@ -30,7 +31,7 @@ const ScaleParams = z.object({
   baseOctave: z.number().int().min(0).max(7).default(3),
 });
 
-const Instrument = z.enum(['sine', 'square', 'sawtooth', 'triangle']);
+const Instrument = InstrumentSchema;
 
 const Params = z.object({
   /** 0 = free glide, 1 = hard snap to scale notes. */
@@ -112,11 +113,10 @@ export const voiceMappingNode = defineNode<Params>({
       ? inputs.scaleLeft
       : generateScale({ ...p.left.scale, type: p.left.scale.type as ScaleTypeId });
 
-    const INSTRUMENTS = ['sine', 'square', 'sawtooth', 'triangle'];
-    const instR = (INSTRUMENTS.includes(inputs.instrumentRight as string)
+    const instR = ((INSTRUMENT_IDS as string[]).includes(inputs.instrumentRight as string)
       ? (inputs.instrumentRight as VoiceParams['instrument'])
       : p.right.instrument);
-    const instL = (INSTRUMENTS.includes(inputs.instrumentLeft as string)
+    const instL = ((INSTRUMENT_IDS as string[]).includes(inputs.instrumentLeft as string)
       ? (inputs.instrumentLeft as VoiceParams['instrument'])
       : p.left.instrument);
 

--- a/src/nodes/music/chord.ts
+++ b/src/nodes/music/chord.ts
@@ -13,6 +13,7 @@ import { z } from 'zod';
 import { Chord, Note } from 'tonal';
 import { defineNode } from '@/dag';
 import { midiToFreq } from '@/music/theory';
+import { InstrumentSchema } from '@/music/instruments';
 import type { SynthParams, VoiceParams } from '../domain';
 
 const Params = z.object({
@@ -20,7 +21,7 @@ const Params = z.object({
   baseOctave: z.number().int().min(0).max(7).default(4),
   /** Cap the number of voices (chord tones) emitted. */
   maxVoices: z.number().int().min(1).max(8).default(4),
-  instrument: z.enum(['sine', 'square', 'sawtooth', 'triangle']).default('sine'),
+  instrument: InstrumentSchema.default('sine'),
 });
 type Params = z.infer<typeof Params>;
 

--- a/src/nodes/music/score.ts
+++ b/src/nodes/music/score.ts
@@ -12,6 +12,7 @@
 import { z } from 'zod';
 import { defineNode } from '@/dag';
 import { midiToFreq } from '@/music/theory';
+import { InstrumentSchema } from '@/music/instruments';
 import type { SynthParams, VoiceParams } from '../domain';
 
 const Note = z.object({
@@ -30,7 +31,7 @@ const Params = z.object({
   loopBeats: z.number().min(0).default(8),
   /** Base output gain multiplier. */
   baseGain: z.number().min(0).max(1).default(0.4),
-  instrument: z.enum(['sine', 'square', 'sawtooth', 'triangle']).default('triangle'),
+  instrument: InstrumentSchema.default('triangle'),
 });
 type Params = z.infer<typeof Params>;
 

--- a/src/nodes/output/webaudio_synth.ts
+++ b/src/nodes/output/webaudio_synth.ts
@@ -1,7 +1,11 @@
 /**
  * `webaudio-synth` node (browser-only) — renders {@link SynthParams} to sound
- * via the Web Audio API. One {@link OscillatorNode}+{@link GainNode} per voice,
- * with smoothed frequency/gain ramps so per-frame parameter updates don't click.
+ * via the Web Audio API, using the instrument preset registry
+ * ({@link getInstrument}). Each voice is built from its preset's additive
+ * oscillator partials, run through an optional tone filter and pitch vibrato,
+ * with a smoothed amplitude envelope so per-frame parameter updates never click.
+ * All voices share a reverb and feed an output compressor bus, which gives the
+ * whole instrument a sense of space and protects headroom when voices stack.
  *
  * The AudioContext and master GainNode are injected through `ctx.resources`
  * (the host owns them, because audio can only start after a user gesture). If
@@ -12,20 +16,44 @@
 import { z } from 'zod';
 import { defineNode } from '@/dag';
 import type { NodeContext } from '@/dag';
+import { getInstrument } from '@/music/instruments';
 import type { SynthParams, VoiceParams } from '../domain';
 
 const Params = z.object({
   /** Frequency smoothing time constant (seconds). */
   freqGlide: z.number().default(0.03),
-  /** Gain smoothing time constant (seconds). */
+  /** Fallback amplitude smoothing time constant when a preset omits attack/release (seconds). */
   gainGlide: z.number().default(0.08),
 });
 type Params = z.infer<typeof Params>;
 
-interface Voice {
+/** One oscillator within a voice, plus its frequency ratio to the fundamental. */
+interface PartialOsc {
   osc: OscillatorNode;
-  gain: GainNode;
-  type: OscillatorType;
+  ratio: number;
+}
+
+interface Voice {
+  /** The instrument id this voice was built for (rebuilt if it changes). */
+  instrument: string;
+  partials: PartialOsc[];
+  vibrato: { lfo: OscillatorNode } | null;
+  /** The amplitude-envelope gain driven by the voice's `gain`. */
+  voiceGain: GainNode;
+  /** Every node to disconnect on teardown. */
+  nodes: AudioNode[];
+  attack: number;
+  release: number;
+}
+
+/** Shared per-synth audio infrastructure, built lazily once audio exists. */
+interface Bus {
+  ac: AudioContext;
+  /** Where voices send their dry signal (a compressor → master). */
+  out: AudioNode;
+  /** Where voices send their wet (reverb) signal. */
+  reverbIn: GainNode;
+  nodes: AudioNode[];
 }
 
 function getAudio(ctx: NodeContext): { ac: AudioContext; master: GainNode } | null {
@@ -35,67 +63,229 @@ function getAudio(ctx: NodeContext): { ac: AudioContext; master: GainNode } | nu
   return { ac, master };
 }
 
+/** Build a decaying-noise impulse response for a simple, pleasant reverb. */
+function makeImpulse(ac: AudioContext, seconds: number, decay: number): AudioBuffer {
+  const rate = ac.sampleRate;
+  const len = Math.max(1, Math.floor(rate * seconds));
+  const buf = ac.createBuffer(2, len, rate);
+  for (let ch = 0; ch < 2; ch++) {
+    const data = buf.getChannelData(ch);
+    for (let i = 0; i < len; i++) {
+      data[i] = (Math.random() * 2 - 1) * Math.pow(1 - i / len, decay);
+    }
+  }
+  return buf;
+}
+
+function ensureBus(ac: AudioContext, master: GainNode, current: Bus | null): Bus {
+  if (current && current.ac === ac) return current;
+  const now = ac.currentTime;
+  // Output compressor acts as a gentle limiter so stacked voices + reverb
+  // don't clip; it is the single connection point into the host master.
+  const comp = ac.createDynamicsCompressor();
+  comp.threshold.setValueAtTime(-14, now);
+  comp.knee.setValueAtTime(24, now);
+  comp.ratio.setValueAtTime(3, now);
+  comp.attack.setValueAtTime(0.005, now);
+  comp.release.setValueAtTime(0.2, now);
+  // Makeup gain recovers the level the compressor sheds, so the instrument is
+  // present at a sensible default volume. The host master fader sits after it.
+  const makeup = ac.createGain();
+  makeup.gain.setValueAtTime(1.6, now);
+  comp.connect(makeup);
+  makeup.connect(master);
+  // Shared reverb: reverbIn → convolver → reverbOut → compressor.
+  const reverbIn = ac.createGain();
+  const convolver = ac.createConvolver();
+  convolver.buffer = makeImpulse(ac, 1.8, 2.2);
+  const reverbOut = ac.createGain();
+  reverbOut.gain.setValueAtTime(0.9, now);
+  reverbIn.connect(convolver);
+  convolver.connect(reverbOut);
+  reverbOut.connect(comp);
+  return { ac, out: comp, reverbIn, nodes: [comp, makeup, reverbIn, convolver, reverbOut] };
+}
+
+function buildVoice(ac: AudioContext, bus: Bus, v: VoiceParams, p: Params): Voice {
+  const preset = getInstrument(v.instrument);
+  const now = ac.currentTime;
+  const nodes: AudioNode[] = [];
+
+  const voiceGain = ac.createGain();
+  voiceGain.gain.setValueAtTime(0, now);
+  nodes.push(voiceGain);
+
+  // Partials sum into an optional filter, then the amplitude-envelope gain.
+  let sumTarget: AudioNode = voiceGain;
+  if (preset.filter) {
+    const filter = ac.createBiquadFilter();
+    filter.type = preset.filter.type;
+    filter.frequency.setValueAtTime(preset.filter.cutoff, now);
+    filter.Q.setValueAtTime(preset.filter.q ?? 0.7, now);
+    filter.connect(voiceGain);
+    nodes.push(filter);
+    sumTarget = filter;
+  }
+
+  const partials: PartialOsc[] = preset.partials.map((part) => {
+    const osc = ac.createOscillator();
+    osc.type = part.type;
+    if (part.detuneCents) osc.detune.setValueAtTime(part.detuneCents, now);
+    const g = ac.createGain();
+    g.gain.setValueAtTime(part.gain ?? 1, now);
+    osc.connect(g);
+    g.connect(sumTarget);
+    osc.start();
+    nodes.push(osc, g);
+    return { osc, ratio: part.ratio ?? 1 };
+  });
+
+  // Vibrato: an LFO modulating every partial's detune (cents).
+  let vibrato: Voice['vibrato'] = null;
+  if (preset.vibrato) {
+    const lfo = ac.createOscillator();
+    lfo.frequency.setValueAtTime(preset.vibrato.rateHz, now);
+    const depth = ac.createGain();
+    depth.gain.setValueAtTime(preset.vibrato.depthCents, now);
+    lfo.connect(depth);
+    partials.forEach((pp) => depth.connect(pp.osc.detune));
+    lfo.start();
+    nodes.push(lfo, depth);
+    vibrato = { lfo };
+  }
+
+  // Output: voiceGain → trim → (dry) compressor; trim → send → reverb.
+  const trim = ac.createGain();
+  trim.gain.setValueAtTime(preset.gain ?? 1, now);
+  voiceGain.connect(trim);
+  trim.connect(bus.out);
+  nodes.push(trim);
+  if (preset.reverbSend && preset.reverbSend > 0) {
+    const send = ac.createGain();
+    send.gain.setValueAtTime(preset.reverbSend, now);
+    trim.connect(send);
+    send.connect(bus.reverbIn);
+    nodes.push(send);
+  }
+
+  return {
+    instrument: v.instrument,
+    partials,
+    vibrato,
+    voiceGain,
+    nodes,
+    attack: preset.attack ?? p.gainGlide,
+    release: preset.release ?? p.gainGlide,
+  };
+}
+
+/**
+ * Tear a voice down. With `fade` (a live instrument swap on a sounding voice),
+ * ramp the amplitude to zero over a few ms and stop the oscillators after a
+ * short tail so the switch doesn't click; otherwise (engine dispose) stop now.
+ */
+function teardownVoice(voice: Voice, ac: AudioContext, fade = false): void {
+  const now = ac.currentTime;
+  const tail = fade ? 0.03 : 0;
+  if (fade) {
+    try {
+      const g = voice.voiceGain.gain;
+      g.cancelScheduledValues(now);
+      g.setValueAtTime(g.value, now);
+      g.linearRampToValueAtTime(0, now + 0.02);
+    } catch {
+      /* param unavailable; fall through to hard stop */
+    }
+  }
+  for (const part of voice.partials) {
+    try {
+      part.osc.stop(now + tail);
+    } catch {
+      /* already stopped */
+    }
+  }
+  if (voice.vibrato) {
+    try {
+      voice.vibrato.lfo.stop(now + tail);
+    } catch {
+      /* already stopped */
+    }
+  }
+  const disconnectAll = () => {
+    for (const n of voice.nodes) {
+      try {
+        n.disconnect();
+      } catch {
+        /* already disconnected */
+      }
+    }
+  };
+  // Disconnect after the fade tail so the ramp is actually heard.
+  if (fade) setTimeout(disconnectAll, 120);
+  else disconnectAll();
+}
+
 export const webAudioSynthNode = defineNode<Params>({
   type: 'webaudio-synth',
   title: 'Web Audio Synth',
-  description: 'Renders synth params to oscillator voices (browser only).',
+  description: 'Renders synth params to instrument-preset voices (browser only).',
   inputs: [{ name: 'params', kind: 'synth-params' }],
   outputs: [],
   params: Params,
   make(p) {
     const voices = new Map<number, Voice>();
-
-    const ensureVoice = (ac: AudioContext, master: GainNode, v: VoiceParams): Voice => {
-      let voice = voices.get(v.id);
-      if (!voice) {
-        const osc = ac.createOscillator();
-        const gain = ac.createGain();
-        osc.type = v.instrument;
-        gain.gain.setValueAtTime(0, ac.currentTime);
-        osc.connect(gain);
-        gain.connect(master);
-        osc.start();
-        voice = { osc, gain, type: v.instrument };
-        voices.set(v.id, voice);
-      }
-      if (voice.type !== v.instrument) {
-        voice.osc.type = v.instrument;
-        voice.type = v.instrument;
-      }
-      return voice;
-    };
+    let bus: Bus | null = null;
 
     return {
       process(inputs, ctx) {
         const audio = getAudio(ctx);
         if (!audio) return {};
         const { ac, master } = audio;
+        bus = ensureBus(ac, master, bus);
         const sp = inputs.params as SynthParams | undefined;
         if (!sp) return {};
         const now = ac.currentTime;
+
         for (const v of sp.voices) {
+          // Guard against non-finite params (a degenerate upstream feature):
+          // setTargetAtTime throws on NaN/Infinity, which would otherwise abort
+          // the whole tick. Skip the bad voice rather than kill the engine.
+          if (!Number.isFinite(v.freq) || !Number.isFinite(v.gain)) continue;
+          let voice = voices.get(v.id);
+          // Instrument changed → fade out the old voice and rebuild.
+          if (voice && voice.instrument !== v.instrument) {
+            teardownVoice(voice, ac, true);
+            voices.delete(v.id);
+            voice = undefined;
+          }
           if (v.present && v.gain > 0) {
-            const voice = ensureVoice(ac, master, v);
-            voice.osc.frequency.setTargetAtTime(v.freq, now, p.freqGlide);
-            voice.gain.gain.setTargetAtTime(v.gain, now, p.gainGlide);
-          } else {
-            const voice = voices.get(v.id);
-            if (voice) voice.gain.gain.setTargetAtTime(0, now, p.gainGlide);
+            if (!voice) {
+              voice = buildVoice(ac, bus, v, p);
+              voices.set(v.id, voice);
+            }
+            for (const part of voice.partials) {
+              part.osc.frequency.setTargetAtTime(v.freq * part.ratio, now, p.freqGlide);
+            }
+            voice.voiceGain.gain.setTargetAtTime(v.gain, now, voice.attack);
+          } else if (voice) {
+            voice.voiceGain.gain.setTargetAtTime(0, now, voice.release);
           }
         }
         return {};
       },
       dispose() {
-        for (const voice of voices.values()) {
-          try {
-            voice.osc.stop();
-            voice.osc.disconnect();
-            voice.gain.disconnect();
-          } catch {
-            /* already torn down */
-          }
-        }
+        if (bus) for (const voice of voices.values()) teardownVoice(voice, bus.ac);
         voices.clear();
+        if (bus) {
+          for (const n of bus.nodes) {
+            try {
+              n.disconnect();
+            } catch {
+              /* already disconnected */
+            }
+          }
+          bus = null;
+        }
       },
     };
   },

--- a/src/nodes/sources/store_controls.ts
+++ b/src/nodes/sources/store_controls.ts
@@ -11,13 +11,14 @@ import { z } from 'zod';
 import { defineNode } from '@/dag';
 import type { NodeContext } from '@/dag';
 import { generateScale, type ScaleTypeId } from '@/music/theory';
+import type { InstrumentId } from '@/music/instruments';
 
 export interface VoiceControlSnapshot {
   root: number;
   type: ScaleTypeId;
   octaves: number;
   baseOctave: number;
-  instrument: 'sine' | 'square' | 'sawtooth' | 'triangle';
+  instrument: InstrumentId;
 }
 export interface ControlSnapshot {
   right: VoiceControlSnapshot;

--- a/test/app_store.test.ts
+++ b/test/app_store.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { useControls } from '@/app/store';
 import { storeControlsNode } from '@/nodes/browser';
 import { generateScale } from '@/music/theory';
+import { DEFAULT_INSTRUMENT_RIGHT, DEFAULT_INSTRUMENT_LEFT } from '@/music/instruments';
 import type { NodeContext } from '@/dag';
 
 beforeEach(() => {
@@ -20,10 +21,13 @@ beforeEach(() => {
 describe('control store', () => {
   it('has sensible defaults', () => {
     const s = useControls.getState();
-    expect(s.right.instrument).toBe('sine');
-    expect(s.left.instrument).toBe('triangle');
+    expect(s.right.instrument).toBe(DEFAULT_INSTRUMENT_RIGHT);
+    expect(s.left.instrument).toBe(DEFAULT_INSTRUMENT_LEFT);
+    // Pentatonic by default — every snapped note sounds consonant.
+    expect(s.right.type).toBe('pentatonic');
+    expect(s.left.type).toBe('pentatonic');
     expect(s.syncHands).toBe(true);
-    expect(s.masterVolume).toBeCloseTo(0.2, 6);
+    expect(s.masterVolume).toBeCloseTo(0.4, 6);
   });
 
   it('setVoice with sync ON mirrors both hands but keeps instruments distinct', () => {
@@ -34,8 +38,8 @@ describe('control store', () => {
     expect(s.right.octaves).toBe(4);
     expect(s.left.octaves).toBe(4);
     // Instruments stay per-hand even when synced.
-    expect(s.right.instrument).toBe('sine');
-    expect(s.left.instrument).toBe('triangle');
+    expect(s.right.instrument).toBe(DEFAULT_INSTRUMENT_RIGHT);
+    expect(s.left.instrument).toBe(DEFAULT_INSTRUMENT_LEFT);
   });
 
   it('setVoice with sync ON applies the patched instrument to the addressed hand only', () => {
@@ -45,7 +49,7 @@ describe('control store', () => {
     useControls.getState().setVoice('right', { instrument: 'square' });
     const s = useControls.getState();
     expect(s.right.instrument).toBe('square');
-    expect(s.left.instrument).toBe('triangle');
+    expect(s.left.instrument).toBe(DEFAULT_INSTRUMENT_LEFT);
   });
 
   it('setSync only flips the flag; it does not re-converge already-diverged hands', () => {
@@ -62,8 +66,8 @@ describe('control store', () => {
     const s2 = useControls.getState();
     expect(s2.right.root).toBe(4);
     expect(s2.left.root).toBe(4);
-    expect(s2.right.instrument).toBe('sine');
-    expect(s2.left.instrument).toBe('triangle');
+    expect(s2.right.instrument).toBe(DEFAULT_INSTRUMENT_RIGHT);
+    expect(s2.left.instrument).toBe(DEFAULT_INSTRUMENT_LEFT);
   });
 
   it('setVoice with sync OFF changes only the addressed hand', () => {

--- a/test/instruments.test.ts
+++ b/test/instruments.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Integrity tests for the instrument preset registry (the SSOT for sounds).
+ * These are pure/headless — they validate the preset *data* (every preset is
+ * well-formed, the raw waveforms and defaults exist, ids resolve). The actual
+ * Web Audio realization lives in the browser-only `webaudio-synth` node and is
+ * verified in the browser.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  INSTRUMENTS,
+  INSTRUMENT_IDS,
+  DEFAULT_INSTRUMENT_RIGHT,
+  DEFAULT_INSTRUMENT_LEFT,
+  getInstrument,
+  InstrumentSchema,
+} from '@/music/instruments';
+
+const OSC_TYPES = ['sine', 'square', 'sawtooth', 'triangle'];
+
+describe('instrument registry', () => {
+  it('lists every registered id, in registry order', () => {
+    expect(INSTRUMENT_IDS).toEqual(Object.keys(INSTRUMENTS));
+    expect(INSTRUMENT_IDS.length).toBeGreaterThanOrEqual(8);
+  });
+
+  it('keeps the four raw oscillator waveforms as ids (backward compatible)', () => {
+    for (const id of OSC_TYPES) expect(INSTRUMENT_IDS).toContain(id);
+  });
+
+  it('every preset is well-formed', () => {
+    for (const id of INSTRUMENT_IDS) {
+      const preset = getInstrument(id); // widened InstrumentPreset view (optionals visible)
+      expect(preset.name.length).toBeGreaterThan(0);
+      expect(preset.partials.length).toBeGreaterThanOrEqual(1);
+      for (const part of preset.partials) {
+        expect(OSC_TYPES).toContain(part.type);
+        if (part.ratio !== undefined) expect(part.ratio).toBeGreaterThan(0);
+        if (part.gain !== undefined) expect(part.gain).toBeGreaterThanOrEqual(0);
+      }
+      if (preset.reverbSend !== undefined) {
+        expect(preset.reverbSend).toBeGreaterThanOrEqual(0);
+        expect(preset.reverbSend).toBeLessThanOrEqual(1);
+      }
+    }
+  });
+
+  it('defaults are registered ids', () => {
+    expect(INSTRUMENT_IDS).toContain(DEFAULT_INSTRUMENT_RIGHT);
+    expect(INSTRUMENT_IDS).toContain(DEFAULT_INSTRUMENT_LEFT);
+  });
+
+  it('getInstrument resolves ids and falls back to sine for unknown', () => {
+    expect(getInstrument('warmPad')).toBe(INSTRUMENTS.warmPad);
+    expect(getInstrument('does-not-exist')).toBe(INSTRUMENTS.sine);
+  });
+
+  it('the zod schema accepts every id and rejects junk', () => {
+    for (const id of INSTRUMENT_IDS) expect(InstrumentSchema.safeParse(id).success).toBe(true);
+    expect(InstrumentSchema.safeParse('nope').success).toBe(false);
+  });
+});


### PR DESCRIPTION
Builds on #32 to make the opt-in `?engine=dag` instrument view pleasant to actually play. Three asks: bigger video, nicer instruments, pentatonic default.

## Video-first UX
- The webcam canvas now **fills the whole viewport** (`object-cover`) — the video is the main cue when playing. Overlay + landmarks scale with it; hand tracking still runs on the full frame even where edges are cropped from view.
- Controls became a **translucent, collapsible overlay** (open by default → minimize to a single gear) so they're available but barely cost visual space.
- Prominent **"tap to play"** call-to-action replaces the old button bar.

## Instruments — SSOT preset registry
- New `src/music/instruments.ts` is the single source of truth for sounds: **10 presets** (the 4 raw waveforms, kept for compatibility, + Warm Pad, Glass, Bell, Organ, Voice, Soft Lead), each a declarative recipe (additive partials + optional filter, vibrato, envelope, reverb send). Adding a sound = adding one entry (open/closed).
- The registry feeds the `InstrumentId` type, the zod schema, the synth, and the UI dropdown — **collapsing the instrument type that was duplicated across 7 files**.
- `webaudio-synth` rewritten to render presets: per-voice partials → filter → amplitude envelope → trim, with a **shared convolution reverb** and a **compressor + makeup-gain bus** for space and headroom.

## Defaults
Pentatonic scale (every snapped note is consonant — forgiving and musical out of the box) + Warm Pad (right) / Glass (left).

## Adversarial review (4 lenses → independent verification): 5 confirmed, 0 blockers — all fixed
- **Robustness:** guard the rAF tick loop + finite-value guards in the synth, so one bad frame can never permanently freeze audio + video.
- **Declick** live instrument changes (fade-out before teardown).
- **Loudness:** raised default master volume + post-compressor makeup gain (was too quiet).
- **Safety:** `partials` typed as a non-empty tuple → an empty-partials preset is now a compile-time error.

## Gates
- Strict typecheck ✅ · **93 tests** ✅ (new `instruments.test.ts`) · `vite build` ✅
- Manual regenerated from the registry (`npm run catalog`), so it lists the new instruments and never drifts.

The default (no-query-string) production app is untouched and does not import the DAG layer.

Refs #6.

https://claude.ai/code/session_01Gp5tDXPQZuM7WaetpZwxij