### PR TITLE
feat(settings): live overlay controls + named presets UI (#48 part 2, #46)

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -41,10 +41,10 @@ Global keyboard input → held / pressed / released key events.
 - **params:** preventDefaultKeys (array=["ArrowUp","ArrowDown","ArrowLeft","ArrowRight"," "])
 
 #### `store-controls` — UI Controls
-Reads the live UI control store → scale + instrument port values.
+Reads the live UI control store → scale + instrument + overlay port values.
 
 - **in:** —
-- **out:** scaleRight:number[], scaleLeft:number[], instrumentRight:instrument, instrumentLeft:instrument
+- **out:** scaleRight:number[], scaleLeft:number[], instrumentRight:instrument, instrumentLeft:instrument, overlay:overlay-config
 - **params:** —
 
 #### `synthetic-hands` — Synthetic Hands
@@ -187,7 +187,7 @@ _Audio + the captured video with overlaid guides._
 #### `canvas-overlay` — Canvas Overlay
 Mirrored video + composable overlay elements (guides, landmarks, markers).
 
-- **in:** hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], octaveShift:number
+- **in:** hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], octaveShift:number, overlayConfig:overlay-config
 - **out:** —
 - **params:** video (object={}), scaleGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={})
 

--- a/public/catalog.json
+++ b/public/catalog.json
@@ -28,6 +28,10 @@
         "name": "octaveShift",
         "kind": "number",
         "default": 0
+      },
+      {
+        "name": "overlayConfig",
+        "kind": "overlay-config"
       }
     ],
     "outputs": [],
@@ -611,7 +615,7 @@
   {
     "type": "store-controls",
     "title": "UI Controls",
-    "description": "Reads the live UI control store → scale + instrument port values.",
+    "description": "Reads the live UI control store → scale + instrument + overlay port values.",
     "inputs": [],
     "outputs": [
       {
@@ -629,6 +633,10 @@
       {
         "name": "instrumentLeft",
         "kind": "instrument"
+      },
+      {
+        "name": "overlay",
+        "kind": "overlay-config"
       }
     ],
     "params": []

--- a/public/manual.html
+++ b/public/manual.html
@@ -48,10 +48,10 @@
     </div>
     <div class="node">
       <h4><code>store-controls</code> <span class="title">UI Controls</span></h4>
-      <p>Reads the live UI control store → scale + instrument port values.</p>
+      <p>Reads the live UI control store → scale + instrument + overlay port values.</p>
       <dl>
         <dt>in</dt><dd>—</dd>
-        <dt>out</dt><dd>scaleRight:number[], scaleLeft:number[], instrumentRight:instrument, instrumentLeft:instrument</dd>
+        <dt>out</dt><dd>scaleRight:number[], scaleLeft:number[], instrumentRight:instrument, instrumentLeft:instrument, overlay:overlay-config</dd>
         <dt>params</dt><dd>—</dd>
       </dl>
     </div>
@@ -218,7 +218,7 @@
       <h4><code>canvas-overlay</code> <span class="title">Canvas Overlay</span></h4>
       <p>Mirrored video + composable overlay elements (guides, landmarks, markers).</p>
       <dl>
-        <dt>in</dt><dd>hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], octaveShift:number</dd>
+        <dt>in</dt><dd>hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], octaveShift:number, overlayConfig:overlay-config</dd>
         <dt>out</dt><dd>—</dd>
         <dt>params</dt><dd>video (object={}), scaleGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={})</dd>
       </dl>

--- a/src/app/ControlsPanel.tsx
+++ b/src/app/ControlsPanel.tsx
@@ -3,14 +3,36 @@
  * any value updates the store; the `store-controls` DAG node reads it on the
  * next tick, so edits take effect live without rebuilding the graph.
  *
+ * Sections: per-hand voice, master/sync, the composable Overlay elements, and
+ * named Presets (save/load/delete via the zodal-backed preset store).
+ *
  * Renders just the controls *content* (no outer card); the host (App) wraps it
  * in a collapsible translucent overlay so the video stays the focus.
  */
+import { useState } from 'react';
 import { NOTES, SCALE_TYPES, type ScaleTypeId } from '@/music/theory';
 import { INSTRUMENTS, INSTRUMENT_IDS } from '@/music/instruments';
 import { useControls, type VoiceControl } from './store';
