### PR TITLE
feat(dag-view): mobile/touch fitness (dvh, responsive panel, front camera)

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -19,7 +19,7 @@ export default function App() {
   const [panelOpen, setPanelOpen] = useState(true);
 
   return (
-    <div className="relative h-screen w-screen overflow-hidden bg-black font-mono text-white">
+    <div className="relative h-dvh w-screen overflow-hidden bg-black font-mono text-white">
       {/* Hidden webcam feed; the DAG draws the mirrored video + overlays to the
           canvas. The buffer is sized to the camera's native resolution in
           useEngine (so the draw is crisp); object-cover then fills the whole
@@ -53,7 +53,7 @@ export default function App() {
       {/* Top-right: collapsible controls — open by default (available), minimize
           to a single gear once you've set things up. */}
       {panelOpen ? (
-        <div className="absolute right-3 top-3 flex max-h-[calc(100vh-1.5rem)] w-72 flex-col overflow-hidden rounded-2xl border border-white/10 bg-black/60 backdrop-blur">
+        <div className="absolute right-3 top-3 flex max-h-[calc(100dvh-1.5rem)] w-72 max-w-[calc(100vw-1.5rem)] flex-col overflow-hidden rounded-2xl border border-white/10 bg-black/60 backdrop-blur">
           <div className="flex items-center justify-between border-b border-white/10 px-4 py-2">
             <span className="text-[11px] font-bold uppercase tracking-widest text-white/70">Controls</span>
             <button

--- a/src/app/useEngine.ts
+++ b/src/app/useEngine.ts
@@ -39,10 +39,16 @@ export function useThoreminEngine() {
       try {
         setStatus('loading');
         const video = videoRef.current!;
-        // Ask for HD 16:9 so the fullscreen video is crisp (the camera returns
-        // the closest mode it supports; `ideal` never fails).
+        // Ask for HD 16:9 so the fullscreen video is crisp, and the front
+        // (user-facing) camera so the mirrored view shows your own hands on
+        // mobile. All are `ideal` soft constraints: the camera returns the
+        // closest mode it supports and never fails.
         stream = await navigator.mediaDevices.getUserMedia({
-          video: { width: { ideal: 1280 }, height: { ideal: 720 } },
+          video: {
+            width: { ideal: 1280 },
+            height: { ideal: 720 },
+            facingMode: { ideal: 'user' },
+          },
           audio: false,
         });
         if (disposed) {


### PR DESCRIPTION
Makes the fullscreen instrument behave on phones/tablets.

- **Root uses `h-dvh`** (dynamic viewport height) so the video fills the screen under mobile browser chrome instead of being clipped by `100vh`.
- **Controls panel caps to the viewport** (`max-w-[calc(100vw-1.5rem)]` + dvh max-height) so it never overflows a narrow screen.
- **Front camera by default** (`facingMode: { ideal: 'user' }`) so the mirrored view shows your own hands on mobile (no-op on single-camera desktops).

App-shell + one soft constraint only. Strict typecheck ✅ · 98 tests ✅ · `vite build` ✅.

Refs #6.

https://claude.ai/code/session_01Gp5tDXPQZuM7WaetpZwxij