### PR TITLE
feat(dag-view): gesture expression (openness→brightness) + more timbres

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -93,7 +93,7 @@ Hand features → tonal synth parameters (x→pitch w/ scale snap, y→volume).
 
 - **in:** features:hand-features, magnetism:number, octaveShift:number, mute:boolean, scaleRight:number[], scaleLeft:number[], instrumentRight:instrument, instrumentLeft:instrument
 - **out:** params:synth-params
-- **params:** magnetism (number=0.8), maxGain (number=0.5), opennessGatesGain (boolean=false), right (object={"scale":{"root":0,"type":"major","octaves":2,"baseOctave":3},"instrument":"sine"}), left (object={"scale":{"root":0,"type":"major","octaves":2,"baseOctave":3},"instrument":"triangle"})
+- **params:** magnetism (number=0.8), maxGain (number=0.5), opennessGatesGain (boolean=false), opennessControlsBrightness (boolean=true), right (object={"scale":{"root":0,"type":"major","octaves":2,"baseOctave":3},"instrument":"sine"}), left (object={"scale":{"root":0,"type":"major","octaves":2,"baseOctave":3},"instrument":"triangle"})
 
 #### `indirect-map` — Indirect Map
 Gesture features → weighted prompts + config dials (steers a generative engine).
@@ -131,7 +131,7 @@ Chord symbol (e.g. Cmaj7) → voiced synth params (one voice per chord tone).
 
 - **in:** chord:chord-symbol, gain:number
 - **out:** params:synth-params
-- **params:** baseOctave (number=4), maxVoices (number=4), instrument (enum(sine | triangle | square | sawtooth | warmPad | glass | bell | organ | voice | softLead)="sine")
+- **params:** baseOctave (number=4), maxVoices (number=4), instrument (enum(sine | triangle | square | sawtooth | warmPad | glass | bell | organ | voice | softLead | strings | flute | brass | choir)="sine")
 
 #### `progression` — Progression
 Roman-numeral progression in a key + position (0..1) → current chord symbol.
@@ -155,7 +155,7 @@ An immutable piece performed live: beat + velocityScale → sounding synth voice
 
 - **in:** beat:number, velocityScale:number
 - **out:** params:synth-params
-- **params:** notes (array=[]), loopBeats (number=8), baseGain (number=0.4), instrument (enum(sine | triangle | square | sawtooth | warmPad | glass | bell | organ | voice | softLead)="triangle")
+- **params:** notes (array=[]), loopBeats (number=8), baseGain (number=0.4), instrument (enum(sine | triangle | square | sawtooth | warmPad | glass | bell | organ | voice | softLead | strings | flute | brass | choir)="triangle")
 
 #### `performance` — Performance
 Control signal → tempo (bpm) + dynamics (velocityScale), with optional humanization.

--- a/public/catalog.json
+++ b/public/catalog.json
@@ -67,7 +67,7 @@
       },
       {
         "name": "instrument",
-        "type": "enum(sine | triangle | square | sawtooth | warmPad | glass | bell | organ | voice | softLead)",
+        "type": "enum(sine | triangle | square | sawtooth | warmPad | glass | bell | organ | voice | softLead | strings | flute | brass | choir)",
         "default": "sine"
       }
     ]
@@ -576,7 +576,7 @@
       },
       {
         "name": "instrument",
-        "type": "enum(sine | triangle | square | sawtooth | warmPad | glass | bell | organ | voice | softLead)",
+        "type": "enum(sine | triangle | square | sawtooth | warmPad | glass | bell | organ | voice | softLead | strings | flute | brass | choir)",
         "default": "triangle"
       }
     ]
@@ -748,6 +748,11 @@
         "name": "opennessGatesGain",
         "type": "boolean",
         "default": false
