### PR TITLE
feat(dag-view): crisp HD fullscreen video

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -21,17 +21,12 @@ export default function App() {
   return (
     <div className="relative h-screen w-screen overflow-hidden bg-black font-mono text-white">
       {/* Hidden webcam feed; the DAG draws the mirrored video + overlays to the
-          canvas. object-cover fills the whole viewport (the video is the primary
-          cue) by scaling uniformly and cropping the overflow edges — overlay and
-          landmarks scale with it, and hand tracking still runs on the full frame
-          even where edges are cropped from view. */}
+          canvas. The buffer is sized to the camera's native resolution in
+          useEngine (so the draw is crisp); object-cover then fills the whole
+          viewport (the video is the primary cue), scaling uniformly and cropping
+          only the overflow edges. Tracking still runs on the full frame. */}
       <video ref={videoRef} autoPlay playsInline muted className="hidden" />
-      <canvas
-        ref={canvasRef}
-        width={640}
-        height={480}
-        className="absolute inset-0 h-full w-full object-cover"
-      />
+      <canvas ref={canvasRef} className="absolute inset-0 h-full w-full object-cover" />
 
       {/* Top-left: minimal brand + status. pointer-events-none so it never
           intercepts clicks over the video. */}

--- a/src/app/useEngine.ts
+++ b/src/app/useEngine.ts
@@ -39,8 +39,10 @@ export function useThoreminEngine() {
       try {
         setStatus('loading');
         const video = videoRef.current!;
+        // Ask for HD 16:9 so the fullscreen video is crisp (the camera returns
+        // the closest mode it supports; `ideal` never fails).
         stream = await navigator.mediaDevices.getUserMedia({
-          video: { width: 640, height: 480 },
+          video: { width: { ideal: 1280 }, height: { ideal: 720 } },
           audio: false,
         });
         if (disposed) {
@@ -56,6 +58,16 @@ export function useThoreminEngine() {
           };
         });
         if (disposed) return; // cleanup stops the now-assigned stream
+
+        // Size the canvas drawing buffer to the camera's native resolution so
+        // the overlay renders at full sharpness (CSS object-cover then scales it
+        // to fill the viewport). Landmarks normalize by the same video dims, so
+        // the overlay stays aligned at any resolution.
+        const canvas = canvasRef.current;
+        if (canvas) {
+          canvas.width = video.videoWidth || 1280;
+          canvas.height = video.videoHeight || 720;
+        }
 
         const resources = resourcesRef.current;
         resources.video = video;


### PR DESCRIPTION
The webcam video is the instrument's primary visual cue, but it was captured at 640×480 and upscaled to fill the screen, so it looked soft.

- Request **HD 16:9** capture (`ideal` 1280×720; the camera picks the closest mode it supports, never fails).
- Size the canvas **drawing buffer to the camera's native resolution** (set in `useEngine` after metadata) instead of a fixed 640×480, so the overlay draws at full sharpness; CSS `object-cover` then fills the viewport. A 16:9 capture fills a widescreen **edge-to-edge with no crop**.

Landmark alignment is unaffected: `webcam-hands` already reports frame dimensions from `video.videoWidth/Height` and the overlay normalizes by them, so the overlay tracks the video at any resolution.

Gates: strict typecheck ✅ · 93 tests ✅ · `vite build` ✅. Refs #6.

https://claude.ai/code/session_01Gp5tDXPQZuM7WaetpZwxij