### PR TITLE
feat(overlay): composable toggleable elements + index-finger guide (#46)

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -185,9 +185,9 @@ Steers a generative engine (Lyria RealTime) from weighted prompts + config dials
 _Audio + the captured video with overlaid guides._
 
 #### `canvas-overlay` — Canvas Overlay
-Draws mirrored video + landmarks + control markers + per-hand note names.
+Mirrored video + composable overlay elements (guides, landmarks, markers).
 
 - **in:** hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], octaveShift:number
 - **out:** —
-- **params:** showLandmarks (boolean=true), showVideo (boolean=true), videoAlpha (number=0.35), showNotes (boolean=true), showScaleGuide (boolean=true)
+- **params:** video (object={}), scaleGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={})
 

--- a/public/catalog.json
+++ b/public/catalog.json
@@ -2,7 +2,7 @@
   {
     "type": "canvas-overlay",
     "title": "Canvas Overlay",
-    "description": "Draws mirrored video + landmarks + control markers + per-hand note names.",
+    "description": "Mirrored video + composable overlay elements (guides, landmarks, markers).",
     "inputs": [
       {
         "name": "hands",
@@ -33,29 +33,29 @@
     "outputs": [],
     "params": [
       {
-        "name": "showLandmarks",
-        "type": "boolean",
-        "default": true
+        "name": "video",
+        "type": "object",
+        "default": {}
       },
       {
-        "name": "showVideo",
-        "type": "boolean",
-        "default": true
+        "name": "scaleGuide",
+        "type": "object",
+        "default": {}
       },
       {
-        "name": "videoAlpha",
-        "type": "number",
-        "default": 0.35
+        "name": "indexGuide",
+        "type": "object",
+        "default": {}
       },
       {
-        "name": "showNotes",
-        "type": "boolean",
-        "default": true
+        "name": "landmarks",
+        "type": "object",
+        "default": {}
       },
       {
-        "name": "showScaleGuide",
-        "type": "boolean",
-        "default": true
+        "name": "markers",
+        "type": "object",
+        "default": {}
       }
     ]
   },

--- a/public/manual.html
+++ b/public/manual.html
@@ -216,11 +216,11 @@
 <section><h3>Output</h3><p class="blurb">Audio + the captured video with overlaid guides.</p><div class="grid">
     <div class="node">
       <h4><code>canvas-overlay</code> <span class="title">Canvas Overlay</span></h4>
-      <p>Draws mirrored video + landmarks + control markers + per-hand note names.</p>
+      <p>Mirrored video + composable overlay elements (guides, landmarks, markers).</p>
       <dl>
         <dt>in</dt><dd>hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], octaveShift:number</dd>
         <dt>out</dt><dd>—</dd>
-        <dt>params</dt><dd>showLandmarks (boolean=true), showVideo (boolean=true), videoAlpha (number=0.35), showNotes (boolean=true), showScaleGuide (boolean=true)</dd>
+        <dt>params</dt><dd>video (object={}), scaleGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={})</dd>
       </dl>
     </div></div></section>
 </div></body></html>

