### PR TITLE
Make the DAG view the default at the bare URL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,14 +8,16 @@ no backend compute — the app is a static Vite bundle).
 
 ## Two front-ends in one build
 
-- **Default (legacy) app** — `src/App.tsx`, `src/components/Theremin.tsx`,
-  `src/plugins/ai-dj/` (Lyria RealTime). Loads at the bare URL. This is what is
-  live at https://apps.thorwhalen.com/thoremin/.
-- **DAG instrument view** — opt-in via `?engine=dag` → `src/app/*`, `src/nodes`,
-  `src/dag`, `src/music`. The architecture everything new is built on.
+- **DAG instrument view (default)** — `src/app/*`, `src/nodes`, `src/dag`,
+  `src/music`. The typed dataflow engine everything new is built on. Loads at
+  the bare URL (https://apps.thorwhalen.com/thoremin/). `?engine=dag` is still
+  honored (it equals the default), so older links keep working.
+- **Legacy app** — opt-in via `?engine=legacy` (alias `?engine=classic`) →
+  `src/App.tsx`, `src/components/Theremin.tsx`, `src/plugins/ai-dj/` (Lyria
+  RealTime). The original hand-theremin; kept reachable for the AI-DJ plugin
+  until it is ported onto the DAG. It is the code-split (lazy) view now.
 
-Changes to the DAG view are additive and zero-risk to the live default until we
-deliberately deploy / flip the default (both outward-facing — get the user's OK).
+Outward-facing changes (deploying, moving the default) still get the user's OK.
 
 ## The architecture in one breath (read this first)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -84,15 +84,17 @@ adjust octave/magnetism/mute live; the UI panel changes scale/key/wave live.
 The overlay draws the mirrored video, landmarks, per-hand control markers
 (openness = ring size, pinch = fill), and a feature HUD.
 
-## The deployed app being folded in (`src/`)
+## The legacy app being folded in (`src/`)
 
-The **currently deployed app** is the React app at the repo root
-(`src/App.tsx`, `src/components/Theremin.tsx`, `src/hooks/`, `src/plugins/`),
-live at https://apps.thorwhalen.com/thoremin/. It is the working app this DAG
-architecture grows from: MediaPipe hands + Web Audio synth + a **Lyria RealTime**
-plugin (`src/plugins/ai-dj/`: `lyria-realtime-exp`, `@google/genai` WebSocket,
-48 kHz PCM, weighted "strain" prompts throttled to 200 ms,
-BPM/density/brightness/guidance config, 10-min sessions).
+The original React app at the repo root (`src/App.tsx`,
+`src/components/Theremin.tsx`, `src/hooks/`, `src/plugins/`) is now the **legacy
+view**, reachable at `?engine=legacy` (the DAG view is the default at the bare
+URL). It is the working app this DAG architecture grew from: MediaPipe hands +
+Web Audio synth + a **Lyria RealTime** plugin (`src/plugins/ai-dj/`:
+`lyria-realtime-exp`, `@google/genai` WebSocket, 48 kHz PCM, weighted "strain"
+prompts throttled to 200 ms, BPM/density/brightness/guidance config, 10-min
+sessions). It stays reachable until the Lyria AI-DJ plugin is ported onto the
+DAG.
 
 The DAG engine + node library (`src/dag/`, `src/nodes/`, `src/music/`) currently
 live **alongside** that app — fully tested, but not yet wired into it. The next

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,31 +1,32 @@
 /**
  * App entry — selects which front-end to mount.
  *
- * By default mounts the current production hand-theremin app (`./App`), exactly
- * as before: a static import that paints synchronously from the entry bundle —
- * the deployed default is untouched. Append `?engine=dag` to the URL to mount
- * the DAG-driven instrument view (`./app/App`) instead — an opt-in alternate
- * that runs the same gesture→audio path through the typed DAG engine. Only the
- * DAG view is code-split (lazy), so it never weighs on the default path.
+ * By default mounts the DAG-driven instrument view (`./app/App`) — the typed
+ * dataflow engine everything new is built on, and now the default at the bare
+ * URL. Append `?engine=legacy` (alias `?engine=classic`) to mount the original
+ * hand-theremin app (`./App`, including the Lyria AI-DJ plugin). `?engine=dag`
+ * is still honored and equals the default, so existing links keep working.
+ * Only the non-default (legacy) view is code-split, so it never weighs on the
+ * default path.
  */
 import {StrictMode, Suspense, lazy} from 'react';
 import {createRoot} from 'react-dom/client';
-import DefaultApp from './App.tsx';
+import DagApp from './app/App.tsx';
 import './index.css';
 
-const useDagEngine =
-  new URLSearchParams(window.location.search).get('engine') === 'dag';
+const engineParam = new URLSearchParams(window.location.search).get('engine');
+const useLegacyEngine = engineParam === 'legacy' || engineParam === 'classic';
 
-const DagApp = lazy(() => import('./app/App.tsx'));
+const LegacyApp = lazy(() => import('./App.tsx'));
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    {useDagEngine ? (
+    {useLegacyEngine ? (
       <Suspense fallback={null}>
-        <DagApp />
+        <LegacyApp />
       </Suspense>
     ) : (
-      <DefaultApp />
+      <DagApp />
     )}
   </StrictMode>,
 );


### PR DESCRIPTION
## What

The bare `/thoremin` URL now serves the **DAG instrument view** (the typed dataflow engine all new work targets). The original hand-theremin app — including the Lyria AI-DJ plugin — becomes an opt-in at **`?engine=legacy`** (alias `?engine=classic`).

`?engine=dag` is still honored (it equals the default), so existing shared links keep working.

## Why

The DAG view is where every recent feature lives (overlay elements, presets, recording, and now live face control). Making it the default is the user-requested flip now that it's at parity for the core instrument.

## How

- `src/main.tsx`: the DAG app is now the eager default import; the legacy app is the code-split (lazy) opt-in. Net effect on the bundle: the legacy app and TF.js move into lazy chunks off the default path.
- Docs updated to match: `CLAUDE.md` ("Two front-ends in one build") and `docs/ARCHITECTURE.md`.

## Tests

`npm run build` (legacy app + TF.js now lazy chunks; face runtime still code-split) + `npm run typecheck` + `npm test` (138) all green. Routing behavior will be confirmed on the live URL after deploy.

Part of #45.

https://claude.ai/code/session_01JEoe7y1hA5KdEAvvpQXxxt
