### PR TITLE
feat(dag-view): left-hand pitch guide + two_hands end-to-end test

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -187,7 +187,7 @@ _Audio + the captured video with overlaid guides._
 #### `canvas-overlay` — Canvas Overlay
 Draws mirrored video + landmarks + control markers + per-hand note names.
 
-- **in:** hands:hands-frame, features:hand-features, params:synth-params, scale:number[], octaveShift:number
+- **in:** hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], octaveShift:number
 - **out:** —
 - **params:** showLandmarks (boolean=true), showVideo (boolean=true), videoAlpha (number=0.35), showNotes (boolean=true), showScaleGuide (boolean=true)
 

--- a/public/catalog.json
+++ b/public/catalog.json
@@ -21,6 +21,10 @@
         "kind": "number[]"
       },
       {
+        "name": "scaleLeft",
+        "kind": "number[]"
+      },
+      {
         "name": "octaveShift",
         "kind": "number",
         "default": 0

--- a/public/manual.html
+++ b/public/manual.html
@@ -218,7 +218,7 @@
       <h4><code>canvas-overlay</code> <span class="title">Canvas Overlay</span></h4>
       <p>Draws mirrored video + landmarks + control markers + per-hand note names.</p>
       <dl>
-        <dt>in</dt><dd>hands:hands-frame, features:hand-features, params:synth-params, scale:number[], octaveShift:number</dd>
+        <dt>in</dt><dd>hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], octaveShift:number</dd>
         <dt>out</dt><dd>—</dd>
         <dt>params</dt><dd>showLandmarks (boolean=true), showVideo (boolean=true), videoAlpha (number=0.35), showNotes (boolean=true), showScaleGuide (boolean=true)</dd>
       </dl>

--- a/src/app/graph.ts
+++ b/src/app/graph.ts
@@ -41,8 +41,9 @@ export function defaultGraph(): GraphSpec {
       { from: { node: 'map', port: 'params' }, to: { node: 'synth', port: 'params' } },
       // Also feed params to the overlay so it can label each hand's note.
       { from: { node: 'map', port: 'params' }, to: { node: 'overlay', port: 'params' } },
-      // And the right hand's scale + octave shift, for the overlay pitch guide.
+      // And both hands' scales + octave shift, for the overlay pitch guides.
       { from: { node: 'ui', port: 'scaleRight' }, to: { node: 'overlay', port: 'scale' } },
+      { from: { node: 'ui', port: 'scaleLeft' }, to: { node: 'overlay', port: 'scaleLeft' } },
       { from: { node: 'kctrl', port: 'octaveShift' }, to: { node: 'overlay', port: 'octaveShift' } },
     ],
   };

