### PR TITLE
feat(dag-view): pinch → vibrato expression

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -93,7 +93,7 @@ Hand features → tonal synth parameters (x→pitch w/ scale snap, y→volume).
 
 - **in:** features:hand-features, magnetism:number, octaveShift:number, mute:boolean, scaleRight:number[], scaleLeft:number[], instrumentRight:instrument, instrumentLeft:instrument
 - **out:** params:synth-params
-- **params:** magnetism (number=0.8), maxGain (number=0.5), opennessGatesGain (boolean=false), opennessControlsBrightness (boolean=true), right (object={"scale":{"root":0,"type":"major","octaves":2,"baseOctave":3},"instrument":"sine"}), left (object={"scale":{"root":0,"type":"major","octaves":2,"baseOctave":3},"instrument":"triangle"})
+- **params:** magnetism (number=0.8), maxGain (number=0.5), opennessGatesGain (boolean=false), opennessControlsBrightness (boolean=true), pinchControlsVibrato (boolean=true), right (object={"scale":{"root":0,"type":"major","octaves":2,"baseOctave":3},"instrument":"sine"}), left (object={"scale":{"root":0,"type":"major","octaves":2,"baseOctave":3},"instrument":"triangle"})
 
 #### `indirect-map` — Indirect Map
 Gesture features → weighted prompts + config dials (steers a generative engine).

