### PR TITLE
feat(dag-view): pitch/scale guide + fixture-verified expression

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -187,7 +187,7 @@ _Audio + the captured video with overlaid guides._
 #### `canvas-overlay` — Canvas Overlay
 Draws mirrored video + landmarks + control markers + per-hand note names.
 
-- **in:** hands:hands-frame, features:hand-features, params:synth-params
+- **in:** hands:hands-frame, features:hand-features, params:synth-params, scale:number[], octaveShift:number
 - **out:** —
-- **params:** showLandmarks (boolean=true), showVideo (boolean=true), videoAlpha (number=0.35), showNotes (boolean=true)
+- **params:** showLandmarks (boolean=true), showVideo (boolean=true), videoAlpha (number=0.35), showNotes (boolean=true), showScaleGuide (boolean=true)
 

--- a/public/catalog.json
+++ b/public/catalog.json
@@ -15,6 +15,15 @@
       {
         "name": "params",
         "kind": "synth-params"
+      },
+      {
+        "name": "scale",
+        "kind": "number[]"
+      },
+      {
+        "name": "octaveShift",
+        "kind": "number",
+        "default": 0
       }
     ],
     "outputs": [],
@@ -36,6 +45,11 @@
       },
       {
         "name": "showNotes",
+        "type": "boolean",
+        "default": true
+      },
+      {
+        "name": "showScaleGuide",
         "type": "boolean",
         "default": true
       }

--- a/public/manual.html
+++ b/public/manual.html
@@ -218,9 +218,9 @@
       <h4><code>canvas-overlay</code> <span class="title">Canvas Overlay</span></h4>
       <p>Draws mirrored video + landmarks + control markers + per-hand note names.</p>
       <dl>
-        <dt>in</dt><dd>hands:hands-frame, features:hand-features, params:synth-params</dd>
+        <dt>in</dt><dd>hands:hands-frame, features:hand-features, params:synth-params, scale:number[], octaveShift:number</dd>
         <dt>out</dt><dd>—</dd>
-        <dt>params</dt><dd>showLandmarks (boolean=true), showVideo (boolean=true), videoAlpha (number=0.35), showNotes (boolean=true)</dd>
+        <dt>params</dt><dd>showLandmarks (boolean=true), showVideo (boolean=true), videoAlpha (number=0.35), showNotes (boolean=true), showScaleGuide (boolean=true)</dd>
       </dl>
     </div></div></section>
 </div></body></html>

--- a/src/app/graph.ts
+++ b/src/app/graph.ts
@@ -41,6 +41,9 @@ export function defaultGraph(): GraphSpec {
       { from: { node: 'map', port: 'params' }, to: { node: 'synth', port: 'params' } },
       // Also feed params to the overlay so it can label each hand's note.
       { from: { node: 'map', port: 'params' }, to: { node: 'overlay', port: 'params' } },
+      // And the right hand's scale + octave shift, for the overlay pitch guide.
+      { from: { node: 'ui', port: 'scaleRight' }, to: { node: 'overlay', port: 'scale' } },
+      { from: { node: 'kctrl', port: 'octaveShift' }, to: { node: 'overlay', port: 'octaveShift' } },
     ],
   };
 }

--- a/src/music/theory.ts
+++ b/src/music/theory.ts
@@ -76,6 +76,19 @@ export function generateScale(spec: ScaleSpec): number[] {
 }
 
 /**
+ * Where each scale note sits along the normalized control axis (x in 0..1),
+ * matching how {@link magneticPitch} maps x → MIDI (linear across the scale's
+ * MIDI span). Used to draw a pitch/scale guide showing the player where each
+ * note is. Returns ascending x; empty for an empty scale.
+ */
+export function scaleGuide(scale: number[]): { midi: number; x: number }[] {
+  if (scale.length === 0) return [];
+  const min = scale[0];
+  const spanMidi = scale[scale.length - 1] - min;
+  return scale.map((midi) => ({ midi, x: spanMidi > 0 ? (midi - min) / spanMidi : 0 }));
+}
+
+/**
  * Map a normalized control value `x` in [0, 1] to a (possibly fractional) MIDI
  * note, snapping toward scale notes by a `magnetism` amount.
  *

--- a/src/nodes/output/canvas_overlay.ts
+++ b/src/nodes/output/canvas_overlay.ts
@@ -9,7 +9,7 @@
 import { z } from 'zod';
 import { defineNode } from '@/dag';
 import type { NodeContext } from '@/dag';
-import { freqToMidi, midiToName } from '@/music/theory';
+import { freqToMidi, midiToName, scaleGuide } from '@/music/theory';
 import { LM, type HandFeatures, type HandsFrame, type SingleHandFeatures, type SynthParams } from '../domain';
 
 const Params = z.object({
@@ -18,6 +18,8 @@ const Params = z.object({
   videoAlpha: z.number().min(0).max(1).default(0.35),
   /** Show the note name each hand is currently playing, above its marker. */
   showNotes: z.boolean().default(true),
