### PR TITLE
feat(dag-view): record your performance to a downloadable audio file

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -10,12 +10,13 @@
  * this component is purely presentational + lifecycle.
  */
 import { useState } from 'react';
-import { Settings, X, Play, BookOpen } from 'lucide-react';
+import { Settings, X, Play, BookOpen, Circle, Square } from 'lucide-react';
 import { useThoreminEngine } from './useEngine';
 import ControlsPanel from './ControlsPanel';
 
 export default function App() {
-  const { videoRef, canvasRef, status, error, audioOn, startAudio } = useThoreminEngine();
+  const { videoRef, canvasRef, status, error, audioOn, isRecording, startAudio, toggleRecording } =
+    useThoreminEngine();
   const [panelOpen, setPanelOpen] = useState(true);
 
   return (
@@ -49,6 +50,23 @@ export default function App() {
       >
         <BookOpen className="h-3 w-3" /> manual
       </a>
+
+      {/* Bottom-right: record the live output to a downloadable audio file
+          (available once audio is running). */}
+      {audioOn && (
+        <button
+          onClick={toggleRecording}
+          aria-label={isRecording ? 'Stop recording' : 'Record'}
+          className={`absolute bottom-3 right-3 flex items-center gap-2 rounded-full px-4 py-2 text-[10px] font-bold uppercase tracking-widest backdrop-blur transition ${
+            isRecording
+              ? 'animate-pulse bg-red-500 text-white'
+              : 'bg-black/50 text-white/80 hover:text-white'
+          }`}
+        >
+          {isRecording ? <Square className="h-3 w-3 fill-current" /> : <Circle className="h-3 w-3 fill-red-500 text-red-500" />}
+          {isRecording ? 'Stop' : 'Record'}
+        </button>
+      )}
 
       {/* Top-right: collapsible controls — open by default (available), minimize
           to a single gear once you've set things up. */}

--- a/src/app/recorder.ts
+++ b/src/app/recorder.ts
@@ -1,0 +1,114 @@
+/**
+ * PerformanceRecorder — capture the live instrument output to a downloadable
+ * audio file. It taps the master bus through a MediaStreamAudioDestinationNode
+ * and records that stream with the browser's built-in MediaRecorder (no extra
+ * dependency, no extra ML). The pure helpers (codec/extension/filename) are
+ * unit-testable; the recorder itself only runs in the browser.
+ */
+
+/** Candidate record codecs, best first. */
+const MIME_CANDIDATES = [
+  'audio/webm;codecs=opus',
+  'audio/webm',
+  'audio/ogg;codecs=opus',
+  'audio/mp4',
+] as const;
+
+/** Pick the first codec the browser's MediaRecorder supports. */
+export function pickMimeType(
+  isSupported: (m: string) => boolean = (m) =>
+    typeof MediaRecorder !== 'undefined' && !!MediaRecorder.isTypeSupported?.(m),
+): string {
+  for (const m of MIME_CANDIDATES) if (isSupported(m)) return m;
+  return 'audio/webm';
+}
+
+/** File extension for a recorded MIME type. */
+export function extForMime(mime: string): string {
+  if (mime.includes('ogg')) return 'ogg';
+  if (mime.includes('mp4')) return 'm4a';
+  return 'webm';
+}
+
+/** A timestamped download name, e.g. thoremin-2026-06-22T07-30-00.webm. */
+export function recordingFilename(isoStamp: string, ext: string): string {
+  const safe = isoStamp.replace(/[:.]/g, '-').replace(/Z$/, '');
+  return `thoremin-${safe}.${ext}`;
+}
+
+/** Trigger a browser download of a blob (browser-only). */
+export function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  // Revoke after the click has had a chance to start the download.
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+export interface PerformanceRecorderOptions {
+  audioContext: AudioContext;
+  /** The node whose output to record (typically the host master gain). */
+  source: AudioNode;
+  mimeType?: string;
+}
+
+export class PerformanceRecorder {
+  private readonly dest: MediaStreamAudioDestinationNode;
+  private readonly source: AudioNode;
+  private rec: MediaRecorder | null = null;
+  private chunks: Blob[] = [];
+  readonly mimeType: string;
+
+  constructor(opts: PerformanceRecorderOptions) {
+    this.dest = opts.audioContext.createMediaStreamDestination();
+    this.source = opts.source;
+    // Tap the master bus: source still reaches the speakers; we also feed the
+    // recorder destination. The stream is silent until voices actually play.
+    this.source.connect(this.dest);
+    this.mimeType = opts.mimeType ?? pickMimeType();
+  }
+
+  get recording(): boolean {
+    return this.rec?.state === 'recording';
+  }
+
+  start(): void {
+    if (this.recording) return;
+    this.chunks = [];
+    this.rec = new MediaRecorder(this.dest.stream, { mimeType: this.mimeType });
+    this.rec.ondataavailable = (e) => {
+      if (e.data.size > 0) this.chunks.push(e.data);
+    };
+    this.rec.start();
+  }
+
+  /** Stop and resolve with the recorded audio as a Blob. */
+  stop(): Promise<Blob> {
+    return new Promise((resolve) => {
+      const r = this.rec;
+      if (!r || r.state === 'inactive') {
+        resolve(new Blob(this.chunks, { type: this.mimeType }));
+        return;
+      }
+      r.onstop = () => resolve(new Blob(this.chunks, { type: this.mimeType }));
+      r.stop();
+    });
+  }
+
+  dispose(): void {
+    try {
+      if (this.rec && this.rec.state !== 'inactive') this.rec.stop();
+    } catch {
+      /* already stopped */
+    }
+    try {
+      this.source.disconnect(this.dest);
+    } catch {
+      /* already disconnected */
+    }
+  }
+}

--- a/src/app/useEngine.ts
+++ b/src/app/useEngine.ts
@@ -10,6 +10,7 @@ import { Engine } from '@/dag';
 import { createAppRegistry } from '@/nodes/browser';
 import { defaultGraph } from './graph';
 import { useControls } from './store';
+import { PerformanceRecorder, recordingFilename, extForMime, downloadBlob } from './recorder';
 
 export type EngineStatus = 'idle' | 'loading' | 'ready' | 'error';
 
@@ -19,11 +20,14 @@ export function useThoreminEngine() {
   const engineRef = useRef<Engine | null>(null);
   const resourcesRef = useRef<Record<string, unknown>>({});
   const masterGainRef = useRef<GainNode | null>(null);
+  const recorderRef = useRef<PerformanceRecorder | null>(null);
+  const recBusyRef = useRef(false);
   const rafRef = useRef<number | null>(null);
 
   const [status, setStatus] = useState<EngineStatus>('idle');
   const [error, setError] = useState<string | null>(null);
   const [audioOn, setAudioOn] = useState(false);
+  const [isRecording, setIsRecording] = useState(false);
 
   const masterVolume = useControls((s) => s.masterVolume);
 
@@ -118,7 +122,15 @@ export function useThoreminEngine() {
       }
       engineRef.current?.dispose();
       engineRef.current = null;
+      recorderRef.current?.dispose();
+      recorderRef.current = null;
       stream?.getTracks().forEach((t) => t.stop());
+      // Close the AudioContext so its nodes (master, recorder tap, voices) are
+      // released instead of leaking one un-closed context per unmount.
+      const ac = resourcesRef.current.audioContext as AudioContext | undefined;
+      if (ac && ac.state !== 'closed') void ac.close().catch(() => {});
+      resourcesRef.current.audioContext = undefined;
+      masterGainRef.current = null;
     };
   }, []);
 
@@ -144,8 +156,33 @@ export function useThoreminEngine() {
       masterGainRef.current = master;
     }
     if (ac.state === 'suspended') await ac.resume();
+    // Set up the recorder once audio exists, tapping the master bus.
+    if (!recorderRef.current && masterGainRef.current) {
+      recorderRef.current = new PerformanceRecorder({ audioContext: ac, source: masterGainRef.current });
+    }
     setAudioOn(true);
   }, []);
 