--- a/public/catalog.json
+++ b/public/catalog.json
@@ -764,6 +764,11 @@
         "default": true
       },
       {
+        "name": "pinchControlsVibrato",
+        "type": "boolean",
+        "default": true
+      },
+      {
         "name": "right",
         "type": "object",
         "default": {

--- a/public/manual.html
+++ b/public/manual.html
@@ -108,7 +108,7 @@
       <dl>
         <dt>in</dt><dd>features:hand-features, magnetism:number, octaveShift:number, mute:boolean, scaleRight:number[], scaleLeft:number[], instrumentRight:instrument, instrumentLeft:instrument</dd>
         <dt>out</dt><dd>params:synth-params</dd>
-        <dt>params</dt><dd>magnetism (number=0.8), maxGain (number=0.5), opennessGatesGain (boolean=false), opennessControlsBrightness (boolean=true), right (object={"scale":{"root":0,"type":"major","octaves":2,"baseOctave":3},"instrument":"sine"}), left (object={"scale":{"root":0,"type":"major","octaves":2,"baseOctave":3},"instrument":"triangle"})</dd>
+        <dt>params</dt><dd>magnetism (number=0.8), maxGain (number=0.5), opennessGatesGain (boolean=false), opennessControlsBrightness (boolean=true), pinchControlsVibrato (boolean=true), right (object={"scale":{"root":0,"type":"major","octaves":2,"baseOctave":3},"instrument":"sine"}), left (object={"scale":{"root":0,"type":"major","octaves":2,"baseOctave":3},"instrument":"triangle"})</dd>
       </dl>
     </div>
     <div class="node">

--- a/src/nodes/domain.ts
+++ b/src/nodes/domain.ts
@@ -73,6 +73,12 @@ export interface VoiceParams {
    * timbre expressively. Optional; absent is treated as 1 (fully open).
    */
   brightness?: number;
+  /**
+   * Live vibrato amount, 0 (none) .. 1 (full). Adds pitch wobble on top of any
+   * preset vibrato, so gestures (e.g. pinch) add expression. Optional; absent
+   * is treated as 0 (no added vibrato).
+   */
+  vibrato?: number;
 }
 
 export interface SynthParams {

--- a/src/nodes/mapping/voice_mapping.ts
+++ b/src/nodes/mapping/voice_mapping.ts
@@ -42,6 +42,8 @@ const Params = z.object({
   opennessGatesGain: z.boolean().default(false),
   /** If true, hand openness shapes tone brightness (open = brighter). */
   opennessControlsBrightness: z.boolean().default(true),
+  /** If true, pinch (thumb-index) adds vibrato (pinch = more wobble). */
+  pinchControlsVibrato: z.boolean().default(true),
   right: z.object({ scale: ScaleParams, instrument: Instrument.default('sine') }).default({
     scale: ScaleParams.parse({}),
     instrument: 'sine',
@@ -69,7 +71,7 @@ function voiceFor(
   ctrl: Control,
 ): VoiceParams {
   if (!feat.present || ctrl.mute) {
-    return { id, present: false, freq: midiToFreq(scaleMidis[0] ?? 60), gain: 0, instrument, brightness: 1 };
+    return { id, present: false, freq: midiToFreq(scaleMidis[0] ?? 60), gain: 0, instrument, brightness: 1, vibrato: 0 };
   }
   const midi = magneticPitch(feat.x, scaleMidis, ctrl.magnetism) + ctrl.octaveShift * 12;
   const freq = midiToFreq(midi);
@@ -78,7 +80,9 @@ function voiceFor(
   // Openness shapes brightness: closed hand stays mellow (0.3) but never fully
   // muffled; open hand is fully present (1.0). Off → neutral (fully open).
   const brightness = p.opennessControlsBrightness ? 0.3 + 0.7 * feat.openness : 1;
-  return { id, present: true, freq, gain, instrument, brightness };
+  // Pinch adds vibrato (0 = none .. 1 = full wobble). Off → none.
+  const vibrato = p.pinchControlsVibrato ? Math.max(0, Math.min(1, feat.pinch)) : 0;
+  return { id, present: true, freq, gain, instrument, brightness, vibrato };
 }
 
 export const voiceMappingNode = defineNode<Params>({

--- a/src/nodes/output/webaudio_synth.ts
+++ b/src/nodes/output/webaudio_synth.ts
@@ -37,7 +37,8 @@ interface Voice {
   /** The instrument id this voice was built for (rebuilt if it changes). */
   instrument: string;
   partials: PartialOsc[];
-  vibrato: { lfo: OscillatorNode } | null;
+  /** Always-on vibrato LFO; `depth` (cents) tracks preset base + live amount. */
+  vibrato: { lfo: OscillatorNode; depth: GainNode; baseCents: number };
   /** Live low-pass whose cutoff tracks the voice's `brightness` (expression). */
   brightnessFilter: BiquadFilterNode;
   /** The amplitude-envelope gain driven by the voice's `gain`. */
@@ -52,6 +53,16 @@ interface Voice {
 function brightnessToCutoff(brightness: number): number {
   const b = Number.isFinite(brightness) ? Math.max(0, Math.min(1, brightness)) : 1;
   return 500 * Math.pow(28, b); // 500 Hz (dark) .. 14 kHz (open)
+}
+
+/** Extra detune (cents) added at full live vibrato, on top of any preset base. */
+const MAX_VIBRATO_CENTS = 35;
+const DFLT_VIBRATO_HZ = 5.5;
+
+/** Total vibrato depth (cents) from a preset base + a live amount (0..1). NaN-safe. */
+function vibratoDepthCents(baseCents: number, amount: number): number {
+  const a = Number.isFinite(amount) ? Math.max(0, Math.min(1, amount)) : 0;
+  return baseCents + a * MAX_VIBRATO_CENTS;
 }
 
 /** Shared per-synth audio infrastructure, built lazily once audio exists. */
@@ -157,19 +168,19 @@ function buildVoice(ac: AudioContext, bus: Bus, v: VoiceParams, p: Params): Voic
     return { osc, ratio: part.ratio ?? 1 };
   });
 
-  // Vibrato: an LFO modulating every partial's detune (cents).
-  let vibrato: Voice['vibrato'] = null;
-  if (preset.vibrato) {
-    const lfo = ac.createOscillator();
-    lfo.frequency.setValueAtTime(preset.vibrato.rateHz, now);
-    const depth = ac.createGain();
-    depth.gain.setValueAtTime(preset.vibrato.depthCents, now);
-    lfo.connect(depth);
-    partials.forEach((pp) => depth.connect(pp.osc.detune));
-    lfo.start();
-    nodes.push(lfo, depth);
-    vibrato = { lfo };
-  }
+  // Vibrato: an always-on LFO modulating every partial's detune (cents). The
+  // depth is the preset's base plus a live amount (e.g. from pinch), so any
+  // instrument can be made to wobble by gesture.
+  const baseCents = preset.vibrato?.depthCents ?? 0;
+  const lfo = ac.createOscillator();
+  lfo.frequency.setValueAtTime(preset.vibrato?.rateHz ?? DFLT_VIBRATO_HZ, now);
+  const depth = ac.createGain();
+  depth.gain.setValueAtTime(vibratoDepthCents(baseCents, v.vibrato ?? 0), now);
+  lfo.connect(depth);
+  partials.forEach((pp) => depth.connect(pp.osc.detune));
+  lfo.start();
+  nodes.push(lfo, depth);
+  const vibrato = { lfo, depth, baseCents };
 
   // Output: voiceGain → trim → (dry) compressor; trim → send → reverb.
   const trim = ac.createGain();
@@ -222,12 +233,10 @@ function teardownVoice(voice: Voice, ac: AudioContext, fade = false): void {
       /* already stopped */
     }
   }
-  if (voice.vibrato) {
-    try {
-      voice.vibrato.lfo.stop(now + tail);
-    } catch {
-      /* already stopped */
-    }
+  try {
+    voice.vibrato.lfo.stop(now + tail);
+  } catch {
+    /* already stopped */
   }
   const disconnectAll = () => {
     for (const n of voice.nodes) {
@@ -288,6 +297,11 @@ export const webAudioSynthNode = defineNode<Params>({
               brightnessToCutoff(v.brightness ?? 1),
               now,
               0.04,
+            );
+            voice.vibrato.depth.gain.setTargetAtTime(
+              vibratoDepthCents(voice.vibrato.baseCents, v.vibrato ?? 0),
+              now,
+              0.05,
             );
             voice.voiceGain.gain.setTargetAtTime(v.gain, now, voice.attack);
           } else if (voice) {

--- a/test/expression.test.ts
+++ b/test/expression.test.ts
@@ -8,17 +8,24 @@ import { describe, it, expect } from 'vitest';
 import { replayNode } from '@/dag';
 import { voiceMappingNode, ABSENT_HAND, type HandFeatures, type SynthParams } from '@/nodes';
 
-function feats(openness: number): HandFeatures {
+function feats(openness: number, pinch = 0): HandFeatures {
   return {
     left: { ...ABSENT_HAND },
-    right: { ...ABSENT_HAND, present: true, x: 0.5, y: 0.3, openness, pinch: 0 },
+    right: { ...ABSENT_HAND, present: true, x: 0.5, y: 0.3, openness, pinch },
   };
 }
 
-async function rightBrightness(openness: number, params: Record<string, unknown> = {}): Promise<number> {
+async function rightVoice(
+  feature: HandFeatures,
+  params: Record<string, unknown> = {},
+): Promise<SynthParams['voices'][number]> {
   const node = voiceMappingNode.make(voiceMappingNode.params.parse(params));
-  const out = await replayNode(node, { features: [feats(openness)] });
-  return (out[0].params as SynthParams).voices[0].brightness!;
+  const out = await replayNode(node, { features: [feature] });
+  return (out[0].params as SynthParams).voices[0];
+}
+
+async function rightBrightness(openness: number, params: Record<string, unknown> = {}): Promise<number> {
+  return (await rightVoice(feats(openness), params)).brightness!;
 }
 
 describe('openness → brightness expression', () => {
@@ -39,5 +46,17 @@ describe('openness → brightness expression', () => {
   it('is neutral (1) when opennessControlsBrightness is off', async () => {
     expect(await rightBrightness(0, { opennessControlsBrightness: false })).toBe(1);
     expect(await rightBrightness(1, { opennessControlsBrightness: false })).toBe(1);
+  });
+});
+
+describe('pinch → vibrato expression', () => {
+  it('pinching adds vibrato; an open pinch adds none (default on)', async () => {
+    expect((await rightVoice(feats(0.5, 1))).vibrato).toBeCloseTo(1, 5);
+    expect((await rightVoice(feats(0.5, 0))).vibrato).toBeCloseTo(0, 5);
+  });
+
+  it('clamps to 0..1 and is 0 when pinchControlsVibrato is off', async () => {
+    expect(await (async () => (await rightVoice(feats(0.5, 5))).vibrato)()).toBeLessThanOrEqual(1);
+    expect((await rightVoice(feats(0.5, 1), { pinchControlsVibrato: false })).vibrato).toBe(0);
   });
 });


### PR DESCRIPTION
Pinch was tracked but inert; now it **adds vibrato** (pinch fingers = wobble), so both hand gestures shape the sound — openness→brightness (#35) and now pinch→vibrato.

- `VoiceParams` gains optional `vibrato` (0..1 live amount; absent = 0, so chord/score voices are unaffected).
- `voice-mapping` maps pinch → vibrato (clamped 0..1) behind a new `pinchControlsVibrato` param (default on).
- `webaudio-synth`: every voice now has an **always-on vibrato LFO** whose depth = the preset's base cents + the live amount (up to +35 cents, NaN-safe). Presets with their own vibrato keep it **exactly** at pinch=0; previously dry presets stay dry until pinched. The LFO is torn down with the voice.

Gates: strict typecheck ✅ · **98 tests** ✅ (expression test extended) · `vite build` ✅ · focused adversarial review: **0 findings** · manual regenerated.

Refs #6.

https://claude.ai/code/session_01Gp5tDXPQZuM7WaetpZwxij