### PR TITLE
Recording settings: output formats + save location + toast (refs #49)

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -13,9 +13,10 @@ import { useState } from 'react';
 import { Settings, X, Play, BookOpen, Circle, Square } from 'lucide-react';
 import { useThoreminEngine } from './useEngine';
 import ControlsPanel from './ControlsPanel';
+import Toaster from './Toaster';
 
 export default function App() {
-  const { videoRef, canvasRef, status, error, audioOn, isRecording, startAudio, toggleRecording } =
+  const { videoRef, canvasRef, status, error, audioOn, isRecording, isSaving, startAudio, toggleRecording } =
     useThoreminEngine();
   const [panelOpen, setPanelOpen] = useState(true);
 
@@ -56,15 +57,18 @@ export default function App() {
       {audioOn && (
         <button
           onClick={toggleRecording}
-          aria-label={isRecording ? 'Stop recording' : 'Record'}
+          disabled={isSaving}
+          aria-label={isRecording ? 'Stop recording' : isSaving ? 'Saving recording' : 'Record'}
           className={`absolute bottom-3 right-3 flex items-center gap-2 rounded-full px-4 py-2 text-[10px] font-bold uppercase tracking-widest backdrop-blur transition ${
             isRecording
               ? 'animate-pulse bg-red-500 text-white'
-              : 'bg-black/50 text-white/80 hover:text-white'
+              : isSaving
+                ? 'bg-black/50 text-white/50'
+                : 'bg-black/50 text-white/80 hover:text-white'
           }`}
         >
           {isRecording ? <Square className="h-3 w-3 fill-current" /> : <Circle className="h-3 w-3 fill-red-500 text-red-500" />}
-          {isRecording ? 'Stop' : 'Record'}
+          {isRecording ? 'Stop' : isSaving ? 'Saving…' : 'Record'}
         </button>
       )}
 
@@ -133,6 +137,9 @@ export default function App() {
           </div>
         </div>
       )}
+
+      {/* Transient "saved as …" notifications (e.g. after a recording). */}
+      <Toaster />
     </div>
   );
 }

--- a/src/app/ControlsPanel.tsx
+++ b/src/app/ControlsPanel.tsx
@@ -14,6 +14,7 @@ import { NOTES, SCALE_TYPES, type ScaleTypeId } from '@/music/theory';
 import { INSTRUMENTS, INSTRUMENT_IDS } from '@/music/instruments';
 import { useControls, type VoiceControl } from './store';
 import { usePresets } from './usePresets';
+import { RECORDING_FORMATS } from './recording/formats';
 
 const selectCls = 'rounded bg-white/10 px-2 py-1 text-xs outline-none focus:bg-white/20';
 
@@ -138,6 +139,29 @@ function FaceControls() {
   );
 }
 
