### PR TITLE
Live face control: lazy webcam-face source (closes #50)

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -21,7 +21,7 @@ This page catalogs the engine's building blocks — every node and how they conn
 - **Discrete triggers** — `hand-features → gesture-classifier → (events)`  
   Fist/open/pinch poses emit enter/exit events to trigger scale changes, stabs, mutes.
 
-## Nodes (21)
+## Nodes (22)
 
 ### Inputs (sources)
 _Where signals enter the graph._
@@ -32,6 +32,13 @@ MediaPipe hand landmark detection from a webcam video element.
 - **in:** —
 - **out:** hands:hands-frame
 - **params:** modelType (enum(lite | full)="full"), maxHands (number=2)
+
+#### `webcam-face` — Webcam Face
+MediaPipe FaceLandmarker blendshapes from the shared webcam (lazy-loaded, off by default).
+
+- **in:** —
+- **out:** face:face-frame
+- **params:** delegate (enum(GPU | CPU)="GPU")
 
 #### `keyboard-source` — Keyboard Source
 Global keyboard input → held / pressed / released key events.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@google/genai": "^1.29.0",
         "@mediapipe/hands": "^0.4.1675469240",
+        "@mediapipe/tasks-vision": "^0.10.35",
         "@tailwindcss/vite": "^4.1.14",
         "@tensorflow-models/hand-pose-detection": "^2.0.1",
         "@tensorflow/tfjs-backend-webgl": "^4.22.0",
@@ -810,6 +811,12 @@
       "version": "0.4.1675469240",
       "resolved": "https://registry.npmjs.org/@mediapipe/hands/-/hands-0.4.1675469240.tgz",
       "integrity": "sha512-GxoZvL1mmhJxFxjuyj7vnC++JIuInGznHBin5c7ZSq/RbcnGyfEcJrkM/bMu5K1Mz/2Ko+vEX6/+wewmEHPrHg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@mediapipe/tasks-vision": {
+      "version": "0.10.35",
+      "resolved": "https://registry.npmjs.org/@mediapipe/tasks-vision/-/tasks-vision-0.10.35.tgz",
+      "integrity": "sha512-HOvadwVRE6JC+45nyYhmnywnr5h/J8KZvOeUNVOG9q/0875pZgItznFB9bRTvLc264YSJqiZ1NsIpCStJw/egg==",
       "license": "Apache-2.0"
     },
     "node_modules/@pkgjs/parseargs": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@google/genai": "^1.29.0",
     "@mediapipe/hands": "^0.4.1675469240",
+    "@mediapipe/tasks-vision": "^0.10.35",
     "@tailwindcss/vite": "^4.1.14",
     "@tensorflow-models/hand-pose-detection": "^2.0.1",
     "@tensorflow/tfjs-backend-webgl": "^4.22.0",

--- a/public/catalog.json
+++ b/public/catalog.json
@@ -866,6 +866,25 @@
     ]
   },
   {
+    "type": "webcam-face",
+    "title": "Webcam Face",
+    "description": "MediaPipe FaceLandmarker blendshapes from the shared webcam (lazy-loaded, off by default).",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "face",
+        "kind": "face-frame"
+      }
+    ],
+    "params": [
+      {
+        "name": "delegate",
+        "type": "enum(GPU | CPU)",
+        "default": "GPU"
+      }
+    ]
+  },
+  {
     "type": "webcam-hands",
     "title": "Webcam Hands",
     "description": "MediaPipe hand landmark detection from a webcam video element.",

--- a/public/manual.html
+++ b/public/manual.html
@@ -23,7 +23,7 @@
   .examples code { color: #7dd3fc; } .note { color: #9aa; font-size: 13px; }
 </style></head><body><div class="wrap">
   <h1>θ Thoremin — Capabilities Manual</h1>
-  <p class="gen">Auto-generated from the node registry. 21 nodes.</p>
+  <p class="gen">Auto-generated from the node registry. 22 nodes.</p>
   <p>Thoremin turns live sensor streams (webcam hand gestures, facial expressions, computer keyboard, later MIDI) into a live audiovisual stream — musical audio plus the captured video with overlaid guides. You build instruments by wiring small, typed <b>nodes</b> into a dataflow graph (DAG): inputs → features → mapping → music-logic → synthesis/generation → output. Every edge can be recorded and replayed.</p><p>The mapping layer spans a spectrum: <b>direct</b> (a gesture *is* a note/parameter — e.g. hand position → scale-snapped pitch) through <b>indirect</b> (a gesture expresses a high-level idea — e.g. openness → musical density steering an AI model), including <b>conductor</b> mode (direct a fixed piece's tempo and dynamics).</p><p>This page catalogs the engine's building blocks — every node and how they connect. Some already run in the deployed app; wiring the full graph into the live instrument is in progress.</p>
   <h3>Example pipelines</h3>
   <ul class="examples"><li><b>Theremin (direct)</b> — <code>webcam-hands → hand-features → voice-mapping → webaudio-synth ( + canvas-overlay)</code><br/><span class="note">Hand x → scale-snapped pitch, y → volume. Two hands = two voices.</span></li><li><b>Gesture → harmony</b> — <code>hand-features → pick('right.x') → progression → chord → webaudio-synth</code><br/><span class="note">Hand position walks an in-key chord progression.</span></li><li><b>Conductor</b> — <code>control → performance → transport → score → webaudio-synth</code><br/><span class="note">A control signal directs a fixed piece's tempo + dynamics (accelerando/crescendo…).</span></li><li><b>Indirect / AI (gesture or expression)</b> — <code>hand-features / face-features → indirect-map → lyria</code><br/><span class="note">Openness/smile/etc. steer weighted prompts + dials of Google Lyria RealTime.</span></li><li><b>Discrete triggers</b> — <code>hand-features → gesture-classifier → (events)</code><br/><span class="note">Fist/open/pinch poses emit enter/exit events to trigger scale changes, stabs, mutes.</span></li></ul>
@@ -35,6 +35,15 @@
         <dt>in</dt><dd>—</dd>
         <dt>out</dt><dd>hands:hands-frame</dd>
         <dt>params</dt><dd>modelType (enum(lite | full)="full"), maxHands (number=2)</dd>
+      </dl>
+    </div>
+    <div class="node">
+      <h4><code>webcam-face</code> <span class="title">Webcam Face</span></h4>
+      <p>MediaPipe FaceLandmarker blendshapes from the shared webcam (lazy-loaded, off by default).</p>
+      <dl>
+        <dt>in</dt><dd>—</dd>
+        <dt>out</dt><dd>face:face-frame</dd>
+        <dt>params</dt><dd>delegate (enum(GPU | CPU)="GPU")</dd>
       </dl>
     </div>
     <div class="node">

--- a/scripts/gen_catalog.ts
+++ b/scripts/gen_catalog.ts
@@ -18,7 +18,7 @@ const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 
 // Layer grouping for the manual (type → category, in display order).
 const CATEGORIES: Array<{ name: string; blurb: string; types: string[] }> = [
-  { name: 'Inputs (sources)', blurb: 'Where signals enter the graph.', types: ['webcam-hands', 'keyboard-source', 'store-controls', 'synthetic-hands', 'replay-source'] },
+  { name: 'Inputs (sources)', blurb: 'Where signals enter the graph.', types: ['webcam-hands', 'webcam-face', 'keyboard-source', 'store-controls', 'synthetic-hands', 'replay-source'] },
   { name: 'Features', blurb: 'Raw sensor data → normalized control signals.', types: ['hand-features', 'face-features', 'gesture-classifier'] },
   { name: 'Mapping (direct ↔ indirect)', blurb: 'Features → engine parameters, across the expression spectrum.', types: ['voice-mapping', 'indirect-map', 'keyboard-control', 'pick', 'one-euro'] },
   { name: 'Music logic (tonal guidance)', blurb: 'Harmony kept in-key.', types: ['chord', 'progression'] },

--- a/src/app/ControlsPanel.tsx
+++ b/src/app/ControlsPanel.tsx
@@ -122,6 +122,22 @@ function OverlayControls() {
   );
 }
 
+function FaceControls() {
+  const faceEnabled = useControls((s) => s.faceEnabled);
+  const setFaceEnabled = useControls((s) => s.setFaceEnabled);
+
+  return (
+    <div className="space-y-2">
+      <h3 className="text-[11px] font-bold uppercase tracking-widest text-white/70">Face control</h3>
+      <Toggle label="Enable face expression" checked={faceEnabled} onChange={setFaceEnabled} />
+      <p className="text-[10px] leading-relaxed text-white/40">
+        Smile → brighter tone, open mouth → vibrato. Loads a face model on first
+        enable; uses the same camera as hand tracking.
+      </p>
+    </div>
+  );
+}
+
 function PresetControls() {
   const { presets, busy, save, load, remove } = usePresets();
   const [name, setName] = useState('');
@@ -208,6 +224,9 @@ export default function ControlsPanel() {
       {!syncHands && <VoiceControls side="left" />}
       <div className="border-t border-white/10 pt-3">
         <OverlayControls />
+      </div>
+      <div className="border-t border-white/10 pt-3">
+        <FaceControls />
       </div>
       <div className="border-t border-white/10 pt-3">
         <PresetControls />

--- a/src/app/graph.ts
+++ b/src/app/graph.ts
@@ -3,10 +3,15 @@
  * play tonal audio with overlays, steerable live by keyboard + UI.
  *
  *   webcam ─┬─▶ hand-features ─┬─▶ voice-mapping ─▶ webaudio-synth
- *           │                  │        ▲ ▲ ▲
- *           └────────▶ overlay ◀┘        │ │ └── store-controls (scale/instrument)
- *                       (video+guides)   │ └──── keyboard-control (magnetism/octave/mute)
- *                                        └────── keyboard-source ─▶ keyboard-control
+ *           │                  │        ▲ ▲ ▲ ▲
+ *           └────────▶ overlay ◀┘        │ │ │ └── store-controls (scale/instrument)
+ *                       (video+guides)   │ │ └──── keyboard-control (magnetism/octave/mute)
+ *                                        │ └────── keyboard-source ─▶ keyboard-control
+ *   webcam-face ─▶ face-features ────────┘ (smile→brightness, mouth→vibrato)
+ *
+ * The face branch is always wired but idle until the player enables face
+ * control: `webcam-face` only loads its model (and emits a present face) when
+ * `faceEnabled` is set in the store, so it costs nothing when off.
  *
  * One output may fan OUT to several inputs (webcam→features & overlay); only
  * fan-IN to a single input port is disallowed.
@@ -18,6 +23,9 @@ export function defaultGraph(): GraphSpec {
     nodes: [
       { id: 'cam', type: 'webcam-hands', params: { modelType: 'full', maxHands: 2 } },
       { id: 'feat', type: 'hand-features', params: { mirrorX: true, mirrorHandedness: true } },
+      // Face branch (idle until the player enables face control in settings).
+      { id: 'camFace', type: 'webcam-face', params: {} },
+      { id: 'faceFeat', type: 'face-features', params: { smoothing: 0.3 } },
       { id: 'kbd', type: 'keyboard-source' },
       { id: 'kctrl', type: 'keyboard-control', params: { magnetismStart: 0.8 } },
       { id: 'ui', type: 'store-controls' },
@@ -30,6 +38,10 @@ export function defaultGraph(): GraphSpec {
     edges: [
       { from: { node: 'cam', port: 'hands' }, to: { node: 'feat', port: 'hands' } },
       { from: { node: 'cam', port: 'hands' }, to: { node: 'overlay', port: 'hands' } },
+      // Face: webcam-face → face-features → voice-mapping's optional `face` input
+      // (smile adds brightness, open mouth adds vibrato). Absent face → no effect.
+      { from: { node: 'camFace', port: 'face' }, to: { node: 'faceFeat', port: 'face' } },
+      { from: { node: 'faceFeat', port: 'features' }, to: { node: 'map', port: 'face' } },
       { from: { node: 'feat', port: 'features' }, to: { node: 'map', port: 'features' } },
       { from: { node: 'feat', port: 'features' }, to: { node: 'overlay', port: 'features' } },
       { from: { node: 'kbd', port: 'pressed' }, to: { node: 'kctrl', port: 'pressed' } },

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -34,11 +34,19 @@ export interface ControlState {
   left: VoiceControl;
   syncHands: boolean;
   masterVolume: number; // 0..1
+  /**
+   * Whether live face control is enabled. Off by default; when on, the
+   * `webcam-face` node lazy-loads the FaceLandmarker model and drives facial
+   * expression into the mapping (smile→brightness, open mouth→vibrato). Read by
+   * the node each tick via `ctx.resources.controls`.
+   */
+  faceEnabled: boolean;
   /** Composable overlay element config (see canvas_overlay.ts). Live-controlled. */
   overlay: OverlayParams;
   setVoice(side: 'right' | 'left', patch: Partial<VoiceControl>): void;
   setSync(v: boolean): void;
   setMasterVolume(v: number): void;
+  setFaceEnabled(v: boolean): void;
   /** Patch one overlay element's options (e.g. setOverlayElement('indexGuide', { show: true })). */
   setOverlayElement<K extends keyof OverlayParams>(key: K, patch: Partial<OverlayParams[K]>): void;
   /** Replace all live controls from a settings snapshot (loading a preset). */
@@ -65,6 +73,7 @@ export function toSettings(s: ControlState): Settings {
     left: s.left,
     syncHands: s.syncHands,
     masterVolume: s.masterVolume,
+    faceEnabled: s.faceEnabled,
     overlay: s.overlay,
   };
 }
@@ -86,6 +95,7 @@ export const useControls = create<ControlState>()(
       left: defaultVoice(DEFAULT_INSTRUMENT_LEFT),
       syncHands: true,
       masterVolume: 0.4,
+      faceEnabled: false,
       overlay: defaultOverlay(),
       setVoice: (side, patch) =>
         set((s) => {
@@ -104,6 +114,7 @@ export const useControls = create<ControlState>()(
         }),
       setSync: (v) => set({ syncHands: v }),
       setMasterVolume: (v) => set({ masterVolume: v }),
+      setFaceEnabled: (v) => set({ faceEnabled: v }),
       setOverlayElement: (key, patch) =>
         set((s) => ({
           overlay: { ...s.overlay, [key]: { ...s.overlay[key], ...patch } } as OverlayParams,
@@ -114,14 +125,15 @@ export const useControls = create<ControlState>()(
           left: st.left,
           syncHands: st.syncHands,
           masterVolume: st.masterVolume,
+          faceEnabled: st.faceEnabled,
           overlay: st.overlay,
         }),
     }),
     {
       name: 'thoremin-controls',
-      // Version stays 1: `overlay` is additive, and the default shallow merge
-      // keeps the initializer's default overlay when an older persisted blob
-      // omits it (no migrate / no discard of existing voice/volume choices).
+      // Version stays 1: `overlay`/`faceEnabled` are additive, and the default
+      // shallow merge keeps the initializer's defaults when an older persisted
+      // blob omits them (no migrate / no discard of existing voice/volume choices).
       version: 1,
       storage: createJSONStorage(controlsStorage),
       // Persist only the control values, never the setter functions.
@@ -130,6 +142,7 @@ export const useControls = create<ControlState>()(
         left: s.left,
         syncHands: s.syncHands,
         masterVolume: s.masterVolume,
+        faceEnabled: s.faceEnabled,
         overlay: s.overlay,
       }),
     },

--- a/src/nodes/browser.ts
+++ b/src/nodes/browser.ts
@@ -7,12 +7,14 @@
 import { createRegistry, type NodeRegistry } from '@/dag';
 import { CORE_NODES } from './index';
 import { webcamHandsNode } from './sources/webcam_hands';
+import { webcamFaceNode } from './sources/webcam_face';
 import { keyboardSourceNode } from './sources/keyboard';
 import { storeControlsNode } from './sources/store_controls';
 import { webAudioSynthNode } from './output/webaudio_synth';
 import { canvasOverlayNode } from './output/canvas_overlay';
 
 export { webcamHandsNode } from './sources/webcam_hands';
+export { webcamFaceNode } from './sources/webcam_face';
 export { keyboardSourceNode } from './sources/keyboard';
 export { storeControlsNode } from './sources/store_controls';
 export { webAudioSynthNode } from './output/webaudio_synth';
@@ -24,6 +26,7 @@ export type { LyriaEngineOptions } from './output/lyria_engine';
 
 export const BROWSER_NODES = [
   webcamHandsNode,
+  webcamFaceNode,
   keyboardSourceNode,
   storeControlsNode,
   webAudioSynthNode,

--- a/src/nodes/sources/store_controls.ts
+++ b/src/nodes/sources/store_controls.ts
@@ -26,6 +26,8 @@ export interface ControlSnapshot {
   left: VoiceControlSnapshot;
   /** Live overlay element config; forwarded to canvas-overlay's overlayConfig. */
   overlay?: OverlayParams;
+  /** Whether live face control is on; read directly by the `webcam-face` node. */
+  faceEnabled?: boolean;
 }
 
 const Params = z.object({});

--- a/src/nodes/sources/webcam_face.ts
+++ b/src/nodes/sources/webcam_face.ts
@@ -1,0 +1,226 @@
+/**
+ * `webcam-face` source node (browser-only) — runs MediaPipe FaceLandmarker on
+ * the shared host `<video>` and outputs the latest {@link FaceFrame} (the 52
+ * blendshape scores). It is the live counterpart of the offline
+ * `scripts/video_to_face.py`, and emits the *same* `{ present, blendshapes }`
+ * shape (identical blendshape keys) as the recorded face fixture, so it replays
+ * validly against `face-features`. (The offline fixture additionally rounds
+ * scores to 5 dp, so individual values are not bit-identical.)
+ *
+ * Three design points, all required by issue #50:
+ *
+ * 1. **Off by default, lazy.** The heavy `@mediapipe/tasks-vision` runtime and
+ *    the model weights are loaded on first *enable* (read from the live controls
+ *    store via `ctx.resources.controls().faceEnabled`), never at startup — so a
+ *    player who never turns on face control pays nothing, and `engine.init()` is
+ *    never blocked. `init()` only captures the shared `<video>` handle.
+ * 2. **Lazy offload.** When face control is toggled back off, the landmarker is
+ *    released (`FaceLandmarker.close()`) and its loop cancelled, so two
+ *    always-on ML models (hands + face) don't compete for the tick budget.
+ * 3. **Detached inference, like `webcam-hands`.** Inference runs in its own
+ *    `requestAnimationFrame` loop and caches the latest frame; `process()` just
+ *    returns that cache — decoupling detection rate from the engine tick rate
+ *    and guaranteeing the first tick after enabling never blocks.
+ */
+import { z } from 'zod';
+import { defineNode } from '@/dag';
+import type { NodeContext } from '@/dag';
+import type { FaceFrame } from '../domain';
+
+// MediaPipe FaceLandmarker assets, loaded from a CDN on demand (mirrors how
+// `webcam-hands` resolves its MediaPipe solution from jsDelivr). The wasm
+// fileset is pinned to the installed `@mediapipe/tasks-vision` version so the
+// runtime matches the imported JS API. The model is the float16
+// `face_landmarker.task` — the same model family `scripts/video_to_face.py`
+// uses, so live and recorded blendshapes are shape-compatible (same model,
+// identical blendshape names).
+const TASKS_VISION_VERSION = '0.10.35';
+const WASM_BASE = `https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@${TASKS_VISION_VERSION}/wasm`;
+const MODEL_URL =
+  'https://storage.googleapis.com/mediapipe-models/face_landmarker/face_landmarker/float16/1/face_landmarker.task';
+
+const Params = z.object({
+  /** Run inference on the GPU (WebGL) when available, else CPU. */
+  delegate: z.enum(['GPU', 'CPU']).default('GPU'),
+});
+type Params = z.infer<typeof Params>;
+
+const ABSENT_FRAME: FaceFrame = { present: false, blendshapes: {} };
+
+/** The minimal slice of a `FaceLandmarkerResult` this node reads. */
+export interface FaceLandmarkerResultLike {
+  faceBlendshapes?: Array<{ categories: Array<{ categoryName: string; score: number }> }>;
+}
+
+/**
+ * Pure converter: a MediaPipe FaceLandmarker result → a {@link FaceFrame}.
+ * Exported so it can be unit-tested headlessly (the live inference itself is
+ * browser-only). Returns the absent frame when no face was detected.
+ */
+export function blendshapesToFaceFrame(result: FaceLandmarkerResultLike): FaceFrame {
+  const categories = result.faceBlendshapes?.[0]?.categories;
+  if (!categories || categories.length === 0) return ABSENT_FRAME;
+  const blendshapes: Record<string, number> = {};
+  for (const c of categories) blendshapes[c.categoryName] = c.score;
+  return { present: true, blendshapes };
+}
+
+/** The minimal runtime surface of MediaPipe used here (browser-only, lazy). */
+interface FaceLandmarkerLike {
+  detectForVideo(video: HTMLVideoElement, timestampMs: number): FaceLandmarkerResultLike;
+  close(): void;
+}
+interface TasksVisionModule {
+  FilesetResolver: { forVisionTasks(wasmBase: string): Promise<unknown> };
+  FaceLandmarker: {
+    createFromOptions(
+      fileset: unknown,
+      opts: {
+        baseOptions: { modelAssetPath: string; delegate?: 'GPU' | 'CPU' };
+        outputFaceBlendshapes?: boolean;
+        numFaces?: number;
+        runningMode?: 'IMAGE' | 'VIDEO';
+      },
+    ): Promise<FaceLandmarkerLike>;
+  };
+}
+
+/** Reads just the enable flag off the live controls snapshot. */
+type FaceControlsGetter = () => { faceEnabled?: boolean };
+
+export const webcamFaceNode = defineNode<Params>({
+  type: 'webcam-face',
+  title: 'Webcam Face',
+  description:
+    'MediaPipe FaceLandmarker blendshapes from the shared webcam (lazy-loaded, off by default).',
+  inputs: [],
+  outputs: [{ name: 'face', kind: 'face-frame' }],
+  params: Params,
+  make(p) {
+    let landmarker: FaceLandmarkerLike | null = null;
+    let loading = false;
+    // Bumped on every offload/dispose; an in-flight load whose generation no
+    // longer matches closes itself instead of resurrecting a released model.
+    let loadGen = 0;
+    // The generation whose load attempt hard-failed (after the CPU fallback).
+    // While `failedGen === loadGen` we don't re-attempt — so a permanent failure
+    // (no GPU + no CPU, offline, blocked CDN) can't spin a per-tick reload storm.
+    // offload() bumps loadGen, so toggling face control off→on retries exactly once.
+    let failedGen = -1;
+    let latest: FaceFrame = ABSENT_FRAME;
+    let raf: number | null = null;
+    let disposed = false;
+    let video: HTMLVideoElement | undefined;
+    let lastVideoTime = -1;
+
+    const stopLoop = () => {
+      if (raf !== null) {
+        cancelAnimationFrame(raf);
+        raf = null;
+      }
+    };
+
+    /** Release the model + loop and reset to the absent frame. */
+    const offload = () => {
+      loadGen++; // invalidate any in-flight load; also clears the failure latch
+      failedGen = -1;
+      stopLoop();
+      landmarker?.close();
+      landmarker = null;
+      latest = ABSENT_FRAME;
+      lastVideoTime = -1;
+    };
+
+    const loop = () => {
+      if (disposed) return;
+      // Only run inference on a fresh, ready video frame; performance.now() is
+      // monotonic, satisfying FaceLandmarker's strictly-increasing-timestamp rule.
+      if (
+        landmarker &&
+        video &&
+        video.readyState >= 2 &&
+        video.videoWidth > 0 &&
+        video.currentTime !== lastVideoTime
+      ) {
+        lastVideoTime = video.currentTime;
+        try {
+          latest = blendshapesToFaceFrame(landmarker.detectForVideo(video, performance.now()));
+        } catch {
+          /* transient inference error; keep the last frame */
+        }
+      }
+      raf = requestAnimationFrame(loop);
+    };
+
+    const optionsFor = (delegate: 'GPU' | 'CPU') => ({
+      baseOptions: { modelAssetPath: MODEL_URL, delegate },
+      outputFaceBlendshapes: true,
+      numFaces: 1,
+      runningMode: 'VIDEO' as const,
+    });
+
+    /** Lazily load the model on first enable; fire-and-forget (never awaited). */
+    const ensureLoaded = () => {
+      if (landmarker || loading || disposed || failedGen === loadGen) return;
+      loading = true;
+      const gen = loadGen;
+      void (async () => {
+        try {
+          const vision = (await import('@mediapipe/tasks-vision')) as unknown as TasksVisionModule;
+          const fileset = await vision.FilesetResolver.forVisionTasks(WASM_BASE);
+          let lm: FaceLandmarkerLike;
+          try {
+            lm = await vision.FaceLandmarker.createFromOptions(fileset, optionsFor(p.delegate));
+          } catch (gpuErr) {
+            // GPU/WebGL unavailable on this client → fall back to the CPU delegate
+            // (the float16 model runs on CPU). If CPU was already chosen, give up.
+            if (p.delegate !== 'GPU') throw gpuErr;
+            lm = await vision.FaceLandmarker.createFromOptions(fileset, optionsFor('CPU'));
+          }
+          if (disposed || gen !== loadGen) {
+            // Toggled off / unmounted while loading — don't resurrect.
+            lm.close();
+            return;
+          }
+          landmarker = lm;
+          failedGen = -1;
+          if (raf === null) raf = requestAnimationFrame(loop);
+        } catch {
+          // Load failed (offline / unsupported / blocked). Latch this generation
+          // so we don't re-attempt the heavy create every tick; toggling face
+          // control off→on bumps loadGen via offload() and retries once.
+          failedGen = gen;
+        } finally {
+          loading = false;
+        }
+      })();
+    };
+
+    return {
+      init(ctx: NodeContext) {
+        // Cheap: only capture the shared <video>. No model download here, so
+        // engine.init() is never blocked and a disabled face source costs nothing.
+        video = ctx.resources.video as HTMLVideoElement | undefined;
+      },
+      process(_inputs, ctx: NodeContext) {
+        video = (ctx.resources.video as HTMLVideoElement | undefined) ?? video;
+        const getControls = ctx.resources.controls as FaceControlsGetter | undefined;
+        const enabled = getControls?.().faceEnabled === true;
+        if (!enabled) {
+          // Release the model if one is loaded/loading; also clear a prior
+          // failure latch so a deliberate re-enable retries the load.
+          if (landmarker || loading || failedGen === loadGen) offload();
+          return { face: ABSENT_FRAME };
+        }
+        // Only spin up the model once we actually have a camera feed (so we
+        // never download a face model with no <video> — e.g. headless).
+        if (video) ensureLoaded();
+        return { face: latest };
+      },
+      dispose() {
+        disposed = true;
+        offload();
+      },
+    };
+  },
+});

--- a/src/settings/schema.ts
+++ b/src/settings/schema.ts
@@ -33,6 +33,9 @@ export const SettingsSchema = z.object({
   left: VoiceSettingsSchema,
   syncHands: z.boolean(),
   masterVolume: z.number().min(0).max(1),
+  // `.default(false)` keeps presets saved before face control was added valid
+  // (the field is filled in on parse rather than failing validation).
+  faceEnabled: z.boolean().default(false),
   overlay: OverlayParamsSchema,
 });
 export type Settings = z.infer<typeof SettingsSchema>;

--- a/test/app_graph.test.ts
+++ b/test/app_graph.test.ts
@@ -20,7 +20,10 @@ describe('production app graph', () => {
     expect(order.indexOf('feat')).toBeLessThan(order.indexOf('map'));
     expect(order.indexOf('map')).toBeLessThan(order.indexOf('synth'));
     expect(order.indexOf('kbd')).toBeLessThan(order.indexOf('kctrl'));
-    expect(order).toHaveLength(8);
+    // face branch: webcam-face → face-features → voice-mapping
+    expect(order.indexOf('camFace')).toBeLessThan(order.indexOf('faceFeat'));
+    expect(order.indexOf('faceFeat')).toBeLessThan(order.indexOf('map'));
+    expect(order).toHaveLength(10);
   });
 
   it('ticks cleanly with no host resources (everything no-ops or idles)', () => {

--- a/test/webcam_face.test.ts
+++ b/test/webcam_face.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tests for the `webcam-face` source node.
+ *
+ * The live MediaPipe inference is browser-only, so `@mediapipe/tasks-vision` is
+ * mocked here — that lets us drive the node's deterministic logic headlessly:
+ *   1. the pure blendshapes → FaceFrame converter (the shape the offline
+ *      `scripts/video_to_face.py` fixture also produces),
+ *   2. the gating contract: off by default, emit the absent frame and never even
+ *      reach the model loader,
+ *   3. lazy offload on disable + retry on re-enable + idempotent dispose,
+ *   4. the GPU→CPU delegate fallback when GPU creation fails.
+ */
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import type { NodeContext } from '@/dag';
+
+// Mocked MediaPipe runtime — hoisted so the vi.mock factory can reference the spies.
+const { forVisionTasks, createFromOptions, fakeLandmarker } = vi.hoisted(() => {
+  const fakeLandmarker = { detectForVideo: () => ({}), close: vi.fn() };
+  return {
+    forVisionTasks: vi.fn(async () => ({})),
+    createFromOptions: vi.fn(async () => fakeLandmarker),
+    fakeLandmarker,
+  };
+});
+vi.mock('@mediapipe/tasks-vision', () => ({
+  FilesetResolver: { forVisionTasks },
+  FaceLandmarker: { createFromOptions },
+}));
+
+// The node lives in a browser-only file; importing it is Node-safe (the heavy
+// runtime is only dynamically imported inside the lazy loader).
+import { webcamFaceNode, blendshapesToFaceFrame } from '@/nodes/sources/webcam_face';
+
+const ABSENT = { face: { present: false, blendshapes: {} } };
+
+const ctx = (faceEnabled?: boolean, video?: unknown): NodeContext =>
+  ({
+    tick: 0,
+    time: 0,
+    dt: 0,
+    resources: {
+      ...(faceEnabled === undefined ? {} : { controls: () => ({ faceEnabled }) }),
+      ...(video === undefined ? {} : { video }),
+    },
+  }) as unknown as NodeContext;
+
+// A truthy <video> stand-in; never "ready" so the inference loop never fires.
+const fakeVideo = () => ({ readyState: 0, videoWidth: 0, currentTime: 0 }) as unknown;
+
+beforeAll(() => {
+  // The node starts a requestAnimationFrame loop once the (mocked) model loads;
+  // a no-op rAF keeps it from recursing or referencing a missing browser global.
+  const g = globalThis as Record<string, unknown>;
+  g.requestAnimationFrame ??= () => 0;
+  g.cancelAnimationFrame ??= () => {};
+});
+
+beforeEach(() => {
+  forVisionTasks.mockClear();
+  createFromOptions.mockClear();
+  createFromOptions.mockImplementation(async () => fakeLandmarker);
+  fakeLandmarker.close.mockClear();
+});
+
+describe('blendshapesToFaceFrame', () => {
+  it('maps MediaPipe categories to a present FaceFrame keyed by name', () => {
+    const frame = blendshapesToFaceFrame({
+      faceBlendshapes: [
+        {
+          categories: [
+            { categoryName: 'mouthSmileLeft', score: 0.5 },
+            { categoryName: 'mouthSmileRight', score: 0.4 },
+            { categoryName: 'jawOpen', score: 0.2 },
+          ],
+        },
+      ],
+    });
+    expect(frame).toEqual({
+      present: true,
+      blendshapes: { mouthSmileLeft: 0.5, mouthSmileRight: 0.4, jawOpen: 0.2 },
+    });
+  });
+
+  it('returns the absent frame when no face was detected', () => {
+    const absent = { present: false, blendshapes: {} };
+    expect(blendshapesToFaceFrame({})).toEqual(absent);
+    expect(blendshapesToFaceFrame({ faceBlendshapes: [] })).toEqual(absent);
+    expect(blendshapesToFaceFrame({ faceBlendshapes: [{ categories: [] }] })).toEqual(absent);
+  });
+});
+
+describe('webcam-face node gating', () => {
+  it('emits the absent frame when face control is off and never loads the model', () => {
+    const inst = webcamFaceNode.make({ delegate: 'GPU' });
+    // No controls getter (headless / pre-wired) and explicitly disabled, both
+    // with a video present — the loader must not be reached either way.
+    expect(inst.process({}, ctx(undefined, fakeVideo()))).toEqual(ABSENT);
+    expect(inst.process({}, ctx(false, fakeVideo()))).toEqual(ABSENT);
+    expect(createFromOptions).not.toHaveBeenCalled();
+    expect(forVisionTasks).not.toHaveBeenCalled();
+  });
+
+  it('does not load the model when enabled but no camera <video> is present', () => {
+    const inst = webcamFaceNode.make({ delegate: 'GPU' });
+    expect(inst.process({}, ctx(true))).toEqual(ABSENT);
+    expect(createFromOptions).not.toHaveBeenCalled();
+  });
+
+  it('offloads on disable, re-enables, and is idempotent on dispose — never throws', () => {
+    const inst = webcamFaceNode.make({ delegate: 'GPU' });
+    let faceEnabled = true;
+    const live = ctx(true, fakeVideo());
+    // Re-point the controls getter at the mutable flag.
+    (live.resources as Record<string, unknown>).controls = () => ({ faceEnabled });
+
+    // Enable + video → loader kicks off (loading set synchronously); absent this tick.
+    expect(inst.process({}, live)).toEqual(ABSENT);
+    // Disable while still loading → offload() runs via the `loading` branch.
+    faceEnabled = false;
+    expect(inst.process({}, live)).toEqual(ABSENT);
+    // Re-enable → no throw, still absent.
+    faceEnabled = true;
+    expect(inst.process({}, live)).toEqual(ABSENT);
+    expect(() => {
+      inst.dispose?.();
+      inst.dispose?.();
+    }).not.toThrow();
+    expect(inst.process({}, live)).toEqual(ABSENT);
+  });
+});
+
+describe('webcam-face delegate fallback', () => {
+  it('falls back to the CPU delegate when GPU model creation fails', async () => {
+    createFromOptions
+      .mockRejectedValueOnce(new Error('no webgl'))
+      .mockResolvedValueOnce(fakeLandmarker);
+    const inst = webcamFaceNode.make({ delegate: 'GPU' });
+    inst.process({}, ctx(true, fakeVideo())); // kicks the async load
+    await vi.waitFor(() => expect(createFromOptions).toHaveBeenCalledTimes(2));
+    const calls = createFromOptions.mock.calls as unknown as Array<
+      [unknown, { baseOptions: { delegate: string } }]
+    >;
+    expect(calls[0][1].baseOptions.delegate).toBe('GPU');
+    expect(calls[1][1].baseOptions.delegate).toBe('CPU');
+    inst.dispose?.();
+  });
+});


### PR DESCRIPTION
## What

Implements #50 — live facial-expression control. Adds a `webcam-face` source node (MediaPipe `FaceLandmarker`, 52 blendshapes) and wires the previously-dormant `face-features` node + `voice-mapping`'s `face` input into the default graph. Facial expression now drives sound: **smile → brightness, open mouth → vibrato**.

## How

- **New `src/nodes/sources/webcam_face.ts`** (browser-only), registered in `BROWSER_NODES`. Mirrors `webcam-hands`: inference runs in its own `requestAnimationFrame` loop and caches the latest frame; `process()` returns the cache, decoupling detection from the engine tick.
- **Off by default.** A `faceEnabled` toggle (zustand store + settings schema + a *Face control* section in `ControlsPanel`) gates it. The heavy `@mediapipe/tasks-vision` runtime + model weights load **on first enable** (never at startup, so `engine.init()` is never blocked) and are **offloaded** (`FaceLandmarker.close()`) on disable — so hands and face models don't both occupy the tick budget when face is off.
- **Robust load:** GPU delegate with automatic **CPU fallback**, plus a failure latch so a model that can't load doesn't trigger a per-tick reload storm (retries once per re-enable).
- Shares the single `getUserMedia` `<video>` via `ctx.resources.video` — no second camera. The face branch is always wired but idle until enabled (no runtime graph mutation).
- `faceEnabled` threaded through store init/setter/`toSettings`/`applySettings`/`partialize` and `SettingsSchema` (`.default(false)` keeps presets saved before this change valid).
- Regenerated catalog (22 nodes; `webcam-face` under Inputs).

## Tests

`npm run typecheck` + `npm test` (138 passing, +6) + `npm run build` (face runtime confirmed **code-split** into its own lazy chunk). New tests: blendshape→`FaceFrame` converter; disabled-path (asserts the model is never loaded); offload/re-enable/idempotent-dispose; GPU→CPU fallback. `app_graph` topology updated 8 → 10 with face ordering.

## Review

An adversarial multi-agent review pass ran against this change; confirmed findings were applied (GPU→CPU fallback, failure latch, doc-accuracy, test coverage). 12 lower-confidence findings were verified and refuted.

Part of #45.

https://claude.ai/code/session_01JEoe7y1hA5KdEAvvpQXxxt
