### PR TITLE
feat(dag-view): stereo panning by hand position

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -93,7 +93,7 @@ Hand features → tonal synth parameters (x→pitch w/ scale snap, y→volume).
 
 - **in:** features:hand-features, magnetism:number, octaveShift:number, mute:boolean, scaleRight:number[], scaleLeft:number[], instrumentRight:instrument, instrumentLeft:instrument, face:face-features
 - **out:** params:synth-params
-- **params:** magnetism (number=0.8), maxGain (number=0.5), opennessGatesGain (boolean=false), opennessControlsBrightness (boolean=true), pinchControlsVibrato (boolean=true), faceControlsExpression (boolean=true), right (object={"scale":{"root":0,"type":"major","octaves":2,"baseOctave":3},"instrument":"sine"}), left (object={"scale":{"root":0,"type":"major","octaves":2,"baseOctave":3},"instrument":"triangle"})
+- **params:** magnetism (number=0.8), maxGain (number=0.5), opennessGatesGain (boolean=false), opennessControlsBrightness (boolean=true), pinchControlsVibrato (boolean=true), faceControlsExpression (boolean=true), panByPosition (boolean=true), panSpread (number=0.5), right (object={"scale":{"root":0,"type":"major","octaves":2,"baseOctave":3},"instrument":"sine"}), left (object={"scale":{"root":0,"type":"major","octaves":2,"baseOctave":3},"instrument":"triangle"})
 
 #### `indirect-map` — Indirect Map
 Gesture features → weighted prompts + config dials (steers a generative engine).