+import { usePresets } from './usePresets';
 
 const selectCls = 'rounded bg-white/10 px-2 py-1 text-xs outline-none focus:bg-white/20';
+
+function Toggle({
+  label,
+  checked,
+  onChange,
+}: {
+  label: string;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+}) {
+  return (
+    <label className="flex items-center gap-2 text-xs">
+      <input type="checkbox" checked={checked} onChange={(e) => onChange(e.target.checked)} />
+      {label}
+    </label>
+  );
+}
 
 function VoiceControls({ side }: { side: 'right' | 'left' }) {
   const voice = useControls((s) => s[side]);
@@ -74,6 +96,93 @@ function VoiceControls({ side }: { side: 'right' | 'left' }) {
   );
 }
 
+function OverlayControls() {
+  const overlay = useControls((s) => s.overlay);
+  const set = useControls((s) => s.setOverlayElement);
+
+  return (
+    <div className="space-y-2">
+      <h3 className="text-[11px] font-bold uppercase tracking-widest text-white/70">Overlay</h3>
+      <Toggle label="Video backdrop" checked={overlay.video.show} onChange={(v) => set('video', { show: v })} />
+      <label className="flex items-center justify-between gap-2 text-xs">
+        Background opacity
+        <input
+          type="range" min={0} max={1} step={0.01} value={overlay.video.alpha}
+          onChange={(e) => set('video', { alpha: Number(e.target.value) })}
+        />
+      </label>
+      <Toggle label="Scale guide" checked={overlay.scaleGuide.show} onChange={(v) => set('scaleGuide', { show: v })} />
+      <Toggle label="Scale guide labels" checked={overlay.scaleGuide.showLabels} onChange={(v) => set('scaleGuide', { showLabels: v })} />
+      <Toggle label="Index-finger guide" checked={overlay.indexGuide.show} onChange={(v) => set('indexGuide', { show: v })} />
+      <Toggle label="Index guide dashed" checked={overlay.indexGuide.dashed} onChange={(v) => set('indexGuide', { dashed: v })} />
+      <Toggle label="Hand landmarks" checked={overlay.landmarks.show} onChange={(v) => set('landmarks', { show: v })} />
+      <Toggle label="Control markers" checked={overlay.markers.show} onChange={(v) => set('markers', { show: v })} />
+      <Toggle label="Note names" checked={overlay.markers.showNotes} onChange={(v) => set('markers', { showNotes: v })} />
+    </div>
+  );
+}
+
+function PresetControls() {
+  const { presets, busy, save, load, remove } = usePresets();
+  const [name, setName] = useState('');
+
+  const doSave = () => {
+    void save(name);
+    setName('');
+  };
+
+  return (
+    <div className="space-y-2">
+      <h3 className="text-[11px] font-bold uppercase tracking-widest text-white/70">Presets</h3>
+      <div className="flex gap-1">
+        <input
+          className={`${selectCls} flex-1`}
+          placeholder="Name this setup…"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') doSave();
+          }}
+        />
+        <button
+          type="button"
+          className="rounded bg-white/10 px-2 py-1 text-xs hover:bg-white/20 disabled:opacity-40"
+          disabled={busy || !name.trim()}
+          onClick={doSave}
+        >
+          Save
+        </button>
+      </div>
+      {presets.length === 0 ? (
+        <p className="text-[10px] text-white/40">No saved presets yet.</p>
+      ) : (
+        <ul className="space-y-1">
+          {presets.map((p) => (
+            <li key={p.id} className="flex items-center justify-between gap-2 text-xs">
+              <button
+                type="button"
+                className="flex-1 truncate text-left hover:text-emerald-300"
+                title="Load this preset"
+                onClick={() => void load(p.id)}
+              >
+                {p.name}
+              </button>
+              <button
+                type="button"
+                className="px-1 text-white/40 hover:text-red-400"
+                title="Delete this preset"
+                onClick={() => void remove(p.id)}
+              >
+                ×
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
 export default function ControlsPanel() {
   const syncHands = useControls((s) => s.syncHands);
   const setSync = useControls((s) => s.setSync);
@@ -97,6 +206,12 @@ export default function ControlsPanel() {
       </div>
       <VoiceControls side="right" />
       {!syncHands && <VoiceControls side="left" />}
+      <div className="border-t border-white/10 pt-3">
+        <OverlayControls />
+      </div>
+      <div className="border-t border-white/10 pt-3">
+        <PresetControls />
+      </div>
       <div className="border-t border-white/10 pt-3 text-[10px] leading-relaxed text-white/50">
         <p className="mb-1 font-bold uppercase tracking-widest text-white/70">Keyboard</p>
         <p>↑ / ↓ — octave shift</p>

--- a/src/app/graph.ts
+++ b/src/app/graph.ts
@@ -47,6 +47,8 @@ export function defaultGraph(): GraphSpec {
       { from: { node: 'ui', port: 'scaleRight' }, to: { node: 'overlay', port: 'scale' } },
       { from: { node: 'ui', port: 'scaleLeft' }, to: { node: 'overlay', port: 'scaleLeft' } },
       { from: { node: 'kctrl', port: 'octaveShift' }, to: { node: 'overlay', port: 'octaveShift' } },
+      // Live overlay element config from the UI store (toggle elements without rebuild).
+      { from: { node: 'ui', port: 'overlay' }, to: { node: 'overlay', port: 'overlayConfig' } },
     ],
   };
 }

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -2,19 +2,24 @@
  * Zustand control store — the single source of truth for live UI controls.
  * The React control panel writes here; the `store-controls` DAG node reads
  * `getState()` each tick and emits the values onto the graph as port values.
- * This keeps UI state out of the graph spec, so changing scale/instrument
+ * This keeps UI state out of the graph spec, so changing scale/instrument/overlay
  * never rebuilds the engine or reloads the ML model.
  *
  * The control *values* (not the setters) are persisted to localStorage via the
- * zustand `persist` middleware, so a player's instrument/scale/volume choices
- * survive a page reload. In non-browser environments (the Node test runtime)
- * a no-op storage is used, so persistence never touches a missing global.
+ * zustand `persist` middleware, so a player's choices survive a reload. In
+ * non-browser environments (the Node test runtime) a no-op storage is used.
+ *
+ * This is the LIVE, synchronous hot layer (read every tick). Named *presets* are
+ * a separate async persistence layer (src/settings) — load a preset by calling
+ * `applySettings`, snapshot the current state with `toSettings`.
  */
 import { create } from 'zustand';
 import { persist, createJSONStorage, type StateStorage } from 'zustand/middleware';
 import type { ScaleTypeId } from '@/music/theory';
 import { DEFAULT_INSTRUMENT_RIGHT, DEFAULT_INSTRUMENT_LEFT } from '@/music/instruments';
+import { OverlayParamsSchema, type OverlayParams } from '@/nodes/output/canvas_overlay';
 import type { VoiceParams } from '@/nodes';
+import type { Settings } from '@/settings/schema';
 
 export interface VoiceControl {
   root: number; // 0..11
@@ -29,9 +34,15 @@ export interface ControlState {
   left: VoiceControl;
   syncHands: boolean;
   masterVolume: number; // 0..1
+  /** Composable overlay element config (see canvas_overlay.ts). Live-controlled. */
+  overlay: OverlayParams;
   setVoice(side: 'right' | 'left', patch: Partial<VoiceControl>): void;
   setSync(v: boolean): void;
   setMasterVolume(v: number): void;
+  /** Patch one overlay element's options (e.g. setOverlayElement('indexGuide', { show: true })). */
+  setOverlayElement<K extends keyof OverlayParams>(key: K, patch: Partial<OverlayParams[K]>): void;
+  /** Replace all live controls from a settings snapshot (loading a preset). */
+  applySettings(s: Settings): void;
 }
 
 const defaultVoice = (instrument: VoiceParams['instrument']): VoiceControl => ({
@@ -43,6 +54,20 @@ const defaultVoice = (instrument: VoiceParams['instrument']): VoiceControl => ({
   baseOctave: 3,
   instrument,
 });
+
+/** The overlay element defaults (all on except the opt-in index-finger guide). */
+const defaultOverlay = (): OverlayParams => OverlayParamsSchema.parse({});
+
+/** Snapshot the persistable settings from the live state (for saving a preset). */
+export function toSettings(s: ControlState): Settings {
+  return {
+    right: s.right,
+    left: s.left,
+    syncHands: s.syncHands,
+    masterVolume: s.masterVolume,
+    overlay: s.overlay,
+  };
+}
 
 // localStorage in the browser; a no-op elsewhere (Node test runtime) so the
 // persist middleware never references a missing `window`/`localStorage`.
@@ -61,6 +86,7 @@ export const useControls = create<ControlState>()(
       left: defaultVoice(DEFAULT_INSTRUMENT_LEFT),
       syncHands: true,
       masterVolume: 0.4,
+      overlay: defaultOverlay(),
       setVoice: (side, patch) =>
         set((s) => {
           const next = { ...s[side], ...patch };
@@ -78,9 +104,24 @@ export const useControls = create<ControlState>()(
         }),
       setSync: (v) => set({ syncHands: v }),
       setMasterVolume: (v) => set({ masterVolume: v }),
+      setOverlayElement: (key, patch) =>
+        set((s) => ({
+          overlay: { ...s.overlay, [key]: { ...s.overlay[key], ...patch } } as OverlayParams,
+        })),
+      applySettings: (st) =>
+        set({
+          right: st.right,
+          left: st.left,
+          syncHands: st.syncHands,
+          masterVolume: st.masterVolume,
+          overlay: st.overlay,
+        }),
     }),
     {
       name: 'thoremin-controls',
+      // Version stays 1: `overlay` is additive, and the default shallow merge
+      // keeps the initializer's default overlay when an older persisted blob
+      // omits it (no migrate / no discard of existing voice/volume choices).
       version: 1,
       storage: createJSONStorage(controlsStorage),
       // Persist only the control values, never the setter functions.
@@ -89,6 +130,7 @@ export const useControls = create<ControlState>()(
         left: s.left,
         syncHands: s.syncHands,
         masterVolume: s.masterVolume,
+        overlay: s.overlay,
       }),
     },
   ),

--- a/src/app/usePresets.ts
+++ b/src/app/usePresets.ts
@@ -1,0 +1,55 @@
+/**
+ * usePresets — React glue between the async preset store (src/settings) and the
+ * live zustand control store. Saving snapshots the current live state; loading
+ * hydrates it. The preset store is the localStorage-backed zodal collection; the
+ * live hot state stays synchronous (we never await a provider in the tick loop).
+ */
+import { useCallback, useEffect, useState } from 'react';
+import { createPresetStore } from '@/settings/presets';
+import type { PresetSummary } from '@/settings/schema';
+import { useControls, toSettings } from './store';
+
+// One localStorage-backed preset store for the app session.
+const presetStore = createPresetStore();
+
+export function usePresets() {
+  const [presets, setPresets] = useState<PresetSummary[]>([]);
+  const [busy, setBusy] = useState(false);
+
+  const refresh = useCallback(async () => {
+    setPresets(await presetStore.list());
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const save = useCallback(
+    async (name: string) => {
+      if (!name.trim()) return;
+      setBusy(true);
+      try {
+        await presetStore.save(name, toSettings(useControls.getState()));
+        await refresh();
+      } finally {
+        setBusy(false);
+      }
+    },
+    [refresh],
+  );
+
+  const load = useCallback(async (id: string) => {
+    const p = await presetStore.load(id);
+    if (p) useControls.getState().applySettings(p.settings);
+  }, []);
+
+  const remove = useCallback(
+    async (id: string) => {
+      await presetStore.remove(id);
+      await refresh();
+    },
+    [refresh],
+  );
+
+  return { presets, busy, save, load, remove, refresh };
+}

--- a/src/nodes/output/canvas_overlay.ts
+++ b/src/nodes/output/canvas_overlay.ts
@@ -311,6 +311,9 @@ export const canvasOverlayNode = defineNode<Params>({
     { name: 'scaleLeft', kind: 'number[]' },
     // Optional: the live octave shift, so guide labels match the sounding pitch.
     { name: 'octaveShift', kind: 'number', default: 0 },
+    // Optional: a live overlay element config (from the UI store) that overrides
+    // the static `params`, so toggling elements never rebuilds the graph.
+    { name: 'overlayConfig', kind: 'overlay-config' },
   ],
   outputs: [],
   params: Params,
@@ -327,11 +330,14 @@ export const canvasOverlayNode = defineNode<Params>({
         const H = canvas.height;
         g.clearRect(0, 0, W, H);
 
+        // A live config on the overlayConfig input overrides the static params,
+        // so UI toggles take effect each tick without rebuilding the graph.
+        const liveConfig = inputs.overlayConfig as OverlayParams | undefined;
         const view: OverlayView = {
           W,
           H,
           video,
-          params: p,
+          params: liveConfig ?? p,
           inputs: {
             hands: inputs.hands as HandsFrame | undefined,
             features: inputs.features as HandFeatures | undefined,

--- a/src/nodes/sources/store_controls.ts
+++ b/src/nodes/sources/store_controls.ts
@@ -12,6 +12,7 @@ import { defineNode } from '@/dag';
 import type { NodeContext } from '@/dag';
 import { generateScale, type ScaleTypeId } from '@/music/theory';
 import type { InstrumentId } from '@/music/instruments';
+import type { OverlayParams } from '@/nodes/output/canvas_overlay';
 
 export interface VoiceControlSnapshot {
   root: number;
@@ -23,6 +24,8 @@ export interface VoiceControlSnapshot {
 export interface ControlSnapshot {
   right: VoiceControlSnapshot;
   left: VoiceControlSnapshot;
+  /** Live overlay element config; forwarded to canvas-overlay's overlayConfig. */
+  overlay?: OverlayParams;
 }
 
 const Params = z.object({});
@@ -30,13 +33,14 @@ const Params = z.object({});
 export const storeControlsNode = defineNode<Record<string, never>>({
   type: 'store-controls',
   title: 'UI Controls',
-  description: 'Reads the live UI control store → scale + instrument port values.',
+  description: 'Reads the live UI control store → scale + instrument + overlay port values.',
   inputs: [],
   outputs: [
     { name: 'scaleRight', kind: 'number[]' },
     { name: 'scaleLeft', kind: 'number[]' },
     { name: 'instrumentRight', kind: 'instrument' },
     { name: 'instrumentLeft', kind: 'instrument' },
+    { name: 'overlay', kind: 'overlay-config' },
   ],
   params: Params,
   make() {
@@ -45,12 +49,14 @@ export const storeControlsNode = defineNode<Record<string, never>>({
         const getter = ctx.resources.controls as (() => ControlSnapshot) | undefined;
         if (!getter) return {};
         const c = getter();
-        return {
+        const out: Record<string, unknown> = {
           scaleRight: generateScale(c.right),
           scaleLeft: generateScale(c.left),
           instrumentRight: c.right.instrument,
           instrumentLeft: c.left.instrument,
         };
+        if (c.overlay) out.overlay = c.overlay;
+        return out;
       },
     };
   },

--- a/test/app_store.test.ts
+++ b/test/app_store.test.ts
@@ -7,7 +7,7 @@
  * audio. (The full graph's topology + clean tick are covered by app_graph.test.)
  */
 import { describe, it, expect, beforeEach } from 'vitest';
-import { useControls } from '@/app/store';
+import { useControls, toSettings } from '@/app/store';
 import { storeControlsNode } from '@/nodes/browser';
 import { generateScale } from '@/music/theory';
 import { DEFAULT_INSTRUMENT_RIGHT, DEFAULT_INSTRUMENT_LEFT } from '@/music/instruments';
@@ -82,6 +82,40 @@ describe('control store', () => {
     useControls.getState().setMasterVolume(0.75);
     expect(useControls.getState().masterVolume).toBeCloseTo(0.75, 6);
   });
+
+  it('has overlay element defaults (index-finger guide opt-in/off)', () => {
+    const o = useControls.getState().overlay;
+    expect(o.video.show).toBe(true);
+    expect(o.scaleGuide.show).toBe(true);
+    expect(o.indexGuide.show).toBe(false);
+  });
+
+  it('setOverlayElement patches one element without touching the others', () => {
+    useControls.getState().setOverlayElement('indexGuide', { show: true });
+    const o = useControls.getState().overlay;
+    expect(o.indexGuide.show).toBe(true);
+    expect(o.indexGuide.dashed).toBe(true); // sibling field untouched
+    expect(o.video.show).toBe(true); // sibling element untouched
+  });
+
+  it('toSettings snapshots the live state and applySettings restores it', () => {
+    useControls.getState().setSync(false);
+    useControls.getState().setVoice('right', { root: 3, instrument: 'bell' });
+    useControls.getState().setMasterVolume(0.6);
+    useControls.getState().setOverlayElement('indexGuide', { show: true });
+    const snap = toSettings(useControls.getState());
+
+    // Mutate away, then restore from the snapshot.
+    useControls.getState().setMasterVolume(0.1);
+    useControls.getState().setOverlayElement('indexGuide', { show: false });
+    useControls.getState().applySettings(snap);
+
+    const s = useControls.getState();
+    expect(s.masterVolume).toBeCloseTo(0.6);
+    expect(s.right.instrument).toBe('bell');
+    expect(s.syncHands).toBe(false);
+    expect(s.overlay.indexGuide.show).toBe(true);
+  });
 });
 
 describe('store-controls node reads the store', () => {
@@ -111,5 +145,13 @@ describe('store-controls node reads the store', () => {
   it('emits nothing when no controls getter is injected (safe before host wires it)', () => {
     const node = storeControlsNode.make(storeControlsNode.params.parse({}));
     expect(node.process({}, ctxWith({}))).toEqual({});
+  });
+
+  it('emits the live overlay element config for canvas-overlay', () => {
+    useControls.getState().setOverlayElement('indexGuide', { show: true });
+    const node = storeControlsNode.make(storeControlsNode.params.parse({}));
+    const out = node.process({}, ctxWith({ controls: () => useControls.getState() }));
+    const overlay = out.overlay as { indexGuide: { show: boolean } } | undefined;
+    expect(overlay?.indexGuide.show).toBe(true);
   });
 });

--- a/test/overlay_elements.test.ts
+++ b/test/overlay_elements.test.ts
@@ -177,6 +177,25 @@ describe('canvas-overlay composable elements', () => {
     expect(noNotes.count('fillText')).toBe(0); // but no note labels
   });
 
+  it('a live overlayConfig input overrides the static params', () => {
+    const rc = makeRecordingCanvas();
+    // Static params: index guide OFF, video ON. Live config flips both.
+    const handlers = canvasOverlayNode.make(canvasOverlayNode.params.parse({}));
+    const liveConfig = canvasOverlayNode.params.parse({
+      indexGuide: { show: true, dashed: true },
+      video: { show: false },
+    });
+    const ctx: NodeContext = {
+      tick: 0,
+      time: 0,
+      dt: 0,
+      resources: { canvas: rc.canvas, video: rc.video },
+    };
+    handlers.process({ ...fullInputs(), overlayConfig: liveConfig }, ctx);
+    expect(rc.count('setLineDash')).toBeGreaterThan(0); // index guide ON via live config
+    expect(rc.count('drawImage')).toBe(0); // video OFF via live config
+  });
+
   it('no canvas resource → no-op, no throw', () => {
     const handlers = canvasOverlayNode.make(canvasOverlayNode.params.parse({}));
     const ctx: NodeContext = { tick: 0, time: 0, dt: 0, resources: {} };


### PR DESCRIPTION
Part 2 of #48 — wires the persistence core into the live app and adds the user-facing controls. Also completes the UI half of #46 (overlay elements are now controllable). Hand-built panel, **no new UI deps**.

## Live overlay control (no graph rebuild)
- The control store gains `overlay: OverlayParams` + `setOverlayElement(...)`, plus `toSettings`/`applySettings` (snapshot ↔ restore). Persisted; additive (version unchanged — the default shallow-merge fills `overlay` for older saved blobs, so existing voice/volume choices survive).
- `store-controls` emits an `overlay` port; `canvas-overlay` gains an `overlayConfig` input that **overrides its static params each tick**; `graph.ts` wires `ui.overlay → overlay.overlayConfig`. So flipping an element (e.g. the index-finger guide) is instant and never reloads the ML model.

## UI (`ControlsPanel`)
- **Overlay** section: a toggle per element + the **background-opacity (grey-out) slider** + the opt-in **index-finger guide** (and its dashed option).
- **Presets** section (`usePresets` over the zodal localStorage store): type a name + **Save**; click a preset to **load** (hydrates the live store); **×** to delete.

## Verification
- `npm run typecheck` clean · `npm test` **132 passed** (+5: store overlay reducer, `toSettings`/`applySettings` round-trip, `store-controls` overlay emit, and the `overlayConfig` live-override on the node) · `npm run build` clean · catalog regenerated.

This is the part worth eyeballing in the browser (`?engine=dag`): toggle the overlay elements live, save a combo as a named preset, reload the page, load it back.