+function RecordingControls() {
+  const formats = useControls((s) => s.recordingFormats);
+  const setFormat = useControls((s) => s.setRecordingFormat);
+
+  return (
+    <div className="space-y-2">
+      <h3 className="text-[11px] font-bold uppercase tracking-widest text-white/70">Recording</h3>
+      {RECORDING_FORMATS.map((f) => (
+        <Toggle
+          key={f.id}
+          label={f.label}
+          checked={formats.includes(f.id)}
+          onChange={(v) => setFormat(f.id, v)}
+        />
+      ))}
+      <p className="text-[10px] leading-relaxed text-white/40">
+        On stop, your take is saved in each selected format. If your browser
+        supports it you'll be asked where to save; otherwise it lands in Downloads.
+      </p>
+    </div>
+  );
+}
+
 function PresetControls() {
   const { presets, busy, save, load, remove } = usePresets();
   const [name, setName] = useState('');
@@ -227,6 +251,9 @@ export default function ControlsPanel() {
       </div>
       <div className="border-t border-white/10 pt-3">
         <FaceControls />
+      </div>
+      <div className="border-t border-white/10 pt-3">
+        <RecordingControls />
       </div>
       <div className="border-t border-white/10 pt-3">
         <PresetControls />

--- a/src/app/Toaster.tsx
+++ b/src/app/Toaster.tsx
@@ -1,0 +1,27 @@
+/**
+ * Toaster — renders the transient notifications from the toast store as a
+ * bottom-center stack. Click a toast to dismiss it early. Pointer-events are off
+ * on the container so toasts never block the instrument underneath.
+ */
+import { useToasts } from './toasts';
+
+export default function Toaster() {
+  const toasts = useToasts((s) => s.toasts);
+  const dismiss = useToasts((s) => s.dismiss);
+  if (toasts.length === 0) return null;
+
+  return (
+    <div className="pointer-events-none fixed inset-x-0 bottom-6 z-50 flex flex-col items-center gap-2">
+      {toasts.map((t) => (
+        <button
+          key={t.id}
+          type="button"
+          onClick={() => dismiss(t.id)}
+          className="pointer-events-auto rounded-full bg-emerald-600/90 px-4 py-1.5 text-xs font-medium text-white shadow-lg backdrop-blur transition hover:bg-emerald-600"
+        >
+          {t.message}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/app/recording/formats.ts
+++ b/src/app/recording/formats.ts
@@ -1,0 +1,66 @@
+/**
+ * Recording format registry — an open-closed list of output formats the user can
+ * choose for a recording. The live capture is always WebM/Opus (the only
+ * container `MediaRecorder` produces natively); each non-native format converts
+ * from that on stop, lazily importing its encoder so a format the user never
+ * picks costs nothing in the bundle.
+ *
+ * Adding a format = appending one entry here (no call-site changes). Planned
+ * follow-ups slot in the same way:
+ *   - MP3 via `lamejs` (small, lazy): `{ id:'mp3', needsDecode:true,
+ *     load: async () => { const { encodeMp3 } = await import('./mp3'); ... } }`.
+ *   - "Any format" via `ffmpeg.wasm` (heavy, opt-in, lazy): same shape.
+ */
+
+/** Inputs available to a converter: the native recording + its decoded audio. */
+export interface ConverterInput {
+  /** The natively-recorded WebM/Opus blob. */
+  native: Blob;
+  /** The decoded audio (present iff some selected format `needsDecode`). */
+  audio: AudioBuffer | null;
+}
+
+export type Converter = (input: ConverterInput) => Blob | Promise<Blob>;
+
+export interface RecordingFormat {
+  /** Stable id persisted in settings. */
+  id: string;
+  /** Human label for the settings UI. */
+  label: string;
+  /** File extension (the native format derives its ext from the recorder mime). */
+  ext: string;
+  /** Whether this format needs the decoded `AudioBuffer` (vs the native blob). */
+  needsDecode: boolean;
+  /** Lazily load the encoder. Keeps unpicked formats out of the bundle. */
+  load(): Promise<Converter>;
+}
+
+export const RECORDING_FORMATS: RecordingFormat[] = [
+  {
+    id: 'webm',
+    label: 'WebM / Opus (native, fast)',
+    ext: 'webm',
+    needsDecode: false,
+    load: async () => ({ native }) => native,
+  },
+  {
+    id: 'wav',
+    label: 'WAV (lossless, larger)',
+    ext: 'wav',
+    needsDecode: true,
+    load: async () => {
+      const { encodeWav } = await import('./wav');
+      return ({ audio }) => {
+        if (!audio) throw new Error('WAV export needs decoded audio');
+        return encodeWav(audio);
+      };
+    },
+  },
+];
+
+/** The default selection (preserves the prior behaviour: native WebM). */
+export const DEFAULT_RECORDING_FORMATS = ['webm'];
+
+export function recordingFormat(id: string): RecordingFormat | undefined {
+  return RECORDING_FORMATS.find((f) => f.id === id);
+}

--- a/src/app/recording/save.ts
+++ b/src/app/recording/save.ts
@@ -1,0 +1,58 @@
+/**
+ * saveBlob — save a recording, preferring the File System Access API
+ * (`showSaveFilePicker`, Chromium) so the player chooses where it lands, and
+ * falling back to a normal anchor download (→ the browser's Downloads folder)
+ * everywhere else. Returns the filename actually used, or `null` if the player
+ * cancelled the picker. The web APIs expose the chosen filename but never a true
+ * absolute OS path, so callers should surface the name, not a path.
+ */
+import { downloadBlob } from '../recorder';
+
+export interface SaveResult {
+  filename: string;
+  /** True if saved via the file picker; false if it fell back to a download. */
+  viaPicker: boolean;
+}
+
+export interface SaveOptions {
+  /**
+   * Offer the native "Save As" picker when supported. Pass `false` to force a
+   * direct download — used for all but the first file when saving several
+   * formats at once, so the player isn't hit with one modal dialog per format.
+   */
+  allowPicker?: boolean;
+}
+
+interface SaveFilePicker {
+  showSaveFilePicker?: (opts: { suggestedName?: string }) => Promise<{
+    name?: string;
+    createWritable(): Promise<{ write(data: Blob): Promise<void>; close(): Promise<void> }>;
+  }>;
+}
+
+export async function saveBlob(
+  blob: Blob,
+  suggestedName: string,
+  opts: SaveOptions = {},
+): Promise<SaveResult | null> {
+  const { allowPicker = true } = opts;
+  const picker = (globalThis as unknown as SaveFilePicker).showSaveFilePicker;
+  if (allowPicker && typeof picker === 'function') {
+    try {
+      const handle = await picker({ suggestedName });
+      const writable = await handle.createWritable();
+      await writable.write(blob);
+      await writable.close();
+      return { filename: handle.name ?? suggestedName, viaPicker: true };
+    } catch (e) {
+      // User dismissed the picker → not an error; report cancellation.
+      if (e instanceof DOMException && e.name === 'AbortError') return null;
+      // Any other picker failure (permission revoked, disk full, lost user
+      // activation): log it — consistent with the rest of the app's error
+      // handling — then fall back to a plain download so the take is never lost.
+      console.warn('[thoremin] file picker save failed; falling back to download', e);
+    }
+  }
+  downloadBlob(blob, suggestedName);
+  return { filename: suggestedName, viaPicker: false };
+}

--- a/src/app/recording/wav.ts
+++ b/src/app/recording/wav.ts
@@ -1,0 +1,66 @@
+/**
+ * Browser WAV encoder — the in-house, dependency-free WAV converter for the
+ * recording format registry. The live recording is captured as WebM/Opus (the
+ * only container MediaRecorder produces natively); on stop we `decodeAudioData`
+ * it into an `AudioBuffer` and re-encode here as 16-bit PCM WAV. This mirrors the
+ * Node-only `scripts/lib_audio.ts` `writeWav` (RIFF/WAVE header layout) but
+ * targets an `ArrayBuffer`/`Blob` and supports the buffer's real sample rate and
+ * channel count, so it runs in the browser with no extra dependency.
+ *
+ * `encodeWav` takes a structural {@link PcmSource} (the subset of `AudioBuffer`
+ * we use) so it is unit-testable headlessly without a real `AudioBuffer`.
+ */
+
+/** The slice of `AudioBuffer` the encoder reads (kept structural for testing). */
+export interface PcmSource {
+  numberOfChannels: number;
+  sampleRate: number;
+  /** Number of sample frames per channel. */
+  length: number;
+  getChannelData(channel: number): Float32Array;
+}
+
+const BYTES_PER_SAMPLE = 2; // 16-bit PCM
+
+/** Encode interleaved 16-bit PCM WAV from an AudioBuffer-like source. */
+export function encodeWav(audio: PcmSource): Blob {
+  const channels = Math.max(1, audio.numberOfChannels);
+  const sampleRate = audio.sampleRate;
+  const frames = audio.length;
+  const blockAlign = channels * BYTES_PER_SAMPLE;
+  const dataBytes = frames * blockAlign;
+
+  const buffer = new ArrayBuffer(44 + dataBytes);
+  const view = new DataView(buffer);
+  const writeStr = (offset: number, s: string) => {
+    for (let i = 0; i < s.length; i++) view.setUint8(offset + i, s.charCodeAt(i));
+  };
+
+  writeStr(0, 'RIFF');
+  view.setUint32(4, 36 + dataBytes, true);
+  writeStr(8, 'WAVE');
+  writeStr(12, 'fmt ');
+  view.setUint32(16, 16, true); // fmt chunk size
+  view.setUint16(20, 1, true); // PCM
+  view.setUint16(22, channels, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * blockAlign, true); // byte rate
+  view.setUint16(32, blockAlign, true);
+  view.setUint16(34, 16, true); // bits per sample
+  writeStr(36, 'data');
+  view.setUint32(40, dataBytes, true);
+
+  const chans: Float32Array[] = [];
+  for (let c = 0; c < channels; c++) chans.push(audio.getChannelData(c));
+
+  let offset = 44;
+  for (let i = 0; i < frames; i++) {
+    for (let c = 0; c < channels; c++) {
+      let s = chans[c][i] ?? 0;
+      s = s < -1 ? -1 : s > 1 ? 1 : s; // clamp before quantizing
+      view.setInt16(offset, Math.round(s * 32767), true);
+      offset += BYTES_PER_SAMPLE;
+    }
+  }
+  return new Blob([buffer], { type: 'audio/wav' });
+}

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -20,6 +20,7 @@ import { DEFAULT_INSTRUMENT_RIGHT, DEFAULT_INSTRUMENT_LEFT } from '@/music/instr
 import { OverlayParamsSchema, type OverlayParams } from '@/nodes/output/canvas_overlay';
 import type { VoiceParams } from '@/nodes';
 import type { Settings } from '@/settings/schema';
+import { DEFAULT_RECORDING_FORMATS } from './recording/formats';
 
 export interface VoiceControl {
   root: number; // 0..11
@@ -43,10 +44,18 @@ export interface ControlState {
   faceEnabled: boolean;
   /** Composable overlay element config (see canvas_overlay.ts). Live-controlled. */
   overlay: OverlayParams;
+  /**
+   * Output formats a recording is saved in (ids from the recording format
+   * registry; always ≥1). A tooling preference — persisted to localStorage but
+   * NOT part of a musical preset (it's orthogonal to the instrument's sound).
+   */
+  recordingFormats: string[];
   setVoice(side: 'right' | 'left', patch: Partial<VoiceControl>): void;
   setSync(v: boolean): void;
   setMasterVolume(v: number): void;
   setFaceEnabled(v: boolean): void;
+  /** Toggle a recording output format on/off (keeps at least one selected). */
+  setRecordingFormat(id: string, on: boolean): void;
   /** Patch one overlay element's options (e.g. setOverlayElement('indexGuide', { show: true })). */
   setOverlayElement<K extends keyof OverlayParams>(key: K, patch: Partial<OverlayParams[K]>): void;
   /** Replace all live controls from a settings snapshot (loading a preset). */
@@ -97,6 +106,7 @@ export const useControls = create<ControlState>()(
       masterVolume: 0.4,
       faceEnabled: false,
       overlay: defaultOverlay(),
+      recordingFormats: [...DEFAULT_RECORDING_FORMATS],
       setVoice: (side, patch) =>
         set((s) => {
           const next = { ...s[side], ...patch };
@@ -115,6 +125,17 @@ export const useControls = create<ControlState>()(
       setSync: (v) => set({ syncHands: v }),
       setMasterVolume: (v) => set({ masterVolume: v }),
       setFaceEnabled: (v) => set({ faceEnabled: v }),
+      setRecordingFormat: (id, on) =>
+        set((s) => {
+          const has = s.recordingFormats.includes(id);
+          if (on && !has) return { recordingFormats: [...s.recordingFormats, id] };
+          if (!on && has) {
+            const next = s.recordingFormats.filter((f) => f !== id);
+            // Keep at least one format selected, so a recording always saves.
+            return next.length ? { recordingFormats: next } : {};
+          }
+          return {};
+        }),
       setOverlayElement: (key, patch) =>
         set((s) => ({
           overlay: { ...s.overlay, [key]: { ...s.overlay[key], ...patch } } as OverlayParams,
@@ -144,6 +165,7 @@ export const useControls = create<ControlState>()(
         masterVolume: s.masterVolume,
         faceEnabled: s.faceEnabled,
         overlay: s.overlay,
+        recordingFormats: s.recordingFormats,
       }),
     },
   ),

--- a/src/app/toasts.ts
+++ b/src/app/toasts.ts
@@ -1,0 +1,35 @@
+/**
+ * Toasts — a tiny transient-notification store. Used to surface "saved as
+ * <name>" feedback after a recording is written (the web APIs expose the
+ * filename but no absolute path, so we report the name). Auto-dismisses; a click
+ * dismisses early. Kept separate from the controls store since these aren't
+ * persisted instrument state.
+ */
+import { create } from 'zustand';
+
+export interface Toast {
+  id: number;
+  message: string;
+}
+
+interface ToastState {
+  toasts: Toast[];
+  /** Show a toast; auto-dismisses after `ttlMs`. */
+  push(message: string, ttlMs?: number): void;
+  dismiss(id: number): void;
+}
+
+let seq = 0;
+const DEFAULT_TTL_MS = 4000;
+
+export const useToasts = create<ToastState>((set) => ({
+  toasts: [],
+  push: (message, ttlMs = DEFAULT_TTL_MS) => {
+    const id = ++seq;
+    set((s) => ({ toasts: [...s.toasts, { id, message }] }));
+    if (typeof setTimeout !== 'undefined') {
+      setTimeout(() => set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) })), ttlMs);
+    }
+  },
+  dismiss: (id) => set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) })),
+}));

--- a/src/app/useEngine.ts
+++ b/src/app/useEngine.ts
@@ -10,9 +10,59 @@ import { Engine } from '@/dag';
 import { createAppRegistry } from '@/nodes/browser';
 import { defaultGraph } from './graph';
 import { useControls } from './store';
-import { PerformanceRecorder, recordingFilename, extForMime, downloadBlob } from './recorder';
+import { PerformanceRecorder, recordingFilename, extForMime } from './recorder';
+import { recordingFormat } from './recording/formats';
+import { saveBlob } from './recording/save';
+import { useToasts } from './toasts';
 
 export type EngineStatus = 'idle' | 'loading' | 'ready' | 'error';
+
+/**
+ * Convert the native (WebM/Opus) recording into each selected output format and
+ * save it, surfacing a toast per saved file. Decodes the audio once if any
+ * selected format needs it. Never throws — a per-format failure toasts and the
+ * remaining formats still save.
+ */
+async function saveRecording(
+  native: Blob,
+  mimeType: string,
+  audioContext: AudioContext | undefined,
+): Promise<void> {
+  const { push } = useToasts.getState();
+  const ids = useControls.getState().recordingFormats;
+  const stamp = new Date().toISOString();
+
+  let audio: AudioBuffer | null = null;
+  if (audioContext && ids.some((id) => recordingFormat(id)?.needsDecode)) {
+    try {
+      // arrayBuffer() returns a fresh copy each call, so decoding here never
+      // detaches the buffer the native passthrough reuses.
+      audio = await audioContext.decodeAudioData(await native.arrayBuffer());
+    } catch (e) {
+      console.error('[thoremin] could not decode recording for conversion', e);
+      push('Could not decode audio for conversion');
+    }
+  }
+
+  // Offer the "Save As" picker for the first saved file only; the rest download
+  // directly, so selecting several formats doesn't trigger one dialog per format.
+  let first = true;
+  for (const id of ids) {
+    const fmt = recordingFormat(id);
+    if (!fmt) continue;
+    try {
+      const convert = await fmt.load();
+      const out = await convert({ native, audio });
+      const ext = id === 'webm' ? extForMime(mimeType) : fmt.ext;
+      const result = await saveBlob(out, recordingFilename(stamp, ext), { allowPicker: first });
+      first = false;
+      if (result) push(`Saved ${result.filename}`);
+    } catch (e) {
+      console.error(`[thoremin] failed to save recording as ${fmt.id}`, e);
+      push(`Couldn't save ${fmt.label}`);
+    }
+  }
+}
 
 export function useThoreminEngine() {
   const videoRef = useRef<HTMLVideoElement>(null);
@@ -28,6 +78,7 @@ export function useThoreminEngine() {
   const [error, setError] = useState<string | null>(null);
   const [audioOn, setAudioOn] = useState(false);
   const [isRecording, setIsRecording] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
 
   const masterVolume = useControls((s) => s.masterVolume);
 
@@ -172,9 +223,17 @@ export function useThoreminEngine() {
     recBusyRef.current = true;
     try {
       if (r.recording) {
-        const blob = await r.stop();
-        downloadBlob(blob, recordingFilename(new Date().toISOString(), extForMime(r.mimeType)));
+        const native = await r.stop();
         setIsRecording(false);
+        const ac = resourcesRef.current.audioContext as AudioContext | undefined;
+        // Converting + the save dialog can take a moment; surface a "saving"
+        // state so the UI is honest while a new record is briefly blocked.
+        setIsSaving(true);
+        try {
+          await saveRecording(native, r.mimeType, ac);
+        } finally {
+          setIsSaving(false);
+        }
       } else {
         r.start();
         setIsRecording(true);
@@ -184,5 +243,5 @@ export function useThoreminEngine() {
     }
   }, []);
 
-  return { videoRef, canvasRef, status, error, audioOn, isRecording, startAudio, toggleRecording };
+  return { videoRef, canvasRef, status, error, audioOn, isRecording, isSaving, startAudio, toggleRecording };
 }

--- a/test/recording.test.ts
+++ b/test/recording.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Tests the recording-settings building blocks (issue #49): the in-house WAV
+ * encoder, the open-closed format registry, the format selection in the store,
+ * the toast store, and the save helper (file-picker + download fallback). The
+ * live MediaRecorder capture is browser-only and not exercised here.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { encodeWav, type PcmSource } from '@/app/recording/wav';
+import {
+  RECORDING_FORMATS,
+  DEFAULT_RECORDING_FORMATS,
+  recordingFormat,
+} from '@/app/recording/formats';
+import { useControls } from '@/app/store';
+import { useToasts } from '@/app/toasts';
+
+vi.mock('@/app/recorder', () => ({ downloadBlob: vi.fn() }));
+import { downloadBlob } from '@/app/recorder';
+import { saveBlob } from '@/app/recording/save';
+
+const readView = async (blob: Blob): Promise<DataView> => new DataView(await blob.arrayBuffer());
+const ascii = (v: DataView, off: number, len: number): string =>
+  Array.from({ length: len }, (_, i) => String.fromCharCode(v.getUint8(off + i))).join('');
+
+/** A structural AudioBuffer stand-in for headless encoding. */
+const pcm = (channels: Float32Array[], sampleRate = 8000): PcmSource => ({
+  numberOfChannels: channels.length,
+  sampleRate,
+  length: channels[0]?.length ?? 0,
+  getChannelData: (c) => channels[c],
+});
+
+describe('encodeWav', () => {
+  it('writes a correct 16-bit PCM WAV header and interleaved data', async () => {
+    const blob = encodeWav(pcm([new Float32Array([0, 1, -1])], 8000));
+    expect(blob.type).toBe('audio/wav');
+    const v = await readView(blob);
+    expect(ascii(v, 0, 4)).toBe('RIFF');
+    expect(ascii(v, 8, 4)).toBe('WAVE');
+    expect(ascii(v, 12, 4)).toBe('fmt ');
+    expect(v.getUint16(20, true)).toBe(1); // PCM
+    expect(v.getUint16(22, true)).toBe(1); // mono
+    expect(v.getUint32(24, true)).toBe(8000); // sample rate
+    expect(v.getUint16(34, true)).toBe(16); // bits per sample
+    expect(ascii(v, 36, 4)).toBe('data');
+    expect(v.getUint32(40, true)).toBe(3 * 2); // 3 mono frames * 2 bytes
+    // samples: 0 -> 0, 1.0 -> 32767, -1.0 clamped -> -32767
+    expect(v.getInt16(44, true)).toBe(0);
+    expect(v.getInt16(46, true)).toBe(32767);
+    expect(v.getInt16(48, true)).toBe(-32767);
+  });
+
+  it('interleaves multiple channels and reports the right byte length', async () => {
+    const blob = encodeWav(pcm([new Float32Array([1, 0]), new Float32Array([0, -1])], 44100));
+    const v = await readView(blob);
+    expect(v.getUint16(22, true)).toBe(2); // stereo
+    expect(v.getUint32(24, true)).toBe(44100);
+    expect(v.getUint32(40, true)).toBe(2 * 2 * 2); // 2 frames * 2 ch * 2 bytes
+    // frame0: L=1 -> 32767, R=0 -> 0 ; frame1: L=0 -> 0, R=-1 -> -32767
+    expect(v.getInt16(44, true)).toBe(32767);
+    expect(v.getInt16(46, true)).toBe(0);
+    expect(v.getInt16(50, true)).toBe(-32767);
+  });
+});
+
+describe('recording format registry', () => {
+  it('defaults to the native webm format', () => {
+    expect(DEFAULT_RECORDING_FORMATS).toEqual(['webm']);
+    expect(recordingFormat('webm')?.needsDecode).toBe(false);
+    expect(recordingFormat('wav')?.needsDecode).toBe(true);
+    expect(recordingFormat('nope')).toBeUndefined();
+  });
+
+  it('webm converter passes the native blob through untouched', async () => {
+    const native = new Blob(['x'], { type: 'audio/webm' });
+    const convert = await recordingFormat('webm')!.load();
+    expect(await convert({ native, audio: null })).toBe(native);
+  });
+
+  it('wav converter encodes the decoded audio (and errors without it)', async () => {
+    const convert = await recordingFormat('wav')!.load();
+    const audio = pcm([new Float32Array([0, 0.5])], 8000) as unknown as AudioBuffer;
+    const out = await convert({ native: new Blob([]), audio });
+    expect((out as Blob).type).toBe('audio/wav');
+    expect(() => convert({ native: new Blob([]), audio: null })).toThrow();
+  });
+
+  it('every format lazily loads a converter', async () => {
+    for (const f of RECORDING_FORMATS) {
+      expect(typeof (await f.load())).toBe('function');
+    }
+  });
+});
+
+describe('store recording formats', () => {
+  beforeEach(() => useControls.setState({ recordingFormats: ['webm'] }));
+
+  it('toggles formats and always keeps at least one selected', () => {
+    const s = () => useControls.getState();
+    s().setRecordingFormat('wav', true);
+    expect(s().recordingFormats).toEqual(['webm', 'wav']);
+    s().setRecordingFormat('webm', false);
+    expect(s().recordingFormats).toEqual(['wav']);
+    s().setRecordingFormat('wav', false); // would empty the list -> ignored
+    expect(s().recordingFormats).toEqual(['wav']);
+  });
+});
+
+describe('toasts', () => {
+  beforeEach(() => useToasts.setState({ toasts: [] }));
+
+  it('pushes and dismisses', () => {
+    useToasts.getState().push('Saved x.wav', 100000);
+    expect(useToasts.getState().toasts.map((t) => t.message)).toEqual(['Saved x.wav']);
+    const id = useToasts.getState().toasts[0].id;
+    useToasts.getState().dismiss(id);
+    expect(useToasts.getState().toasts).toEqual([]);
+  });
+});
+
+describe('saveBlob', () => {
+  const g = globalThis as Record<string, unknown>;
+  afterEach(() => {
+    delete g.showSaveFilePicker;
+    vi.mocked(downloadBlob).mockClear();
+  });
+
+  it('uses the file picker when available and returns the chosen name', async () => {
+    const write = vi.fn();
+    const close = vi.fn();
+    g.showSaveFilePicker = vi.fn(async () => ({
+      name: 'take.wav',
+      createWritable: async () => ({ write, close }),
+    }));
+    const res = await saveBlob(new Blob(['a']), 'suggested.wav');
+    expect(res).toEqual({ filename: 'take.wav', viaPicker: true });
+    expect(write).toHaveBeenCalledOnce();
+    expect(close).toHaveBeenCalledOnce();
+    expect(downloadBlob).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the user cancels the picker', async () => {
+    g.showSaveFilePicker = vi.fn(async () => {
+      throw new DOMException('cancelled', 'AbortError');
+    });
+    expect(await saveBlob(new Blob(['a']), 'x.wav')).toBeNull();
+    expect(downloadBlob).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a download (not null) on a non-cancel picker failure', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    g.showSaveFilePicker = vi.fn(async () => {
+      throw new Error('disk full');
+    });
+    const res = await saveBlob(new Blob(['a']), 'x.wav');
+    expect(res).toEqual({ filename: 'x.wav', viaPicker: false });
+    expect(downloadBlob).toHaveBeenCalledWith(expect.any(Blob), 'x.wav');
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('skips the picker and downloads directly when allowPicker is false', async () => {
+    const picker = vi.fn();
+    g.showSaveFilePicker = picker;
+    const res = await saveBlob(new Blob(['a']), 'x.wav', { allowPicker: false });
+    expect(res).toEqual({ filename: 'x.wav', viaPicker: false });
+    expect(picker).not.toHaveBeenCalled();
+    expect(downloadBlob).toHaveBeenCalledWith(expect.any(Blob), 'x.wav');
+  });
+
+  it('falls back to a download when no picker exists', async () => {
+    const res = await saveBlob(new Blob(['a']), 'x.wav');
+    expect(res).toEqual({ filename: 'x.wav', viaPicker: false });
+    expect(downloadBlob).toHaveBeenCalledWith(expect.any(Blob), 'x.wav');
+  });
+});

--- a/test/webcam_face.test.ts
+++ b/test/webcam_face.test.ts
@@ -10,8 +10,11 @@
  *   3. lazy offload on disable + retry on re-enable + idempotent dispose,
  *   4. the GPU→CPU delegate fallback when GPU creation fails.
  */
-import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { NodeContext } from '@/dag';
+
+/** Drain pending microtasks (the mocked async load chain resolves on them). */
+const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
 
 // Mocked MediaPipe runtime — hoisted so the vi.mock factory can reference the spies.
 const { forVisionTasks, createFromOptions, fakeLandmarker } = vi.hoisted(() => {
@@ -47,19 +50,27 @@ const ctx = (faceEnabled?: boolean, video?: unknown): NodeContext =>
 // A truthy <video> stand-in; never "ready" so the inference loop never fires.
 const fakeVideo = () => ({ readyState: 0, videoWidth: 0, currentTime: 0 }) as unknown;
 
-beforeAll(() => {
-  // The node starts a requestAnimationFrame loop once the (mocked) model loads;
-  // a no-op rAF keeps it from recursing or referencing a missing browser global.
-  const g = globalThis as Record<string, unknown>;
-  g.requestAnimationFrame ??= () => 0;
-  g.cancelAnimationFrame ??= () => {};
-});
+// The node starts a requestAnimationFrame loop once the (mocked) model loads.
+// Force a no-op rAF (and restore it after) so the loop never schedules real work
+// and we don't pollute the shared global for other test files.
+const g = globalThis as Record<string, unknown>;
+let savedRaf: unknown;
+let savedCaf: unknown;
 
 beforeEach(() => {
+  savedRaf = g.requestAnimationFrame;
+  savedCaf = g.cancelAnimationFrame;
+  g.requestAnimationFrame = () => 0;
+  g.cancelAnimationFrame = () => {};
   forVisionTasks.mockClear();
   createFromOptions.mockClear();
   createFromOptions.mockImplementation(async () => fakeLandmarker);
   fakeLandmarker.close.mockClear();
+});
+
+afterEach(() => {
+  g.requestAnimationFrame = savedRaf;
+  g.cancelAnimationFrame = savedCaf;
 });
 
 describe('blendshapesToFaceFrame', () => {
@@ -106,7 +117,7 @@ describe('webcam-face node gating', () => {
     expect(createFromOptions).not.toHaveBeenCalled();
   });
 
-  it('offloads on disable, re-enables, and is idempotent on dispose — never throws', () => {
+  it('offloads on disable, re-enables, and is idempotent on dispose — never throws', async () => {
     const inst = webcamFaceNode.make({ delegate: 'GPU' });
     let faceEnabled = true;
     const live = ctx(true, fakeVideo());
@@ -126,22 +137,34 @@ describe('webcam-face node gating', () => {
       inst.dispose?.();
     }).not.toThrow();
     expect(inst.process({}, live)).toEqual(ABSENT);
+    await flush(); // let the dangling mocked load settle (it self-closes)
   });
 });
 
 describe('webcam-face delegate fallback', () => {
   it('falls back to the CPU delegate when GPU model creation fails', async () => {
+    // Resolve exactly when the 2nd (CPU) create is invoked — deterministic under
+    // any load, unlike a timed flush of the import→fileset→create chain.
+    let resolveSecondCall = () => {};
+    const secondCall = new Promise<void>((r) => {
+      resolveSecondCall = r;
+    });
     createFromOptions
       .mockRejectedValueOnce(new Error('no webgl'))
-      .mockResolvedValueOnce(fakeLandmarker);
+      .mockImplementationOnce(async () => {
+        resolveSecondCall();
+        return fakeLandmarker;
+      });
     const inst = webcamFaceNode.make({ delegate: 'GPU' });
-    inst.process({}, ctx(true, fakeVideo())); // kicks the async load
-    await vi.waitFor(() => expect(createFromOptions).toHaveBeenCalledTimes(2));
+    inst.process({}, ctx(true, fakeVideo())); // kicks the async load (GPU fails → CPU)
+    await secondCall;
+    expect(createFromOptions).toHaveBeenCalledTimes(2);
     const calls = createFromOptions.mock.calls as unknown as Array<
       [unknown, { baseOptions: { delegate: string } }]
     >;
     expect(calls[0][1].baseOptions.delegate).toBe('GPU');
     expect(calls[1][1].baseOptions.delegate).toBe('CPU');
     inst.dispose?.();
+    await flush(); // settle the resolved load (no-op rAF; landmarker set then disposed)
   });
 });


### PR DESCRIPTION
## What

The core of #49 — recording settings. You can now choose the **output format(s)** for a take, pick **where it's saved**, and get a **"saved as …" toast**, on top of the existing WebM/Opus capture.

## How

- **Open-closed format registry** (`src/app/recording/formats.ts`): WebM (native passthrough) + in-house **WAV** (lazy-imported encoder). The native take is decoded once and re-encoded per non-native format. MP3 (lamejs) and ffmpeg.wasm "any format" slot in via the same lazy-loader shape.
- **Browser WAV encoder** (`src/app/recording/wav.ts`): 16-bit PCM, multi-channel, `ArrayBuffer`/`Blob`; mirrors `scripts/lib_audio.ts` `writeWav`. Pure + unit-tested (header bytes, interleave, clamp).
- **Save location** (`src/app/recording/save.ts`): `showSaveFilePicker` when supported, else an anchor download (→ Downloads). The picker is offered for the **first** file only when several formats are selected — one stop = at most one dialog; a non-cancel picker failure logs and falls back so the take is never lost.
- **Toasts** (`src/app/toasts.ts` + `Toaster.tsx`): a tiny store + bottom-center UI; one "Saved &lt;name&gt;" per file.
- **Settings** (`store.ts` + a **Recording** section in `ControlsPanel`): `recordingFormats` persisted (always ≥1 selected); a tooling preference, deliberately not part of a musical preset.
- `useEngine`: on stop, convert + save each selected format + toast; a **"Saving…"** button state while the save / file dialog is pending.

## Review

An adversarial multi-agent review ran against the change; the 3 confirmed (UX-polish) findings were applied: single-dialog multi-format policy, the "Saving…" feedback, and picker-failure logging. 7 lower findings were verified and refuted. Also de-flaked the webcam-face CPU-fallback test (deterministic completion signal).

## Tests

`npm run typecheck` + `npm test` (155, stable over 4 runs) + `npm run build` (WAV encoder code-split). New `test/recording.test.ts` covers the WAV encoder, the format registry, the store invariant, the toast store, and `saveBlob` (picker / cancel / non-cancel-failure / allowPicker:false / no-picker fallback).

## Deferred (follow-ups on #49)

MP3 (lamejs) + ffmpeg.wasm "any format"; what-to-record beyond audio — overlay-as-video (`canvas.captureStream`), raw video, and feature-stream NDJSON taps. Using `refs #49` (not `closes`) so the issue stays open for these.

Part of #45.

https://claude.ai/code/session_01JEoe7y1hA5KdEAvvpQXxxt