--- a/src/app/graph.ts
+++ b/src/app/graph.ts
@@ -23,7 +23,9 @@ export function defaultGraph(): GraphSpec {
       { id: 'ui', type: 'store-controls' },
       { id: 'map', type: 'voice-mapping', params: { magnetism: 0.8, maxGain: 0.5 } },
       { id: 'synth', type: 'webaudio-synth' },
-      { id: 'overlay', type: 'canvas-overlay', params: { showLandmarks: true, showVideo: true } },
+      // Overlay elements default on (video/scaleGuide/landmarks/markers); the
+      // opt-in index-finger guide is off by default. See canvas_overlay.ts.
+      { id: 'overlay', type: 'canvas-overlay', params: {} },
     ],
     edges: [
       { from: { node: 'cam', port: 'hands' }, to: { node: 'feat', port: 'hands' } },

--- a/src/nodes/output/canvas_overlay.ts
+++ b/src/nodes/output/canvas_overlay.ts
@@ -1,35 +1,296 @@
 /**
- * `canvas-overlay` node (browser-only) — the visual output + guides. Draws the
- * mirrored webcam frame, hand landmark dots, a control marker per hand (with
- * openness as ring size, pinch as fill), and a small HUD of feature values.
+ * `canvas-overlay` node (browser-only) — the visual output + guides.
+ *
+ * The overlay is composed of an ordered list of independent **overlay elements**
+ * (see `OVERLAY_ELEMENTS`): the mirrored webcam backdrop, a per-scale-note pitch
+ * guide ("fretboard"), an index-finger guide (a dashed line from the fingertip to
+ * the frame edge), hand landmark dots, and a per-hand control marker (openness =
+ * ring size, pinch = fill) with the sounding note name.
+ *
+ * Each element is drawn in list order (= z-order), reads only the inputs/params
+ * it needs, and is toggled/parameterized by its own sub-object in `Params`. This
+ * is the worked example of the project's "sub-components are toggled functions
+ * inside one node, never separate DAG nodes" rule (the engine forbids fan-in to
+ * the single canvas, and the elements share the 2D context, mirror transform, and
+ * z-order). See `docs/design/component-model.md`.
  *
  * Canvas + video are injected via `ctx.resources`. Pure drawing; produces no
- * port output. This is the "video with overlaid visual artifacts/guides" output.
+ * port output.
  */
 import { z } from 'zod';
 import { defineNode } from '@/dag';
 import type { NodeContext } from '@/dag';
 import { freqToMidi, midiToName, scaleGuide } from '@/music/theory';
-import { LM, type HandFeatures, type HandsFrame, type SingleHandFeatures, type SynthParams } from '../domain';
+import {
+  kp,
+  LM,
+  type HandFeatures,
+  type HandsFrame,
+  type SingleHandFeatures,
+  type SynthParams,
+} from '../domain';
 
+/**
+ * Per-element configuration. Each element has its own sub-object so it can be
+ * toggled and parameterized independently — and so a settings panel can be
+ * generated one collapsible section per element.
+ */
 const Params = z.object({
-  showLandmarks: z.boolean().default(true),
-  showVideo: z.boolean().default(true),
-  videoAlpha: z.number().min(0).max(1).default(0.35),
-  /** Show the note name each hand is currently playing, above its marker. */
-  showNotes: z.boolean().default(true),
-  /** Show a faint vertical guide at each scale note (a "fretboard"). */
-  showScaleGuide: z.boolean().default(true),
+  /** Mirrored webcam backdrop. `alpha` is the "grey-out" amount (0 = hidden). */
+  video: z
+    .object({
+      show: z.boolean().default(true),
+      alpha: z.number().min(0).max(1).default(0.35),
+    })
+    .default({}),
+  /** Faint vertical guide at each scale note (a "fretboard"), with note labels. */
+  scaleGuide: z
+    .object({
+      show: z.boolean().default(true),
+      /** Draw the note-name labels (split from the lines so each toggles alone). */
+      showLabels: z.boolean().default(true),
+    })
+    .default({}),
+  /** Dashed vertical line from each index fingertip to the frame edge. Opt-in. */
+  indexGuide: z
+    .object({
+      show: z.boolean().default(false),
+      dashed: z.boolean().default(true),
+    })
+    .default({}),
+  /** Hand landmark dots + a ring around each index fingertip. */
+  landmarks: z
+    .object({
+      show: z.boolean().default(true),
+    })
+    .default({}),
+  /** Per-hand control marker (openness = ring size, pinch = fill). */
+  markers: z
+    .object({
+      show: z.boolean().default(true),
+      /** Show the note name each hand is sounding, above its marker. */
+      showNotes: z.boolean().default(true),
+    })
+    .default({}),
 });
 type Params = z.infer<typeof Params>;
 
 const RIGHT_COLOR = '#10b981';
 const LEFT_COLOR = '#3b82f6';
 
+/**
+ * Everything an overlay element needs to draw a frame. `inputs` mirrors the
+ * node's input ports; `video` is the optional backdrop resource. All x are drawn
+ * mirrored to match the flipped webcam (helpers below).
+ */
+export interface OverlayView {
+  W: number;
+  H: number;
+  video?: HTMLVideoElement;
+  inputs: {
+    hands?: HandsFrame;
+    features?: HandFeatures;
+    params?: SynthParams;
+    scale?: number[];
+    scaleLeft?: number[];
+    octaveShift: number;
+  };
+  params: Params;
+}
+
+/**
+ * One composable piece of the overlay. `draw` is responsible for honoring its
+ * own `view.params.<name>.show` toggle. Elements are plain functions held inside
+ * this node — deliberately NOT DAG nodes (see the module docstring).
+ */
+export interface OverlayElement {
+  name: string;
+  draw(g: CanvasRenderingContext2D, view: OverlayView): void;
+}
+
+/** Mirror a source-frame x (pixels) into mirrored canvas x. */
+function mirrorX(xPx: number, frameW: number, W: number): number {
+  return W - (xPx / frameW) * W;
+}
+
+/** The displayed-right hand is the detected 'Left' (the video is mirrored). */
+function isDisplayedRight(handedness: string): boolean {
+  return handedness === 'Left';
+}
+
+const videoBackdrop: OverlayElement = {
+  name: 'video',
+  draw(g, { W, H, video, params }) {
+    if (!params.video.show) return;
+    if (!video || video.readyState < 2) return;
+    g.save();
+    g.globalAlpha = params.video.alpha;
+    g.scale(-1, 1);
+    g.translate(-W, 0);
+    g.drawImage(video, 0, 0, W, H);
+    g.restore();
+  },
+};
+
+const arrEq = (a?: number[], b?: number[]) =>
+  !!a && !!b && a.length === b.length && a.every((v, i) => v === b[i]);
+
+const scaleGuideElement: OverlayElement = {
+  name: 'scaleGuide',
+  draw(g, { W, H, inputs, params }) {
+    if (!params.scaleGuide.show) return;
+    const scaleR = inputs.scale;
+    if (!Array.isArray(scaleR) || scaleR.length <= 1) return;
+    const shift = inputs.octaveShift;
+    const drawGuide = (s: number[], color: string, alpha: number, labelY: number) => {
+      g.save();
+      g.font = '11px monospace';
+      g.textAlign = 'center';
+      for (const { midi, x } of scaleGuide(s)) {
+        const sx = x * W;
+        g.globalAlpha = alpha;
+        g.strokeStyle = color;
+        g.lineWidth = 1;
+        g.beginPath();
+        g.moveTo(sx, H * 0.12);
+        g.lineTo(sx, H * 0.86);
+        g.stroke();
+        if (params.scaleGuide.showLabels) {
+          g.globalAlpha = Math.min(1, alpha * 4);
+          g.fillStyle = color;
+          g.fillText(midiToName(midi + shift * 12), sx, labelY);
+        }
+      }
+      g.restore();
+    };
+    drawGuide(scaleR, '#ffffff', 0.1, H * 0.82);
+    const scaleL = inputs.scaleLeft;
+    if (Array.isArray(scaleL) && scaleL.length > 1 && !arrEq(scaleL, scaleR)) {
+      drawGuide(scaleL, LEFT_COLOR, 0.12, H * 0.18);
+    }
+  },
+};
+
+/**
+ * The "old" overlay the player remembers: a dashed vertical line from each index
+ * fingertip up to the top edge (displayed-right hand) or down to the bottom edge
+ * (displayed-left hand), in the hand's colour. Reconstructed from the legacy
+ * `src/components/Theremin.tsx` (which used `keypoint.name`; here we use the
+ * MediaPipe index `LM.index_tip` via `kp()`). Opt-in alongside the marker/guide.
+ */
+const indexFingerGuide: OverlayElement = {
+  name: 'indexGuide',
+  draw(g, { W, H, inputs, params }) {
+    if (!params.indexGuide.show) return;
+    const frame = inputs.hands;
+    if (!frame) return;
+    for (const hand of frame.hands) {
+      const tip = kp(hand, LM.index_tip);
+      if (!tip) continue;
+      const sx = mirrorX(tip.x, frame.width, W);
+      const sy = (tip.y / frame.height) * H;
+      const right = isDisplayedRight(hand.handedness);
+      g.save();
+      g.globalAlpha = 0.4;
+      g.strokeStyle = right ? RIGHT_COLOR : LEFT_COLOR;
+      g.lineWidth = 2;
+      if (params.indexGuide.dashed) g.setLineDash([5, 5]);
+      g.beginPath();
+      g.moveTo(sx, sy);
+      g.lineTo(sx, right ? 0 : H);
+      g.stroke();
+      g.restore();
+    }
+  },
+};
+
+const landmarkDots: OverlayElement = {
+  name: 'landmarks',
+  draw(g, { W, H, inputs, params }) {
+    if (!params.landmarks.show) return;
+    const frame = inputs.hands;
+    if (!frame) return;
+    for (const hand of frame.hands) {
+      const color = hand.handedness === 'Left' ? RIGHT_COLOR : LEFT_COLOR; // mirrored
+      g.fillStyle = color;
+      for (const k of hand.keypoints) {
+        const sx = mirrorX(k.x, frame.width, W);
+        const sy = (k.y / frame.height) * H;
+        g.beginPath();
+        g.arc(sx, sy, 3, 0, Math.PI * 2);
+        g.fill();
+      }
+      const tip = hand.keypoints[LM.index_tip];
+      if (tip) {
+        const sx = mirrorX(tip.x, frame.width, W);
+        const sy = (tip.y / frame.height) * H;
+        g.beginPath();
+        g.arc(sx, sy, 10, 0, Math.PI * 2);
+        g.strokeStyle = '#fff';
+        g.lineWidth = 2;
+        g.stroke();
+      }
+    }
+  },
+};
+
+const controlMarkers: OverlayElement = {
+  name: 'markers',
+  draw(g, { W, H, inputs, params }) {
+    if (!params.markers.show) return;
+    const feats = inputs.features;
+    if (!feats) return;
+    const sp = inputs.params;
+    const noteFor = (voiceId: number): string | null => {
+      const v = sp?.voices?.[voiceId];
+      if (!v || !v.present || v.freq <= 0) return null;
+      return midiToName(freqToMidi(v.freq));
+    };
+    const drawMarker = (f: SingleHandFeatures, color: string, note: string | null) => {
+      if (!f.present) return;
+      const sx = f.x * W;
+      const sy = f.y * H;
+      const ring = 14 + f.openness * 26;
+      g.beginPath();
+      g.arc(sx, sy, ring, 0, Math.PI * 2);
+      g.strokeStyle = color;
+      g.lineWidth = 2;
+      g.stroke();
+      g.globalAlpha = 0.3 + 0.7 * f.pinch;
+      g.fillStyle = color;
+      g.beginPath();
+      g.arc(sx, sy, 8, 0, Math.PI * 2);
+      g.fill();
+      g.globalAlpha = 1;
+      if (params.markers.showNotes && note) {
+        g.fillStyle = color;
+        g.font = 'bold 22px monospace';
+        g.textAlign = 'center';
+        g.fillText(note, sx, sy - ring - 10);
+        g.textAlign = 'left';
+      }
+    };
+    drawMarker(feats.right, RIGHT_COLOR, noteFor(0));
+    drawMarker(feats.left, LEFT_COLOR, noteFor(1));
+  },
+};
+
+/**
+ * The overlay elements, in draw (z) order. Append here to add a new element;
+ * give it a `<name>` sub-object in `Params` with at least a `show` toggle.
+ */
+export const OVERLAY_ELEMENTS: readonly OverlayElement[] = [
+  videoBackdrop,
+  scaleGuideElement,
+  indexFingerGuide,
+  landmarkDots,
+  controlMarkers,
+];
+
 export const canvasOverlayNode = defineNode<Params>({
   type: 'canvas-overlay',
   title: 'Canvas Overlay',
-  description: 'Draws mirrored video + landmarks + control markers + per-hand note names.',
+  description: 'Mirrored video + composable overlay elements (guides, landmarks, markers).',
   inputs: [
     { name: 'hands', kind: 'hands-frame' },
     { name: 'features', kind: 'hand-features' },
@@ -58,120 +319,22 @@ export const canvasOverlayNode = defineNode<Params>({
         const H = canvas.height;
         g.clearRect(0, 0, W, H);
 
-        // Mirrored faint video backdrop.
-        if (p.showVideo && video && video.readyState >= 2) {
-          g.save();
-          g.globalAlpha = p.videoAlpha;
-          g.scale(-1, 1);
-          g.translate(-W, 0);
-          g.drawImage(video, 0, 0, W, H);
-          g.restore();
-        }
-
-        // Pitch guides: a faint vertical line + note name at each scale note,
-        // drawn at the x where that note sounds (positions match the x→pitch
-        // mapping; labels include the live octave shift so they agree with the
-        // per-hand note labels). The right hand's guide is always drawn; the
-        // left's is drawn only when it differs (unsynced, distinct scale), in
-        // the left colour, so each hand has a matching reference.
-        const shift = typeof inputs.octaveShift === 'number' ? inputs.octaveShift : 0;
-        const scaleR = inputs.scale as number[] | undefined;
-        const scaleL = inputs.scaleLeft as number[] | undefined;
-        const arrEq = (a?: number[], b?: number[]) =>
-          !!a && !!b && a.length === b.length && a.every((v, i) => v === b[i]);
-        const drawGuide = (s: number[], color: string, alpha: number, labelY: number) => {
-          g.save();
-          g.font = '11px monospace';
-          g.textAlign = 'center';
-          for (const { midi, x } of scaleGuide(s)) {
-            const sx = x * W;
-            g.globalAlpha = alpha;
-            g.strokeStyle = color;
-            g.lineWidth = 1;
-            g.beginPath();
-            g.moveTo(sx, H * 0.12);
-            g.lineTo(sx, H * 0.86);
-            g.stroke();
-            g.globalAlpha = Math.min(1, alpha * 4);
-            g.fillStyle = color;
-            g.fillText(midiToName(midi + shift * 12), sx, labelY);
-          }
-          g.restore();
-        };
-        if (p.showScaleGuide && Array.isArray(scaleR) && scaleR.length > 1) {
-          drawGuide(scaleR, '#ffffff', 0.1, H * 0.82);
-          if (Array.isArray(scaleL) && scaleL.length > 1 && !arrEq(scaleL, scaleR)) {
-            drawGuide(scaleL, LEFT_COLOR, 0.12, H * 0.18);
-          }
-        }
-
-        const frame = inputs.hands as HandsFrame | undefined;
-        const feats = inputs.features as HandFeatures | undefined;
-
-        // Landmark dots (mirror x to match the mirrored video).
-        if (p.showLandmarks && frame) {
-          for (const hand of frame.hands) {
-            const color = hand.handedness === 'Left' ? RIGHT_COLOR : LEFT_COLOR; // mirrored
-            g.fillStyle = color;
-            for (const k of hand.keypoints) {
-              const sx = W - (k.x / frame.width) * W;
-              const sy = (k.y / frame.height) * H;
-              g.beginPath();
-              g.arc(sx, sy, 3, 0, Math.PI * 2);
-              g.fill();
-            }
-            const tip = hand.keypoints[LM.index_tip];
-            if (tip) {
-              const sx = W - (tip.x / frame.width) * W;
-              const sy = (tip.y / frame.height) * H;
-              g.beginPath();
-              g.arc(sx, sy, 10, 0, Math.PI * 2);
-              g.strokeStyle = '#fff';
-              g.lineWidth = 2;
-              g.stroke();
-            }
-          }
-        }
-
-        // The synth params let us label each hand with the note it's sounding
-        // (voice 0 = right, 1 = left, by convention).
-        const sp = inputs.params as SynthParams | undefined;
-        const noteFor = (voiceId: number): string | null => {
-          const v = sp?.voices?.[voiceId];
-          if (!v || !v.present || v.freq <= 0) return null;
-          return midiToName(freqToMidi(v.freq));
+        const view: OverlayView = {
+          W,
+          H,
+          video,
+          params: p,
+          inputs: {
+            hands: inputs.hands as HandsFrame | undefined,
+            features: inputs.features as HandFeatures | undefined,
+            params: inputs.params as SynthParams | undefined,
+            scale: inputs.scale as number[] | undefined,
+            scaleLeft: inputs.scaleLeft as number[] | undefined,
+            octaveShift: typeof inputs.octaveShift === 'number' ? inputs.octaveShift : 0,
+          },
         };
 
-        // Control markers from features (x already mirrored, matches video),
-        // with the current note drawn above each present hand.
-        const drawMarker = (f: SingleHandFeatures, color: string, note: string | null) => {
-          if (!f.present) return;
-          const sx = f.x * W;
-          const sy = f.y * H;
-          const ring = 14 + f.openness * 26;
-          g.beginPath();
-          g.arc(sx, sy, ring, 0, Math.PI * 2);
-          g.strokeStyle = color;
-          g.lineWidth = 2;
-          g.stroke();
-          g.globalAlpha = 0.3 + 0.7 * f.pinch;
-          g.fillStyle = color;
-          g.beginPath();
-          g.arc(sx, sy, 8, 0, Math.PI * 2);
-          g.fill();
-          g.globalAlpha = 1;
-          if (p.showNotes && note) {
-            g.fillStyle = color;
-            g.font = 'bold 22px monospace';
-            g.textAlign = 'center';
-            g.fillText(note, sx, sy - ring - 10);
-            g.textAlign = 'left';
-          }
-        };
-        if (feats) {
-          drawMarker(feats.right, RIGHT_COLOR, noteFor(0));
-          drawMarker(feats.left, LEFT_COLOR, noteFor(1));
-        }
+        for (const element of OVERLAY_ELEMENTS) element.draw(g, view);
 
         return {};
       },

--- a/test/overlay_elements.test.ts
+++ b/test/overlay_elements.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Drives the `canvas-overlay` node with a recording 2D context and asserts that
+ * each composable overlay element is independently toggled/parameterized by its
+ * own params sub-object — the contract behind the per-overlay settings panel.
+ *
+ * Uses a fake canvas/context (the test runtime is Node, no DOM) that records
+ * every draw call (and the live `globalAlpha` at call time), so we can assert
+ * which primitives an element drew without rendering pixels.
+ */
+import { describe, it, expect } from 'vitest';
+import { Engine } from '@/dag';
+import type { NodeContext } from '@/dag';
+import { createAppRegistry } from '@/nodes/browser';
+import { defaultGraph } from '@/app/graph';
+import { canvasOverlayNode, OVERLAY_ELEMENTS } from '@/nodes/output/canvas_overlay';
+import {
+  makeHandKeypoints,
+  type HandFeatures,
+  type HandsFrame,
+  type SynthParams,
+} from '@/nodes/domain';
+
+interface Call {
+  m: string;
+  args: unknown[];
+  alpha: number;
+}
+
+function makeRecordingCanvas(width = 1280, height = 720) {
+  const calls: Call[] = [];
+  // `ctx` is referenced by the recorders so they can snapshot live props.
+  const ctx: Record<string, unknown> = {
+    globalAlpha: 1,
+    strokeStyle: '',
+    fillStyle: '',
+    lineWidth: 1,
+    font: '',
+    textAlign: '',
+  };
+  const rec =
+    (m: string) =>
+    (...args: unknown[]) => {
+      calls.push({ m, args, alpha: ctx.globalAlpha as number });
+    };
+  for (const m of [
+    'clearRect', 'save', 'restore', 'beginPath', 'arc', 'fill', 'stroke',
+    'moveTo', 'lineTo', 'drawImage', 'fillText', 'setLineDash', 'scale', 'translate',
+  ]) {
+    ctx[m] = rec(m);
+  }
+  const canvas = {
+    width,
+    height,
+    getContext: () => ctx,
+  } as unknown as HTMLCanvasElement;
+  const video = { readyState: 2 } as unknown as HTMLVideoElement;
+  return { canvas, video, calls, count: (m: string) => calls.filter((c) => c.m === m).length };
+}
+
+function fullInputs() {
+  const frame: HandsFrame = {
+    width: 640,
+    height: 480,
+    hands: [
+      {
+        handedness: 'Left', // displayed-right
+        keypoints: makeHandKeypoints({ cx: 200, cy: 240, scale: 60, spread: 0.7, pinch: 0.2, handedness: 'Left' }),
+        score: 1,
+      },
+      {
+        handedness: 'Right', // displayed-left
+        keypoints: makeHandKeypoints({ cx: 440, cy: 240, scale: 60, spread: 0.3, pinch: 0.8, handedness: 'Right' }),
+        score: 1,
+      },
+    ],
+  };
+  const features: HandFeatures = {
+    right: { present: true, x: 0.7, y: 0.4, openness: 0.6, pinch: 0.2 },
+    left: { present: true, x: 0.3, y: 0.6, openness: 0.3, pinch: 0.8 },
+  };
+  const params: SynthParams = {
+    voices: [
+      { id: 0, present: true, freq: 440, gain: 0.5, instrument: 'warmPad' },
+      { id: 1, present: true, freq: 330, gain: 0.4, instrument: 'glass' },
+    ],
+  };
+  return {
+    hands: frame,
+    features,
+    params,
+    scale: [48, 50, 52, 55, 57, 60],
+    scaleLeft: [45, 48, 50, 52, 55, 57],
+    octaveShift: 0,
+  };
+}
+
+function draw(paramsPartial: unknown, resourcesExtra: Record<string, unknown> = {}) {
+  const rc = makeRecordingCanvas();
+  const handlers = canvasOverlayNode.make(canvasOverlayNode.params.parse(paramsPartial ?? {}));
+  const ctx: NodeContext = {
+    tick: 0,
+    time: 0,
+    dt: 0,
+    resources: { canvas: rc.canvas, video: rc.video, ...resourcesExtra },
+  };
+  handlers.process(fullInputs(), ctx);
+  return rc;
+}
+
+describe('canvas-overlay composable elements', () => {
+  it('the element list and the params schema agree on names', () => {
+    const names = OVERLAY_ELEMENTS.map((e) => e.name);
+    const paramKeys = Object.keys(canvasOverlayNode.params.parse({}) as Record<string, unknown>);
+    for (const n of names) expect(paramKeys).toContain(n);
+    // z-order: video first, markers last.
+    expect(names[0]).toBe('video');
+    expect(names[names.length - 1]).toBe('markers');
+  });
+
+  it('defaults: clears once, draws the video, guide, and markers; index-guide OFF', () => {
+    const rc = draw({});
+    expect(rc.count('clearRect')).toBe(1);
+    expect(rc.count('drawImage')).toBe(1); // video backdrop
+    expect(rc.count('moveTo')).toBeGreaterThan(0); // scale-guide vertical lines
+    expect(rc.count('fillText')).toBeGreaterThan(0); // guide labels + note names
+    expect(rc.count('setLineDash')).toBe(0); // index-finger guide is opt-in
+  });
+
+  it('video: show toggles the backdrop; alpha is the grey-out amount', () => {
+    expect(draw({ video: { show: false } }).count('drawImage')).toBe(0);
+    const rc = draw({ video: { show: true, alpha: 0.1 } });
+    const img = rc.calls.find((c) => c.m === 'drawImage');
+    expect(img?.alpha).toBeCloseTo(0.1);
+  });
+
+  it('scaleGuide: lines and labels toggle independently', () => {
+    // No guide at all → no vertical lines (markers use arcs, not moveTo).
+    expect(draw({ scaleGuide: { show: false }, indexGuide: { show: false } }).count('moveTo')).toBe(0);
+    // Lines on, labels off, markers off → fillText not called.
+    expect(
+      draw({ scaleGuide: { show: true, showLabels: false }, markers: { show: false } }).count('fillText'),
+    ).toBe(0);
+    // Lines on, labels on, markers off → guide labels drawn.
+    expect(
+      draw({ scaleGuide: { show: true, showLabels: true }, markers: { show: false } }).count('fillText'),
+    ).toBeGreaterThan(0);
+  });
+
+  it('indexGuide: opt-in dashed line, one per detected hand', () => {
+    const on = draw({ indexGuide: { show: true, dashed: true } });
+    const dashes = on.calls.filter((c) => c.m === 'setLineDash' && Array.isArray(c.args[0]) && (c.args[0] as number[]).length === 2);
+    expect(dashes.length).toBe(2); // two hands
+    // dashed=false → still drawn (lineTo) but no dash pattern set.
+    const solid = draw({ indexGuide: { show: true, dashed: false } });
+    expect(solid.count('setLineDash')).toBe(0);
+    expect(solid.count('lineTo')).toBeGreaterThan(0);
+  });
+
+  it('landmarks and markers toggle off cleanly', () => {
+    // Everything off → only the one clearRect, nothing drawn.
+    const rc = draw({
+      video: { show: false },
+      scaleGuide: { show: false },
+      indexGuide: { show: false },
+      landmarks: { show: false },
+      markers: { show: false },
+    });
+    expect(rc.count('clearRect')).toBe(1);
+    expect(rc.count('arc')).toBe(0);
+    expect(rc.count('drawImage')).toBe(0);
+    expect(rc.count('fillText')).toBe(0);
+  });
+
+  it('markers.showNotes hides the per-hand note label without hiding the marker', () => {
+    const noNotes = draw({ markers: { show: true, showNotes: false }, scaleGuide: { show: false } });
+    expect(noNotes.count('arc')).toBeGreaterThan(0); // rings + fills still drawn
+    expect(noNotes.count('fillText')).toBe(0); // but no note labels
+  });
+
+  it('no canvas resource → no-op, no throw', () => {
+    const handlers = canvasOverlayNode.make(canvasOverlayNode.params.parse({}));
+    const ctx: NodeContext = { tick: 0, time: 0, dt: 0, resources: {} };
+    expect(() => handlers.process(fullInputs(), ctx)).not.toThrow();
+  });
+
+  it('runs inside the real production graph (overlay clears the canvas each tick)', () => {
+    const rc = makeRecordingCanvas();
+    const engine = new Engine(defaultGraph(), createAppRegistry(), {
+      resources: { canvas: rc.canvas }, // no video → webcam/backdrop stay no-op
+    });
+    expect(() => {
+      engine.tick();
+      engine.tick();
+    }).not.toThrow();
+    expect(rc.count('clearRect')).toBe(2); // overlay ran both ticks
+  });
+});


### PR DESCRIPTION
First build under the component model (#45). Turns `canvas-overlay` into an ordered list of independent **overlay elements**, each toggled/parameterized by its own params sub-object — the seam behind a per-overlay settings panel. Part of #46.

## What changed
- **`OVERLAY_ELEMENTS`** (ordered = z-order): `videoBackdrop` · `scaleGuide` · `indexFingerGuide` · `landmarkDots` · `controlMarkers`. Each is an in-node function (deliberately **not** a DAG node — the engine forbids fan-in to the single canvas; elements share the 2D context/mirror/z-order). See `docs/design/component-model.md`.
- **Index-finger guide (NEW, opt-in):** reconstructs the "old" overlay the player remembered — a dashed vertical line from each index fingertip to the top edge (displayed-right hand) / bottom edge (displayed-left), in the hand's colour. Found in the legacy `src/components/Theremin.tsx`; ported to the DAG keypoint convention (`LM.index_tip` via `kp()`). **Off by default**, so the live look is unchanged until selected.
- **Video grey-out** is now the `video.alpha` option (0 = hidden). **Guide lines and labels** toggle separately (the user wanted the labels on their own switch).
- `graph.ts` overlay params → `{}` (defaults reproduce the current look exactly).

## What this sets up (next PRs)
Live control of these toggles from settings + a dedicated overlay panel (the element list + per-element sub-schemas generate it), and saving combos as presets (#48).

## Verification
- `npm run typecheck` clean · `npm test` **120 passed** (+9 new in `test/overlay_elements.test.ts`, which drives the node with a recording 2D context and asserts each element honors its toggle, including a run through the real production graph) · `npm run build` clean · node catalog regenerated.

No new dependencies, no engine/registry change. Additive and zero-risk to the live default.