### PR TITLE
Mapping-slot contract + developer-facing node-swap seam (refs #51)

### DIFF
--- a/src/app/graph.ts
+++ b/src/app/graph.ts
@@ -16,9 +16,95 @@
  * One output may fan OUT to several inputs (webcam→features & overlay); only
  * fan-IN to a single input port is disallowed.
  */
-import type { GraphSpec } from '@/dag';
+import type { GraphSpec, NodeRegistry, Role } from '@/dag';
+import { MAPPING_SLOT_CONTRACT, type SlotContract } from '@/nodes/mapping/mapping_contract';
 
-export function defaultGraph(): GraphSpec {
+/**
+ * A Slot is a named, role-typed swap point the graph builder fills from config.
+ * `default` is used when no/invalid selection is given; `candidates` is the set
+ * of REAL interchangeable implementations today (the SSOT for "what can fill
+ * this slot" — not `registry.listByRole`, which is advisory and broader).
+ *
+ * Governance (docs/design/component-model.md): a slot graduates to a user-facing
+ * dropdown only at >=2 candidates. The `mapping` slot has one today, so this is a
+ * developer-facing seam (graphs are data): selection is honored + validated, but
+ * there is no UI. Adding the second hand-features→synth-params mapping is a
+ * one-line `candidates` extension that activates real swapping.
+ */
+export interface SlotDef {
+  role: Role;
+  default: string;
+  candidates: string[];
+  contract: SlotContract;
+}
+
+export const SLOTS: Record<string, SlotDef> = {
+  mapping: {
+    role: 'mapping',
+    default: 'voice-mapping',
+    candidates: ['voice-mapping'],
+    contract: MAPPING_SLOT_CONTRACT,
+  },
+};
+
+/** Per-slot chosen node types (keys ⊆ SLOTS keys); all optional → defaults used. */
+export type SlotSelection = Partial<Record<keyof typeof SLOTS, string>>;
+
+/**
+ * Why a node type does NOT satisfy a slot, or `null` if it does. Checks, in order:
+ * registered, carries the slot role, emits the slot's output port+kind, and
+ * declares every required input port. (The engine's validateEdge only checks port
+ * names, so this is the pre-flight that catches a bad swap before construction.)
+ */
+function slotFillReason(type: string, slot: SlotDef, registry: NodeRegistry): string | null {
+  if (!registry.has(type)) return 'is not a registered node type';
+  const def = registry.get(type);
+  if (!def.roles?.includes(slot.role)) return `does not carry role "${slot.role}"`;
+  const out = def.outputs.find((p) => p.name === slot.contract.output.name);
+  if (!out) return `has no output port "${slot.contract.output.name}"`;
+  if (out.kind !== slot.contract.output.kind) {
+    return `output "${out.name}" is kind "${out.kind}", not "${slot.contract.output.kind}"`;
+  }
+  const inputNames = new Set(def.inputs.map((p) => p.name));
+  const missing = slot.contract.requiredInputs.filter((n) => !inputNames.has(n));
+  if (missing.length) return `is missing required input ports: ${missing.join(', ')}`;
+  return null;
+}
+
+/**
+ * Resolve a slot to a concrete node type. Returns the slot default unless a valid,
+ * contract-satisfying selection is given; warns and falls back on a stale/invalid
+ * one (or when no registry is available to validate against).
+ */
+export function resolveSlot(
+  slotKey: keyof typeof SLOTS,
+  selection?: SlotSelection,
+  registry?: NodeRegistry,
+  warn: (msg: string) => void = (m) => console.warn(m),
+): string {
+  const slot = SLOTS[slotKey];
+  const chosen = selection?.[slotKey];
+  if (!chosen || chosen === slot.default) return slot.default;
+  if (!registry) {
+    warn(`Slot "${slotKey}": cannot validate "${chosen}" without a registry; using "${slot.default}".`);
+    return slot.default;
+  }
+  const reason = slotFillReason(chosen, slot, registry);
+  if (reason) {
+    warn(`Slot "${slotKey}": "${chosen}" ${reason}; falling back to "${slot.default}".`);
+    return slot.default;
+  }
+  return chosen;
+}
+
+/**
+ * Build the default instrument graph. With no `selection` it is byte-identical to
+ * before (all slots use their defaults). A `selection` (validated against
+ * `registry`) swaps slot-bound node types — the edges reference only port names
+ * the slot contract guarantees, so a contract-satisfying swap stays edge-stable.
+ */
+export function defaultGraph(selection?: SlotSelection, registry?: NodeRegistry): GraphSpec {
+  const mappingType = resolveSlot('mapping', selection, registry);
   return {
     nodes: [
       { id: 'cam', type: 'webcam-hands', params: { modelType: 'full', maxHands: 2 } },
@@ -29,7 +115,7 @@ export function defaultGraph(): GraphSpec {
       { id: 'kbd', type: 'keyboard-source' },
       { id: 'kctrl', type: 'keyboard-control', params: { magnetismStart: 0.8 } },
       { id: 'ui', type: 'store-controls' },
-      { id: 'map', type: 'voice-mapping', params: { magnetism: 0.8, maxGain: 0.5 } },
+      { id: 'map', type: mappingType, params: { magnetism: 0.8, maxGain: 0.5 } },
       { id: 'synth', type: 'webaudio-synth' },
       // Overlay elements default on (video/scaleGuide/landmarks/markers); the
       // opt-in index-finger guide is off by default. See canvas_overlay.ts.

--- a/src/nodes/mapping/mapping_contract.ts
+++ b/src/nodes/mapping/mapping_contract.ts
@@ -1,0 +1,57 @@
+/**
+ * The mapping-slot contract — the shared, exported input/output port surface that
+ * any node intending to fill the `mapping` slot (hand features + live controls →
+ * `synth-params`) must declare. This is the load-bearing prerequisite for
+ * node-swap slots (see docs/design/component-model.md, "Two corrections" #1):
+ *
+ * `validateEdge` (src/dag/engine.ts) accepts an edge only if the target node
+ * DECLARES an input port of that name. The default graph wires nine edges into
+ * the mapping slot (features + face + the keyboard/UI control surface). So a node
+ * can only be swapped into that slot without orphaning those edges if it declares
+ * the same input port NAMES — which it guarantees by spreading these specs.
+ *
+ * Structural contract only: port *names* are what the engine checks; `kind` is
+ * advisory (never runtime-enforced), per the design doc's deliberate stance. No
+ * Zod validator and no kind enforcement here — "a shared TS type on the swap
+ * contract is free and enough".
+ *
+ * Today `voice-mapping` is the sole implementation; the contract makes the next
+ * hand-features→synth-params mapping a clean, edge-stable drop-in.
+ */
+import type { PortSpec, Role } from '@/dag';
+
+/**
+ * Input ports every mapping-slot node must declare so the default graph's
+ * features/face/control edges stay valid across a swap. Spread into `inputs`.
+ */
+export const MAPPING_SLOT_INPUTS: PortSpec[] = [
+  { name: 'features', kind: 'hand-features' },
+  // Live control side-inputs (from keyboard-control); unconnected → static params.
+  { name: 'magnetism', kind: 'number', description: 'Override magnetism 0..1' },
+  { name: 'octaveShift', kind: 'number', default: 0, description: 'Transpose by N octaves' },
+  { name: 'mute', kind: 'boolean', default: false },
+  // Live scale/instrument overrides (from store-controls).
+  { name: 'scaleRight', kind: 'number[]' },
+  { name: 'scaleLeft', kind: 'number[]' },
+  { name: 'instrumentRight', kind: 'instrument' },
+  { name: 'instrumentLeft', kind: 'instrument' },
+  // Optional facial expression (from face-features).
+  { name: 'face', kind: 'face-features' },
+];
+
+/** The output port a mapping-slot node must emit (consumed by synth + overlay). */
+export const MAPPING_SLOT_OUTPUT: PortSpec = { name: 'params', kind: 'synth-params' };
+
+/**
+ * What a candidate node must satisfy to fill the mapping slot: the advisory role,
+ * the required input port names (engine checks these), and the output port
+ * name+kind (so downstream `synth`/`overlay` edges keep working). Consumed by the
+ * slot resolver's validation in `src/app/graph.ts`.
+ */
+export const MAPPING_SLOT_CONTRACT = {
+  role: 'mapping' as Role,
+  requiredInputs: MAPPING_SLOT_INPUTS.map((p) => p.name),
+  output: MAPPING_SLOT_OUTPUT,
+} as const;
+
+export type SlotContract = typeof MAPPING_SLOT_CONTRACT;

--- a/src/nodes/mapping/voice_mapping.ts
+++ b/src/nodes/mapping/voice_mapping.ts
@@ -22,6 +22,7 @@ import {
 } from '@/music/theory';
 import { InstrumentSchema, INSTRUMENT_IDS } from '@/music/instruments';
 import { ABSENT_HAND, type FaceFeatures, type HandFeatures, type SynthParams, type VoiceParams } from '../domain';
+import { MAPPING_SLOT_INPUTS, MAPPING_SLOT_OUTPUT } from './mapping_contract';
 
 /** How much a full smile / open mouth add to brightness / vibrato (0..1). */
 const FACE_SMILE_BRIGHTNESS = 0.5;
@@ -114,23 +115,11 @@ export const voiceMappingNode = defineNode<Params>({
   roles: ['mapping'],
   title: 'Voice Mapping',
   description: 'Hand features → tonal synth parameters (x→pitch w/ scale snap, y→volume).',
-  inputs: [
-    { name: 'features', kind: 'hand-features' },
-    // Optional live control. When unconnected, the static params are used.
-    { name: 'magnetism', kind: 'number', description: 'Override magnetism 0..1' },
-    { name: 'octaveShift', kind: 'number', default: 0, description: 'Transpose by N octaves' },
-    { name: 'mute', kind: 'boolean', default: false },
-    // Optional live scale override (list of MIDI notes). Lets the UI change
-    // scale/key without rebuilding the graph or reloading the ML model.
-    { name: 'scaleRight', kind: 'number[]' },
-    { name: 'scaleLeft', kind: 'number[]' },
-    { name: 'instrumentRight', kind: 'instrument' },
-    { name: 'instrumentLeft', kind: 'instrument' },
-    // Optional face expression (from face-features). When present, smile adds
-    // brightness and an open mouth adds vibrato. Unconnected → no effect.
-    { name: 'face', kind: 'face-features' },
-  ],
-  outputs: [{ name: 'params', kind: 'synth-params' }],
+  // The reference implementation of the mapping slot: declares exactly the
+  // shared input/output contract (src/nodes/mapping/mapping_contract.ts), so any
+  // future hand-features→synth-params mapping is an edge-stable drop-in.
+  inputs: [...MAPPING_SLOT_INPUTS],
+  outputs: [MAPPING_SLOT_OUTPUT],
   params: Params,
   process(inputs, p) {
     const f = (inputs.features as HandFeatures | undefined) ?? {

--- a/test/slots.test.ts
+++ b/test/slots.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests the node-swap slots seam (issue #51): the shared mapping contract, slot
+ * resolution + validation/fallback, and — the load-bearing guarantee — that a
+ * contract-satisfying node swaps into the mapping slot without the engine's
+ * validateEdge orphaning any of the slot's nine incoming / two outgoing edges.
+ *
+ * This is a developer-facing seam (no UI today; only `voice-mapping` fills the
+ * slot). The stub-node tests prove the machinery so the next real mapping impl
+ * is a one-line `candidates` addition.
+ */
+import { describe, it, expect } from 'vitest';
+import { Engine, createRegistry, defineNode, type NodeRegistry } from '@/dag';
+import { createAppRegistry, BROWSER_NODES } from '@/nodes/browser';
+import { CORE_NODES } from '@/nodes';
+import { voiceMappingNode } from '@/nodes/mapping/voice_mapping';
+import { SLOTS, resolveSlot, defaultGraph, type SlotSelection } from '@/app/graph';
+import {
+  MAPPING_SLOT_INPUTS,
+  MAPPING_SLOT_OUTPUT,
+  MAPPING_SLOT_CONTRACT,
+} from '@/nodes/mapping/mapping_contract';
+
+const appRegistry = (): NodeRegistry => createAppRegistry();
+
+/** Resolve with a capturing warn so we can assert the fallback reason. */
+const resolveWithWarn = (sel: SlotSelection, reg?: NodeRegistry) => {
+  const warnings: string[] = [];
+  const type = resolveSlot('mapping', sel, reg, (m) => warnings.push(m));
+  return { type, warnings };
+};
+
+describe('mapping slot contract', () => {
+  it('voice-mapping (the reference impl) satisfies its own contract', () => {
+    const names = new Set(voiceMappingNode.inputs.map((p) => p.name));
+    for (const required of MAPPING_SLOT_CONTRACT.requiredInputs) {
+      expect(names.has(required)).toBe(true);
+    }
+    const out = voiceMappingNode.outputs.find((p) => p.name === MAPPING_SLOT_OUTPUT.name);
+    expect(out?.kind).toBe(MAPPING_SLOT_OUTPUT.kind);
+    expect(voiceMappingNode.roles).toContain('mapping');
+  });
+
+  it('the mapping slot defaults to voice-mapping with one candidate today', () => {
+    expect(SLOTS.mapping.default).toBe('voice-mapping');
+    expect(SLOTS.mapping.candidates).toEqual(['voice-mapping']);
+  });
+});
+
+describe('resolveSlot', () => {
+  it('returns the default when no selection is given', () => {
+    expect(resolveSlot('mapping')).toBe('voice-mapping');
+    expect(resolveSlot('mapping', {})).toBe('voice-mapping');
+  });
+
+  it('honors an explicit, valid selection', () => {
+    expect(resolveSlot('mapping', { mapping: 'voice-mapping' }, appRegistry())).toBe('voice-mapping');
+  });
+
+  it('falls back + warns on an unregistered type', () => {
+    const { type, warnings } = resolveWithWarn({ mapping: 'nope' }, appRegistry());
+    expect(type).toBe('voice-mapping');
+    expect(warnings[0]).toContain('is not a registered node type');
+  });
+
+  it('falls back + warns on a wrong-role type', () => {
+    const { type, warnings } = resolveWithWarn({ mapping: 'hand-features' }, appRegistry());
+    expect(type).toBe('voice-mapping');
+    expect(warnings[0]).toContain('does not carry role "mapping"');
+  });
+
+  it('falls back + warns when the type lacks the slot output port', () => {
+    // indirect-map IS role:mapping but emits `steer:generative-steer`, not `params`.
+    const { type, warnings } = resolveWithWarn({ mapping: 'indirect-map' }, appRegistry());
+    expect(type).toBe('voice-mapping');
+    expect(warnings[0]).toContain('has no output port "params"');
+  });
+
+  it('falls back + warns on a wrong output kind', () => {
+    const reg = appRegistry();
+    reg.register(
+      defineNode({
+        type: 'wrong-kind-mapping',
+        roles: ['mapping'],
+        inputs: [...MAPPING_SLOT_INPUTS],
+        outputs: [{ name: 'params', kind: 'not-synth-params' }],
+        process: () => ({ params: null }),
+      }),
+    );
+    const { type, warnings } = resolveWithWarn({ mapping: 'wrong-kind-mapping' }, reg);
+    expect(type).toBe('voice-mapping');
+    expect(warnings[0]).toContain('not "synth-params"');
+  });
+
+  it('falls back + warns when required input ports are missing', () => {
+    const reg = appRegistry();
+    reg.register(
+      defineNode({
+        type: 'thin-mapping',
+        roles: ['mapping'],
+        inputs: [{ name: 'features', kind: 'hand-features' }], // missing magnetism, face, …
+        outputs: [MAPPING_SLOT_OUTPUT],
+        process: () => ({ params: { voices: [] } }),
+      }),
+    );
+    const { type, warnings } = resolveWithWarn({ mapping: 'thin-mapping' }, reg);
+    expect(type).toBe('voice-mapping');
+    expect(warnings[0]).toContain('missing required input ports');
+    expect(warnings[0]).toContain('magnetism');
+  });
+
+  it('falls back + warns when given a selection but no registry to validate', () => {
+    const { type, warnings } = resolveWithWarn({ mapping: 'voice-mapping-x' }, undefined);
+    expect(type).toBe('voice-mapping');
+    expect(warnings[0]).toContain('without a registry');
+  });
+});
+
+describe('defaultGraph slot binding', () => {
+  it('is byte-identical with no selection vs the default selection', () => {
+    expect(defaultGraph()).toEqual(defaultGraph({}, appRegistry()));
+    expect(defaultGraph()).toEqual(defaultGraph({ mapping: 'voice-mapping' }, appRegistry()));
+  });
+
+  it('builds a valid engine with the default mapping (regression)', () => {
+    expect(() => new Engine(defaultGraph(), createAppRegistry())).not.toThrow();
+  });
+
+  it('EDGE-STABILITY: a contract-satisfying node swaps in without orphaning edges', () => {
+    const reg = createRegistry([...CORE_NODES, ...BROWSER_NODES]);
+    // A second mapping impl that declares exactly the shared contract.
+    reg.register(
+      defineNode({
+        type: 'alt-mapping',
+        roles: ['mapping'],
+        inputs: [...MAPPING_SLOT_INPUTS],
+        outputs: [MAPPING_SLOT_OUTPUT],
+        process: () => ({ params: { voices: [] } }),
+      }),
+    );
+    const spec = defaultGraph({ mapping: 'alt-mapping' }, reg);
+    expect(spec.nodes.find((n) => n.id === 'map')?.type).toBe('alt-mapping');
+    // The real engine validates every edge against the swapped node's ports.
+    expect(() => new Engine(spec, reg)).not.toThrow();
+  });
+
+  it('a non-conforming selection falls back so the engine still builds', () => {
+    const reg = createAppRegistry();
+    const spec = defaultGraph({ mapping: 'indirect-map' }, reg, );
+    expect(spec.nodes.find((n) => n.id === 'map')?.type).toBe('voice-mapping');
+    expect(() => new Engine(spec, reg)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## What

The honest, correctly-scoped #51: the **load-bearing prerequisite** (a shared mapping input/params contract) + a **tested, developer-facing slots seam** — and deliberately **not** a user-facing "swap the algorithm" dropdown, which the design doc defers.

## Why this scope (the audit result)

The three `synth-params` producers share only the **output**:
- `voice-mapping` (role `mapping`) — driven by hand features + the keyboard/UI control surface (9 inputs).
- `chord` / `score` (role `music`) — disjoint inputs, disjoint upstream subgraphs (`progression` / `transport`).
- `indirect-map` (role `mapping`) — emits `generative-steer` → Lyria, not `synth-params`.

So there is exactly **one** implementation of the mapping slot today. The governance gate for a user-facing dropdown (**≥2 real interchangeable impls**) is not met. Per `docs/design/component-model.md`, this stays a developer-facing seam ("graphs are data, ready to surface later").

## How

- **`src/nodes/mapping/mapping_contract.ts`** — the shared contract: `MAPPING_SLOT_INPUTS` (features/face + control surface), `MAPPING_SLOT_OUTPUT` (`params:synth-params`), `MAPPING_SLOT_CONTRACT`. Structural only — port **names** are what `validateEdge` checks; `kind` stays advisory.
- **`voice-mapping`** adopts the contract (`inputs: [...MAPPING_SLOT_INPUTS]`) — byte-identical port list, zero behavior change; it's now the slot's reference implementation.
- **`graph.ts`** — a `SLOTS` table (role-typed swap points), `resolveSlot()` + `slotFillReason()` validation (registered **AND** role **AND** output port+kind **AND** required inputs → else default + warn), and `defaultGraph(selection?, registry?)` that binds the `map` node's type from the slot. With no selection it's byte-identical to before.

## Tests (+14, `test/slots.test.ts`)

Contract self-satisfaction; resolution; **every** fallback reason (unregistered / wrong role / no output port / wrong output kind / missing inputs / no-registry); a byte-identical-graph regression guard; and the **load-bearing edge-stability proof** — a contract-satisfying stub node swaps into the slot and the real `Engine` constructs without orphaning any of the slot's 9 incoming / 2 outgoing edges. `npm run typecheck` + `npm test` (169) + `npm run build` all green.

## Deferred (until a real 2nd mapping impl exists, per governance)

Persisting a selection in the store; the live engine-rebuild-on-swap lifecycle (incl. a MediaPipe model-reuse cache so a swap doesn't reload the model / freeze the loop); any swap UI. **No user-facing change** — build + catalog are byte-identical, so no deploy is warranted.

Part of #45.

https://claude.ai/code/session_01JEoe7y1hA5KdEAvvpQXxxt
