### PR TITLE
feat(dag-view): show the note name each hand is playing

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -185,9 +185,9 @@ Steers a generative engine (Lyria RealTime) from weighted prompts + config dials
 _Audio + the captured video with overlaid guides._
 
 #### `canvas-overlay` — Canvas Overlay
-Draws mirrored video + landmarks + control markers + HUD.
+Draws mirrored video + landmarks + control markers + per-hand note names.
 
-- **in:** hands:hands-frame, features:hand-features
+- **in:** hands:hands-frame, features:hand-features, params:synth-params
 - **out:** —
-- **params:** showLandmarks (boolean=true), showVideo (boolean=true), videoAlpha (number=0.35)
+- **params:** showLandmarks (boolean=true), showVideo (boolean=true), videoAlpha (number=0.35), showNotes (boolean=true)
 

--- a/public/catalog.json
+++ b/public/catalog.json
@@ -2,7 +2,7 @@
   {
     "type": "canvas-overlay",
     "title": "Canvas Overlay",
-    "description": "Draws mirrored video + landmarks + control markers + HUD.",
+    "description": "Draws mirrored video + landmarks + control markers + per-hand note names.",
     "inputs": [
       {
         "name": "hands",
@@ -11,6 +11,10 @@
       {
         "name": "features",
         "kind": "hand-features"
+      },
+      {
+        "name": "params",
+        "kind": "synth-params"
       }
     ],
     "outputs": [],
@@ -29,6 +33,11 @@
         "name": "videoAlpha",
         "type": "number",
         "default": 0.35
+      },
+      {
+        "name": "showNotes",
+        "type": "boolean",
+        "default": true
       }
     ]
   },

--- a/public/manual.html
+++ b/public/manual.html
@@ -216,11 +216,11 @@
 <section><h3>Output</h3><p class="blurb">Audio + the captured video with overlaid guides.</p><div class="grid">
     <div class="node">
       <h4><code>canvas-overlay</code> <span class="title">Canvas Overlay</span></h4>
-      <p>Draws mirrored video + landmarks + control markers + HUD.</p>
+      <p>Draws mirrored video + landmarks + control markers + per-hand note names.</p>
       <dl>
-        <dt>in</dt><dd>hands:hands-frame, features:hand-features</dd>
+        <dt>in</dt><dd>hands:hands-frame, features:hand-features, params:synth-params</dd>
         <dt>out</dt><dd>—</dd>
-        <dt>params</dt><dd>showLandmarks (boolean=true), showVideo (boolean=true), videoAlpha (number=0.35)</dd>
+        <dt>params</dt><dd>showLandmarks (boolean=true), showVideo (boolean=true), videoAlpha (number=0.35), showNotes (boolean=true)</dd>
       </dl>
     </div></div></section>
 </div></body></html>

--- a/src/app/graph.ts
+++ b/src/app/graph.ts
@@ -39,6 +39,8 @@ export function defaultGraph(): GraphSpec {
       { from: { node: 'ui', port: 'instrumentRight' }, to: { node: 'map', port: 'instrumentRight' } },
       { from: { node: 'ui', port: 'instrumentLeft' }, to: { node: 'map', port: 'instrumentLeft' } },
       { from: { node: 'map', port: 'params' }, to: { node: 'synth', port: 'params' } },
+      // Also feed params to the overlay so it can label each hand's note.
+      { from: { node: 'map', port: 'params' }, to: { node: 'overlay', port: 'params' } },
     ],
   };
 }

--- a/src/nodes/output/canvas_overlay.ts
+++ b/src/nodes/output/canvas_overlay.ts
@@ -9,12 +9,15 @@
 import { z } from 'zod';
 import { defineNode } from '@/dag';
 import type { NodeContext } from '@/dag';
-import { LM, type HandFeatures, type HandsFrame, type SingleHandFeatures } from '../domain';
+import { freqToMidi, midiToName } from '@/music/theory';
+import { LM, type HandFeatures, type HandsFrame, type SingleHandFeatures, type SynthParams } from '../domain';
 
 const Params = z.object({
   showLandmarks: z.boolean().default(true),
   showVideo: z.boolean().default(true),
   videoAlpha: z.number().min(0).max(1).default(0.35),
+  /** Show the note name each hand is currently playing, above its marker. */
+  showNotes: z.boolean().default(true),
 });
 type Params = z.infer<typeof Params>;
 