--- a/src/nodes/output/canvas_overlay.ts
+++ b/src/nodes/output/canvas_overlay.ts
@@ -38,6 +38,8 @@ export const canvasOverlayNode = defineNode<Params>({
     { name: 'params', kind: 'synth-params' },
     // Optional: the right hand's scale (MIDI notes) to draw a pitch guide.
     { name: 'scale', kind: 'number[]' },
+    // Optional: the left hand's scale, drawn as a second guide when it differs.
+    { name: 'scaleLeft', kind: 'number[]' },
     // Optional: the live octave shift, so guide labels match the sounding pitch.
     { name: 'octaveShift', kind: 'number', default: 0 },
   ],
@@ -66,30 +68,41 @@ export const canvasOverlayNode = defineNode<Params>({
           g.restore();
         }
 
-        // Pitch guide: a faint vertical line + note name at each note of the
-        // RIGHT hand's scale, drawn at the x where that note sounds. The line
-        // positions match the x→pitch mapping for both hands while synced
-        // (default); when hands are unsynced with different scales, the guide
-        // reflects the right hand. Labels include the live octave shift so they
-        // agree with the per-hand note labels (which read the actual frequency).
-        const scale = inputs.scale as number[] | undefined;
-        if (p.showScaleGuide && Array.isArray(scale) && scale.length > 1) {
-          const shift = typeof inputs.octaveShift === 'number' ? inputs.octaveShift : 0;
+        // Pitch guides: a faint vertical line + note name at each scale note,
+        // drawn at the x where that note sounds (positions match the x→pitch
+        // mapping; labels include the live octave shift so they agree with the
+        // per-hand note labels). The right hand's guide is always drawn; the
+        // left's is drawn only when it differs (unsynced, distinct scale), in
+        // the left colour, so each hand has a matching reference.
+        const shift = typeof inputs.octaveShift === 'number' ? inputs.octaveShift : 0;
+        const scaleR = inputs.scale as number[] | undefined;
+        const scaleL = inputs.scaleLeft as number[] | undefined;
+        const arrEq = (a?: number[], b?: number[]) =>
+          !!a && !!b && a.length === b.length && a.every((v, i) => v === b[i]);
+        const drawGuide = (s: number[], color: string, alpha: number, labelY: number) => {
           g.save();
           g.font = '11px monospace';
           g.textAlign = 'center';
-          for (const { midi, x } of scaleGuide(scale)) {
+          for (const { midi, x } of scaleGuide(s)) {
             const sx = x * W;
-            g.strokeStyle = 'rgba(255,255,255,0.10)';
+            g.globalAlpha = alpha;
+            g.strokeStyle = color;
             g.lineWidth = 1;
             g.beginPath();
             g.moveTo(sx, H * 0.12);
             g.lineTo(sx, H * 0.86);
             g.stroke();
-            g.fillStyle = 'rgba(255,255,255,0.4)';
-            g.fillText(midiToName(midi + shift * 12), sx, H * 0.82);
+            g.globalAlpha = Math.min(1, alpha * 4);
+            g.fillStyle = color;
+            g.fillText(midiToName(midi + shift * 12), sx, labelY);
           }
           g.restore();
+        };
+        if (p.showScaleGuide && Array.isArray(scaleR) && scaleR.length > 1) {
+          drawGuide(scaleR, '#ffffff', 0.1, H * 0.82);
+          if (Array.isArray(scaleL) && scaleL.length > 1 && !arrEq(scaleL, scaleR)) {
+            drawGuide(scaleL, LEFT_COLOR, 0.12, H * 0.18);
+          }
         }
 
         const frame = inputs.hands as HandsFrame | undefined;

--- a/test/fixture_replay.test.ts
+++ b/test/fixture_replay.test.ts
@@ -16,6 +16,7 @@ import { fileURLToPath } from 'node:url';
 import { describe, it, expect } from 'vitest';
 import { valuesFromNDJSON, replayNode } from '@/dag';
 import { voiceMappingNode, type HandFeatures, type SynthParams } from '@/nodes';
+import { freqToMidi, midiToName } from '@/music/theory';
 import { SCENARIOS } from '../scripts/scenarios';
 
 const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), 'fixtures');
@@ -53,5 +54,38 @@ describe('fixture replay (sweep_right)', () => {
     expect(recordedParams.every((p) => p.voices[0].present)).toBe(true);
     const freqs = recordedParams.map((p) => p.voices[0].freq);
     expect(Math.max(...freqs)).toBeGreaterThan(Math.min(...freqs)); // pitch moved
+  });
+});
+
+describe('fixture replay (two_hands) — both voices end to end', () => {
+  const SC = 'two_hands';
+  const features = loadStream(SC, 'feat.features') as HandFeatures[];
+
+  it('both hands are present and drive two well-formed, expressive voices', async () => {
+    expect(features.length).toBeGreaterThan(50);
+    expect(features.every((f) => f.right.present && f.left.present)).toBe(true);
+
+    const parsed = voiceMappingNode.params.parse(
+      SCENARIOS[SC].graph.nodes.find((n) => n.id === 'map')!.params,
+    );
+    const out = (await replayNode(voiceMappingNode.make(parsed), { features }, { dt: 1 / 30 })).map(
+      (o) => o.params as SynthParams,
+    );
+
+    // Two voices every frame; all synth fields the renderer consumes are finite
+    // and in range; each present voice resolves to a valid note name.
+    for (const p of out) {
+      expect(p.voices).toHaveLength(2);
+      for (const v of p.voices) {
+        expect(Number.isFinite(v.freq) && v.freq > 0).toBe(true);
+        expect(Number.isFinite(v.gain) && v.gain >= 0).toBe(true);
+        expect(v.brightness! >= 0 && v.brightness! <= 1).toBe(true);
+        expect(v.vibrato! >= 0 && v.vibrato! <= 1).toBe(true);
+        expect(midiToName(freqToMidi(v.freq))).toMatch(/^[A-G]#?-?\d+$/);
+      }
+    }
+    // The two hands occupy different x → generally different pitches (distinct voices).
+    const distinct = out.filter((p) => p.voices[0].freq !== p.voices[1].freq).length;
+    expect(distinct).toBeGreaterThan(out.length * 0.5);
   });
 });


### PR DESCRIPTION
Completes the pitch-guide review finding (#39) and exercises previously-unused intermediate data.

- `canvas-overlay` draws a **second pitch guide for the left hand** (in the left colour) **only when its scale differs** from the right (unsynced, distinct scales) — so each hand has a matching reference, while the common synced case still shows a single guide. Wired `ui.scaleLeft → overlay.scaleLeft`.
- New `fixture_replay` **two_hands** case: replays the recorded both-hands features through `voice-mapping` and asserts two well-formed, expressive voices every frame (finite freq/gain, brightness & vibrato in 0..1, valid note name) and that the hands generally sound distinct pitches — using the previously-unreferenced `two_hands` intermediate-data fixture.

Gates: strict typecheck ✅ · **103 tests** ✅ · `vite build` ✅ · manual regenerated.

Refs #6.

https://claude.ai/code/session_01Gp5tDXPQZuM7WaetpZwxij