-  return { videoRef, canvasRef, status, error, audioOn, startAudio };
+  // Start/stop recording the live output; stopping downloads the audio file.
+  // recBusyRef guards against a double-click racing stop() against a new
+  // start() (which would clear the chunks mid-stop and download an empty file).
+  const toggleRecording = useCallback(async () => {
+    const r = recorderRef.current;
+    if (!r || recBusyRef.current) return;
+    recBusyRef.current = true;
+    try {
+      if (r.recording) {
+        const blob = await r.stop();
+        downloadBlob(blob, recordingFilename(new Date().toISOString(), extForMime(r.mimeType)));
+        setIsRecording(false);
+      } else {
+        r.start();
+        setIsRecording(true);
+      }
+    } finally {
+      recBusyRef.current = false;
+    }
+  }, []);
+
+  return { videoRef, canvasRef, status, error, audioOn, isRecording, startAudio, toggleRecording };
 }

--- a/test/recorder.test.ts
+++ b/test/recorder.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Unit tests for the pure helpers of the performance recorder (codec choice,
+ * extension, filename). The PerformanceRecorder class itself uses browser-only
+ * Web Audio + MediaRecorder APIs and is exercised in the browser.
+ */
+import { describe, it, expect } from 'vitest';
+import { pickMimeType, extForMime, recordingFilename } from '@/app/recorder';
+
+describe('recorder helpers', () => {
+  it('picks the first supported codec, preferring opus webm', () => {
+    expect(pickMimeType(() => true)).toBe('audio/webm;codecs=opus');
+    expect(pickMimeType((m) => m === 'audio/mp4')).toBe('audio/mp4');
+    expect(pickMimeType(() => false)).toBe('audio/webm'); // safe fallback
+  });
+
+  it('maps mime types to file extensions', () => {
+    expect(extForMime('audio/webm;codecs=opus')).toBe('webm');
+    expect(extForMime('audio/webm')).toBe('webm');
+    expect(extForMime('audio/ogg;codecs=opus')).toBe('ogg');
+    expect(extForMime('audio/mp4')).toBe('m4a');
+  });
+
+  it('builds a filesystem-safe timestamped filename', () => {
+    const name = recordingFilename('2026-06-22T07:30:00.123Z', 'webm');
+    expect(name).toBe('thoremin-2026-06-22T07-30-00-123.webm');
+    expect(name).not.toContain(':'); // colons are illegal on some filesystems
+    expect(name.slice(0, -'.webm'.length)).not.toContain('.'); // only the extension dot
+  });
+});


### PR DESCRIPTION
A **Record button** captures the live instrument output and downloads it — using the browser's built-in `MediaRecorder`, **no new dependency**.

- `src/app/recorder.ts`: `PerformanceRecorder` taps the master bus via a `MediaStreamAudioDestinationNode` (Web Audio fan-out, so playback is unchanged) and records it. Pure helpers (codec pick / extension / timestamped filename / download) are unit-tested.
- `useEngine` creates the recorder when audio starts and exposes `isRecording` + `toggleRecording` (stop → download). `App` shows a Record button once audio is on (red + pulsing while recording).

## Adversarial review (focused) — fixed both real findings
- **Double-click race:** a re-entrancy guard stops a second click from calling `start()` (clearing chunks) while `stop()` is still awaiting → no empty downloads.
- **AudioContext leak:** the context is now closed on unmount (it was leaked; the recorder added a node to that leak), releasing master/recorder/voice nodes cleanly.

Gates: strict typecheck ✅ · **107 tests** ✅ (new recorder helper tests) · `vite build` ✅. Records the full post-master mix; nothing runs before the audio gesture; default app unaffected.

Refs #6.

https://claude.ai/code/session_01Gp5tDXPQZuM7WaetpZwxij