--- a/public/catalog.json
+++ b/public/catalog.json
@@ -796,6 +796,16 @@
         "default": true
       },
       {
+        "name": "panByPosition",
+        "type": "boolean",
+        "default": true
+      },
+      {
+        "name": "panSpread",
+        "type": "number",
+        "default": 0.5
+      },
+      {
         "name": "right",
         "type": "object",
         "default": {

--- a/public/manual.html
+++ b/public/manual.html
@@ -108,7 +108,7 @@
       <dl>
         <dt>in</dt><dd>features:hand-features, magnetism:number, octaveShift:number, mute:boolean, scaleRight:number[], scaleLeft:number[], instrumentRight:instrument, instrumentLeft:instrument, face:face-features</dd>
         <dt>out</dt><dd>params:synth-params</dd>
-        <dt>params</dt><dd>magnetism (number=0.8), maxGain (number=0.5), opennessGatesGain (boolean=false), opennessControlsBrightness (boolean=true), pinchControlsVibrato (boolean=true), faceControlsExpression (boolean=true), right (object={"scale":{"root":0,"type":"major","octaves":2,"baseOctave":3},"instrument":"sine"}), left (object={"scale":{"root":0,"type":"major","octaves":2,"baseOctave":3},"instrument":"triangle"})</dd>
+        <dt>params</dt><dd>magnetism (number=0.8), maxGain (number=0.5), opennessGatesGain (boolean=false), opennessControlsBrightness (boolean=true), pinchControlsVibrato (boolean=true), faceControlsExpression (boolean=true), panByPosition (boolean=true), panSpread (number=0.5), right (object={"scale":{"root":0,"type":"major","octaves":2,"baseOctave":3},"instrument":"sine"}), left (object={"scale":{"root":0,"type":"major","octaves":2,"baseOctave":3},"instrument":"triangle"})</dd>
       </dl>
     </div>
     <div class="node">

--- a/src/nodes/domain.ts
+++ b/src/nodes/domain.ts
@@ -79,6 +79,11 @@ export interface VoiceParams {
    * is treated as 0 (no added vibrato).
    */
   vibrato?: number;
+  /**
+   * Stereo pan, -1 (hard left) .. +1 (hard right). Lets hand position place the
+   * voice in the stereo field. Optional; absent is treated as 0 (centre).
+   */
+  pan?: number;
 }
 
 export interface SynthParams {

--- a/src/nodes/mapping/voice_mapping.ts
+++ b/src/nodes/mapping/voice_mapping.ts
@@ -58,6 +58,10 @@ const Params = z.object({
   pinchControlsVibrato: z.boolean().default(true),
   /** If true, a connected face adds expression (smile→brighter, mouth→vibrato). */
   faceControlsExpression: z.boolean().default(true),
+  /** If true, hand x position pans the voice in stereo (left→left, right→right). */
+  panByPosition: z.boolean().default(true),
+  /** Max stereo spread (0..1) at the edges of the frame when panByPosition is on. */
+  panSpread: z.number().min(0).max(1).default(0.5),
   right: z.object({ scale: ScaleParams, instrument: Instrument.default('sine') }).default({
     scale: ScaleParams.parse({}),
     instrument: 'sine',
@@ -86,7 +90,7 @@ function voiceFor(
   faceMod: FaceMod,
 ): VoiceParams {
   if (!feat.present || ctrl.mute) {
-    return { id, present: false, freq: midiToFreq(scaleMidis[0] ?? 60), gain: 0, instrument, brightness: 1, vibrato: 0 };
+    return { id, present: false, freq: midiToFreq(scaleMidis[0] ?? 60), gain: 0, instrument, brightness: 1, vibrato: 0, pan: 0 };
   }
   const midi = magneticPitch(feat.x, scaleMidis, ctrl.magnetism) + ctrl.octaveShift * 12;
   const freq = midiToFreq(midi);
@@ -100,7 +104,9 @@ function voiceFor(
   // Pinch adds vibrato (0 = none .. 1 = full wobble); an open mouth adds more.
   const baseVib = p.pinchControlsVibrato ? clamp01(feat.pinch) : 0;
   const vibrato = clamp01(baseVib + faceMod.vibrato);
-  return { id, present: true, freq, gain, instrument, brightness, vibrato };
+  // Hand x places the voice in stereo: centre at x=0.5, spreading to ±panSpread.
+  const pan = p.panByPosition ? Math.max(-1, Math.min(1, (feat.x - 0.5) * 2 * p.panSpread)) : 0;
+  return { id, present: true, freq, gain, instrument, brightness, vibrato, pan };
 }
 
 export const voiceMappingNode = defineNode<Params>({

--- a/src/nodes/output/webaudio_synth.ts
+++ b/src/nodes/output/webaudio_synth.ts
@@ -41,6 +41,8 @@ interface Voice {
   vibrato: { lfo: OscillatorNode; depth: GainNode; baseCents: number };
   /** Live low-pass whose cutoff tracks the voice's `brightness` (expression). */
   brightnessFilter: BiquadFilterNode;
+  /** Stereo panner on the dry path, tracking the voice's `pan`. */
+  panner: StereoPannerNode;
   /** The amplitude-envelope gain driven by the voice's `gain`. */
   voiceGain: GainNode;
   /** Every node to disconnect on teardown. */
@@ -182,12 +184,17 @@ function buildVoice(ac: AudioContext, bus: Bus, v: VoiceParams, p: Params): Voic
   nodes.push(lfo, depth);
   const vibrato = { lfo, depth, baseCents };
 
-  // Output: voiceGain → trim → (dry) compressor; trim → send → reverb.
+  // Output: voiceGain → trim → panner → (dry) compressor; trim → send → reverb.
+  // The dry signal is panned by hand position; the reverb send stays centred so
+  // the ambience is shared.
   const trim = ac.createGain();
   trim.gain.setValueAtTime(preset.gain ?? 1, now);
   voiceGain.connect(trim);
-  trim.connect(bus.out);
-  nodes.push(trim);
+  const panner = ac.createStereoPanner();
+  panner.pan.setValueAtTime(Math.max(-1, Math.min(1, v.pan ?? 0)), now);
+  trim.connect(panner);
+  panner.connect(bus.out);
+  nodes.push(trim, panner);
   if (preset.reverbSend && preset.reverbSend > 0) {
     const send = ac.createGain();
     send.gain.setValueAtTime(preset.reverbSend, now);
@@ -201,6 +208,7 @@ function buildVoice(ac: AudioContext, bus: Bus, v: VoiceParams, p: Params): Voic
     partials,
     vibrato,
     brightnessFilter,
+    panner,
     voiceGain,
     nodes,
     attack: preset.attack ?? p.gainGlide,
@@ -303,6 +311,8 @@ export const webAudioSynthNode = defineNode<Params>({
               now,
               0.05,
             );
+            const pan = Number.isFinite(v.pan) ? Math.max(-1, Math.min(1, v.pan!)) : 0;
+            voice.panner.pan.setTargetAtTime(pan, now, 0.05);
             voice.voiceGain.gain.setTargetAtTime(v.gain, now, voice.attack);
           } else if (voice) {
             voice.voiceGain.gain.setTargetAtTime(0, now, voice.release);

--- a/test/expression.test.ts
+++ b/test/expression.test.ts
@@ -8,10 +8,10 @@ import { describe, it, expect } from 'vitest';
 import { replayNode } from '@/dag';
 import { voiceMappingNode, ABSENT_HAND, type HandFeatures, type SynthParams } from '@/nodes';
 
-function feats(openness: number, pinch = 0): HandFeatures {
+function feats(openness: number, pinch = 0, x = 0.5): HandFeatures {
   return {
     left: { ...ABSENT_HAND },
-    right: { ...ABSENT_HAND, present: true, x: 0.5, y: 0.3, openness, pinch },
+    right: { ...ABSENT_HAND, present: true, x, y: 0.3, openness, pinch },
   };
 }
 
@@ -58,5 +58,22 @@ describe('pinch → vibrato expression', () => {
   it('clamps to 0..1 and is 0 when pinchControlsVibrato is off', async () => {
     expect(await (async () => (await rightVoice(feats(0.5, 5))).vibrato)()).toBeLessThanOrEqual(1);
     expect((await rightVoice(feats(0.5, 1), { pinchControlsVibrato: false })).vibrato).toBe(0);
+  });
+});
+
+describe('hand x → stereo pan', () => {
+  it('centres at x=0.5 and spreads to ±panSpread at the frame edges', async () => {
+    expect((await rightVoice(feats(0.3, 0, 0.5))).pan).toBeCloseTo(0, 5);
+    expect((await rightVoice(feats(0.3, 0, 0.0))).pan).toBeCloseTo(-0.5, 5); // default panSpread 0.5
+    expect((await rightVoice(feats(0.3, 0, 1.0))).pan).toBeCloseTo(0.5, 5);
+  });
+
+  it('respects panSpread and clamps to [-1, 1]', async () => {
+    expect((await rightVoice(feats(0.3, 0, 1.0), { panSpread: 1 })).pan).toBeCloseTo(1, 5);
+    expect((await rightVoice(feats(0.3, 0, 0.0), { panSpread: 1 })).pan).toBeCloseTo(-1, 5);
+  });
+
+  it('is centred (0) when panByPosition is off', async () => {
+    expect((await rightVoice(feats(0.3, 0, 0.0), { panByPosition: false })).pan).toBe(0);
   });
 });

--- a/test/video_fixtures.test.ts
+++ b/test/video_fixtures.test.ts
@@ -88,6 +88,24 @@ describe('video fixtures drive gesture expression (real tracking)', () => {
     expect(atMaxOpen.brightness).toBeGreaterThan(atMinOpen.brightness); // open → brighter
   });
 
+  it('hand_sweep: the sweeping hand pans across the stereo field', async () => {
+    const feats = load('video_hand_sweep', 'feat.features') as HandFeatures[];
+    const parsed = voiceMappingNode.params.parse({ magnetism: 1 });
+    const out = (await replayNode(voiceMappingNode.make(parsed), { features: feats })).map((o) => o.params as SynthParams);
+    const pairs = feats
+      .map((f, i) => {
+        const side = f.right.present ? 'right' : f.left.present ? 'left' : null;
+        if (!side) return null;
+        return { x: f[side].x, pan: out[i].voices[side === 'right' ? 0 : 1].pan ?? 0 };
+      })
+      .filter((r): r is { x: number; pan: number } => !!r);
+
+    expect(span(pairs.map((p) => p.pan))).toBeGreaterThan(0.2); // pan actually moves
+    const atMaxX = pairs.reduce((a, b) => (b.x > a.x ? b : a));
+    const atMinX = pairs.reduce((a, b) => (b.x < a.x ? b : a));
+    expect(atMaxX.pan).toBeGreaterThan(atMinX.pan); // hand right → pan right
+  });
+
   it('hand_pinch: pinch drives a varying, correlated vibrato', async () => {
     const feats = load('video_hand_pinch', 'feat.features') as HandFeatures[];
     const parsed = voiceMappingNode.params.parse({ magnetism: 1 });


### PR DESCRIPTION
The instrument was mono; now **hand x places each voice in the stereo field** (left→left, right→right) — a spatial "keyboard" that reinforces the pitch guide and separates the two hands.

- `VoiceParams` gains optional `pan` (-1..1; absent = centre).
- `voice-mapping` maps `x → pan = clamp(-1,1,(x-0.5)*2*panSpread)` behind new params `panByPosition` (default true) and `panSpread` (default 0.5).
- `webaudio-synth` gives each voice a `StereoPanner` on its dry path (`voiceGain→trim→panner→bus`); the reverb send is **pre-pan** so the ambience stays centred. Pan is set live (NaN-safe, clamped) and torn down with the voice.

Gates: strict typecheck ✅ · **111 tests** ✅ (pan unit tests + a `video_hand_sweep` fixture test: the sweeping hand pans across the field) · `vite build` ✅ · focused adversarial review **0 findings** · manual regenerated.

Refs #6.

https://claude.ai/code/session_01Gp5tDXPQZuM7WaetpZwxij