+  /** Show a faint vertical guide at each scale note (a "fretboard"). */
+  showScaleGuide: z.boolean().default(true),
 });
 type Params = z.infer<typeof Params>;
 
@@ -34,6 +36,10 @@ export const canvasOverlayNode = defineNode<Params>({
     // Optional: the synth params (voice 0 = right, 1 = left) so the overlay can
     // label each hand with the note it is sounding. Unconnected → no labels.
     { name: 'params', kind: 'synth-params' },
+    // Optional: the right hand's scale (MIDI notes) to draw a pitch guide.
+    { name: 'scale', kind: 'number[]' },
+    // Optional: the live octave shift, so guide labels match the sounding pitch.
+    { name: 'octaveShift', kind: 'number', default: 0 },
   ],
   outputs: [],
   params: Params,
@@ -57,6 +63,32 @@ export const canvasOverlayNode = defineNode<Params>({
           g.scale(-1, 1);
           g.translate(-W, 0);
           g.drawImage(video, 0, 0, W, H);
+          g.restore();
+        }
+
+        // Pitch guide: a faint vertical line + note name at each note of the
+        // RIGHT hand's scale, drawn at the x where that note sounds. The line
+        // positions match the x→pitch mapping for both hands while synced
+        // (default); when hands are unsynced with different scales, the guide
+        // reflects the right hand. Labels include the live octave shift so they
+        // agree with the per-hand note labels (which read the actual frequency).
+        const scale = inputs.scale as number[] | undefined;
+        if (p.showScaleGuide && Array.isArray(scale) && scale.length > 1) {
+          const shift = typeof inputs.octaveShift === 'number' ? inputs.octaveShift : 0;
+          g.save();
+          g.font = '11px monospace';
+          g.textAlign = 'center';
+          for (const { midi, x } of scaleGuide(scale)) {
+            const sx = x * W;
+            g.strokeStyle = 'rgba(255,255,255,0.10)';
+            g.lineWidth = 1;
+            g.beginPath();
+            g.moveTo(sx, H * 0.12);
+            g.lineTo(sx, H * 0.86);
+            g.stroke();
+            g.fillStyle = 'rgba(255,255,255,0.4)';
+            g.fillText(midiToName(midi + shift * 12), sx, H * 0.82);
+          }
           g.restore();
         }
 

--- a/test/music_theory.test.ts
+++ b/test/music_theory.test.ts
@@ -7,8 +7,29 @@ import {
   nearestScaleNote,
   rangeMap,
   midiToName,
+  scaleGuide,
   DEFAULT_SCALE,
 } from '@/music/theory';
+
+describe('scaleGuide', () => {
+  it('places notes at ascending normalized x matching the magneticPitch mapping', () => {
+    const scale = generateScale(DEFAULT_SCALE); // C major, 2 octaves
+    const guide = scaleGuide(scale);
+    expect(guide.length).toBe(scale.length);
+    expect(guide[0].x).toBeCloseTo(0, 6); // lowest note at x=0
+    expect(guide[guide.length - 1].x).toBeCloseTo(1, 6); // highest at x=1
+    // x is strictly ascending and each x lands where magneticPitch(x)=that note.
+    for (let i = 1; i < guide.length; i++) expect(guide[i].x).toBeGreaterThan(guide[i - 1].x);
+    for (const { midi, x } of guide) {
+      expect(magneticPitch(x, scale, 0)).toBeCloseTo(midi, 6); // free glide hits the note exactly
+    }
+  });
+
+  it('handles empty and single-note scales', () => {
+    expect(scaleGuide([])).toEqual([]);
+    expect(scaleGuide([60])).toEqual([{ midi: 60, x: 0 }]);
+  });
+});
 
 describe('pitch conversions', () => {
   it('midiToFreq / freqToMidi are inverse, A4 = 440', () => {

--- a/test/video_fixtures.test.ts
+++ b/test/video_fixtures.test.ts
@@ -55,6 +55,52 @@ describe('video hand fixtures (real MediaPipe tracking)', () => {
   }
 });
 
+describe('video fixtures drive gesture expression (real tracking)', () => {
+  // Per present frame, pair the hand feature with the voice the synth receives
+  // (voice 0 = right, 1 = left), so we confirm a real gesture moves the
+  // expression value the synth actually consumes.
+  it('hand_open_close: openness drives a varying, correlated brightness', async () => {
+    const feats = load('video_hand_open_close', 'feat.features') as HandFeatures[];
+    const parsed = voiceMappingNode.params.parse({ magnetism: 1 });
+    const out = (await replayNode(voiceMappingNode.make(parsed), { features: feats })).map((o) => o.params as SynthParams);
+    const pairs = feats
+      .map((f, i) => {
+        const side = f.right.present ? 'right' : f.left.present ? 'left' : null;
+        if (!side) return null;
+        const v = out[i].voices[side === 'right' ? 0 : 1];
+        return { openness: f[side].openness, brightness: v.brightness ?? 1 };
+      })
+      .filter((r): r is { openness: number; brightness: number } => !!r);
+
+    expect(pairs.length).toBeGreaterThan(feats.length * 0.5);
+    const brights = pairs.map((p) => p.brightness);
+    expect(span(brights)).toBeGreaterThan(0.2); // brightness actually moves
+    const atMaxOpen = pairs.reduce((a, b) => (b.openness > a.openness ? b : a));
+    const atMinOpen = pairs.reduce((a, b) => (b.openness < a.openness ? b : a));
+    expect(atMaxOpen.brightness).toBeGreaterThan(atMinOpen.brightness); // open → brighter
+  });
+
+  it('hand_pinch: pinch drives a varying, correlated vibrato', async () => {
+    const feats = load('video_hand_pinch', 'feat.features') as HandFeatures[];
+    const parsed = voiceMappingNode.params.parse({ magnetism: 1 });
+    const out = (await replayNode(voiceMappingNode.make(parsed), { features: feats })).map((o) => o.params as SynthParams);
+    const pairs = feats
+      .map((f, i) => {
+        const side = f.right.present ? 'right' : f.left.present ? 'left' : null;
+        if (!side) return null;
+        const v = out[i].voices[side === 'right' ? 0 : 1];
+        return { pinch: f[side].pinch, vibrato: v.vibrato ?? 0 };
+      })
+      .filter((r): r is { pinch: number; vibrato: number } => !!r);
+
+    expect(pairs.length).toBeGreaterThan(feats.length * 0.5);
+    expect(span(pairs.map((p) => p.vibrato))).toBeGreaterThan(0.4); // vibrato moves
+    const atMaxPinch = pairs.reduce((a, b) => (b.pinch > a.pinch ? b : a));
+    const atMinPinch = pairs.reduce((a, b) => (b.pinch < a.pinch ? b : a));
+    expect(atMaxPinch.vibrato).toBeGreaterThan(atMinPinch.vibrato); // pinch → more wobble
+  });
+});
+
 describe('video face fixture (MediaPipe blendshapes — M4 prep)', () => {
   it('detects a face and key expression blendshapes vary', () => {
     type FaceFrame = { present: boolean; blendshapes: Record<string, number> };


### PR DESCRIPTION
Makes pitches findable on screen, and verifies the gesture-expression features against the **real test videos**.

## Pitch/scale guide
- New pure helper `theory.scaleGuide(scale)` → each note's normalized x, matching the `magneticPitch` x→MIDI mapping (unit-tested: endpoints at 0/1, ascending, `magneticPitch(x,scale,0)===midi`).
- `canvas-overlay` draws a faint "fretboard" line + note name at each scale note, fed the right hand's live scale (`ui.scaleRight`) and octave shift (`kctrl.octaveShift`). New `showScaleGuide` param.

## Verify expression on real gestures (per the test strategy)
`video_fixtures.test` replays the recorded features of `video_hand_open_close` / `video_hand_pinch` through the current `voice-mapping` and asserts **brightness/vibrato vary and correlate** with openness/pinch — proving #35/#37 work on real MediaPipe-tracked gestures, not just synthetic frames.

## Adversarial review (2 lenses → independent verify): 3 confirmed, all fixed
- **major:** guide note names now include the octave shift, so they no longer contradict the per-hand marker labels after ArrowUp/Down (line *positions* were always correct — a constant transpose doesn't move scale-degree x).
- **minor:** guide comment scoped to the right-hand scale (it matches both hands while synced — the default; differs only when unsynced with distinct scales).
- **minor:** guide labels pulled into the visible band so `object-cover`'s top/bottom crop doesn't clip them.

Gates: strict typecheck ✅ · **102 tests** ✅ · `vite build` ✅ · manual regenerated.

Refs #6.

https://claude.ai/code/session_01Gp5tDXPQZuM7WaetpZwxij