+      },
+      {
+        "name": "opennessControlsBrightness",
+        "type": "boolean",
+        "default": true
       },
       {
         "name": "right",

--- a/public/manual.html
+++ b/public/manual.html
@@ -108,7 +108,7 @@
       <dl>
         <dt>in</dt><dd>features:hand-features, magnetism:number, octaveShift:number, mute:boolean, scaleRight:number[], scaleLeft:number[], instrumentRight:instrument, instrumentLeft:instrument</dd>
         <dt>out</dt><dd>params:synth-params</dd>
-        <dt>params</dt><dd>magnetism (number=0.8), maxGain (number=0.5), opennessGatesGain (boolean=false), right (object={"scale":{"root":0,"type":"major","octaves":2,"baseOctave":3},"instrument":"sine"}), left (object={"scale":{"root":0,"type":"major","octaves":2,"baseOctave":3},"instrument":"triangle"})</dd>
+        <dt>params</dt><dd>magnetism (number=0.8), maxGain (number=0.5), opennessGatesGain (boolean=false), opennessControlsBrightness (boolean=true), right (object={"scale":{"root":0,"type":"major","octaves":2,"baseOctave":3},"instrument":"sine"}), left (object={"scale":{"root":0,"type":"major","octaves":2,"baseOctave":3},"instrument":"triangle"})</dd>
       </dl>
     </div>
     <div class="node">
@@ -154,7 +154,7 @@
       <dl>
         <dt>in</dt><dd>chord:chord-symbol, gain:number</dd>
         <dt>out</dt><dd>params:synth-params</dd>
-        <dt>params</dt><dd>baseOctave (number=4), maxVoices (number=4), instrument (enum(sine | triangle | square | sawtooth | warmPad | glass | bell | organ | voice | softLead)="sine")</dd>
+        <dt>params</dt><dd>baseOctave (number=4), maxVoices (number=4), instrument (enum(sine | triangle | square | sawtooth | warmPad | glass | bell | organ | voice | softLead | strings | flute | brass | choir)="sine")</dd>
       </dl>
     </div>
     <div class="node">
@@ -182,7 +182,7 @@
       <dl>
         <dt>in</dt><dd>beat:number, velocityScale:number</dd>
         <dt>out</dt><dd>params:synth-params</dd>
-        <dt>params</dt><dd>notes (array=[]), loopBeats (number=8), baseGain (number=0.4), instrument (enum(sine | triangle | square | sawtooth | warmPad | glass | bell | organ | voice | softLead)="triangle")</dd>
+        <dt>params</dt><dd>notes (array=[]), loopBeats (number=8), baseGain (number=0.4), instrument (enum(sine | triangle | square | sawtooth | warmPad | glass | bell | organ | voice | softLead | strings | flute | brass | choir)="triangle")</dd>
       </dl>
     </div>
     <div class="node">

--- a/src/music/instruments.ts
+++ b/src/music/instruments.ts
@@ -144,6 +144,60 @@ export const INSTRUMENTS = {
     reverbSend: 0.18,
     gain: 0.8,
   },
+  strings: {
+    name: 'Strings',
+    partials: [
+      { type: 'sawtooth', detuneCents: -9 },
+      { type: 'sawtooth' },
+      { type: 'sawtooth', detuneCents: 9 },
+    ],
+    filter: { type: 'lowpass', cutoff: 2600, q: 0.5 },
+    vibrato: { rateHz: 5.2, depthCents: 7 },
+    attack: 0.22,
+    release: 0.3,
+    reverbSend: 0.4,
+    gain: 0.7,
+  },
+  flute: {
+    name: 'Flute',
+    partials: [
+      { type: 'sine' },
+      { type: 'triangle', gain: 0.15, ratio: 2 },
+    ],
+    filter: { type: 'lowpass', cutoff: 2000, q: 0.7 },
+    vibrato: { rateHz: 5.5, depthCents: 8 },
+    attack: 0.06,
+    release: 0.14,
+    reverbSend: 0.3,
+    gain: 0.85,
+  },
+  brass: {
+    name: 'Brass',
+    partials: [
+      { type: 'sawtooth' },
+      { type: 'square', gain: 0.3, detuneCents: 4 },
+    ],
+    filter: { type: 'lowpass', cutoff: 2400, q: 1 },
+    vibrato: { rateHz: 5, depthCents: 5 },
+    attack: 0.07,
+    release: 0.12,
+    reverbSend: 0.2,
+    gain: 0.75,
+  },
+  choir: {
+    name: 'Choir',
+    partials: [
+      { type: 'triangle', detuneCents: -6 },
+      { type: 'sine' },
+      { type: 'triangle', detuneCents: 6 },
+    ],
+    filter: { type: 'lowpass', cutoff: 1800, q: 1.2 },
+    vibrato: { rateHz: 4.8, depthCents: 10 },
+    attack: 0.16,
+    release: 0.3,
+    reverbSend: 0.45,
+    gain: 0.78,
+  },
 } as const satisfies Record<string, InstrumentPreset>;
 
 /** A valid instrument id (literal union of {@link INSTRUMENTS} keys). */

