### PR TITLE
feat(dag-view): persist control settings across reloads

### DIFF
--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -4,8 +4,14 @@
  * `getState()` each tick and emits the values onto the graph as port values.
  * This keeps UI state out of the graph spec, so changing scale/instrument
  * never rebuilds the engine or reloads the ML model.
+ *
+ * The control *values* (not the setters) are persisted to localStorage via the
+ * zustand `persist` middleware, so a player's instrument/scale/volume choices
+ * survive a page reload. In non-browser environments (the Node test runtime)
+ * a no-op storage is used, so persistence never touches a missing global.
  */
 import { create } from 'zustand';
+import { persist, createJSONStorage, type StateStorage } from 'zustand/middleware';
 import type { ScaleTypeId } from '@/music/theory';
 import { DEFAULT_INSTRUMENT_RIGHT, DEFAULT_INSTRUMENT_LEFT } from '@/music/instruments';
 import type { VoiceParams } from '@/nodes';
@@ -38,26 +44,52 @@ const defaultVoice = (instrument: VoiceParams['instrument']): VoiceControl => ({
   instrument,
 });
 
-export const useControls = create<ControlState>((set) => ({
-  right: defaultVoice(DEFAULT_INSTRUMENT_RIGHT),
-  left: defaultVoice(DEFAULT_INSTRUMENT_LEFT),
-  syncHands: true,
-  masterVolume: 0.4,
-  setVoice: (side, patch) =>
-    set((s) => {
-      const next = { ...s[side], ...patch };
-      if (s.syncHands) {
-        // When synced, both hands share settings — including the patched
-        // instrument on the *addressed* hand — but each hand keeps its OWN
-        // instrument otherwise, so the two voices stay timbrally distinct.
-        const other = side === 'right' ? 'left' : 'right';
-        return {
-          [side]: next,
-          [other]: { ...next, instrument: s[other].instrument },
-        } as Pick<ControlState, 'right' | 'left'>;
-      }
-      return { [side]: next } as Pick<ControlState, 'right' | 'left'>;
+// localStorage in the browser; a no-op elsewhere (Node test runtime) so the
+// persist middleware never references a missing `window`/`localStorage`.
+const noopStorage: StateStorage = {
+  getItem: () => null,
+  setItem: () => {},
+  removeItem: () => {},
+};
+const controlsStorage = (): StateStorage =>
+  typeof window !== 'undefined' && window.localStorage ? window.localStorage : noopStorage;
+
+export const useControls = create<ControlState>()(
+  persist(
+    (set) => ({
+      right: defaultVoice(DEFAULT_INSTRUMENT_RIGHT),
+      left: defaultVoice(DEFAULT_INSTRUMENT_LEFT),
+      syncHands: true,
+      masterVolume: 0.4,
+      setVoice: (side, patch) =>
+        set((s) => {
+          const next = { ...s[side], ...patch };
+          if (s.syncHands) {
+            // When synced, both hands share settings — including the patched
+            // instrument on the *addressed* hand — but each hand keeps its OWN
+            // instrument otherwise, so the two voices stay timbrally distinct.
+            const other = side === 'right' ? 'left' : 'right';
+            return {
+              [side]: next,
+              [other]: { ...next, instrument: s[other].instrument },
+            } as Pick<ControlState, 'right' | 'left'>;
+          }
+          return { [side]: next } as Pick<ControlState, 'right' | 'left'>;
+        }),
+      setSync: (v) => set({ syncHands: v }),
+      setMasterVolume: (v) => set({ masterVolume: v }),
     }),
-  setSync: (v) => set({ syncHands: v }),
-  setMasterVolume: (v) => set({ masterVolume: v }),
-}));
+    {
+      name: 'thoremin-controls',
+      version: 1,
+      storage: createJSONStorage(controlsStorage),
+      // Persist only the control values, never the setter functions.
+      partialize: (s) => ({
+        right: s.right,
+        left: s.left,
+        syncHands: s.syncHands,
+        masterVolume: s.masterVolume,
+      }),
+    },
+  ),
+);


### PR DESCRIPTION
A player's **instrument / scale / root / octaves / volume / sync** choices now survive a page reload, via zustand's `persist` middleware (**no new dependency**).

- The control **values** (not the setter functions) are saved to `localStorage` under `thoremin-controls` and restored on load (`partialize` keeps the setters out of storage; the default shallow-merge restores them from the creator).
- A **no-op storage** is used when there's no `window` (the Node test runtime), so persistence never references a missing global — existing store tests pass unchanged (the `getInitialState`/`setState` reset still works through `persist`).

Gates: strict typecheck ✅ · **111 tests** ✅ · `vite build` ✅. The round-trip is browser-only (verified in the browser).

Refs #6.

https://claude.ai/code/session_01Gp5tDXPQZuM7WaetpZwxij