### PR TITLE
Advisory node roles + registry.listByRole (refs #47)

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -29,6 +29,7 @@ _Where signals enter the graph._
 #### `webcam-hands` — Webcam Hands
 MediaPipe hand landmark detection from a webcam video element.
 
+- **roles:** source
 - **in:** —
 - **out:** hands:hands-frame
 - **params:** modelType (enum(lite | full)="full"), maxHands (number=2)
@@ -36,6 +37,7 @@ MediaPipe hand landmark detection from a webcam video element.
 #### `webcam-face` — Webcam Face
 MediaPipe FaceLandmarker blendshapes from the shared webcam (lazy-loaded, off by default).
 
+- **roles:** source
 - **in:** —
 - **out:** face:face-frame
 - **params:** delegate (enum(GPU | CPU)="GPU")
@@ -43,6 +45,7 @@ MediaPipe FaceLandmarker blendshapes from the shared webcam (lazy-loaded, off by
 #### `keyboard-source` — Keyboard Source
 Global keyboard input → held / pressed / released key events.
 
+- **roles:** source
 - **in:** —
 - **out:** held:string[], pressed:string[], released:string[]
 - **params:** preventDefaultKeys (array=["ArrowUp","ArrowDown","ArrowLeft","ArrowRight"," "])
@@ -50,6 +53,7 @@ Global keyboard input → held / pressed / released key events.
 #### `store-controls` — UI Controls
 Reads the live UI control store → scale + instrument + overlay port values.
 
+- **roles:** source, control
 - **in:** —
 - **out:** scaleRight:number[], scaleLeft:number[], instrumentRight:instrument, instrumentLeft:instrument, overlay:overlay-config
 - **params:** —
@@ -57,6 +61,7 @@ Reads the live UI control store → scale + instrument + overlay port values.
 #### `synthetic-hands` — Synthetic Hands
 Camera-free animated hand landmark source for tests & demos.
 
+- **roles:** source
 - **in:** —
 - **out:** hands:hands-frame
 - **params:** width (number=640), height (number=480), sweepPeriod (number=4), opennessPeriod (number=3), pinchPeriod (number=2.5), hands (enum(right | left | both)="right"), yNorm (number=0.5), scale (number=80)
@@ -64,6 +69,7 @@ Camera-free animated hand landmark source for tests & demos.
 #### `replay-source` — Replay Source
 Emits a recorded value stream, one value per tick.
 
+- **roles:** source
 - **in:** —
 - **out:** value
 - **params:** values (array=[]), loop (boolean=false)
@@ -74,6 +80,7 @@ _Raw sensor data → normalized control signals._
 #### `hand-features` — Hand Features
 Landmarks → normalized per-hand position, openness, pinch.
 
+- **roles:** feature
 - **in:** hands:hands-frame
 - **out:** features:hand-features
 - **params:** mirrorX (boolean=true), mirrorHandedness (boolean=true), opennessMin (number=1.3), opennessMax (number=2.3), pinchTouch (number=0.25), pinchApart (number=1.2)
@@ -81,6 +88,7 @@ Landmarks → normalized per-hand position, openness, pinch.
 #### `face-features` — Face Features
 Face blendshapes → normalized expression controls (smile, mouthOpen, brow, blink).
 
+- **roles:** feature
 - **in:** face:face-frame
 - **out:** features:face-features
 - **params:** gain (number=1), smoothing (number=0)
@@ -88,6 +96,7 @@ Face blendshapes → normalized expression controls (smile, mouthOpen, brow, bli
 #### `gesture-classifier` — Gesture Classifier
 Hand features → discrete poses (fist/open/pinch) + enter/exit edge events.
 
+- **roles:** feature
 - **in:** features:hand-features
 - **out:** poses:poses, events:gesture-events
 - **params:** pinchOn (number=0.6), pinchOff (number=0.45), fistBelow (number=0.25), openAbove (number=0.6), hysteresis (number=0.05)
@@ -98,6 +107,7 @@ _Features → engine parameters, across the expression spectrum._
 #### `voice-mapping` — Voice Mapping
 Hand features → tonal synth parameters (x→pitch w/ scale snap, y→volume).
 
+- **roles:** mapping
 - **in:** features:hand-features, magnetism:number, octaveShift:number, mute:boolean, scaleRight:number[], scaleLeft:number[], instrumentRight:instrument, instrumentLeft:instrument, face:face-features
 - **out:** params:synth-params
 - **params:** magnetism (number=0.8), maxGain (number=0.5), opennessGatesGain (boolean=false), opennessControlsBrightness (boolean=true), pinchControlsVibrato (boolean=true), faceControlsExpression (boolean=true), panByPosition (boolean=true), panSpread (number=0.5), right (object={"scale":{"root":0,"type":"major","octaves":2,"baseOctave":3},"instrument":"sine"}), left (object={"scale":{"root":0,"type":"major","octaves":2,"baseOctave":3},"instrument":"triangle"})
@@ -105,6 +115,7 @@ Hand features → tonal synth parameters (x→pitch w/ scale snap, y→volume).
 #### `indirect-map` — Indirect Map
 Gesture features → weighted prompts + config dials (steers a generative engine).
 
+- **roles:** mapping
 - **in:** features:hand-features, face:face-features
 - **out:** steer:generative-steer
 - **params:** strains (array=[]), dials (array=[]), smoothing (number=0), throttleSec (number=0)
@@ -112,6 +123,7 @@ Gesture features → weighted prompts + config dials (steers a generative engine
 #### `keyboard-control` — Keyboard Control
 Keyboard key-press events → octave shift, magnetism, mute.
 
+- **roles:** mapping, control
 - **in:** pressed:string[]
 - **out:** octaveShift:number, magnetism:number, mute:boolean
 - **params:** magnetismStep (number=0.1), magnetismStart (number=0.8), octaveMin (number=-2), octaveMax (number=2)
@@ -119,6 +131,7 @@ Keyboard key-press events → octave shift, magnetism, mute.
 #### `pick` — Pick
 Extract a scalar from a structured input by dotted path (e.g. right.x).
 
+- **roles:** mapping
 - **in:** in:any
 - **out:** value:number
 - **params:** path (string=""), default (number=0)
@@ -126,6 +139,7 @@ Extract a scalar from a structured input by dotted path (e.g. right.x).
 #### `one-euro` — One-Euro Filter
 Adaptive jitter smoothing for a noisy control value (smooth at rest, responsive when fast).
 
+- **roles:** mapping
 - **in:** value:number
 - **out:** value:number
 - **params:** minCutoff (number=1), beta (number=0.01), dCutoff (number=1), fallbackDt (number=0.016666666666666666)
@@ -136,6 +150,7 @@ _Harmony kept in-key._
 #### `chord` — Chord
 Chord symbol (e.g. Cmaj7) → voiced synth params (one voice per chord tone).
 
+- **roles:** music
 - **in:** chord:chord-symbol, gain:number
 - **out:** params:synth-params
 - **params:** baseOctave (number=4), maxVoices (number=4), instrument (enum(sine | triangle | square | sawtooth | warmPad | glass | bell | organ | voice | softLead | strings | flute | brass | choir)="sine")
@@ -143,6 +158,7 @@ Chord symbol (e.g. Cmaj7) → voiced synth params (one voice per chord tone).
 #### `progression` — Progression
 Roman-numeral progression in a key + position (0..1) → current chord symbol.
 
+- **roles:** music
 - **in:** position:number
 - **out:** chord:chord-symbol, index:number
 - **params:** key (string="C"), romanNumerals (array=["I","IV","V","vi"])
@@ -153,6 +169,7 @@ _Direct a fixed piece with gesture (tempo + dynamics)._
 #### `transport` — Transport
 Beat clock: integrates BPM over time into a running beat position.
 
+- **roles:** music
 - **in:** bpm:number
 - **out:** beat:number
 - **params:** startBeat (number=0)
@@ -160,6 +177,7 @@ Beat clock: integrates BPM over time into a running beat position.
 #### `score` — Score
 An immutable piece performed live: beat + velocityScale → sounding synth voices.
 
+- **roles:** music
 - **in:** beat:number, velocityScale:number
 - **out:** params:synth-params
 - **params:** notes (array=[]), loopBeats (number=8), baseGain (number=0.4), instrument (enum(sine | triangle | square | sawtooth | warmPad | glass | bell | organ | voice | softLead | strings | flute | brass | choir)="triangle")
@@ -167,6 +185,7 @@ An immutable piece performed live: beat + velocityScale → sounding synth voice
 #### `performance` — Performance
 Control signal → tempo (bpm) + dynamics (velocityScale), with optional humanization.
 
+- **roles:** music
 - **in:** control:number
 - **out:** bpm:number, velocityScale:number
 - **params:** bpmMin (number=60), bpmMax (number=160), dynMin (number=0.4), dynMax (number=1), humanizeBpm (number=0), humanizeVel (number=0)
@@ -177,6 +196,7 @@ _Make sound — direct synthesis or steered AI music._
 #### `webaudio-synth` — Web Audio Synth
 Renders synth params to instrument-preset voices (browser only).
 
+- **roles:** synth
 - **in:** params:synth-params
 - **out:** —
 - **params:** freqGlide (number=0.03), gainGlide (number=0.08)
@@ -184,6 +204,7 @@ Renders synth params to instrument-preset voices (browser only).
 #### `lyria` — Lyria Generative
 Steers a generative engine (Lyria RealTime) from weighted prompts + config dials.
 
+- **roles:** synth, generate
 - **in:** steer:generative-steer, playing:boolean
 - **out:** state:string
 - **params:** throttleSec (number=0.2)
@@ -194,6 +215,7 @@ _Audio + the captured video with overlaid guides._
 #### `canvas-overlay` — Canvas Overlay
 Mirrored video + composable overlay elements (guides, landmarks, markers).
 
+- **roles:** overlay
 - **in:** hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], octaveShift:number, overlayConfig:overlay-config
 - **out:** —
 - **params:** video (object={}), scaleGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={})

--- a/public/catalog.json
+++ b/public/catalog.json
@@ -3,6 +3,9 @@
     "type": "canvas-overlay",
     "title": "Canvas Overlay",
     "description": "Mirrored video + composable overlay elements (guides, landmarks, markers).",
+    "roles": [
+      "overlay"
+    ],
     "inputs": [
       {
         "name": "hands",
@@ -67,6 +70,9 @@
     "type": "chord",
     "title": "Chord",
     "description": "Chord symbol (e.g. Cmaj7) → voiced synth params (one voice per chord tone).",
+    "roles": [
+      "music"
+    ],
     "inputs": [
       {
         "name": "chord",
@@ -107,6 +113,9 @@
     "type": "face-features",
     "title": "Face Features",
     "description": "Face blendshapes → normalized expression controls (smile, mouthOpen, brow, blink).",
+    "roles": [
+      "feature"
+    ],
     "inputs": [
       {
         "name": "face",
@@ -136,6 +145,9 @@
     "type": "gesture-classifier",
     "title": "Gesture Classifier",
     "description": "Hand features → discrete poses (fist/open/pinch) + enter/exit edge events.",
+    "roles": [
+      "feature"
+    ],
     "inputs": [
       {
         "name": "features",
@@ -184,6 +196,9 @@
     "type": "hand-features",
     "title": "Hand Features",
     "description": "Landmarks → normalized per-hand position, openness, pinch.",
+    "roles": [
+      "feature"
+    ],
     "inputs": [
       {
         "name": "hands",
@@ -233,6 +248,9 @@
     "type": "indirect-map",
     "title": "Indirect Map",
     "description": "Gesture features → weighted prompts + config dials (steers a generative engine).",
+    "roles": [
+      "mapping"
+    ],
     "inputs": [
       {
         "name": "features",
@@ -276,6 +294,10 @@
     "type": "keyboard-control",
     "title": "Keyboard Control",
     "description": "Keyboard key-press events → octave shift, magnetism, mute.",
+    "roles": [
+      "mapping",
+      "control"
+    ],
     "inputs": [
       {
         "name": "pressed",
@@ -324,6 +346,9 @@
     "type": "keyboard-source",
     "title": "Keyboard Source",
     "description": "Global keyboard input → held / pressed / released key events.",
+    "roles": [
+      "source"
+    ],
     "inputs": [],
     "outputs": [
       {
@@ -357,6 +382,10 @@
     "type": "lyria",
     "title": "Lyria Generative",
     "description": "Steers a generative engine (Lyria RealTime) from weighted prompts + config dials.",
+    "roles": [
+      "synth",
+      "generate"
+    ],
     "inputs": [
       {
         "name": "steer",
@@ -386,6 +415,9 @@
     "type": "one-euro",
     "title": "One-Euro Filter",
     "description": "Adaptive jitter smoothing for a noisy control value (smooth at rest, responsive when fast).",
+    "roles": [
+      "mapping"
+    ],
     "inputs": [
       {
         "name": "value",
@@ -426,6 +458,9 @@
     "type": "performance",
     "title": "Performance",
     "description": "Control signal → tempo (bpm) + dynamics (velocityScale), with optional humanization.",
+    "roles": [
+      "music"
+    ],
     "inputs": [
       {
         "name": "control",
@@ -480,6 +515,9 @@
     "type": "pick",
     "title": "Pick",
     "description": "Extract a scalar from a structured input by dotted path (e.g. right.x).",
+    "roles": [
+      "mapping"
+    ],
     "inputs": [
       {
         "name": "in",
@@ -509,6 +547,9 @@
     "type": "progression",
     "title": "Progression",
     "description": "Roman-numeral progression in a key + position (0..1) → current chord symbol.",
+    "roles": [
+      "music"
+    ],
     "inputs": [
       {
         "name": "position",
@@ -548,6 +589,9 @@
     "type": "replay-source",
     "title": "Replay Source",
     "description": "Emits a recorded value stream, one value per tick.",
+    "roles": [
+      "source"
+    ],
     "inputs": [],
     "outputs": [
       {
@@ -571,6 +615,9 @@
     "type": "score",
     "title": "Score",
     "description": "An immutable piece performed live: beat + velocityScale → sounding synth voices.",
+    "roles": [
+      "music"
+    ],
     "inputs": [
       {
         "name": "beat",
@@ -616,6 +663,10 @@
     "type": "store-controls",
     "title": "UI Controls",
     "description": "Reads the live UI control store → scale + instrument + overlay port values.",
+    "roles": [
+      "source",
+      "control"
+    ],
     "inputs": [],
     "outputs": [
       {
@@ -645,6 +696,9 @@
     "type": "synthetic-hands",
     "title": "Synthetic Hands",
     "description": "Camera-free animated hand landmark source for tests & demos.",
+    "roles": [
+      "source"
+    ],
     "inputs": [],
     "outputs": [
       {
@@ -699,6 +753,9 @@
     "type": "transport",
     "title": "Transport",
     "description": "Beat clock: integrates BPM over time into a running beat position.",
+    "roles": [
+      "music"
+    ],
     "inputs": [
       {
         "name": "bpm",
@@ -724,6 +781,9 @@
     "type": "voice-mapping",
     "title": "Voice Mapping",
     "description": "Hand features → tonal synth parameters (x→pitch w/ scale snap, y→volume).",
+    "roles": [
+      "mapping"
+    ],
     "inputs": [
       {
         "name": "features",
@@ -845,6 +905,9 @@
     "type": "webaudio-synth",
     "title": "Web Audio Synth",
     "description": "Renders synth params to instrument-preset voices (browser only).",
+    "roles": [
+      "synth"
+    ],
     "inputs": [
       {
         "name": "params",
@@ -869,6 +932,9 @@
     "type": "webcam-face",
     "title": "Webcam Face",
     "description": "MediaPipe FaceLandmarker blendshapes from the shared webcam (lazy-loaded, off by default).",
+    "roles": [
+      "source"
+    ],
     "inputs": [],
     "outputs": [
       {
@@ -888,6 +954,9 @@
     "type": "webcam-hands",
     "title": "Webcam Hands",
     "description": "MediaPipe hand landmark detection from a webcam video element.",
+    "roles": [
+      "source"
+    ],
     "inputs": [],
     "outputs": [
       {

--- a/public/manual.html
+++ b/public/manual.html
@@ -32,6 +32,7 @@
       <h4><code>webcam-hands</code> <span class="title">Webcam Hands</span></h4>
       <p>MediaPipe hand landmark detection from a webcam video element.</p>
       <dl>
+        <dt>roles</dt><dd>source</dd>
         <dt>in</dt><dd>—</dd>
         <dt>out</dt><dd>hands:hands-frame</dd>
         <dt>params</dt><dd>modelType (enum(lite | full)="full"), maxHands (number=2)</dd>
@@ -41,6 +42,7 @@
       <h4><code>webcam-face</code> <span class="title">Webcam Face</span></h4>
       <p>MediaPipe FaceLandmarker blendshapes from the shared webcam (lazy-loaded, off by default).</p>
       <dl>
+        <dt>roles</dt><dd>source</dd>
         <dt>in</dt><dd>—</dd>
         <dt>out</dt><dd>face:face-frame</dd>
         <dt>params</dt><dd>delegate (enum(GPU | CPU)="GPU")</dd>
@@ -50,6 +52,7 @@
       <h4><code>keyboard-source</code> <span class="title">Keyboard Source</span></h4>
       <p>Global keyboard input → held / pressed / released key events.</p>
       <dl>
+        <dt>roles</dt><dd>source</dd>
         <dt>in</dt><dd>—</dd>
         <dt>out</dt><dd>held:string[], pressed:string[], released:string[]</dd>
         <dt>params</dt><dd>preventDefaultKeys (array=["ArrowUp","ArrowDown","ArrowLeft","ArrowRight"," "])</dd>
@@ -59,6 +62,7 @@
       <h4><code>store-controls</code> <span class="title">UI Controls</span></h4>
       <p>Reads the live UI control store → scale + instrument + overlay port values.</p>
       <dl>
+        <dt>roles</dt><dd>source, control</dd>
         <dt>in</dt><dd>—</dd>
         <dt>out</dt><dd>scaleRight:number[], scaleLeft:number[], instrumentRight:instrument, instrumentLeft:instrument, overlay:overlay-config</dd>
         <dt>params</dt><dd>—</dd>
@@ -68,6 +72,7 @@
       <h4><code>synthetic-hands</code> <span class="title">Synthetic Hands</span></h4>
       <p>Camera-free animated hand landmark source for tests &amp; demos.</p>
       <dl>
+        <dt>roles</dt><dd>source</dd>
         <dt>in</dt><dd>—</dd>
         <dt>out</dt><dd>hands:hands-frame</dd>
         <dt>params</dt><dd>width (number=640), height (number=480), sweepPeriod (number=4), opennessPeriod (number=3), pinchPeriod (number=2.5), hands (enum(right | left | both)="right"), yNorm (number=0.5), scale (number=80)</dd>
@@ -77,6 +82,7 @@
       <h4><code>replay-source</code> <span class="title">Replay Source</span></h4>
       <p>Emits a recorded value stream, one value per tick.</p>
       <dl>
+        <dt>roles</dt><dd>source</dd>
         <dt>in</dt><dd>—</dd>
         <dt>out</dt><dd>value</dd>
         <dt>params</dt><dd>values (array=[]), loop (boolean=false)</dd>
@@ -87,6 +93,7 @@
       <h4><code>hand-features</code> <span class="title">Hand Features</span></h4>
       <p>Landmarks → normalized per-hand position, openness, pinch.</p>
       <dl>
+        <dt>roles</dt><dd>feature</dd>
         <dt>in</dt><dd>hands:hands-frame</dd>
         <dt>out</dt><dd>features:hand-features</dd>
         <dt>params</dt><dd>mirrorX (boolean=true), mirrorHandedness (boolean=true), opennessMin (number=1.3), opennessMax (number=2.3), pinchTouch (number=0.25), pinchApart (number=1.2)</dd>
@@ -96,6 +103,7 @@
       <h4><code>face-features</code> <span class="title">Face Features</span></h4>
       <p>Face blendshapes → normalized expression controls (smile, mouthOpen, brow, blink).</p>
       <dl>
+        <dt>roles</dt><dd>feature</dd>
         <dt>in</dt><dd>face:face-frame</dd>
         <dt>out</dt><dd>features:face-features</dd>
         <dt>params</dt><dd>gain (number=1), smoothing (number=0)</dd>
@@ -105,6 +113,7 @@
       <h4><code>gesture-classifier</code> <span class="title">Gesture Classifier</span></h4>
       <p>Hand features → discrete poses (fist/open/pinch) + enter/exit edge events.</p>
       <dl>
+        <dt>roles</dt><dd>feature</dd>
         <dt>in</dt><dd>features:hand-features</dd>
         <dt>out</dt><dd>poses:poses, events:gesture-events</dd>
         <dt>params</dt><dd>pinchOn (number=0.6), pinchOff (number=0.45), fistBelow (number=0.25), openAbove (number=0.6), hysteresis (number=0.05)</dd>
@@ -115,6 +124,7 @@
       <h4><code>voice-mapping</code> <span class="title">Voice Mapping</span></h4>
       <p>Hand features → tonal synth parameters (x→pitch w/ scale snap, y→volume).</p>
       <dl>
+        <dt>roles</dt><dd>mapping</dd>
         <dt>in</dt><dd>features:hand-features, magnetism:number, octaveShift:number, mute:boolean, scaleRight:number[], scaleLeft:number[], instrumentRight:instrument, instrumentLeft:instrument, face:face-features</dd>
         <dt>out</dt><dd>params:synth-params</dd>
         <dt>params</dt><dd>magnetism (number=0.8), maxGain (number=0.5), opennessGatesGain (boolean=false), opennessControlsBrightness (boolean=true), pinchControlsVibrato (boolean=true), faceControlsExpression (boolean=true), panByPosition (boolean=true), panSpread (number=0.5), right (object={"scale":{"root":0,"type":"major","octaves":2,"baseOctave":3},"instrument":"sine"}), left (object={"scale":{"root":0,"type":"major","octaves":2,"baseOctave":3},"instrument":"triangle"})</dd>
@@ -124,6 +134,7 @@
       <h4><code>indirect-map</code> <span class="title">Indirect Map</span></h4>
       <p>Gesture features → weighted prompts + config dials (steers a generative engine).</p>
       <dl>
+        <dt>roles</dt><dd>mapping</dd>
         <dt>in</dt><dd>features:hand-features, face:face-features</dd>
         <dt>out</dt><dd>steer:generative-steer</dd>
         <dt>params</dt><dd>strains (array=[]), dials (array=[]), smoothing (number=0), throttleSec (number=0)</dd>
@@ -133,6 +144,7 @@
       <h4><code>keyboard-control</code> <span class="title">Keyboard Control</span></h4>
       <p>Keyboard key-press events → octave shift, magnetism, mute.</p>
       <dl>
+        <dt>roles</dt><dd>mapping, control</dd>
         <dt>in</dt><dd>pressed:string[]</dd>
         <dt>out</dt><dd>octaveShift:number, magnetism:number, mute:boolean</dd>
         <dt>params</dt><dd>magnetismStep (number=0.1), magnetismStart (number=0.8), octaveMin (number=-2), octaveMax (number=2)</dd>
@@ -142,6 +154,7 @@
       <h4><code>pick</code> <span class="title">Pick</span></h4>
       <p>Extract a scalar from a structured input by dotted path (e.g. right.x).</p>
       <dl>
+        <dt>roles</dt><dd>mapping</dd>
         <dt>in</dt><dd>in:any</dd>
         <dt>out</dt><dd>value:number</dd>
         <dt>params</dt><dd>path (string=""), default (number=0)</dd>
@@ -151,6 +164,7 @@
       <h4><code>one-euro</code> <span class="title">One-Euro Filter</span></h4>
       <p>Adaptive jitter smoothing for a noisy control value (smooth at rest, responsive when fast).</p>
       <dl>
+        <dt>roles</dt><dd>mapping</dd>
         <dt>in</dt><dd>value:number</dd>
         <dt>out</dt><dd>value:number</dd>
         <dt>params</dt><dd>minCutoff (number=1), beta (number=0.01), dCutoff (number=1), fallbackDt (number=0.016666666666666666)</dd>
@@ -161,6 +175,7 @@
       <h4><code>chord</code> <span class="title">Chord</span></h4>
       <p>Chord symbol (e.g. Cmaj7) → voiced synth params (one voice per chord tone).</p>
       <dl>
+        <dt>roles</dt><dd>music</dd>
         <dt>in</dt><dd>chord:chord-symbol, gain:number</dd>
         <dt>out</dt><dd>params:synth-params</dd>
         <dt>params</dt><dd>baseOctave (number=4), maxVoices (number=4), instrument (enum(sine | triangle | square | sawtooth | warmPad | glass | bell | organ | voice | softLead | strings | flute | brass | choir)="sine")</dd>
@@ -170,6 +185,7 @@
       <h4><code>progression</code> <span class="title">Progression</span></h4>
       <p>Roman-numeral progression in a key + position (0..1) → current chord symbol.</p>
       <dl>
+        <dt>roles</dt><dd>music</dd>
         <dt>in</dt><dd>position:number</dd>
         <dt>out</dt><dd>chord:chord-symbol, index:number</dd>
         <dt>params</dt><dd>key (string="C"), romanNumerals (array=["I","IV","V","vi"])</dd>
@@ -180,6 +196,7 @@
       <h4><code>transport</code> <span class="title">Transport</span></h4>
       <p>Beat clock: integrates BPM over time into a running beat position.</p>
       <dl>
+        <dt>roles</dt><dd>music</dd>
         <dt>in</dt><dd>bpm:number</dd>
         <dt>out</dt><dd>beat:number</dd>
         <dt>params</dt><dd>startBeat (number=0)</dd>
@@ -189,6 +206,7 @@
       <h4><code>score</code> <span class="title">Score</span></h4>
       <p>An immutable piece performed live: beat + velocityScale → sounding synth voices.</p>
       <dl>
+        <dt>roles</dt><dd>music</dd>
         <dt>in</dt><dd>beat:number, velocityScale:number</dd>
         <dt>out</dt><dd>params:synth-params</dd>
         <dt>params</dt><dd>notes (array=[]), loopBeats (number=8), baseGain (number=0.4), instrument (enum(sine | triangle | square | sawtooth | warmPad | glass | bell | organ | voice | softLead | strings | flute | brass | choir)="triangle")</dd>
@@ -198,6 +216,7 @@
       <h4><code>performance</code> <span class="title">Performance</span></h4>
       <p>Control signal → tempo (bpm) + dynamics (velocityScale), with optional humanization.</p>
       <dl>
+        <dt>roles</dt><dd>music</dd>
         <dt>in</dt><dd>control:number</dd>
         <dt>out</dt><dd>bpm:number, velocityScale:number</dd>
         <dt>params</dt><dd>bpmMin (number=60), bpmMax (number=160), dynMin (number=0.4), dynMax (number=1), humanizeBpm (number=0), humanizeVel (number=0)</dd>
@@ -208,6 +227,7 @@
       <h4><code>webaudio-synth</code> <span class="title">Web Audio Synth</span></h4>
       <p>Renders synth params to instrument-preset voices (browser only).</p>
       <dl>
+        <dt>roles</dt><dd>synth</dd>
         <dt>in</dt><dd>params:synth-params</dd>
         <dt>out</dt><dd>—</dd>
         <dt>params</dt><dd>freqGlide (number=0.03), gainGlide (number=0.08)</dd>
@@ -217,6 +237,7 @@
       <h4><code>lyria</code> <span class="title">Lyria Generative</span></h4>
       <p>Steers a generative engine (Lyria RealTime) from weighted prompts + config dials.</p>
       <dl>
+        <dt>roles</dt><dd>synth, generate</dd>
         <dt>in</dt><dd>steer:generative-steer, playing:boolean</dd>
         <dt>out</dt><dd>state:string</dd>
         <dt>params</dt><dd>throttleSec (number=0.2)</dd>
@@ -227,6 +248,7 @@
       <h4><code>canvas-overlay</code> <span class="title">Canvas Overlay</span></h4>
       <p>Mirrored video + composable overlay elements (guides, landmarks, markers).</p>
       <dl>
+        <dt>roles</dt><dd>overlay</dd>
         <dt>in</dt><dd>hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], octaveShift:number, overlayConfig:overlay-config</dd>
         <dt>out</dt><dd>—</dd>
         <dt>params</dt><dd>video (object={}), scaleGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={})</dd>

--- a/scripts/gen_catalog.ts
+++ b/scripts/gen_catalog.ts
@@ -69,7 +69,7 @@ function toMarkdown(catalog: CatalogEntry[]): string {
   for (const g of grouped(catalog)) {
     L.push(`### ${g.name}`, g.blurb ? `_${g.blurb}_` : '', '');
     for (const e of g.entries) {
-      L.push(`#### \`${e.type}\` — ${e.title}`, e.description, '', `- **in:** ${ports(e.inputs)}`, `- **out:** ${ports(e.outputs)}`, `- **params:** ${params(e.params)}`, '');
+      L.push(`#### \`${e.type}\` — ${e.title}`, e.description, '', `- **roles:** ${e.roles.join(', ') || '—'}`, `- **in:** ${ports(e.inputs)}`, `- **out:** ${ports(e.outputs)}`, `- **params:** ${params(e.params)}`, '');
     }
   }
   return L.join('\n');
@@ -83,6 +83,7 @@ function toHtml(catalog: CatalogEntry[]): string {
       <h4><code>${esc(e.type)}</code> <span class="title">${esc(e.title)}</span></h4>
       <p>${esc(e.description)}</p>
       <dl>
+        <dt>roles</dt><dd>${esc(e.roles.join(', ') || '—')}</dd>
         <dt>in</dt><dd>${esc(ports(e.inputs))}</dd>
         <dt>out</dt><dd>${esc(ports(e.outputs))}</dd>
         <dt>params</dt><dd>${esc(params(e.params))}</dd>

--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -8,7 +8,7 @@
  * is unit-testable headlessly.
  */
 import type { NodeRegistry } from '@/dag';
-import type { NodeDef, PortSpec } from '@/dag';
+import type { NodeDef, PortSpec, Role } from '@/dag';
 
 export interface PortInfo {
   name: string;
@@ -27,6 +27,8 @@ export interface CatalogEntry {
   type: string;
   title: string;
   description: string;
+  /** Advisory role tag(s) on the node def (see {@link Role}); [] if untagged. */
+  roles: Role[];
   inputs: PortInfo[];
   outputs: PortInfo[];
   params: ParamInfo[];
@@ -110,6 +112,7 @@ export function buildCatalog(registry: NodeRegistry): CatalogEntry[] {
       type: def.type,
       title: def.title ?? def.type,
       description: def.description ?? '',
+      roles: def.roles ?? [],
       inputs: def.inputs.map(portInfo),
       outputs: def.outputs.map(portInfo),
       params: paramsOf(def),

--- a/src/dag/node.ts
+++ b/src/dag/node.ts
@@ -10,29 +10,29 @@
  * Both produce a {@link NodeDef}; the engine treats them identically.
  */
 import { z } from 'zod';
-import type { NodeContext, NodeDef, NodeHandlers, ParamsSchema, PortSpec, PortValues } from './types';
+import type { NodeContext, NodeDef, NodeHandlers, ParamsSchema, PortSpec, PortValues, Role } from './types';
 
-/** Spec for a pure (stateless) node. */
-interface PureNodeSpec<P> {
+/** Fields common to both node-spec flavours. */
+interface BaseNodeSpec<P> {
   type: string;
   title?: string;
   description?: string;
+  /** Advisory role tag(s) (see {@link Role}); never gates execution. */
+  roles?: Role[];
   inputs: PortSpec[];
   outputs: PortSpec[];
   /** Defaults to an empty-object schema when omitted. */
   params?: ParamsSchema<P>;
+}
+
+/** Spec for a pure (stateless) node. */
+interface PureNodeSpec<P> extends BaseNodeSpec<P> {
   /** Pure transform: inputs + params -> outputs. */
   process(inputs: PortValues, params: P, ctx: NodeContext): PortValues;
 }
 
 /** Spec for a stateful node (owns per-instance state via a factory). */
-interface StatefulNodeSpec<P> {
-  type: string;
-  title?: string;
-  description?: string;
-  inputs: PortSpec[];
-  outputs: PortSpec[];
-  params?: ParamsSchema<P>;
+interface StatefulNodeSpec<P> extends BaseNodeSpec<P> {
   /** Build per-instance handlers from validated params. */
   make(params: P): NodeHandlers;
 }
@@ -61,6 +61,7 @@ export function defineNode<P = Record<string, never>>(
     type: spec.type,
     title: spec.title,
     description: spec.description,
+    roles: spec.roles,
     inputs: spec.inputs,
     outputs: spec.outputs,
     params,

--- a/src/dag/registry.ts
+++ b/src/dag/registry.ts
@@ -4,7 +4,7 @@
  * explicit (rather than a global) makes tests hermetic: a test can build a
  * registry with exactly the nodes it needs.
  */
-import type { NodeDef } from './types';
+import type { NodeDef, Role } from './types';
 
 export class NodeRegistry {
   private defs = new Map<string, NodeDef<any>>();
@@ -36,6 +36,16 @@ export class NodeRegistry {
 
   list(): NodeDef<any>[] {
     return [...this.defs.values()];
+  }
+
+  /**
+   * Filtered view over {@link list}: every registered def whose `roles` include
+   * `role`. A node may carry several roles, so it can appear under more than one.
+   * Advisory only — this powers docs and the future swap UI; it never affects
+   * engine execution. No second storage structure: it scans the existing map.
+   */
+  listByRole(role: Role): NodeDef<any>[] {
+    return [...this.defs.values()].filter((def) => def.roles?.includes(role));
   }
 }
 

--- a/src/dag/types.ts
+++ b/src/dag/types.ts
@@ -26,6 +26,30 @@ import type { ZodType } from 'zod';
  */
 export type ParamsSchema<P> = ZodType<P, any, any>;
 
+/**
+ * Advisory role tag(s) a node *definition* carries — descriptive metadata, like
+ * {@link PortSpec.kind}, **never enforced by the engine**. A node may carry
+ * several (e.g. `store-controls` is `['source', 'control']`, `lyria` is
+ * `['synth', 'generate']`). Roles power docs/onboarding, `registry.listByRole`,
+ * and (eventually) the settings swap UI. See `docs/design/component-model.md`.
+ *
+ * **Terminology:** `role` is for NODES; `kind` is the PORT data contract
+ * ({@link PortSpec.kind}). Never add a node-level `kind`.
+ *
+ * The first six are primary signal-flow roles (`source → feature → mapping →
+ * music → synth/overlay`); `control` and `generate` are cross-cutting modifiers
+ * that combine with a primary role.
+ */
+export type Role =
+  | 'source'
+  | 'feature'
+  | 'mapping'
+  | 'music'
+  | 'synth'
+  | 'overlay'
+  | 'control'
+  | 'generate';
+
 /** A frame of values flowing on a node's ports, keyed by port name. */
 export type PortValues = Record<string, unknown>;
 
@@ -91,6 +115,12 @@ export interface NodeDef<P = unknown> {
   outputs: PortSpec[];
   /** Zod schema validating (and defaulting) this node's params. */
   params: ParamsSchema<P>;
+  /**
+   * Advisory role tag(s) (see {@link Role}); never gates engine execution. A
+   * node may carry several. Powers `registry.listByRole`, docs, and the future
+   * swap UI. Optional so third-party defs don't have to declare it.
+   */
+  roles?: Role[];
   /** Build the instance behaviour from validated params. */
   make(params: P): NodeHandlers;
 }

--- a/src/nodes/features/face_features.ts
+++ b/src/nodes/features/face_features.ts
@@ -27,6 +27,7 @@ function clamp01(v: number): number {
 
 export const faceFeaturesNode = defineNode<Params>({
   type: 'face-features',
+  roles: ['feature'],
   title: 'Face Features',
   description: 'Face blendshapes → normalized expression controls (smile, mouthOpen, brow, blink).',
   inputs: [{ name: 'face', kind: 'face-frame' }],

--- a/src/nodes/features/gesture_classifier.ts
+++ b/src/nodes/features/gesture_classifier.ts
@@ -41,6 +41,7 @@ function classify(f: SingleHandFeatures, prev: Pose, p: Params): Pose {
 
 export const gestureClassifierNode = defineNode<Params>({
   type: 'gesture-classifier',
+  roles: ['feature'],
   title: 'Gesture Classifier',
   description: 'Hand features → discrete poses (fist/open/pinch) + enter/exit edge events.',
   inputs: [{ name: 'features', kind: 'hand-features' }],

--- a/src/nodes/features/hand_features.ts
+++ b/src/nodes/features/hand_features.ts
@@ -108,6 +108,7 @@ function extractOne(hand: Hand, frame: HandsFrame, p: Params): SingleHandFeature
 
 export const handFeaturesNode = defineNode<Params>({
   type: 'hand-features',
+  roles: ['feature'],
   title: 'Hand Features',
   description: 'Landmarks → normalized per-hand position, openness, pinch.',
   inputs: [{ name: 'hands', kind: 'hands-frame' }],

--- a/src/nodes/mapping/indirect_map.ts
+++ b/src/nodes/mapping/indirect_map.ts
@@ -69,6 +69,7 @@ function readFeature(hands: HandFeatures, face: FaceFeatures, ref: Ref): number 
 
 export const indirectMapNode = defineNode<Params>({
   type: 'indirect-map',
+  roles: ['mapping'],
   title: 'Indirect Map',
   description: 'Gesture features → weighted prompts + config dials (steers a generative engine).',
   inputs: [

--- a/src/nodes/mapping/keyboard_control.ts
+++ b/src/nodes/mapping/keyboard_control.ts
@@ -28,6 +28,7 @@ function clamp(v: number, lo: number, hi: number): number {
 
 export const keyboardControlNode = defineNode<Params>({
   type: 'keyboard-control',
+  roles: ['mapping', 'control'],
   title: 'Keyboard Control',
   description: 'Keyboard key-press events → octave shift, magnetism, mute.',
   inputs: [{ name: 'pressed', kind: 'string[]', default: [] }],

--- a/src/nodes/mapping/one_euro.ts
+++ b/src/nodes/mapping/one_euro.ts
@@ -32,6 +32,7 @@ function smoothingAlpha(cutoffHz: number, dt: number): number {
 
 export const oneEuroNode = defineNode<Params>({
   type: 'one-euro',
+  roles: ['mapping'],
   title: 'One-Euro Filter',
   description: 'Adaptive jitter smoothing for a noisy control value (smooth at rest, responsive when fast).',
   inputs: [{ name: 'value', kind: 'number', default: 0 }],

--- a/src/nodes/mapping/pick.ts
+++ b/src/nodes/mapping/pick.ts
@@ -18,6 +18,7 @@ type Params = z.infer<typeof Params>;
 
 export const pickNode = defineNode<Params>({
   type: 'pick',
+  roles: ['mapping'],
   title: 'Pick',
   description: 'Extract a scalar from a structured input by dotted path (e.g. right.x).',
   inputs: [{ name: 'in', kind: 'any' }],

--- a/src/nodes/mapping/voice_mapping.ts
+++ b/src/nodes/mapping/voice_mapping.ts
@@ -111,6 +111,7 @@ function voiceFor(
 
 export const voiceMappingNode = defineNode<Params>({
   type: 'voice-mapping',
+  roles: ['mapping'],
   title: 'Voice Mapping',
   description: 'Hand features → tonal synth parameters (x→pitch w/ scale snap, y→volume).',
   inputs: [

--- a/src/nodes/music/chord.ts
+++ b/src/nodes/music/chord.ts
@@ -47,6 +47,7 @@ export function voiceChord(symbol: string, baseOctave: number, maxVoices: number
 
 export const chordNode = defineNode<Params>({
   type: 'chord',
+  roles: ['music'],
   title: 'Chord',
   description: 'Chord symbol (e.g. Cmaj7) → voiced synth params (one voice per chord tone).',
   inputs: [

--- a/src/nodes/music/performance.ts
+++ b/src/nodes/music/performance.ts
@@ -33,6 +33,7 @@ function hashNoise(t: number): number {
 
 export const performanceNode = defineNode<Params>({
   type: 'performance',
+  roles: ['music'],
   title: 'Performance',
   description: 'Control signal → tempo (bpm) + dynamics (velocityScale), with optional humanization.',
   inputs: [{ name: 'control', kind: 'number', default: 0.5 }],

--- a/src/nodes/music/progression.ts
+++ b/src/nodes/music/progression.ts
@@ -42,6 +42,7 @@ function romanToDegree(rn: string): number {
 
 export const progressionNode = defineNode<Params>({
   type: 'progression',
+  roles: ['music'],
   title: 'Progression',
   description: 'Roman-numeral progression in a key + position (0..1) → current chord symbol.',
   inputs: [{ name: 'position', kind: 'number', default: 0 }],

--- a/src/nodes/music/score.ts
+++ b/src/nodes/music/score.ts
@@ -37,6 +37,7 @@ type Params = z.infer<typeof Params>;
 
 export const scoreNode = defineNode<Params>({
   type: 'score',
+  roles: ['music'],
   title: 'Score',
   description: 'An immutable piece performed live: beat + velocityScale → sounding synth voices.',
   inputs: [

--- a/src/nodes/music/transport.ts
+++ b/src/nodes/music/transport.ts
@@ -16,6 +16,7 @@ type Params = z.infer<typeof Params>;
 
 export const transportNode = defineNode<Params>({
   type: 'transport',
+  roles: ['music'],
   title: 'Transport',
   description: 'Beat clock: integrates BPM over time into a running beat position.',
   inputs: [{ name: 'bpm', kind: 'number', default: 120 }],

--- a/src/nodes/output/canvas_overlay.ts
+++ b/src/nodes/output/canvas_overlay.ts
@@ -297,6 +297,7 @@ export const OVERLAY_ELEMENTS: readonly OverlayElement[] = [
 
 export const canvasOverlayNode = defineNode<Params>({
   type: 'canvas-overlay',
+  roles: ['overlay'],
   title: 'Canvas Overlay',
   description: 'Mirrored video + composable overlay elements (guides, landmarks, markers).',
   inputs: [

--- a/src/nodes/output/lyria.ts
+++ b/src/nodes/output/lyria.ts
@@ -25,6 +25,7 @@ type Params = z.infer<typeof Params>;
 
 export const lyriaNode = defineNode<Params>({
   type: 'lyria',
+  roles: ['synth', 'generate'],
   title: 'Lyria Generative',
   description: 'Steers a generative engine (Lyria RealTime) from weighted prompts + config dials.',
   inputs: [

--- a/src/nodes/output/webaudio_synth.ts
+++ b/src/nodes/output/webaudio_synth.ts
@@ -262,6 +262,7 @@ function teardownVoice(voice: Voice, ac: AudioContext, fade = false): void {
 
 export const webAudioSynthNode = defineNode<Params>({
   type: 'webaudio-synth',
+  roles: ['synth'],
   title: 'Web Audio Synth',
   description: 'Renders synth params to instrument-preset voices (browser only).',
   inputs: [{ name: 'params', kind: 'synth-params' }],

--- a/src/nodes/sources/keyboard.ts
+++ b/src/nodes/sources/keyboard.ts
@@ -19,6 +19,7 @@ type Params = z.infer<typeof Params>;
 
 export const keyboardSourceNode = defineNode<Params>({
   type: 'keyboard-source',
+  roles: ['source'],
   title: 'Keyboard Source',
   description: 'Global keyboard input → held / pressed / released key events.',
   inputs: [],

--- a/src/nodes/sources/replay.ts
+++ b/src/nodes/sources/replay.ts
@@ -18,6 +18,7 @@ type Params = z.infer<typeof Params>;
 
 export const replaySourceNode = defineNode<Params>({
   type: 'replay-source',
+  roles: ['source'],
   title: 'Replay Source',
   description: 'Emits a recorded value stream, one value per tick.',
   inputs: [],

--- a/src/nodes/sources/store_controls.ts
+++ b/src/nodes/sources/store_controls.ts
@@ -34,6 +34,7 @@ const Params = z.object({});
 
 export const storeControlsNode = defineNode<Record<string, never>>({
   type: 'store-controls',
+  roles: ['source', 'control'],
   title: 'UI Controls',
   description: 'Reads the live UI control store → scale + instrument + overlay port values.',
   inputs: [],

--- a/src/nodes/sources/synthetic_hands.ts
+++ b/src/nodes/sources/synthetic_hands.ts
@@ -33,6 +33,7 @@ function osc(time: number, period: number, phase = 0): number {
 
 export const syntheticHandsNode = defineNode<Params>({
   type: 'synthetic-hands',
+  roles: ['source'],
   title: 'Synthetic Hands',
   description: 'Camera-free animated hand landmark source for tests & demos.',
   inputs: [],

--- a/src/nodes/sources/webcam_face.ts
+++ b/src/nodes/sources/webcam_face.ts
@@ -90,6 +90,7 @@ type FaceControlsGetter = () => { faceEnabled?: boolean };
 
 export const webcamFaceNode = defineNode<Params>({
   type: 'webcam-face',
+  roles: ['source'],
   title: 'Webcam Face',
   description:
     'MediaPipe FaceLandmarker blendshapes from the shared webcam (lazy-loaded, off by default).',

--- a/src/nodes/sources/webcam_hands.ts
+++ b/src/nodes/sources/webcam_hands.ts
@@ -27,6 +27,7 @@ const EMPTY: HandsFrame = { width: 640, height: 480, hands: [] };
 
 export const webcamHandsNode = defineNode<Params>({
   type: 'webcam-hands',
+  roles: ['source'],
   title: 'Webcam Hands',
   description: 'MediaPipe hand landmark detection from a webcam video element.',
   inputs: [],

--- a/test/node_roles.test.ts
+++ b/test/node_roles.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Tests the advisory node-role taxonomy (issue #47): every node carries role(s),
+ * `registry.listByRole` filters by them (a node may appear under several), and
+ * the catalog surfaces them for the manual. Roles are descriptive metadata and
+ * never gate engine execution, so these are pure, headless checks.
+ */
+import { describe, it, expect } from 'vitest';
+import type { Role } from '@/dag';
+import { createAppRegistry } from '@/nodes/browser';
+import { buildCatalog } from '@/catalog';
+
+const reg = createAppRegistry();
+const typesWithRole = (role: Role): string[] =>
+  reg
+    .listByRole(role)
+    .map((d) => d.type)
+    .sort();
+
+describe('node roles', () => {
+  it('every registered node carries at least one role', () => {
+    const untagged = reg
+      .list()
+      .filter((d) => !d.roles || d.roles.length === 0)
+      .map((d) => d.type);
+    expect(untagged).toEqual([]);
+  });
+
+  it('listByRole filters by advisory role', () => {
+    // generate is a rare modifier — only the AI engine carries it.
+    expect(typesWithRole('generate')).toEqual(['lyria']);
+    // synth includes both the deterministic synth and the generative one.
+    expect(typesWithRole('synth')).toEqual(expect.arrayContaining(['webaudio-synth', 'lyria']));
+    expect(typesWithRole('source')).toEqual(
+      expect.arrayContaining(['webcam-hands', 'webcam-face', 'keyboard-source', 'store-controls']),
+    );
+    expect(typesWithRole('overlay')).toEqual(['canvas-overlay']);
+  });
+
+  it('a multi-role node appears under each of its roles', () => {
+    // store-controls is both a source and a control modifier.
+    expect(typesWithRole('source')).toContain('store-controls');
+    expect(typesWithRole('control')).toContain('store-controls');
+  });
+
+  it('surfaces roles in the catalog (docs/onboarding)', () => {
+    const byType = Object.fromEntries(buildCatalog(reg).map((e) => [e.type, e]));
+    expect(byType['lyria'].roles).toEqual(['synth', 'generate']);
+    expect(byType['canvas-overlay'].roles).toEqual(['overlay']);
+    expect(byType['voice-mapping'].roles).toEqual(['mapping']);
+  });
+});


### PR DESCRIPTION
## What

Implements the in-code part of #47 — the **role taxonomy** as advisory metadata on node definitions, a `registry.listByRole` query, and roles surfaced in the catalog/manual.

## How

- `src/dag/types.ts`: new `Role` type — primary signal-flow roles `source | feature | mapping | music | synth | overlay` plus cross-cutting modifiers `control | generate` — and an optional `roles?: Role[]` on `NodeDef`. **`role` is for nodes; `kind` stays the port contract** (never a node-level `kind`).
- `src/dag/node.ts`: `defineNode` accepts and forwards `roles`.
- `src/dag/registry.ts`: `listByRole(role)` — a filtered view over the existing map (no second storage structure).
- **Tagged all 22 node defs.** A node may carry several: `store-controls` → `['source','control']`, `lyria` → `['synth','generate']`, `keyboard-control` → `['mapping','control']`, etc.
- `src/catalog.ts` + `scripts/gen_catalog.ts`: roles are part of the catalog entry and rendered in the manual (the "docs/onboarding" payoff). Regenerated `docs/CATALOG.md`, `public/manual.html`, `public/catalog.json`.

Roles are **advisory** — they never gate engine execution (same stance as `PortSpec.kind`). Governance unchanged: a role earns a user-facing swap dropdown only when ≥2 real implementations exist.

## Tests

New `test/node_roles.test.ts`: every node carries ≥1 role; `listByRole` filters correctly (incl. multi-role nodes appearing under each role); the catalog carries roles. `npm run typecheck` + `npm test` (142) + `npm run build` all green.

## Not in this PR

The remaining #47 checklist item — posting a superseding summary as a comment on **public Discussion #3** — is deferred for the maintainer's OK (posting public content). Using `refs #47` rather than `closes` so the issue stays open for that step.

Part of #45.

https://claude.ai/code/session_01JEoe7y1hA5KdEAvvpQXxxt