--- a/src/nodes/domain.ts
+++ b/src/nodes/domain.ts
@@ -67,6 +67,12 @@ export interface VoiceParams {
   gain: number;
   /** Instrument timbre — an id from the {@link InstrumentId} registry. */
   instrument: InstrumentId;
+  /**
+   * Live tone brightness, 0 (dark/mellow) .. 1 (open/present). Drives a
+   * per-voice low-pass in the synth so gestures (e.g. hand openness) shape
+   * timbre expressively. Optional; absent is treated as 1 (fully open).
+   */
+  brightness?: number;
 }
 
 export interface SynthParams {

--- a/src/nodes/mapping/voice_mapping.ts
+++ b/src/nodes/mapping/voice_mapping.ts
@@ -40,6 +40,8 @@ const Params = z.object({
   maxGain: z.number().min(0).max(1).default(0.5),
   /** If true, a closed fist mutes the voice (openness gates gain). */
   opennessGatesGain: z.boolean().default(false),
+  /** If true, hand openness shapes tone brightness (open = brighter). */
+  opennessControlsBrightness: z.boolean().default(true),
   right: z.object({ scale: ScaleParams, instrument: Instrument.default('sine') }).default({
     scale: ScaleParams.parse({}),
     instrument: 'sine',
@@ -67,13 +69,16 @@ function voiceFor(
   ctrl: Control,
 ): VoiceParams {
   if (!feat.present || ctrl.mute) {
-    return { id, present: false, freq: midiToFreq(scaleMidis[0] ?? 60), gain: 0, instrument };
+    return { id, present: false, freq: midiToFreq(scaleMidis[0] ?? 60), gain: 0, instrument, brightness: 1 };
   }
   const midi = magneticPitch(feat.x, scaleMidis, ctrl.magnetism) + ctrl.octaveShift * 12;
   const freq = midiToFreq(midi);
   let gain = (1 - feat.y) * p.maxGain;
   if (p.opennessGatesGain) gain *= feat.openness;
-  return { id, present: true, freq, gain, instrument };
+  // Openness shapes brightness: closed hand stays mellow (0.3) but never fully
+  // muffled; open hand is fully present (1.0). Off → neutral (fully open).
+  const brightness = p.opennessControlsBrightness ? 0.3 + 0.7 * feat.openness : 1;
+  return { id, present: true, freq, gain, instrument, brightness };
 }
 
 export const voiceMappingNode = defineNode<Params>({

--- a/src/nodes/output/webaudio_synth.ts
+++ b/src/nodes/output/webaudio_synth.ts
@@ -38,12 +38,20 @@ interface Voice {
   instrument: string;
   partials: PartialOsc[];
   vibrato: { lfo: OscillatorNode } | null;
+  /** Live low-pass whose cutoff tracks the voice's `brightness` (expression). */
+  brightnessFilter: BiquadFilterNode;
   /** The amplitude-envelope gain driven by the voice's `gain`. */
   voiceGain: GainNode;
   /** Every node to disconnect on teardown. */
   nodes: AudioNode[];
   attack: number;
   release: number;
+}
+
+/** Map a brightness (0..1) to a low-pass cutoff (Hz), exponentially. NaN-safe. */
+function brightnessToCutoff(brightness: number): number {
+  const b = Number.isFinite(brightness) ? Math.max(0, Math.min(1, brightness)) : 1;
+  return 500 * Math.pow(28, b); // 500 Hz (dark) .. 14 kHz (open)
 }
 
 /** Shared per-synth audio infrastructure, built lazily once audio exists. */
@@ -115,14 +123,23 @@ function buildVoice(ac: AudioContext, bus: Bus, v: VoiceParams, p: Params): Voic
   voiceGain.gain.setValueAtTime(0, now);
   nodes.push(voiceGain);
 
-  // Partials sum into an optional filter, then the amplitude-envelope gain.
-  let sumTarget: AudioNode = voiceGain;
+  // Live brightness low-pass (expression) sits just before the envelope gain,
+  // so every preset responds to gesture even if it has no filter of its own.
+  const brightnessFilter = ac.createBiquadFilter();
+  brightnessFilter.type = 'lowpass';
+  brightnessFilter.frequency.setValueAtTime(brightnessToCutoff(v.brightness ?? 1), now);
+  brightnessFilter.Q.setValueAtTime(0.7, now);
+  brightnessFilter.connect(voiceGain);
+  nodes.push(brightnessFilter);
+
+  // Partials sum into the preset filter (if any), then the brightness filter.
+  let sumTarget: AudioNode = brightnessFilter;
   if (preset.filter) {
     const filter = ac.createBiquadFilter();
     filter.type = preset.filter.type;
     filter.frequency.setValueAtTime(preset.filter.cutoff, now);
     filter.Q.setValueAtTime(preset.filter.q ?? 0.7, now);
-    filter.connect(voiceGain);
+    filter.connect(brightnessFilter);
     nodes.push(filter);
     sumTarget = filter;
   }
@@ -172,6 +189,7 @@ function buildVoice(ac: AudioContext, bus: Bus, v: VoiceParams, p: Params): Voic
     instrument: v.instrument,
     partials,
     vibrato,
+    brightnessFilter,
     voiceGain,
     nodes,
     attack: preset.attack ?? p.gainGlide,
@@ -266,6 +284,11 @@ export const webAudioSynthNode = defineNode<Params>({
             for (const part of voice.partials) {
               part.osc.frequency.setTargetAtTime(v.freq * part.ratio, now, p.freqGlide);
             }
+            voice.brightnessFilter.frequency.setTargetAtTime(
+              brightnessToCutoff(v.brightness ?? 1),
+              now,
+              0.04,
+            );
             voice.voiceGain.gain.setTargetAtTime(v.gain, now, voice.attack);
           } else if (voice) {
             voice.voiceGain.gain.setTargetAtTime(0, now, voice.release);

--- a/test/expression.test.ts
+++ b/test/expression.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Tests the gesture-expression mapping added to voice-mapping: hand openness
+ * shapes a live `brightness` (0..1) on each voice, which the synth turns into a
+ * per-voice low-pass cutoff. Pure/headless — the audio realization is verified
+ * in the browser; here we check the control value the synth consumes.
+ */
+import { describe, it, expect } from 'vitest';
+import { replayNode } from '@/dag';
+import { voiceMappingNode, ABSENT_HAND, type HandFeatures, type SynthParams } from '@/nodes';
+
+function feats(openness: number): HandFeatures {
+  return {
+    left: { ...ABSENT_HAND },
+    right: { ...ABSENT_HAND, present: true, x: 0.5, y: 0.3, openness, pinch: 0 },
+  };
+}
+
+async function rightBrightness(openness: number, params: Record<string, unknown> = {}): Promise<number> {
+  const node = voiceMappingNode.make(voiceMappingNode.params.parse(params));
+  const out = await replayNode(node, { features: [feats(openness)] });
+  return (out[0].params as SynthParams).voices[0].brightness!;
+}
+
+describe('openness → brightness expression', () => {
+  it('an open hand is brighter than a fist (default on)', async () => {
+    const open = await rightBrightness(1);
+    const fist = await rightBrightness(0);
+    expect(open).toBeGreaterThan(fist);
+    expect(open).toBeCloseTo(1, 5); // fully open → fully present
+    expect(fist).toBeCloseTo(0.3, 5); // closed stays mellow, never fully muffled
+  });
+
+  it('maps monotonically across the openness range', async () => {
+    const lo = await rightBrightness(0.25);
+    const hi = await rightBrightness(0.75);
+    expect(hi).toBeGreaterThan(lo);
+  });
+
+  it('is neutral (1) when opennessControlsBrightness is off', async () => {
+    expect(await rightBrightness(0, { opennessControlsBrightness: false })).toBe(1);
+    expect(await rightBrightness(1, { opennessControlsBrightness: false })).toBe(1);
+  });
+});


### PR DESCRIPTION
Makes the instrument expressive and adds variety.

## Gesture expression
Your finger **openness now shapes the tone** — open hand = bright/present, closed = mellow. Previously openness/pinch were tracked and shown but did nothing audible.
- `VoiceParams` gains an optional `brightness` (0 dark .. 1 open; absent = fully open, so chord/score voices are unaffected).
- `voice-mapping` maps `openness → brightness` (`0.3 + 0.7·openness` — closed stays mellow, never fully muffled), behind a new `opennessControlsBrightness` param (default on).
- `webaudio-synth` gives every voice a **live low-pass** whose cutoff tracks `brightness` (exponential 500 Hz .. 14 kHz, NaN-safe), inserted after any preset filter so **every** instrument responds. The filter is torn down with the voice.

## More timbres
Added **Strings, Flute, Brass, Choir** (14 instruments total).

## Gates
- Strict typecheck ✅ · **96 tests** ✅ (new `test/expression.test.ts` — mapping, monotonicity, off-path) · `vite build` ✅
- Adversarial review (2 lenses → independent verify): **0 findings**.
- Manual regenerated from the registry.

Refs #6.

https://claude.ai/code/session_01Gp5tDXPQZuM7WaetpZwxij