@@ -24,10 +27,13 @@ const LEFT_COLOR = '#3b82f6';
 export const canvasOverlayNode = defineNode<Params>({
   type: 'canvas-overlay',
   title: 'Canvas Overlay',
-  description: 'Draws mirrored video + landmarks + control markers + HUD.',
+  description: 'Draws mirrored video + landmarks + control markers + per-hand note names.',
   inputs: [
     { name: 'hands', kind: 'hands-frame' },
     { name: 'features', kind: 'hand-features' },
+    // Optional: the synth params (voice 0 = right, 1 = left) so the overlay can
+    // label each hand with the note it is sounding. Unconnected → no labels.
+    { name: 'params', kind: 'synth-params' },
   ],
   outputs: [],
   params: Params,
@@ -82,8 +88,18 @@ export const canvasOverlayNode = defineNode<Params>({
           }
         }
 
-        // Control markers from features (x already mirrored, matches video).
-        const drawMarker = (f: SingleHandFeatures, color: string) => {
+        // The synth params let us label each hand with the note it's sounding
+        // (voice 0 = right, 1 = left, by convention).
+        const sp = inputs.params as SynthParams | undefined;
+        const noteFor = (voiceId: number): string | null => {
+          const v = sp?.voices?.[voiceId];
+          if (!v || !v.present || v.freq <= 0) return null;
+          return midiToName(freqToMidi(v.freq));
+        };
+
+        // Control markers from features (x already mirrored, matches video),
+        // with the current note drawn above each present hand.
+        const drawMarker = (f: SingleHandFeatures, color: string, note: string | null) => {
           if (!f.present) return;
           const sx = f.x * W;
           const sy = f.y * H;
@@ -99,27 +115,17 @@ export const canvasOverlayNode = defineNode<Params>({
           g.arc(sx, sy, 8, 0, Math.PI * 2);
           g.fill();
           g.globalAlpha = 1;
+          if (p.showNotes && note) {
+            g.fillStyle = color;
+            g.font = 'bold 22px monospace';
+            g.textAlign = 'center';
+            g.fillText(note, sx, sy - ring - 10);
+            g.textAlign = 'left';
+          }
         };
         if (feats) {
-          drawMarker(feats.right, RIGHT_COLOR);
-          drawMarker(feats.left, LEFT_COLOR);
-
-          // HUD
-          g.fillStyle = 'rgba(255,255,255,0.7)';
-          g.font = '11px monospace';
-          const hud = (label: string, f: SingleHandFeatures, y: number) => {
-            if (!f.present) {
-              g.fillText(`${label}: --`, 8, y);
-              return;
-            }
-            g.fillText(
-              `${label}  x:${f.x.toFixed(2)} y:${f.y.toFixed(2)} open:${f.openness.toFixed(2)} pinch:${f.pinch.toFixed(2)}`,
-              8,
-              y,
-            );
-          };
-          hud('R', feats.right, H - 24);
-          hud('L', feats.left, H - 8);
+          drawMarker(feats.right, RIGHT_COLOR, noteFor(0));
+          drawMarker(feats.left, LEFT_COLOR, noteFor(1));
         }
 
         return {};


### PR DESCRIPTION
Replaces the techy debug HUD (x/y/openness/pinch) with **musical feedback**: the note each hand is currently sounding, drawn above its control marker — so you can see what you're playing.

- `canvas-overlay` gains an optional `params` input (synth params) and a `showNotes` param (default on). It labels voice 0 → right hand, voice 1 → left, via `midiToName(freqToMidi(freq))`. Unconnected params → no labels (backward compatible for other graphs).
- `graph.ts` fans `map.params` out to the overlay as well as the synth.
- Drawing the note **above the marker** (not a bottom HUD) keeps it visible under the fullscreen `object-cover` crop.

Gates: strict typecheck ✅ · **96 tests** ✅ (`app_graph` validates the new edge) · `vite build` ✅ · manual regenerated.

Refs #6.

https://claude.ai/code/session_01Gp5tDXPQZuM7WaetpZwxij