### PR TITLE
Face mapping chooser + expression→chord + face feedback (#64, #65)

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -21,7 +21,7 @@ This page catalogs the engine's building blocks — every node and how they conn
 - **Discrete triggers** — `hand-features → gesture-classifier → (events)`  
   Fist/open/pinch poses emit enter/exit events to trigger scale changes, stabs, mutes.
 
-## Nodes (22)
+## Nodes (25)
 
 ### Inputs (sources)
 _Where signals enter the graph._
@@ -39,7 +39,7 @@ MediaPipe FaceLandmarker blendshapes from the shared webcam (lazy-loaded, off by
 
 - **roles:** source
 - **in:** —
-- **out:** face:face-frame
+- **out:** face:face-frame, status:face-status
 - **params:** delegate (enum(GPU | CPU)="GPU")
 
 #### `keyboard-source` — Keyboard Source
@@ -55,7 +55,7 @@ Reads the live UI control store → scale + instrument + overlay port values.
 
 - **roles:** source, control
 - **in:** —
-- **out:** scaleRight:number[], scaleLeft:number[], instrumentRight:instrument, instrumentLeft:instrument, overlay:overlay-config
+- **out:** scaleRight:number[], scaleLeft:number[], instrumentRight:instrument, instrumentLeft:instrument, overlay:overlay-config, rightSpec:scale-spec, faceMapping:face-mapping
 - **params:** —
 
 #### `synthetic-hands` — Synthetic Hands
@@ -92,6 +92,14 @@ Face blendshapes → normalized expression controls (smile, mouthOpen, brow, bli
 - **in:** face:face-frame
 - **out:** features:face-features
 - **params:** gain (number=1), smoothing (number=0)
+
+#### `face-expression` — Face Expression
+Face blendshapes → softmax over 7 expressions (happy/sad/angry/surprised/fearful/disgusted/neutral) with smoothing + hysteresis.
+
+- **roles:** feature
+- **in:** face:face-frame
+- **out:** expression:face-expression
+- **params:** smoothing (number=0.4), temperature (number=0.12), holdMargin (number=0.06)
 
 #### `gesture-classifier` — Gesture Classifier
 Hand features → discrete poses (fist/open/pinch) + enter/exit edge events.
@@ -144,6 +152,14 @@ Adaptive jitter smoothing for a noisy control value (smooth at rest, responsive 
 - **out:** value:number
 - **params:** minCutoff (number=1), beta (number=0.01), dCutoff (number=1), fallbackDt (number=0.016666666666666666)
 
+#### `synth-merge` — Synth Merge
+Union two synth-params voice streams into one (e.g. hand voices + face-chord voices).
+
+- **roles:** mapping
+- **in:** a:synth-params, b:synth-params
+- **out:** params:synth-params
+- **params:** —
+
 ### Music logic (tonal guidance)
 _Harmony kept in-key._
 
@@ -162,6 +178,14 @@ Roman-numeral progression in a key + position (0..1) → current chord symbol.
 - **in:** position:number
 - **out:** chord:chord-symbol, index:number
 - **params:** key (string="C"), romanNumerals (array=["I","IV","V","vi"])
+
+#### `expression-chord` — Expression Chord
+Facial expression → the diatonic triad on its confusion-aware scale degree (active only in face "chord" mode on seven-note scales).
+
+- **roles:** music
+- **in:** expression:face-expression, spec:scale-spec, faceMapping:face-mapping, octaveShift:number
+- **out:** params:synth-params, triad:number[]
+- **params:** gain (number=0.22), instrument (enum(sine | triangle | square | sawtooth | warmPad | glass | bell | organ | voice | softLead | strings | flute | brass | choir)="triangle")
 
 ### Conductor mode
 _Direct a fixed piece with gesture (tempo + dynamics)._
@@ -216,7 +240,7 @@ _Audio + the captured video with overlaid guides._
 Mirrored video + composable overlay elements (guides, landmarks, markers).
 
 - **roles:** overlay
-- **in:** hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], octaveShift:number, overlayConfig:overlay-config
+- **in:** hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], chord:number[], octaveShift:number, overlayConfig:overlay-config
 - **out:** —
-- **params:** video (object={}), scaleGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={})
+- **params:** video (object={}), scaleGuide (object={}), chordGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={})
 

--- a/public/catalog.json
+++ b/public/catalog.json
@@ -28,6 +28,10 @@
         "kind": "number[]"
       },
       {
+        "name": "chord",
+        "kind": "number[]"
+      },
+      {
         "name": "octaveShift",
         "kind": "number",
         "default": 0
@@ -46,6 +50,11 @@
       },
       {
         "name": "scaleGuide",
+        "type": "object",
+        "default": {}
+      },
+      {
+        "name": "chordGuide",
         "type": "object",
         "default": {}
       },
@@ -106,6 +115,93 @@
         "name": "instrument",
         "type": "enum(sine | triangle | square | sawtooth | warmPad | glass | bell | organ | voice | softLead | strings | flute | brass | choir)",
         "default": "sine"
+      }
+    ]
+  },
+  {
+    "type": "expression-chord",
+    "title": "Expression Chord",
+    "description": "Facial expression → the diatonic triad on its confusion-aware scale degree (active only in face \"chord\" mode on seven-note scales).",
+    "roles": [
+      "music"
+    ],
+    "inputs": [
+      {
+        "name": "expression",
+        "kind": "face-expression"
+      },
+      {
+        "name": "spec",
+        "kind": "scale-spec"
+      },
+      {
+        "name": "faceMapping",
+        "kind": "face-mapping",
+        "default": "none"
+      },
+      {
+        "name": "octaveShift",
+        "kind": "number",
+        "default": 0
+      }
+    ],
+    "outputs": [
+      {
+        "name": "params",
+        "kind": "synth-params"
+      },
+      {
+        "name": "triad",
+        "kind": "number[]"
+      }
+    ],
+    "params": [
+      {
+        "name": "gain",
+        "type": "number",
+        "default": 0.22
+      },
+      {
+        "name": "instrument",
+        "type": "enum(sine | triangle | square | sawtooth | warmPad | glass | bell | organ | voice | softLead | strings | flute | brass | choir)",
+        "default": "triangle"
+      }
+    ]
+  },
+  {
+    "type": "face-expression",
+    "title": "Face Expression",
+    "description": "Face blendshapes → softmax over 7 expressions (happy/sad/angry/surprised/fearful/disgusted/neutral) with smoothing + hysteresis.",
+    "roles": [
+      "feature"
+    ],
+    "inputs": [
+      {
+        "name": "face",
+        "kind": "face-frame"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "expression",
+        "kind": "face-expression"
+      }
+    ],
+    "params": [
+      {
+        "name": "smoothing",
+        "type": "number",
+        "default": 0.4
+      },
+      {
+        "name": "temperature",
+        "type": "number",
+        "default": 0.12
+      },
+      {
+        "name": "holdMargin",
+        "type": "number",
+        "default": 0.06
       }
     ]
   },
@@ -688,6 +784,39 @@
       {
         "name": "overlay",
         "kind": "overlay-config"
+      },
+      {
+        "name": "rightSpec",
+        "kind": "scale-spec"
+      },
+      {
+        "name": "faceMapping",
+        "kind": "face-mapping"
+      }
+    ],
+    "params": []
+  },
+  {
+    "type": "synth-merge",
+    "title": "Synth Merge",
+    "description": "Union two synth-params voice streams into one (e.g. hand voices + face-chord voices).",
+    "roles": [
+      "mapping"
+    ],
+    "inputs": [
+      {
+        "name": "a",
+        "kind": "synth-params"
+      },
+      {
+        "name": "b",
+        "kind": "synth-params"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "params",
+        "kind": "synth-params"
       }
     ],
     "params": []
@@ -940,6 +1069,10 @@
       {
         "name": "face",
         "kind": "face-frame"
+      },
+      {
+        "name": "status",
+        "kind": "face-status"
       }
     ],
     "params": [

--- a/public/manual.html
+++ b/public/manual.html
@@ -23,7 +23,7 @@
   .examples code { color: #7dd3fc; } .note { color: #9aa; font-size: 13px; }
 </style></head><body><div class="wrap">
   <h1>θ Thoremin — Capabilities Manual</h1>
-  <p class="gen">Auto-generated from the node registry. 22 nodes.</p>
+  <p class="gen">Auto-generated from the node registry. 25 nodes.</p>
   <p>Thoremin turns live sensor streams (webcam hand gestures, facial expressions, computer keyboard, later MIDI) into a live audiovisual stream — musical audio plus the captured video with overlaid guides. You build instruments by wiring small, typed <b>nodes</b> into a dataflow graph (DAG): inputs → features → mapping → music-logic → synthesis/generation → output. Every edge can be recorded and replayed.</p><p>The mapping layer spans a spectrum: <b>direct</b> (a gesture *is* a note/parameter — e.g. hand position → scale-snapped pitch) through <b>indirect</b> (a gesture expresses a high-level idea — e.g. openness → musical density steering an AI model), including <b>conductor</b> mode (direct a fixed piece's tempo and dynamics).</p><p>This page catalogs the engine's building blocks — every node and how they connect. Some already run in the deployed app; wiring the full graph into the live instrument is in progress.</p>
   <h3>Example pipelines</h3>
   <ul class="examples"><li><b>Theremin (direct)</b> — <code>webcam-hands → hand-features → voice-mapping → webaudio-synth ( + canvas-overlay)</code><br/><span class="note">Hand x → scale-snapped pitch, y → volume. Two hands = two voices.</span></li><li><b>Gesture → harmony</b> — <code>hand-features → pick('right.x') → progression → chord → webaudio-synth</code><br/><span class="note">Hand position walks an in-key chord progression.</span></li><li><b>Conductor</b> — <code>control → performance → transport → score → webaudio-synth</code><br/><span class="note">A control signal directs a fixed piece's tempo + dynamics (accelerando/crescendo…).</span></li><li><b>Indirect / AI (gesture or expression)</b> — <code>hand-features / face-features → indirect-map → lyria</code><br/><span class="note">Openness/smile/etc. steer weighted prompts + dials of Google Lyria RealTime.</span></li><li><b>Discrete triggers</b> — <code>hand-features → gesture-classifier → (events)</code><br/><span class="note">Fist/open/pinch poses emit enter/exit events to trigger scale changes, stabs, mutes.</span></li></ul>
@@ -44,7 +44,7 @@
       <dl>
         <dt>roles</dt><dd>source</dd>
         <dt>in</dt><dd>—</dd>
-        <dt>out</dt><dd>face:face-frame</dd>
+        <dt>out</dt><dd>face:face-frame, status:face-status</dd>
         <dt>params</dt><dd>delegate (enum(GPU | CPU)="GPU")</dd>
       </dl>
     </div>
@@ -64,7 +64,7 @@
       <dl>
         <dt>roles</dt><dd>source, control</dd>
         <dt>in</dt><dd>—</dd>
-        <dt>out</dt><dd>scaleRight:number[], scaleLeft:number[], instrumentRight:instrument, instrumentLeft:instrument, overlay:overlay-config</dd>
+        <dt>out</dt><dd>scaleRight:number[], scaleLeft:number[], instrumentRight:instrument, instrumentLeft:instrument, overlay:overlay-config, rightSpec:scale-spec, faceMapping:face-mapping</dd>
         <dt>params</dt><dd>—</dd>
       </dl>
     </div>
@@ -107,6 +107,16 @@
         <dt>in</dt><dd>face:face-frame</dd>
         <dt>out</dt><dd>features:face-features</dd>
         <dt>params</dt><dd>gain (number=1), smoothing (number=0)</dd>
+      </dl>
+    </div>
+    <div class="node">
+      <h4><code>face-expression</code> <span class="title">Face Expression</span></h4>
+      <p>Face blendshapes → softmax over 7 expressions (happy/sad/angry/surprised/fearful/disgusted/neutral) with smoothing + hysteresis.</p>
+      <dl>
+        <dt>roles</dt><dd>feature</dd>
+        <dt>in</dt><dd>face:face-frame</dd>
+        <dt>out</dt><dd>expression:face-expression</dd>
+        <dt>params</dt><dd>smoothing (number=0.4), temperature (number=0.12), holdMargin (number=0.06)</dd>
       </dl>
     </div>
     <div class="node">
@@ -169,6 +179,16 @@
         <dt>out</dt><dd>value:number</dd>
         <dt>params</dt><dd>minCutoff (number=1), beta (number=0.01), dCutoff (number=1), fallbackDt (number=0.016666666666666666)</dd>
       </dl>
+    </div>
+    <div class="node">
+      <h4><code>synth-merge</code> <span class="title">Synth Merge</span></h4>
+      <p>Union two synth-params voice streams into one (e.g. hand voices + face-chord voices).</p>
+      <dl>
+        <dt>roles</dt><dd>mapping</dd>
+        <dt>in</dt><dd>a:synth-params, b:synth-params</dd>
+        <dt>out</dt><dd>params:synth-params</dd>
+        <dt>params</dt><dd>—</dd>
+      </dl>
     </div></div></section>
 <section><h3>Music logic (tonal guidance)</h3><p class="blurb">Harmony kept in-key.</p><div class="grid">
     <div class="node">
@@ -189,6 +209,16 @@
         <dt>in</dt><dd>position:number</dd>
         <dt>out</dt><dd>chord:chord-symbol, index:number</dd>
         <dt>params</dt><dd>key (string="C"), romanNumerals (array=["I","IV","V","vi"])</dd>
+      </dl>
+    </div>
+    <div class="node">
+      <h4><code>expression-chord</code> <span class="title">Expression Chord</span></h4>
+      <p>Facial expression → the diatonic triad on its confusion-aware scale degree (active only in face "chord" mode on seven-note scales).</p>
+      <dl>
+        <dt>roles</dt><dd>music</dd>
+        <dt>in</dt><dd>expression:face-expression, spec:scale-spec, faceMapping:face-mapping, octaveShift:number</dd>
+        <dt>out</dt><dd>params:synth-params, triad:number[]</dd>
+        <dt>params</dt><dd>gain (number=0.22), instrument (enum(sine | triangle | square | sawtooth | warmPad | glass | bell | organ | voice | softLead | strings | flute | brass | choir)="triangle")</dd>
       </dl>
     </div></div></section>
 <section><h3>Conductor mode</h3><p class="blurb">Direct a fixed piece with gesture (tempo + dynamics).</p><div class="grid">
@@ -249,9 +279,9 @@
       <p>Mirrored video + composable overlay elements (guides, landmarks, markers).</p>
       <dl>
         <dt>roles</dt><dd>overlay</dd>
-        <dt>in</dt><dd>hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], octaveShift:number, overlayConfig:overlay-config</dd>
+        <dt>in</dt><dd>hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], chord:number[], octaveShift:number, overlayConfig:overlay-config</dd>
         <dt>out</dt><dd>—</dd>
-        <dt>params</dt><dd>video (object={}), scaleGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={})</dd>
+        <dt>params</dt><dd>video (object={}), scaleGuide (object={}), chordGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={})</dd>
       </dl>
     </div></div></section>
 </div></body></html>

--- a/scripts/gen_catalog.ts
+++ b/scripts/gen_catalog.ts
@@ -19,9 +19,9 @@ const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 // Layer grouping for the manual (type → category, in display order).
 const CATEGORIES: Array<{ name: string; blurb: string; types: string[] }> = [
   { name: 'Inputs (sources)', blurb: 'Where signals enter the graph.', types: ['webcam-hands', 'webcam-face', 'keyboard-source', 'store-controls', 'synthetic-hands', 'replay-source'] },
-  { name: 'Features', blurb: 'Raw sensor data → normalized control signals.', types: ['hand-features', 'face-features', 'gesture-classifier'] },
-  { name: 'Mapping (direct ↔ indirect)', blurb: 'Features → engine parameters, across the expression spectrum.', types: ['voice-mapping', 'indirect-map', 'keyboard-control', 'pick', 'one-euro'] },
-  { name: 'Music logic (tonal guidance)', blurb: 'Harmony kept in-key.', types: ['chord', 'progression'] },
+  { name: 'Features', blurb: 'Raw sensor data → normalized control signals.', types: ['hand-features', 'face-features', 'face-expression', 'gesture-classifier'] },
+  { name: 'Mapping (direct ↔ indirect)', blurb: 'Features → engine parameters, across the expression spectrum.', types: ['voice-mapping', 'indirect-map', 'keyboard-control', 'pick', 'one-euro', 'synth-merge'] },
+  { name: 'Music logic (tonal guidance)', blurb: 'Harmony kept in-key.', types: ['chord', 'progression', 'expression-chord'] },
   { name: 'Conductor mode', blurb: 'Direct a fixed piece with gesture (tempo + dynamics).', types: ['transport', 'score', 'performance'] },
   { name: 'Synthesis & generation', blurb: 'Make sound — direct synthesis or steered AI music.', types: ['webaudio-synth', 'lyria'] },
   { name: 'Output', blurb: 'Audio + the captured video with overlaid guides.', types: ['canvas-overlay'] },

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -12,8 +12,43 @@
 import { useState } from 'react';
 import { Settings, X, Play, BookOpen, Circle, Square } from 'lucide-react';
 import { useThoreminEngine } from './useEngine';
+import { useControls } from './store';
+import { useFaceStatus } from './faceStatus';
 import ControlsPanel from './ControlsPanel';
 import Toaster from './Toaster';
+
+/** A compact face-status chip, visible even when the controls panel is collapsed
+ * (issue #65): only shown once a face mapping is active. */
+function FaceChip() {
+  const faceMapping = useControls((s) => s.faceMapping);
+  const status = useFaceStatus((s) => s.status);
+  const label = useFaceStatus((s) => s.label);
+  if (faceMapping === 'none') return null;
+
+  let dot = 'bg-white/40';
+  let text = 'face starting…';
+  if (status.phase === 'loading') {
+    dot = 'bg-amber-400 animate-pulse';
+    text = 'face loading';
+  } else if (status.phase === 'error') {
+    dot = 'bg-rose-500';
+    text = 'face error';
+  } else if (status.phase === 'ready') {
+    if (status.faceDetected) {
+      dot = 'bg-emerald-400';
+      text = label ?? 'face';
+    } else {
+      dot = 'bg-sky-400';
+      text = 'face ready';
+    }
+  }
+  return (
+    <div className="pointer-events-none absolute left-3 top-12 flex items-center gap-1.5 rounded-full bg-black/40 px-2 py-0.5 text-[9px] uppercase tracking-widest text-white/70 backdrop-blur">
+      <span className={`inline-block h-1.5 w-1.5 rounded-full ${dot}`} />
+      {text}
+    </div>
+  );
+}
 
 export default function App() {
   const { videoRef, canvasRef, status, error, audioOn, isRecording, isSaving, startAudio, toggleRecording } =
@@ -43,6 +78,7 @@ export default function App() {
           </div>
         </div>
       </div>
+      <FaceChip />
 
       {/* Bottom-left: link to the generated capabilities manual. */}
       <a

--- a/src/app/ControlsPanel.tsx
+++ b/src/app/ControlsPanel.tsx
@@ -10,9 +10,11 @@
  * in a collapsible translucent overlay so the video stays the focus.
  */
 import { useState } from 'react';
-import { NOTES, SCALE_TYPES, type ScaleTypeId } from '@/music/theory';
+import { NOTES, SCALE_TYPES, isSevenNoteScale, type ScaleTypeId } from '@/music/theory';
 import { INSTRUMENTS, INSTRUMENT_IDS } from '@/music/instruments';
+import type { FaceMapping } from '@/nodes';
 import { useControls, type VoiceControl } from './store';
+import { useFaceStatus } from './faceStatus';
 import { usePresets } from './usePresets';
 import { RECORDING_FORMATS } from './recording/formats';
 
@@ -114,6 +116,7 @@ function OverlayControls() {
       </label>
       <Toggle label="Scale guide" checked={overlay.scaleGuide.show} onChange={(v) => set('scaleGuide', { show: v })} />
       <Toggle label="Scale guide labels" checked={overlay.scaleGuide.showLabels} onChange={(v) => set('scaleGuide', { showLabels: v })} />
+      <Toggle label="Face chord highlight" checked={overlay.chordGuide.show} onChange={(v) => set('chordGuide', { show: v })} />
       <Toggle label="Index-finger guide" checked={overlay.indexGuide.show} onChange={(v) => set('indexGuide', { show: v })} />
       <Toggle label="Index guide dashed" checked={overlay.indexGuide.dashed} onChange={(v) => set('indexGuide', { dashed: v })} />
       <Toggle label="Hand landmarks" checked={overlay.landmarks.show} onChange={(v) => set('landmarks', { show: v })} />
@@ -123,18 +126,88 @@ function OverlayControls() {
   );
 }
 
+const FACE_MODE_OPTIONS: { value: FaceMapping; label: string }[] = [
+  { value: 'none', label: 'Off' },
+  { value: 'timbre', label: 'Expression → timbre' },
+  { value: 'chord', label: 'Expression → chord' },
+];
+
+const FACE_MODE_HINT: Record<FaceMapping, string> = {
+  none: 'No face detection. Pick a mode to map your expression to sound. Uses the same camera as hand tracking; loads a small face model on first use.',
+  timbre: 'Smile → brighter tone, open mouth → vibrato — shaping the notes your hands play.',
+  chord: "Your expression plays a diatonic triad on the right hand's scale (needs a 7-note scale).",
+};
+
+/** Live face-model status + detected expression, driven by the engine (#65). */
+function FaceStatusReadout({ active }: { active: boolean }) {
+  const status = useFaceStatus((s) => s.status);
+  const label = useFaceStatus((s) => s.label);
+
+  let dot = 'bg-white/30';
+  let text = 'Off';
+  if (active) {
+    switch (status.phase) {
+      case 'loading':
+        dot = 'bg-amber-400 animate-pulse';
+        text = 'Loading face model…';
+        break;
+      case 'error':
+        dot = 'bg-rose-500';
+        text = 'Model failed to load';
+        break;
+      case 'ready':
+        if (status.faceDetected) {
+          dot = 'bg-emerald-400';
+          text = label ? `Face detected — ${label}` : 'Face detected';
+        } else {
+          dot = 'bg-sky-400';
+          text = 'Ready — no face in frame';
+        }
+        break;
+      default:
+        dot = 'bg-white/30';
+        text = 'Starting…';
+    }
+  }
+  return (
+    <div className="flex items-center gap-2 text-[11px] text-white/70">
+      <span className={`inline-block h-2 w-2 rounded-full ${dot}`} aria-hidden />
+      <span>{text}</span>
+    </div>
+  );
+}
+
 function FaceControls() {
-  const faceEnabled = useControls((s) => s.faceEnabled);
-  const setFaceEnabled = useControls((s) => s.setFaceEnabled);
+  const faceMapping = useControls((s) => s.faceMapping);
+  const setFaceMapping = useControls((s) => s.setFaceMapping);
+  const rightType = useControls((s) => s.right.type);
+  const sevenNote = isSevenNoteScale(rightType);
 
   return (
     <div className="space-y-2">
       <h3 className="text-[11px] font-bold uppercase tracking-widest text-white/70">Face control</h3>
-      <Toggle label="Enable face expression" checked={faceEnabled} onChange={setFaceEnabled} />
-      <p className="text-[10px] leading-relaxed text-white/40">
-        Smile → brighter tone, open mouth → vibrato. Loads a face model on first
-        enable; uses the same camera as hand tracking.
-      </p>
+      <label className="flex items-center justify-between gap-2 text-xs">
+        Mapping
+        <select
+          className={selectCls}
+          value={faceMapping}
+          onChange={(e) => setFaceMapping(e.target.value as FaceMapping)}
+        >
+          {FACE_MODE_OPTIONS.map((o) => (
+            <option key={o.value} value={o.value} disabled={o.value === 'chord' && !sevenNote}>
+              {o.label}
+              {o.value === 'chord' && !sevenNote ? ' (needs 7-note scale)' : ''}
+            </option>
+          ))}
+        </select>
+      </label>
+      <FaceStatusReadout active={faceMapping !== 'none'} />
+      {faceMapping === 'chord' && !sevenNote && (
+        <p className="text-[10px] leading-relaxed text-amber-300/80">
+          Chord mode needs a 7-note scale (Major / Natural Minor / Harmonic Minor) on the right hand.
+        </p>
+      )}
+      <p className="text-[10px] leading-relaxed text-white/40">{FACE_MODE_HINT[faceMapping]}</p>
     </div>
   );
 }

--- a/src/app/Toaster.tsx
+++ b/src/app/Toaster.tsx
@@ -17,7 +17,11 @@ export default function Toaster() {
           key={t.id}
           type="button"
           onClick={() => dismiss(t.id)}
-          className="pointer-events-auto rounded-full bg-emerald-600/90 px-4 py-1.5 text-xs font-medium text-white shadow-lg backdrop-blur transition hover:bg-emerald-600"
+          className={`pointer-events-auto rounded-full px-4 py-1.5 text-xs font-medium text-white shadow-lg backdrop-blur transition ${
+            t.level === 'error'
+              ? 'bg-rose-600/90 hover:bg-rose-600'
+              : 'bg-emerald-600/90 hover:bg-emerald-600'
+          }`}
         >
           {t.message}
         </button>

--- a/src/app/faceStatus.ts
+++ b/src/app/faceStatus.ts
@@ -1,0 +1,31 @@
+/**
+ * faceStatus — a tiny store the engine writes the live face-model status and
+ * classified expression into each frame (throttled), so the UI can show the
+ * player feedback: is the model loading / ready / failed, is a face detected,
+ * and what expression is currently read (issue #65). Kept separate from the
+ * persisted controls store since it is ephemeral, per-frame runtime state — the
+ * DAG produces it; React only displays it.
+ */
+import { create } from 'zustand';
+import { ABSENT_FACE_STATUS, type FaceStatus } from '@/nodes';
+import { EXPRESSIONS, type ExpressionLabel } from '@/music/expression';
+
+const EMPTY_PROBS: number[] = EXPRESSIONS.map(() => 0);
+
+export interface FaceStatusState {
+  status: FaceStatus;
+  /** Latest classified expression label (null when no face / model not ready). */
+  label: ExpressionLabel | null;
+  /** Softmax over {@link EXPRESSIONS} (for the live readout bars). */
+  probs: number[];
+  report(status: FaceStatus, label: ExpressionLabel | null, probs: number[]): void;
+  reset(): void;
+}
+
+export const useFaceStatus = create<FaceStatusState>((set) => ({
+  status: ABSENT_FACE_STATUS,
+  label: null,
+  probs: EMPTY_PROBS,
+  report: (status, label, probs) => set({ status, label, probs }),
+  reset: () => set({ status: ABSENT_FACE_STATUS, label: null, probs: EMPTY_PROBS }),
+}));

--- a/src/app/graph.ts
+++ b/src/app/graph.ts
@@ -2,16 +2,21 @@
  * The default Thoremin instrument graph — the wiring that makes hand gestures
  * play tonal audio with overlays, steerable live by keyboard + UI.
  *
- *   webcam ─┬─▶ hand-features ─┬─▶ voice-mapping ─▶ webaudio-synth
- *           │                  │        ▲ ▲ ▲ ▲
- *           └────────▶ overlay ◀┘        │ │ │ └── store-controls (scale/instrument)
- *                       (video+guides)   │ │ └──── keyboard-control (magnetism/octave/mute)
+ *   webcam ─┬─▶ hand-features ─┬─▶ voice-mapping ─▶ synth-merge ─▶ webaudio-synth
+ *           │                  │        ▲ ▲ ▲ ▲          ▲
+ *           └────────▶ overlay ◀┘        │ │ │ │         │ (+ face chord)
+ *                       (video+guides)   │ │ │ └── store-controls (scale/instrument)
+ *                                        │ │ └──── keyboard-control (magnetism/octave/mute)
  *                                        │ └────── keyboard-source ─▶ keyboard-control
- *   webcam-face ─▶ face-features ────────┘ (smile→brightness, mouth→vibrato)
+ *   webcam-face ─┬─▶ face-features ──────┘ (timbre: smile→brightness, mouth→vibrato)
+ *                └─▶ face-expression ─▶ expression-chord ─▶ synth-merge
+ *                       (chord: expression → diatonic triad)
  *
- * The face branch is always wired but idle until the player enables face
- * control: `webcam-face` only loads its model (and emits a present face) when
- * `faceEnabled` is set in the store, so it costs nothing when off.
+ * The face branch is always wired but idle until the player picks a face mapping:
+ * `webcam-face` only loads its model (and emits a present face) when `faceMapping`
+ * is not `none`, so it costs nothing when off. The chord path (`expression-chord`)
+ * emits silent voices unless the mode is `chord`, so the merge passes the hand
+ * voices through unchanged otherwise.
  *
  * One output may fan OUT to several inputs (webcam→features & overlay); only
  * fan-IN to a single input port is disallowed.
@@ -109,13 +114,18 @@ export function defaultGraph(selection?: SlotSelection, registry?: NodeRegistry)
     nodes: [
       { id: 'cam', type: 'webcam-hands', params: { modelType: 'full', maxHands: 2 } },
       { id: 'feat', type: 'hand-features', params: { mirrorX: true, mirrorHandedness: true } },
-      // Face branch (idle until the player enables face control in settings).
+      // Face branch (idle until the player picks a face mapping in settings).
       { id: 'camFace', type: 'webcam-face', params: {} },
       { id: 'faceFeat', type: 'face-features', params: { smoothing: 0.3 } },
+      // Chord path: classify the expression, then play its diatonic triad.
+      { id: 'faceExpr', type: 'face-expression', params: {} },
+      { id: 'exprChord', type: 'expression-chord', params: {} },
       { id: 'kbd', type: 'keyboard-source' },
       { id: 'kctrl', type: 'keyboard-control', params: { magnetismStart: 0.8 } },
       { id: 'ui', type: 'store-controls' },
       { id: 'map', type: mappingType, params: { magnetism: 0.8, maxGain: 0.5 } },
+      // Union the hand voices with the face-chord voices before the synth.
+      { id: 'merge', type: 'synth-merge', params: {} },
       { id: 'synth', type: 'webaudio-synth' },
       // Overlay elements default on (video/scaleGuide/landmarks/markers); the
       // opt-in index-finger guide is off by default. See canvas_overlay.ts.
@@ -124,10 +134,19 @@ export function defaultGraph(selection?: SlotSelection, registry?: NodeRegistry)
     edges: [
       { from: { node: 'cam', port: 'hands' }, to: { node: 'feat', port: 'hands' } },
       { from: { node: 'cam', port: 'hands' }, to: { node: 'overlay', port: 'hands' } },
-      // Face: webcam-face → face-features → voice-mapping's optional `face` input
-      // (smile adds brightness, open mouth adds vibrato). Absent face → no effect.
+      // Face timbre: webcam-face → face-features → voice-mapping's optional `face`
+      // input (smile adds brightness, open mouth adds vibrato). Absent face / chord
+      // mode → no effect.
       { from: { node: 'camFace', port: 'face' }, to: { node: 'faceFeat', port: 'face' } },
       { from: { node: 'faceFeat', port: 'features' }, to: { node: 'map', port: 'face' } },
+      // Face chord: webcam-face → face-expression → expression-chord (fed the live
+      // scale spec + face mode). Emits silent voices unless mode is 'chord'.
+      { from: { node: 'camFace', port: 'face' }, to: { node: 'faceExpr', port: 'face' } },
+      { from: { node: 'faceExpr', port: 'expression' }, to: { node: 'exprChord', port: 'expression' } },
+      { from: { node: 'ui', port: 'rightSpec' }, to: { node: 'exprChord', port: 'spec' } },
+      { from: { node: 'ui', port: 'faceMapping' }, to: { node: 'exprChord', port: 'faceMapping' } },
+      // Keep the face chord in the same register as the hand melody (octave shift).
+      { from: { node: 'kctrl', port: 'octaveShift' }, to: { node: 'exprChord', port: 'octaveShift' } },
       { from: { node: 'feat', port: 'features' }, to: { node: 'map', port: 'features' } },
       { from: { node: 'feat', port: 'features' }, to: { node: 'overlay', port: 'features' } },
       { from: { node: 'kbd', port: 'pressed' }, to: { node: 'kctrl', port: 'pressed' } },
@@ -138,13 +157,18 @@ export function defaultGraph(selection?: SlotSelection, registry?: NodeRegistry)
       { from: { node: 'ui', port: 'scaleLeft' }, to: { node: 'map', port: 'scaleLeft' } },
       { from: { node: 'ui', port: 'instrumentRight' }, to: { node: 'map', port: 'instrumentRight' } },
       { from: { node: 'ui', port: 'instrumentLeft' }, to: { node: 'map', port: 'instrumentLeft' } },
-      { from: { node: 'map', port: 'params' }, to: { node: 'synth', port: 'params' } },
-      // Also feed params to the overlay so it can label each hand's note.
+      // Merge the hand voices (map) with the face-chord voices, then to the synth.
+      { from: { node: 'map', port: 'params' }, to: { node: 'merge', port: 'a' } },
+      { from: { node: 'exprChord', port: 'params' }, to: { node: 'merge', port: 'b' } },
+      { from: { node: 'merge', port: 'params' }, to: { node: 'synth', port: 'params' } },
+      // Also feed the hand params to the overlay so it can label each hand's note.
       { from: { node: 'map', port: 'params' }, to: { node: 'overlay', port: 'params' } },
       // And both hands' scales + octave shift, for the overlay pitch guides.
       { from: { node: 'ui', port: 'scaleRight' }, to: { node: 'overlay', port: 'scale' } },
       { from: { node: 'ui', port: 'scaleLeft' }, to: { node: 'overlay', port: 'scaleLeft' } },
       { from: { node: 'kctrl', port: 'octaveShift' }, to: { node: 'overlay', port: 'octaveShift' } },
+      // The face chord's tones, so the overlay can highlight them on the guide.
+      { from: { node: 'exprChord', port: 'triad' }, to: { node: 'overlay', port: 'chord' } },
       // Live overlay element config from the UI store (toggle elements without rebuild).
       { from: { node: 'ui', port: 'overlay' }, to: { node: 'overlay', port: 'overlayConfig' } },
     ],

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -18,7 +18,7 @@ import { persist, createJSONStorage, type StateStorage } from 'zustand/middlewar
 import type { ScaleTypeId } from '@/music/theory';
 import { DEFAULT_INSTRUMENT_RIGHT, DEFAULT_INSTRUMENT_LEFT } from '@/music/instruments';
 import { OverlayParamsSchema, type OverlayParams } from '@/nodes/output/canvas_overlay';
-import type { VoiceParams } from '@/nodes';
+import { FACE_MAPPINGS, legacyFaceToMapping, type VoiceParams, type FaceMapping } from '@/nodes';
 import type { Settings } from '@/settings/schema';
 import { DEFAULT_RECORDING_FORMATS } from './recording/formats';
 
@@ -36,12 +36,12 @@ export interface ControlState {
   syncHands: boolean;
   masterVolume: number; // 0..1
   /**
-   * Whether live face control is enabled. Off by default; when on, the
-   * `webcam-face` node lazy-loads the FaceLandmarker model and drives facial
-   * expression into the mapping (smile→brightness, open mouth→vibrato). Read by
-   * the node each tick via `ctx.resources.controls`.
+   * What the player's facial expression maps to: `none` (off, default), `timbre`
+   * (smile→brightness, open mouth→vibrato), or `chord` (expression selects a
+   * diatonic triad). Any non-`none` mode lazy-loads the `webcam-face` model. Read
+   * by the nodes each tick via `ctx.resources.controls`.
    */
-  faceEnabled: boolean;
+  faceMapping: FaceMapping;
   /** Composable overlay element config (see canvas_overlay.ts). Live-controlled. */
   overlay: OverlayParams;
   /**
@@ -53,7 +53,7 @@ export interface ControlState {
   setVoice(side: 'right' | 'left', patch: Partial<VoiceControl>): void;
   setSync(v: boolean): void;
   setMasterVolume(v: number): void;
-  setFaceEnabled(v: boolean): void;
+  setFaceMapping(v: FaceMapping): void;
   /** Toggle a recording output format on/off (keeps at least one selected). */
   setRecordingFormat(id: string, on: boolean): void;
   /** Patch one overlay element's options (e.g. setOverlayElement('indexGuide', { show: true })). */
@@ -82,9 +82,51 @@ export function toSettings(s: ControlState): Settings {
     left: s.left,
     syncHands: s.syncHands,
     masterVolume: s.masterVolume,
-    faceEnabled: s.faceEnabled,
+    faceMapping: s.faceMapping,
     overlay: s.overlay,
   };
+}
+
+/**
+ * Persist migration (v1 → v2): the #64 face-mapping chooser replaced the boolean
+ * `faceEnabled` with the tri-state `faceMapping`. Maps a saved `faceEnabled:true`
+ * → `faceMapping:'timbre'` so a returning player keeps face control on instead of
+ * silently reverting to off. Exported for direct testing.
+ */
+export function migrateControls(persisted: unknown, version: number): ControlState {
+  const s = { ...(persisted as Record<string, unknown>) };
+  if (version < 2) {
+    if (s.faceMapping === undefined) {
+      s.faceMapping = legacyFaceToMapping(s.faceEnabled as boolean | undefined);
+    }
+    delete s.faceEnabled;
+  }
+  return s as unknown as ControlState;
+}
+
+/**
+ * Merge a rehydrated blob over the current (initializer) state. Beyond zustand's
+ * default shallow merge it HEALS two things so an older/corrupt blob can't crash
+ * newer readers: it re-parses `overlay` through the schema (filling defaults for
+ * overlay elements added since the blob was written — e.g. `chordGuide` in #64,
+ * whose absence would otherwise throw in `overlay.chordGuide.show`), and clamps
+ * `faceMapping` to a known mode (unknown values → derived from any legacy
+ * `faceEnabled`, else `none`). Exported for direct testing.
+ */
+export function mergeControls(persisted: unknown, current: ControlState): ControlState {
+  const p = (persisted ?? {}) as Partial<ControlState> & { faceEnabled?: boolean };
+  let overlay = current.overlay;
+  if (p.overlay) {
+    try {
+      overlay = OverlayParamsSchema.parse(p.overlay);
+    } catch {
+      overlay = current.overlay;
+    }
+  }
+  const faceMapping = (FACE_MAPPINGS as readonly string[]).includes(p.faceMapping as string)
+    ? (p.faceMapping as FaceMapping)
+    : legacyFaceToMapping(p.faceEnabled);
+  return { ...current, ...p, overlay, faceMapping };
 }
 
 // localStorage in the browser; a no-op elsewhere (Node test runtime) so the
@@ -104,7 +146,7 @@ export const useControls = create<ControlState>()(
       left: defaultVoice(DEFAULT_INSTRUMENT_LEFT),
       syncHands: true,
       masterVolume: 0.4,
-      faceEnabled: false,
+      faceMapping: 'none',
       overlay: defaultOverlay(),
       recordingFormats: [...DEFAULT_RECORDING_FORMATS],
       setVoice: (side, patch) =>
@@ -124,7 +166,7 @@ export const useControls = create<ControlState>()(
         }),
       setSync: (v) => set({ syncHands: v }),
       setMasterVolume: (v) => set({ masterVolume: v }),
-      setFaceEnabled: (v) => set({ faceEnabled: v }),
+      setFaceMapping: (v) => set({ faceMapping: v }),
       setRecordingFormat: (id, on) =>
         set((s) => {
           const has = s.recordingFormats.includes(id);
@@ -146,16 +188,18 @@ export const useControls = create<ControlState>()(
           left: st.left,
           syncHands: st.syncHands,
           masterVolume: st.masterVolume,
-          faceEnabled: st.faceEnabled,
+          faceMapping: st.faceMapping,
           overlay: st.overlay,
         }),
     }),
     {
       name: 'thoremin-controls',
-      // Version stays 1: `overlay`/`faceEnabled` are additive, and the default
-      // shallow merge keeps the initializer's defaults when an older persisted
-      // blob omits them (no migrate / no discard of existing voice/volume choices).
-      version: 1,
+      // Version 2: the face-mapping chooser (#64) replaced the boolean
+      // `faceEnabled` with the tri-state `faceMapping`. See migrateControls (field
+      // rename) and mergeControls (heals a stale `overlay` + clamps `faceMapping`).
+      version: 2,
+      migrate: migrateControls,
+      merge: mergeControls,
       storage: createJSONStorage(controlsStorage),
       // Persist only the control values, never the setter functions.
       partialize: (s) => ({
@@ -163,7 +207,7 @@ export const useControls = create<ControlState>()(
         left: s.left,
         syncHands: s.syncHands,
         masterVolume: s.masterVolume,
-        faceEnabled: s.faceEnabled,
+        faceMapping: s.faceMapping,
         overlay: s.overlay,
         recordingFormats: s.recordingFormats,
       }),

--- a/src/app/toasts.ts
+++ b/src/app/toasts.ts
@@ -7,15 +7,19 @@
  */
 import { create } from 'zustand';
 
+/** Toast severity — drives the colour (success/info vs failure). */
+export type ToastLevel = 'info' | 'error';
+
 export interface Toast {
   id: number;
   message: string;
+  level: ToastLevel;
 }
 
 interface ToastState {
   toasts: Toast[];
-  /** Show a toast; auto-dismisses after `ttlMs`. */
-  push(message: string, ttlMs?: number): void;
+  /** Show a toast; auto-dismisses after `ttlMs`. `level` styles it (error = red). */
+  push(message: string, ttlMs?: number, level?: ToastLevel): void;
   dismiss(id: number): void;
 }
 
@@ -24,9 +28,9 @@ const DEFAULT_TTL_MS = 4000;
 
 export const useToasts = create<ToastState>((set) => ({
   toasts: [],
-  push: (message, ttlMs = DEFAULT_TTL_MS) => {
+  push: (message, ttlMs = DEFAULT_TTL_MS, level = 'info') => {
     const id = ++seq;
-    set((s) => ({ toasts: [...s.toasts, { id, message }] }));
+    set((s) => ({ toasts: [...s.toasts, { id, message, level }] }));
     if (typeof setTimeout !== 'undefined') {
       setTimeout(() => set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) })), ttlMs);
     }

--- a/src/app/useEngine.ts
+++ b/src/app/useEngine.ts
@@ -14,8 +14,14 @@ import { PerformanceRecorder, recordingFilename, extForMime } from './recorder';
 import { recordingFormat } from './recording/formats';
 import { saveBlob } from './recording/save';
 import { useToasts } from './toasts';
+import { useFaceStatus } from './faceStatus';
+import type { FaceStatus } from '@/nodes';
+import type { ExpressionScores } from '@/music/expression';
 
 export type EngineStatus = 'idle' | 'loading' | 'ready' | 'error';
+
+/** Min interval (ms) between face-status reports to React (throttle the readout). */
+const FACE_REPORT_MS = 100;
 
 /**
  * Convert the native (WebM/Opus) recording into each selected output format and
@@ -145,12 +151,47 @@ export function useThoreminEngine() {
         engineRef.current = engine;
         setStatus('ready');
 
+        // Bridge the face model's status + classified expression from the DAG
+        // back to React for the indicator/readout (#65), throttled so the bars
+        // don't re-render 60×/s. A transition into 'error' surfaces a toast once.
+        let lastFaceReport = 0;
+        let lastPhase: FaceStatus['phase'] | null = null;
+        let lastDetected = false;
+        const reportFace = (now: number) => {
+          const fs = engine.getOutput('camFace', 'status') as FaceStatus | undefined;
+          if (!fs) return;
+          const phaseChanged = fs.phase !== lastPhase;
+          const detectedChanged = fs.faceDetected !== lastDetected;
+          // The 10/s cadence is only needed while a face is being read (for the
+          // live label); when idle/loading/error we report only on transitions, so
+          // an off/idle face control doesn't re-render the UI every 100ms.
+          const live = fs.phase === 'ready' && fs.faceDetected;
+          if (!phaseChanged && !detectedChanged && (!live || now - lastFaceReport < FACE_REPORT_MS)) {
+            return;
+          }
+          if (fs.phase === 'error' && lastPhase !== null && lastPhase !== 'error') {
+            useToasts.getState().push(
+              'Face model failed to load — check your connection and re-pick a face mode',
+              6000,
+              'error',
+            );
+          }
+          const expr = engine.getOutput('faceExpr', 'expression') as ExpressionScores | undefined;
+          const detected = fs.phase === 'ready' && fs.faceDetected && expr?.present;
+          useFaceStatus.getState().report(fs, detected ? expr!.label : null, expr?.probs ?? []);
+          lastFaceReport = now;
+          lastPhase = fs.phase;
+          lastDetected = fs.faceDetected;
+        };
+
         const loop = () => {
           // Guard the tick: one node throwing on a frame (e.g. a degenerate
           // value) must never stop the loop — drop that frame and keep going,
           // so audio + video recover instead of freezing permanently.
           try {
-            engine.tick(performance.now() / 1000);
+            const t = performance.now();
+            engine.tick(t / 1000);
+            reportFace(t);
           } catch (err) {
             console.error('[thoremin] engine tick error (frame dropped)', err);
           }
@@ -173,6 +214,7 @@ export function useThoreminEngine() {
       }
       engineRef.current?.dispose();
       engineRef.current = null;
+      useFaceStatus.getState().reset();
       recorderRef.current?.dispose();
       recorderRef.current = null;
       stream?.getTracks().forEach((t) => t.stop());

--- a/src/music/expression.ts
+++ b/src/music/expression.ts
@@ -1,0 +1,329 @@
+/**
+ * Facial-expression classification + the confusion-aware expression→chord map.
+ *
+ * Two pure, dependency-free pieces (no DOM, no MediaPipe, no Tonal), so both are
+ * trivially unit-testable and reusable by the DAG nodes:
+ *
+ *  1. {@link blendshapesToExpression} — turn the 52 MediaPipe/ARKit blendshapes
+ *     into a softmax distribution over seven canonical expressions via cosine
+ *     similarity to FACS-grounded prototype vectors. No second model, no extra
+ *     bytes: it reuses the blendshapes the FaceLandmarker already emits.
+ *
+ *  2. {@link optimalExpressionToDegree} + {@link RECOMMENDED_EXPRESSION_TO_DEGREE} —
+ *     the *confusion-aware* assignment of the seven expressions to the seven
+ *     scale degrees. Expression pairs that a classifier confuses more often are
+ *     mapped to diatonic triads that share more notes, so a misclassification
+ *     lands on a neighbouring chord (a soft harmonic slip) instead of a jarring
+ *     jump. The assignment is the bijection maximizing
+ *     `Σ confusion(i,j) · sharedTriadNotes(degree(i), degree(j))`; with only
+ *     7! = 5040 candidates it is brute-forced, so it can be recomputed from any
+ *     *measured* confusion matrix (see issue #64).
+ *
+ * The prototype weights and the confusion matrix are exported data (open/closed):
+ * swap them for a model-specific calibration without touching the algorithms.
+ */
+
+/** The seven canonical expressions, in a stable index order. */
+export const EXPRESSIONS = [
+  'happy',
+  'sad',
+  'angry',
+  'surprised',
+  'fearful',
+  'disgusted',
+  'neutral',
+] as const;
+
+export type ExpressionLabel = (typeof EXPRESSIONS)[number];
+
+/** A sparse weighting over blendshape names (missing keys = 0). */
+export type BlendshapeWeights = Record<string, number>;
+
+/** The classifier's result: a softmax over {@link EXPRESSIONS} + its argmax. */
+export interface ExpressionScores {
+  present: boolean;
+  /** Softmax probabilities, aligned to {@link EXPRESSIONS} (sums to 1). */
+  probs: number[];
+  /** argmax label. */
+  label: ExpressionLabel;
+  /** Probability of {@link label} (= max of {@link probs}); 0 when absent. */
+  confidence: number;
+}
+
+/**
+ * FACS-grounded prototype blendshape vectors, one per expression. Primary action
+ * units carry weight 1; supporting units less. Neutral is anchored on the
+ * model's own `_neutral` blendshape, so a resting face scores neutral highest.
+ * Seeded from the ARKit-blendshape emotion literature (issue #64 refs [1][2]);
+ * override via {@link ExpressionOptions.prototypes} for a calibrated set.
+ */
+export const EXPRESSION_PROTOTYPES: Record<ExpressionLabel, BlendshapeWeights> = {
+  happy: { mouthSmileLeft: 1, mouthSmileRight: 1, cheekSquintLeft: 0.4, cheekSquintRight: 0.4 },
+  sad: {
+    mouthFrownLeft: 1,
+    mouthFrownRight: 1,
+    browInnerUp: 0.7,
+    mouthLowerDownLeft: 0.2,
+    mouthLowerDownRight: 0.2,
+  },
+  angry: {
+    browDownLeft: 1,
+    browDownRight: 1,
+    noseSneerLeft: 0.4,
+    noseSneerRight: 0.4,
+    mouthPressLeft: 0.3,
+    mouthPressRight: 0.3,
+  },
+  surprised: {
+    jawOpen: 1,
+    eyeWideLeft: 0.8,
+    eyeWideRight: 0.8,
+    browOuterUpLeft: 0.7,
+    browOuterUpRight: 0.7,
+    browInnerUp: 0.4,
+  },
+  fearful: {
+    jawOpen: 0.7,
+    eyeWideLeft: 0.9,
+    eyeWideRight: 0.9,
+    browInnerUp: 0.9,
+    browOuterUpLeft: 0.3,
+    browOuterUpRight: 0.3,
+    mouthStretchLeft: 0.3,
+    mouthStretchRight: 0.3,
+  },
+  disgusted: {
+    noseSneerLeft: 1,
+    noseSneerRight: 1,
+    mouthUpperUpLeft: 0.8,
+    mouthUpperUpRight: 0.8,
+    browDownLeft: 0.4,
+    browDownRight: 0.4,
+  },
+  neutral: { _neutral: 1 },
+};
+
+/** The blendshape dimensions the classifier scores over (union of all prototype
+ * keys). Restricting cosine to these FACS-relevant dims keeps gaze/blink noise
+ * out of the norm. */
+const PROTOTYPE_DIMS: string[] = (() => {
+  const dims = new Set<string>();
+  for (const proto of Object.values(EXPRESSION_PROTOTYPES)) {
+    for (const k of Object.keys(proto)) dims.add(k);
+  }
+  return [...dims];
+})();
+
+export interface ExpressionOptions {
+  /** Override the prototype vectors (e.g. a calibrated set). */
+  prototypes?: Record<ExpressionLabel, BlendshapeWeights>;
+  /** Softmax temperature; lower = sharper. Default 0.12. */
+  temperature?: number;
+}
+
+function dot(a: BlendshapeWeights, b: BlendshapeWeights, dims: string[]): number {
+  let s = 0;
+  for (const k of dims) s += (a[k] ?? 0) * (b[k] ?? 0);
+  return s;
+}
+
+function norm(a: BlendshapeWeights, dims: string[]): number {
+  return Math.sqrt(dot(a, a, dims));
+}
+
+function softmax(xs: number[], temperature: number): number[] {
+  const t = temperature > 0 ? temperature : 1e-6;
+  const scaled = xs.map((x) => x / t);
+  const max = Math.max(...scaled);
+  const exps = scaled.map((x) => Math.exp(x - max));
+  const sum = exps.reduce((a, b) => a + b, 0) || 1;
+  return exps.map((e) => e / sum);
+}
+
+/**
+ * Classify a blendshape frame into a softmax distribution over the seven
+ * {@link EXPRESSIONS}. Cosine similarity to each {@link EXPRESSION_PROTOTYPES}
+ * vector (over the FACS-relevant dims) is passed through a temperature softmax.
+ * A near-zero face (no activation) falls back to neutral.
+ */
+export function blendshapesToExpression(
+  blendshapes: BlendshapeWeights,
+  opts: ExpressionOptions = {},
+): ExpressionScores {
+  const prototypes = opts.prototypes ?? EXPRESSION_PROTOTYPES;
+  const temperature = opts.temperature ?? 0.12;
+  const inputNorm = norm(blendshapes, PROTOTYPE_DIMS);
+
+  let sims: number[];
+  if (inputNorm < 1e-6) {
+    // No measurable expression → certain neutral.
+    sims = EXPRESSIONS.map((label) => (label === 'neutral' ? 1 : 0));
+  } else {
+    sims = EXPRESSIONS.map((label) => {
+      const proto = prototypes[label];
+      const pn = norm(proto, PROTOTYPE_DIMS);
+      if (pn < 1e-6) return 0;
+      return dot(blendshapes, proto, PROTOTYPE_DIMS) / (inputNorm * pn);
+    });
+  }
+
+  const probs = softmax(sims, temperature);
+  let argmax = 0;
+  for (let i = 1; i < probs.length; i++) if (probs[i] > probs[argmax]) argmax = i;
+  return { present: true, probs, label: EXPRESSIONS[argmax], confidence: probs[argmax] };
+}
+
+/** The absent/rest expression: certain neutral, no probs to act on. */
+export const ABSENT_EXPRESSION: ExpressionScores = {
+  present: false,
+  probs: EXPRESSIONS.map((l) => (l === 'neutral' ? 1 : 0)),
+  label: 'neutral',
+  confidence: 1,
+};
+
+// ---- Confusion-aware expression → scale-degree assignment -----------------
+
+/**
+ * The three scale-degree indices (0..6) of the diatonic triad rooted on
+ * `degree`: the degree itself plus stacked scale-thirds (degree+2, degree+4),
+ * wrapped into 0..6. This is the harmonic-distance structure used to score the
+ * assignment — two triads sharing more of these degrees sound more alike.
+ */
+export function triadDegreeSet(degree: number): [number, number, number] {
+  const d = ((degree % 7) + 7) % 7;
+  return [d, (d + 2) % 7, (d + 4) % 7];
+}
+
+/** How many notes two diatonic triads share (0..3), by their root degrees. */
+export function sharedTriadNotes(degreeA: number, degreeB: number): number {
+  const a = new Set(triadDegreeSet(degreeA));
+  let shared = 0;
+  for (const n of triadDegreeSet(degreeB)) if (a.has(n)) shared++;
+  return shared;
+}
+
+/**
+ * Symmetric expression-confusion weights, seeded from FER2013 and corroborating
+ * FER literature/human studies (issue #64 refs [6]-[9]): higher = more often
+ * mistaken for one another. The negative cluster {anger, disgust, fear, sad} +
+ * neutral is the confusable core; happy is the most distinct, surprise second.
+ * Indexed by {@link EXPRESSIONS} order; only the listed pairs are non-zero.
+ * Override with a *measured* matrix and re-run {@link optimalExpressionToDegree}.
+ */
+export const CONFUSION_FER2013: number[][] = buildConfusionMatrix({
+  'sad|neutral': 0.3,
+  'fearful|sad': 0.22,
+  'angry|disgusted': 0.18,
+  'angry|sad': 0.14,
+  'angry|fearful': 0.12,
+  'fearful|neutral': 0.08,
+  'fearful|surprised': 0.08,
+  'happy|neutral': 0.07,
+  'disgusted|sad': 0.06,
+  'angry|neutral': 0.06,
+  'disgusted|fearful': 0.05,
+  'disgusted|neutral': 0.05,
+  'surprised|happy': 0.03,
+});
+
+function buildConfusionMatrix(pairs: Record<string, number>): number[][] {
+  const idx = new Map(EXPRESSIONS.map((e, i) => [e, i]));
+  const n = EXPRESSIONS.length;
+  const m = Array.from({ length: n }, () => new Array(n).fill(0));
+  for (const [pair, w] of Object.entries(pairs)) {
+    const [a, b] = pair.split('|') as ExpressionLabel[];
+    const i = idx.get(a);
+    const j = idx.get(b);
+    if (i === undefined || j === undefined) throw new Error(`unknown expression in pair: ${pair}`);
+    m[i][j] = w;
+    m[j][i] = w;
+  }
+  return m;
+}
+
+/** An expression→degree bijection, keyed by {@link ExpressionLabel}. */
+export type ExpressionToDegree = Record<ExpressionLabel, number>;
+
+/**
+ * The assignment objective: total confusion-weighted shared-note mass. Higher is
+ * better — confused pairs landing on note-sharing triads contribute the most.
+ */
+export function assignmentObjective(
+  assignment: ExpressionToDegree,
+  confusion: number[][] = CONFUSION_FER2013,
+): number {
+  let total = 0;
+  for (let i = 0; i < EXPRESSIONS.length; i++) {
+    for (let j = i + 1; j < EXPRESSIONS.length; j++) {
+      const w = confusion[i][j];
+      if (w === 0) continue;
+      total += w * sharedTriadNotes(assignment[EXPRESSIONS[i]], assignment[EXPRESSIONS[j]]);
+    }
+  }
+  return total;
+}
+
+/**
+ * Brute-force the bijection (expressions → degrees 0..6) maximizing
+ * {@link assignmentObjective}. 7! = 5040 permutations, so exhaustive search is
+ * cheap and exact. Ties are broken deterministically (first permutation wins).
+ */
+export function optimalExpressionToDegree(
+  confusion: number[][] = CONFUSION_FER2013,
+): ExpressionToDegree {
+  let best: ExpressionToDegree | null = null;
+  let bestScore = -Infinity;
+  for (const perm of permutations([0, 1, 2, 3, 4, 5, 6])) {
+    const assignment = Object.fromEntries(
+      EXPRESSIONS.map((e, i) => [e, perm[i]]),
+    ) as ExpressionToDegree;
+    const score = assignmentObjective(assignment, confusion);
+    if (score > bestScore) {
+      bestScore = score;
+      best = assignment;
+    }
+  }
+  return best as ExpressionToDegree;
+}
+
+function* permutations(items: number[]): Generator<number[]> {
+  if (items.length <= 1) {
+    yield [...items];
+    return;
+  }
+  for (let i = 0; i < items.length; i++) {
+    const rest = [...items.slice(0, i), ...items.slice(i + 1)];
+    for (const p of permutations(rest)) yield [items[i], ...p];
+  }
+}
+
+/**
+ * The shipped assignment: the objective-maximizing bijection for the seeded
+ * {@link CONFUSION_FER2013} matrix, i.e. the value of
+ * `optimalExpressionToDegree(CONFUSION_FER2013)` (issue #64 asks to recompute the
+ * mapping on the shipped classifier's matrix rather than reuse the issue's
+ * illustrative FER2013-literature table). It is genuinely optimal (objective ≈
+ * 2.11), and conveniently it ALSO keeps `happy` on the tonic (degree 0, the
+ * resting "home" chord) and places all FIVE non-trivial confusion pairs on
+ * 2-note-sharing triads — disgust↔anger, anger↔fear, fear↔sad, sad↔neutral, and
+ * happy↔neutral. (The issue's hand-table left happy↔neutral on a 1-note pair;
+ * the true optimum fixes that at no cost to the tonic placement.)
+ *
+ *   happy→I(0)  fearful→ii(1)  surprised→iii(2)  sad→IV(3)
+ *   disgusted→V(4)  neutral→vi(5)  angry→vii°(6)
+ *
+ * Recompute with {@link optimalExpressionToDegree} against a *measured* confusion
+ * matrix to retune for a calibrated classifier.
+ */
+export const RECOMMENDED_EXPRESSION_TO_DEGREE: ExpressionToDegree = {
+  happy: 0,
+  fearful: 1,
+  surprised: 2,
+  sad: 3,
+  disgusted: 4,
+  neutral: 5,
+  angry: 6,
+};
+
+/** The expression→degree assignment the chord mapping ships with. */
+export const DEFAULT_EXPRESSION_TO_DEGREE = RECOMMENDED_EXPRESSION_TO_DEGREE;

--- a/src/music/theory.ts
+++ b/src/music/theory.ts
@@ -75,6 +75,36 @@ export function generateScale(spec: ScaleSpec): number[] {
   return [...new Set(scale)].sort((a, b) => a - b);
 }
 
+/** True for scales with exactly seven degrees (major / natural minor / harmonic
+ * minor) — the scales on which a diatonic triad (stacked thirds) is well-defined.
+ * Pentatonic (5), blues (6) and chromatic (12) are not seven-note. */
+export function isSevenNoteScale(type: ScaleTypeId): boolean {
+  return SCALE_TYPES[type].intervals.length === 7;
+}
+
+/**
+ * The diatonic triad rooted on scale `degree` (0 = tonic .. 6 = leading tone) of
+ * a seven-note scale, as three ascending MIDI notes. The triad is built by
+ * stacking scale-thirds — degrees `degree`, `degree + 2`, `degree + 4` — within
+ * the scale's own interval set, so it yields the correct chord quality for *any*
+ * seven-note scale (major I/ii/iii…, harmonic-minor's augmented III and
+ * diminished ii°, etc.) without naming the chord. Degrees that step past the
+ * octave wrap up by 12 semitones, keeping the triad ascending.
+ *
+ * Returns `[]` for non-seven-note scales (see {@link isSevenNoteScale}) so callers
+ * degrade gracefully (no chord) rather than indexing out of range.
+ */
+export function diatonicTriad(spec: ScaleSpec, degree: number): number[] {
+  const intervals = SCALE_TYPES[spec.type].intervals;
+  if (intervals.length !== 7) return [];
+  const baseNote = (spec.baseOctave + 1) * 12 + spec.root;
+  const d = ((degree % 7) + 7) % 7;
+  return [0, 2, 4].map((third) => {
+    const idx = d + third;
+    return baseNote + intervals[idx % 7] + 12 * Math.floor(idx / 7);
+  });
+}
+
 /**
  * Where each scale note sits along the normalized control axis (x in 0..1),
  * matching how {@link magneticPitch} maps x → MIDI (linear across the scale's

--- a/src/nodes/domain.ts
+++ b/src/nodes/domain.ts
@@ -90,6 +90,24 @@ export interface SynthParams {
   voices: VoiceParams[];
 }
 
+/**
+ * What the player's facial expression maps to (the face-mapping chooser, #64):
+ *  - `none`   : no face detection or mapping (the model never loads).
+ *  - `timbre` : expression continuously shapes the active voices (smile→brightness,
+ *               open mouth→vibrato).
+ *  - `chord`  : expression selects a diatonic triad on the current seven-note scale.
+ */
+export const FACE_MAPPINGS = ['none', 'timbre', 'chord'] as const;
+export type FaceMapping = (typeof FACE_MAPPINGS)[number];
+
+/** Map the legacy boolean `faceEnabled` (pre-#64) onto the tri-state mapping: a
+ * saved `true` becomes `timbre` (the old behaviour), `false`/absent → `none`. The
+ * single source of truth for this migration, shared by the store persist migrate,
+ * the preset preprocess, and the store-controls snapshot fallback. */
+export function legacyFaceToMapping(faceEnabled: boolean | undefined): FaceMapping {
+  return faceEnabled ? 'timbre' : 'none';
+}
+
 // ---- Face (MediaPipe Face Landmarker blendshapes) ------------------------
 
 /**
@@ -125,6 +143,19 @@ export const ABSENT_FACE: FaceFeatures = {
   browFurrow: 0,
   eyeBlink: 0,
 };
+
+/**
+ * Lifecycle + detection status of the lazy `webcam-face` model, surfaced so the
+ * UI can give the player feedback (issue #65): is the model loading, ready, or
+ * did it fail to load, and is a face currently in frame.
+ */
+export type FaceStatusPhase = 'idle' | 'loading' | 'ready' | 'error';
+export interface FaceStatus {
+  phase: FaceStatusPhase;
+  /** A face is currently detected in frame (only meaningful while `ready`). */
+  faceDetected: boolean;
+}
+export const ABSENT_FACE_STATUS: FaceStatus = { phase: 'idle', faceDetected: false };
 
 // ---- MediaPipe Hands landmark indices ------------------------------------
 

--- a/src/nodes/features/face_expression.ts
+++ b/src/nodes/features/face_expression.ts
@@ -1,0 +1,95 @@
+/**
+ * `face-expression` node — classifies the 52 MediaPipe/ARKit blendshapes of a
+ * {@link FaceFrame} into a softmax distribution over the seven canonical
+ * expressions (happy / sad / angry / surprised / fearful / disgusted / neutral),
+ * the sibling of `face-features`. It uses {@link blendshapesToExpression} (cosine
+ * similarity to FACS-grounded prototypes) — no extra model, no extra bytes — and
+ * adds temporal stability the raw frame lacks:
+ *
+ *  - **per-class EMA smoothing** of the softmax (the simplex is preserved, since
+ *    a convex blend of probability vectors is still a probability vector), so the
+ *    distribution eases rather than jumps;
+ *  - **argmax margin-hold hysteresis**, so the winning expression (which drives
+ *    the chord in `expression-chord`) only switches when a challenger leads by a
+ *    margin — preventing chord chatter at decision boundaries.
+ *
+ * Pure + Node-safe (no DOM/MediaPipe): the live `webcam-face` node feeds it the
+ * same `{ present, blendshapes }` frames the offline fixture replays.
+ */
+import { z } from 'zod';
+import { defineNode } from '@/dag';
+import type { FaceFrame } from '../domain';
+import {
+  EXPRESSIONS,
+  ABSENT_EXPRESSION,
+  blendshapesToExpression,
+  type ExpressionScores,
+} from '@/music/expression';
+
+const NEUTRAL_INDEX = EXPRESSIONS.indexOf('neutral');
+
+const Params = z.object({
+  /** Per-class EMA smoothing 0..1 (0 = instant, higher = smoother/slower). */
+  smoothing: z.number().min(0).max(0.999).default(0.4),
+  /** Softmax temperature; lower = sharper distribution. */
+  temperature: z.number().min(0.01).max(2).default(0.12),
+  /** A challenger must lead the held expression by this probability margin
+   *  before the argmax switches (hysteresis against chord flicker). */
+  holdMargin: z.number().min(0).max(1).default(0.06),
+});
+type Params = z.infer<typeof Params>;
+
+/** Rest distribution: certain neutral. */
+const restProbs = (): number[] => EXPRESSIONS.map((l) => (l === 'neutral' ? 1 : 0));
+
+export const faceExpressionNode = defineNode<Params>({
+  type: 'face-expression',
+  roles: ['feature'],
+  title: 'Face Expression',
+  description:
+    'Face blendshapes → softmax over 7 expressions (happy/sad/angry/surprised/fearful/disgusted/neutral) with smoothing + hysteresis.',
+  inputs: [{ name: 'face', kind: 'face-frame' }],
+  outputs: [{ name: 'expression', kind: 'face-expression' }],
+  params: Params,
+  make(p) {
+    const smoothed = restProbs();
+    let held = NEUTRAL_INDEX;
+
+    const ema = (targets: number[]) => {
+      for (let i = 0; i < smoothed.length; i++) {
+        smoothed[i] = smoothed[i] + (1 - p.smoothing) * (targets[i] - smoothed[i]);
+      }
+    };
+
+    return {
+      process(inputs) {
+        const face = inputs.face as FaceFrame | undefined;
+        if (!face || !face.present) {
+          // Decay toward rest so a lost face relaxes to neutral rather than
+          // freezing the last chord, and report absent.
+          ema(restProbs());
+          held = NEUTRAL_INDEX;
+          return { expression: { ...ABSENT_EXPRESSION } };
+        }
+
+        const raw = blendshapesToExpression(face.blendshapes, { temperature: p.temperature });
+        ema(raw.probs);
+
+        // Argmax of the SMOOTHED distribution, with margin-hold hysteresis.
+        let argmax = 0;
+        for (let i = 1; i < smoothed.length; i++) if (smoothed[i] > smoothed[argmax]) argmax = i;
+        if (argmax !== held && smoothed[argmax] - smoothed[held] < p.holdMargin) argmax = held;
+        held = argmax;
+
+        const probs = [...smoothed];
+        const out: ExpressionScores = {
+          present: true,
+          probs,
+          label: EXPRESSIONS[argmax],
+          confidence: probs[argmax],
+        };
+        return { expression: out };
+      },
+    };
+  },
+});

--- a/src/nodes/index.ts
+++ b/src/nodes/index.ts
@@ -12,14 +12,17 @@ import { syntheticHandsNode } from './sources/synthetic_hands';
 import { replaySourceNode } from './sources/replay';
 import { handFeaturesNode } from './features/hand_features';
 import { faceFeaturesNode } from './features/face_features';
+import { faceExpressionNode } from './features/face_expression';
 import { gestureClassifierNode } from './features/gesture_classifier';
 import { voiceMappingNode } from './mapping/voice_mapping';
 import { keyboardControlNode } from './mapping/keyboard_control';
 import { indirectMapNode } from './mapping/indirect_map';
+import { synthMergeNode } from './mapping/synth_merge';
 import { pickNode } from './mapping/pick';
 import { oneEuroNode } from './mapping/one_euro';
 import { lyriaNode } from './output/lyria';
 import { chordNode } from './music/chord';
+import { expressionChordNode } from './music/expression_chord';
 import { progressionNode } from './music/progression';
 import { transportNode } from './music/transport';
 import { scoreNode } from './music/score';
@@ -29,15 +32,18 @@ export { syntheticHandsNode } from './sources/synthetic_hands';
 export { replaySourceNode } from './sources/replay';
 export { handFeaturesNode } from './features/hand_features';
 export { faceFeaturesNode } from './features/face_features';
+export { faceExpressionNode } from './features/face_expression';
 export { gestureClassifierNode } from './features/gesture_classifier';
 export type { Pose, GestureEvent } from './features/gesture_classifier';
 export { voiceMappingNode } from './mapping/voice_mapping';
 export { keyboardControlNode } from './mapping/keyboard_control';
 export { indirectMapNode } from './mapping/indirect_map';
+export { synthMergeNode } from './mapping/synth_merge';
 export { pickNode } from './mapping/pick';
 export { oneEuroNode } from './mapping/one_euro';
 export { lyriaNode } from './output/lyria';
 export { chordNode, voiceChord } from './music/chord';
+export { expressionChordNode, CHORD_VOICE_ID_BASE } from './music/expression_chord';
 export { progressionNode } from './music/progression';
 export { transportNode } from './music/transport';
 export { scoreNode } from './music/score';
@@ -51,14 +57,17 @@ export const CORE_NODES = [
   replaySourceNode,
   handFeaturesNode,
   faceFeaturesNode,
+  faceExpressionNode,
   gestureClassifierNode,
   voiceMappingNode,
   keyboardControlNode,
   indirectMapNode,
+  synthMergeNode,
   pickNode,
   oneEuroNode,
   lyriaNode,
   chordNode,
+  expressionChordNode,
   progressionNode,
   transportNode,
   scoreNode,

--- a/src/nodes/mapping/synth_merge.ts
+++ b/src/nodes/mapping/synth_merge.ts
@@ -1,0 +1,39 @@
+/**
+ * `synth-merge` node — unions two {@link SynthParams} voice streams into one.
+ *
+ * The engine forbids fan-IN to a single input port, so two producers of synth
+ * params (e.g. the hand `voice-mapping` and the face `expression-chord`) cannot
+ * both wire into the synth's one `params` input. This node is the merge point:
+ * it takes them on distinct ports and concatenates their voices, so the player's
+ * hand melody and face-driven chord sound together. Voices keep their own ids
+ * (hands use 0/1, chords use ids ≥ 2), so the synth voices them independently.
+ *
+ * Pure + deterministic. An absent/empty input contributes no voices, so when the
+ * face chord is idle the merge passes the hand voices through unchanged.
+ */
+import { defineNode } from '@/dag';
+import type { SynthParams } from '../domain';
+
+const EMPTY: SynthParams = { voices: [] };
+
+const asParams = (v: unknown): SynthParams =>
+  v && typeof v === 'object' && Array.isArray((v as SynthParams).voices)
+    ? (v as SynthParams)
+    : EMPTY;
+
+export const synthMergeNode = defineNode({
+  type: 'synth-merge',
+  roles: ['mapping'],
+  title: 'Synth Merge',
+  description: 'Union two synth-params voice streams into one (e.g. hand voices + face-chord voices).',
+  inputs: [
+    { name: 'a', kind: 'synth-params' },
+    { name: 'b', kind: 'synth-params' },
+  ],
+  outputs: [{ name: 'params', kind: 'synth-params' }],
+  process(inputs) {
+    const a = asParams(inputs.a);
+    const b = asParams(inputs.b);
+    return { params: { voices: [...a.voices, ...b.voices] } };
+  },
+});

--- a/src/nodes/mapping/voice_mapping.ts
+++ b/src/nodes/mapping/voice_mapping.ts
@@ -121,7 +121,7 @@ export const voiceMappingNode = defineNode<Params>({
   inputs: [...MAPPING_SLOT_INPUTS],
   outputs: [MAPPING_SLOT_OUTPUT],
   params: Params,
-  process(inputs, p) {
+  process(inputs, p, ctx) {
     const f = (inputs.features as HandFeatures | undefined) ?? {
       left: { ...ABSENT_HAND },
       right: { ...ABSENT_HAND },
@@ -146,10 +146,18 @@ export const voiceMappingNode = defineNode<Params>({
       ? (inputs.instrumentLeft as VoiceParams['instrument'])
       : p.left.instrument);
 
-    // Face expression is global (one face modulates both hands).
+    // Face expression is global (one face modulates both hands). The face→timbre
+    // mapping only applies in the 'timbre' face mode: in 'chord' mode the face
+    // drives chords instead (via `expression-chord`), so suppress timbre here.
+    // The mode is read live from the control store; when it is absent (pure
+    // headless tests, or a host that predates the chooser) timbre applies as
+    // before — preserving the original face→brightness behaviour.
+    const faceMapping = (ctx?.resources?.controls as (() => { faceMapping?: string }) | undefined)?.()
+      ?.faceMapping;
+    const timbreMode = faceMapping === undefined || faceMapping === 'timbre';
     const face = inputs.face as FaceFeatures | undefined;
     const faceMod: FaceMod =
-      p.faceControlsExpression && face?.present
+      timbreMode && p.faceControlsExpression && face?.present
         ? {
             brightness: clamp01(face.smile) * FACE_SMILE_BRIGHTNESS,
             vibrato: clamp01(face.mouthOpen) * FACE_MOUTH_VIBRATO,

--- a/src/nodes/music/expression_chord.ts
+++ b/src/nodes/music/expression_chord.ts
@@ -1,0 +1,90 @@
+/**
+ * `expression-chord` node — turns a classified facial expression into the
+ * diatonic triad on its confusion-aware scale degree (issue #64). It is the
+ * "expression → chord" half of the face-mapping chooser: the player's expression
+ * (from `face-expression`) selects a scale degree via
+ * {@link DEFAULT_EXPRESSION_TO_DEGREE}, and the triad is built on the active
+ * seven-note scale ({@link diatonicTriad}).
+ *
+ * It emits chord voices on ids ≥ {@link CHORD_VOICE_ID_BASE}, so they never
+ * collide with the two hand voices (0, 1) and can be unioned into the synth
+ * alongside the hand melody (see `synth-merge`). The node is the live gate for
+ * the chord mode: it emits voices ONLY when `faceMapping === 'chord'`, the
+ * expression is present, and the current scale has seven notes — otherwise it
+ * emits nothing (silent), so timbre/none modes and pentatonic-style scales
+ * degrade gracefully.
+ *
+ * Pure + deterministic — testable from canned expression frames via `replayNode`.
+ */
+import { z } from 'zod';
+import { defineNode } from '@/dag';
+import { diatonicTriad, midiToFreq, type ScaleSpec } from '@/music/theory';
+import { InstrumentSchema } from '@/music/instruments';
+import { DEFAULT_EXPRESSION_TO_DEGREE, type ExpressionScores } from '@/music/expression';
+import type { VoiceParams } from '../domain';
+
+/** Chord voices start at this id, above the two hand voices (0 = right, 1 = left). */
+export const CHORD_VOICE_ID_BASE = 2;
+
+/** A diatonic triad has three tones; we always emit exactly this many voices. */
+const TRIAD_SIZE = 3;
+
+const Params = z.object({
+  /** Gain of each chord voice (0..1) — gentle by default so the triad supports,
+   *  rather than overpowers, the hand melody. */
+  gain: z.number().min(0).max(1).default(0.22),
+  /** Instrument timbre for the chord voices. */
+  instrument: InstrumentSchema.default('triangle'),
+});
+type Params = z.infer<typeof Params>;
+
+export const expressionChordNode = defineNode<Params>({
+  type: 'expression-chord',
+  roles: ['music'],
+  title: 'Expression Chord',
+  description:
+    'Facial expression → the diatonic triad on its confusion-aware scale degree (active only in face "chord" mode on seven-note scales).',
+  inputs: [
+    { name: 'expression', kind: 'face-expression' },
+    { name: 'spec', kind: 'scale-spec' },
+    { name: 'faceMapping', kind: 'face-mapping', default: 'none' },
+    // Live keyboard octave shift, so the chord tracks the same register as the
+    // hand melody (which also applies it). Unconnected → 0 (no shift).
+    { name: 'octaveShift', kind: 'number', default: 0 },
+  ],
+  outputs: [
+    { name: 'params', kind: 'synth-params' },
+    // The chosen triad as *un-shifted* scale MIDI notes, so the overlay highlight
+    // matches the raw scale-guide lines (whose labels already include the shift —
+    // so the highlighted line, its label, and the sounding pitch all agree).
+    { name: 'triad', kind: 'number[]' },
+  ],
+  params: Params,
+  process(inputs, p) {
+    const expr = inputs.expression as ExpressionScores | undefined;
+    const spec = inputs.spec as ScaleSpec | undefined;
+    const active = inputs.faceMapping === 'chord' && !!expr && expr.present && !!spec;
+    const shift = typeof inputs.octaveShift === 'number' ? inputs.octaveShift : 0;
+    // diatonicTriad returns 3 notes for seven-note scales, [] otherwise. These are
+    // the un-shifted scale tones (the `triad` output the overlay highlights).
+    const triad = active ? diatonicTriad(spec!, DEFAULT_EXPRESSION_TO_DEGREE[expr!.label]) : [];
+    // ALWAYS emit TRIAD_SIZE voices on stable ids: a present/sounding voice when
+    // active, an absent (gain 0) voice when idle. The synth releases voices it
+    // still sees in the array — so a vanishing voice would leave a chord stuck
+    // sounding. Keeping the ids stable lets it fade the triad out cleanly. The
+    // sounding pitch applies the octave shift so it stays in the melody's register.
+    const voices: VoiceParams[] = [];
+    for (let i = 0; i < TRIAD_SIZE; i++) {
+      const midi = triad[i];
+      const present = midi !== undefined;
+      voices.push({
+        id: CHORD_VOICE_ID_BASE + i,
+        present,
+        freq: midiToFreq((present ? midi : 60) + 12 * shift),
+        gain: present ? p.gain : 0,
+        instrument: p.instrument,
+      });
+    }
+    return { params: { voices }, triad };
+  },
+});

--- a/src/nodes/output/canvas_overlay.ts
+++ b/src/nodes/output/canvas_overlay.ts
@@ -51,6 +51,12 @@ const Params = z.object({
       showLabels: z.boolean().default(true),
     })
     .default({}),
+  /** Highlight the face-driven chord's tones on the pitch guide (face chord mode). */
+  chordGuide: z
+    .object({
+      show: z.boolean().default(true),
+    })
+    .default({}),
   /** Dashed vertical line from each index fingertip to the frame edge. Opt-in. */
   indexGuide: z
     .object({
@@ -102,6 +108,8 @@ export interface OverlayView {
     scale?: number[];
     scaleLeft?: number[];
     octaveShift: number;
+    /** The face-driven chord's tones (MIDI), to highlight on the pitch guide. */
+    chord?: number[];
   };
   params: Params;
 }
@@ -176,6 +184,44 @@ const scaleGuideElement: OverlayElement = {
     if (Array.isArray(scaleL) && scaleL.length > 1 && !arrEq(scaleL, scaleR)) {
       drawGuide(scaleL, LEFT_COLOR, 0.12, H * 0.18);
     }
+  },
+};
+
+/**
+ * Highlights the face-driven chord (issue #64): when the player is in face "chord"
+ * mode, each tone of the chosen diatonic triad lights up on the existing pitch
+ * guide, so the player sees which notes their expression is playing. The triad
+ * tones are scale notes, so they align exactly with the scaleGuide lines; this
+ * draws a brighter/thicker band over them. Idle (no chord) → draws nothing.
+ */
+const CHORD_COLOR = '#f5d142'; // warm gold, distinct from the white/blue scale guides
+const chordGuideElement: OverlayElement = {
+  name: 'chordGuide',
+  draw(g, { W, H, inputs, params }) {
+    if (!params.chordGuide.show) return;
+    const chord = inputs.chord;
+    const scale = inputs.scale;
+    if (!Array.isArray(chord) || chord.length === 0) return;
+    if (!Array.isArray(scale) || scale.length <= 1) return;
+    const guide = scaleGuide(scale);
+    g.save();
+    g.globalAlpha = 0.55;
+    g.strokeStyle = CHORD_COLOR;
+    g.lineWidth = 3;
+    const samePitchClass = (a: number, b: number) => (((a - b) % 12) + 12) % 12 === 0;
+    for (const midi of chord) {
+      // Prefer the exact guide line; when the tone is above the displayed range
+      // (e.g. the V/vii° top note in a 1-octave scale) fall back to its pitch
+      // class so it still lights up rather than silently dropping.
+      const entry = guide.find((e) => e.midi === midi) ?? guide.find((e) => samePitchClass(e.midi, midi));
+      if (!entry) continue;
+      const sx = entry.x * W;
+      g.beginPath();
+      g.moveTo(sx, H * 0.12);
+      g.lineTo(sx, H * 0.86);
+      g.stroke();
+    }
+    g.restore();
   },
 };
 
@@ -290,6 +336,7 @@ const controlMarkers: OverlayElement = {
 export const OVERLAY_ELEMENTS: readonly OverlayElement[] = [
   videoBackdrop,
   scaleGuideElement,
+  chordGuideElement,
   indexFingerGuide,
   landmarkDots,
   controlMarkers,
@@ -310,6 +357,8 @@ export const canvasOverlayNode = defineNode<Params>({
     { name: 'scale', kind: 'number[]' },
     // Optional: the left hand's scale, drawn as a second guide when it differs.
     { name: 'scaleLeft', kind: 'number[]' },
+    // Optional: the face-driven chord's tones (MIDI), highlighted on the guide.
+    { name: 'chord', kind: 'number[]' },
     // Optional: the live octave shift, so guide labels match the sounding pitch.
     { name: 'octaveShift', kind: 'number', default: 0 },
     // Optional: a live overlay element config (from the UI store) that overrides
@@ -346,6 +395,7 @@ export const canvasOverlayNode = defineNode<Params>({
             scale: inputs.scale as number[] | undefined,
             scaleLeft: inputs.scaleLeft as number[] | undefined,
             octaveShift: typeof inputs.octaveShift === 'number' ? inputs.octaveShift : 0,
+            chord: inputs.chord as number[] | undefined,
           },
         };
 

--- a/src/nodes/sources/store_controls.ts
+++ b/src/nodes/sources/store_controls.ts
@@ -10,8 +10,9 @@
 import { z } from 'zod';
 import { defineNode } from '@/dag';
 import type { NodeContext } from '@/dag';
-import { generateScale, type ScaleTypeId } from '@/music/theory';
+import { generateScale, type ScaleSpec, type ScaleTypeId } from '@/music/theory';
 import type { InstrumentId } from '@/music/instruments';
+import { legacyFaceToMapping, type FaceMapping } from '@/nodes/domain';
 import type { OverlayParams } from '@/nodes/output/canvas_overlay';
 
 export interface VoiceControlSnapshot {
@@ -26,8 +27,12 @@ export interface ControlSnapshot {
   left: VoiceControlSnapshot;
   /** Live overlay element config; forwarded to canvas-overlay's overlayConfig. */
   overlay?: OverlayParams;
-  /** Whether live face control is on; read directly by the `webcam-face` node. */
+  /** Legacy face on/off flag; superseded by {@link faceMapping}. Kept so older
+   *  hosts / saved data still gate the `webcam-face` model load. */
   faceEnabled?: boolean;
+  /** What the face controls: none / timbre / chord. Read by `webcam-face` (model
+   *  gating) and fed to `expression-chord` (chord-mode gating) as a port. */
+  faceMapping?: FaceMapping;
 }
 
 const Params = z.object({});
@@ -44,6 +49,9 @@ export const storeControlsNode = defineNode<Record<string, never>>({
     { name: 'instrumentRight', kind: 'instrument' },
     { name: 'instrumentLeft', kind: 'instrument' },
     { name: 'overlay', kind: 'overlay-config' },
+    // The right voice's scale spec + the face mode, for the expression→chord path.
+    { name: 'rightSpec', kind: 'scale-spec' },
+    { name: 'faceMapping', kind: 'face-mapping' },
   ],
   params: Params,
   make() {
@@ -52,11 +60,19 @@ export const storeControlsNode = defineNode<Record<string, never>>({
         const getter = ctx.resources.controls as (() => ControlSnapshot) | undefined;
         if (!getter) return {};
         const c = getter();
+        const rightSpec: ScaleSpec = {
+          root: c.right.root,
+          type: c.right.type,
+          octaves: c.right.octaves,
+          baseOctave: c.right.baseOctave,
+        };
         const out: Record<string, unknown> = {
           scaleRight: generateScale(c.right),
           scaleLeft: generateScale(c.left),
           instrumentRight: c.right.instrument,
           instrumentLeft: c.left.instrument,
+          rightSpec,
+          faceMapping: c.faceMapping ?? legacyFaceToMapping(c.faceEnabled),
         };
         if (c.overlay) out.overlay = c.overlay;
         return out;

--- a/src/nodes/sources/webcam_face.ts
+++ b/src/nodes/sources/webcam_face.ts
@@ -190,6 +190,7 @@ export const webcamFaceNode = defineNode<Params>({
             // GPU/WebGL unavailable on this client → fall back to the CPU delegate
             // (the float16 model runs on CPU). If CPU was already chosen, give up.
             if (p.delegate !== 'GPU') throw gpuErr;
+            console.warn('[thoremin] face model GPU delegate failed; falling back to CPU', gpuErr);
             lm = await vision.FaceLandmarker.createFromOptions(fileset, optionsFor('CPU'));
           }
           if (disposed || gen !== loadGen) {
@@ -200,10 +201,13 @@ export const webcamFaceNode = defineNode<Params>({
           landmarker = lm;
           failedGen = -1;
           if (raf === null) raf = requestAnimationFrame(loop);
-        } catch {
+        } catch (err) {
           // Load failed (offline / unsupported / blocked). Latch this generation
           // so we don't re-attempt the heavy create every tick; toggling face
-          // control off→on bumps loadGen via offload() and retries once.
+          // control off→on bumps loadGen via offload() and retries once. The error
+          // is logged (in addition to the user-facing toast) so the actual cause
+          // is diagnosable from the console.
+          console.warn('[thoremin] face model failed to load', err);
           failedGen = gen;
         } finally {
           loading = false;

--- a/src/nodes/sources/webcam_face.ts
+++ b/src/nodes/sources/webcam_face.ts
@@ -25,7 +25,7 @@
 import { z } from 'zod';
 import { defineNode } from '@/dag';
 import type { NodeContext } from '@/dag';
-import type { FaceFrame } from '../domain';
+import type { FaceFrame, FaceMapping, FaceStatus } from '../domain';
 
 // MediaPipe FaceLandmarker assets, loaded from a CDN on demand (mirrors how
 // `webcam-hands` resolves its MediaPipe solution from jsDelivr). The wasm
@@ -85,8 +85,17 @@ interface TasksVisionModule {
   };
 }
 
-/** Reads just the enable flag off the live controls snapshot. */
-type FaceControlsGetter = () => { faceEnabled?: boolean };
+/** Reads the face-mapping mode off the live controls snapshot. `faceMapping`
+ * supersedes the legacy boolean `faceEnabled` (kept for back-compat / tests). */
+type FaceControlsGetter = () => { faceEnabled?: boolean; faceMapping?: FaceMapping };
+
+/** Is any face mode active? `faceMapping !== 'none'`, falling back to the legacy
+ * `faceEnabled` flag when the newer field is absent (older callers / tests). */
+function faceActive(controls: ReturnType<FaceControlsGetter> | undefined): boolean {
+  if (!controls) return false;
+  if (controls.faceMapping !== undefined) return controls.faceMapping !== 'none';
+  return controls.faceEnabled === true;
+}
 
 export const webcamFaceNode = defineNode<Params>({
   type: 'webcam-face',
@@ -95,7 +104,12 @@ export const webcamFaceNode = defineNode<Params>({
   description:
     'MediaPipe FaceLandmarker blendshapes from the shared webcam (lazy-loaded, off by default).',
   inputs: [],
-  outputs: [{ name: 'face', kind: 'face-frame' }],
+  outputs: [
+    { name: 'face', kind: 'face-frame' },
+    // Lifecycle + detection status, so the UI can surface loading/ready/error
+    // and a face-detected indicator (issue #65).
+    { name: 'status', kind: 'face-status' },
+  ],
   params: Params,
   make(p) {
     let landmarker: FaceLandmarkerLike | null = null;
@@ -197,6 +211,14 @@ export const webcamFaceNode = defineNode<Params>({
       })();
     };
 
+    /** Snapshot the lazy-load lifecycle for the UI (issue #65). */
+    const statusOf = (enabled: boolean): FaceStatus => {
+      if (!enabled) return { phase: 'idle', faceDetected: false };
+      if (failedGen === loadGen) return { phase: 'error', faceDetected: false };
+      if (landmarker) return { phase: 'ready', faceDetected: latest.present };
+      return { phase: 'loading', faceDetected: false };
+    };
+
     return {
       init(ctx: NodeContext) {
         // Cheap: only capture the shared <video>. No model download here, so
@@ -206,17 +228,17 @@ export const webcamFaceNode = defineNode<Params>({
       process(_inputs, ctx: NodeContext) {
         video = (ctx.resources.video as HTMLVideoElement | undefined) ?? video;
         const getControls = ctx.resources.controls as FaceControlsGetter | undefined;
-        const enabled = getControls?.().faceEnabled === true;
+        const enabled = faceActive(getControls?.());
         if (!enabled) {
           // Release the model if one is loaded/loading; also clear a prior
           // failure latch so a deliberate re-enable retries the load.
           if (landmarker || loading || failedGen === loadGen) offload();
-          return { face: ABSENT_FRAME };
+          return { face: ABSENT_FRAME, status: statusOf(false) };
         }
         // Only spin up the model once we actually have a camera feed (so we
         // never download a face model with no <video> — e.g. headless).
         if (video) ensureLoaded();
-        return { face: latest };
+        return { face: latest, status: statusOf(true) };
       },
       dispose() {
         disposed = true;

--- a/src/nodes/sources/webcam_hands.ts
+++ b/src/nodes/sources/webcam_hands.ts
@@ -1,7 +1,15 @@
 /**
- * `webcam-hands` node (browser-only) — runs MediaPipe Hands (via
- * @tensorflow-models/hand-pose-detection) on a host-provided `<video>` element
- * and outputs the latest {@link HandsFrame}.
+ * `webcam-hands` source node (browser-only) — runs MediaPipe `HandLandmarker`
+ * (from `@mediapipe/tasks-vision`) on a host-provided `<video>` and outputs the
+ * latest {@link HandsFrame}.
+ *
+ * It uses **tasks-vision** — the SAME runtime as `webcam-face` — rather than the
+ * `@mediapipe/hands` Emscripten "solution" (via @tensorflow-models/hand-pose-
+ * detection's `runtime: 'mediapipe'`). Two *different* MediaPipe Emscripten
+ * modules collide on the global `Module` object, which aborts the FaceLandmarker
+ * load whenever both are present. Running hands and face on one tasks-vision
+ * runtime lets them coexist (one Emscripten module hosting two tasks), and keeps
+ * both at first-class MediaPipe quality.
  *
  * Key design point: ML inference is async and slower than the render loop, so
  * detection runs in its own loop and caches the latest result. `process` simply
@@ -9,21 +17,76 @@
  * `<video>` element is injected via `ctx.resources.video`.
  */
 import { z } from 'zod';
-// Type-only import is erased at runtime, so this module stays Node-safe; the
-// heavy TF.js/MediaPipe runtime is dynamically imported inside init() (browser
-// only). This lets the full app registry be built & topology-tested headlessly.
-import type * as HPD from '@tensorflow-models/hand-pose-detection';
 import { defineNode } from '@/dag';
 import type { NodeContext } from '@/dag';
 import type { Hand, Handedness, HandsFrame, Keypoint } from '../domain';
 
+// tasks-vision assets, loaded from a CDN on demand. The wasm fileset is pinned to
+// the installed `@mediapipe/tasks-vision` version (shared with `webcam-face`), and
+// the model is the float16 `hand_landmarker.task` (21 landmarks per hand).
+const TASKS_VISION_VERSION = '0.10.35';
+const WASM_BASE = `https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@${TASKS_VISION_VERSION}/wasm`;
+const MODEL_URL =
+  'https://storage.googleapis.com/mediapipe-models/hand_landmarker/hand_landmarker/float16/1/hand_landmarker.task';
+
 const Params = z.object({
+  // Retained for graph/preset compatibility; tasks-vision ships a single
+  // float16 hand model, so this does not select a model variant today.
   modelType: z.enum(['lite', 'full']).default('full'),
   maxHands: z.number().int().min(1).max(4).default(2),
 });
 type Params = z.infer<typeof Params>;
 
 const EMPTY: HandsFrame = { width: 640, height: 480, hands: [] };
+
+interface NormalizedLandmarkLike {
+  x: number;
+  y: number;
+  z?: number;
+}
+interface CategoryLike {
+  categoryName: string;
+}
+/** The minimal slice of a `HandLandmarkerResult` this node reads. */
+export interface HandLandmarkerResultLike {
+  landmarks: NormalizedLandmarkLike[][];
+  handedness: CategoryLike[][];
+}
+
+/**
+ * Pure converter: a tasks-vision `HandLandmarkerResult` (normalized landmarks,
+ * 0..1) → a {@link HandsFrame} with pixel keypoints in MediaPipe's 21-point order
+ * and 'Left'/'Right' handedness. Exported so it can be unit-tested headlessly
+ * (the live inference itself is browser-only). Landmark indices are unchanged, so
+ * `kp()`/`LM` keep working downstream (the names are absent, but lookups fall back
+ * to the index).
+ */
+export function resultToHandsFrame(res: HandLandmarkerResultLike, w: number, h: number): HandsFrame {
+  const hands: Hand[] = (res.landmarks ?? []).map((lms, i) => ({
+    handedness: (res.handedness?.[i]?.[0]?.categoryName as Handedness) ?? 'Right',
+    keypoints: lms.map((l): Keypoint => ({ x: l.x * w, y: l.y * h, z: l.z })),
+  }));
+  return { width: w, height: h, hands };
+}
+
+/** The minimal runtime surface of tasks-vision used here (browser-only, lazy). */
+interface HandLandmarkerLike {
+  detectForVideo(video: HTMLVideoElement, timestampMs: number): HandLandmarkerResultLike;
+  close(): void;
+}
+interface TasksVisionModule {
+  FilesetResolver: { forVisionTasks(wasmBase: string): Promise<unknown> };
+  HandLandmarker: {
+    createFromOptions(
+      fileset: unknown,
+      opts: {
+        baseOptions: { modelAssetPath: string; delegate?: 'GPU' | 'CPU' };
+        numHands?: number;
+        runningMode?: 'IMAGE' | 'VIDEO';
+      },
+    ): Promise<HandLandmarkerLike>;
+  };
+}
 
 export const webcamHandsNode = defineNode<Params>({
   type: 'webcam-hands',
@@ -34,49 +97,59 @@ export const webcamHandsNode = defineNode<Params>({
   outputs: [{ name: 'hands', kind: 'hands-frame' }],
   params: Params,
   make(p) {
-    let detector: HPD.HandDetector | null = null;
+    let landmarker: HandLandmarkerLike | null = null;
     let latest: HandsFrame = EMPTY;
     let raf: number | null = null;
     let disposed = false;
     let video: HTMLVideoElement | undefined;
+    let lastVideoTime = -1;
 
-    const toFrame = (hands: HPD.Hand[], w: number, h: number): HandsFrame => ({
-      width: w,
-      height: h,
-      hands: hands.map(
-        (hand): Hand => ({
-          handedness: (hand.handedness as Handedness) ?? 'Right',
-          score: hand.score,
-          keypoints: hand.keypoints.map((k): Keypoint => ({ x: k.x, y: k.y, name: k.name })),
-        }),
-      ),
-    });
-
-    const loop = async () => {
+    const loop = () => {
       if (disposed) return;
-      try {
-        if (detector && video && video.readyState >= 2 && video.videoWidth > 0) {
-          const hands = await detector.estimateHands(video, { flipHorizontal: false });
-          latest = toFrame(hands, video.videoWidth, video.videoHeight);
+      // Only run inference on a fresh, ready video frame; performance.now() is
+      // monotonic, satisfying detectForVideo's strictly-increasing-timestamp rule.
+      if (
+        landmarker &&
+        video &&
+        video.readyState >= 2 &&
+        video.videoWidth > 0 &&
+        video.currentTime !== lastVideoTime
+      ) {
+        lastVideoTime = video.currentTime;
+        try {
+          const res = landmarker.detectForVideo(video, performance.now());
+          latest = resultToHandsFrame(res, video.videoWidth, video.videoHeight);
+        } catch {
+          /* transient inference error; keep last frame */
         }
-      } catch {
-        /* transient inference error; keep last frame */
       }
       raf = requestAnimationFrame(loop);
     };
 
+    const optionsFor = (delegate: 'GPU' | 'CPU') => ({
+      baseOptions: { modelAssetPath: MODEL_URL, delegate },
+      numHands: p.maxHands,
+      runningMode: 'VIDEO' as const,
+    });
+
     return {
       async init(ctx: NodeContext) {
         video = ctx.resources.video as HTMLVideoElement | undefined;
-        const handPoseDetection = await import('@tensorflow-models/hand-pose-detection');
-        await import('@tensorflow/tfjs-backend-webgl');
-        const model = handPoseDetection.SupportedModels.MediaPipeHands;
-        detector = await handPoseDetection.createDetector(model, {
-          runtime: 'mediapipe',
-          solutionPath: 'https://cdn.jsdelivr.net/npm/@mediapipe/hands',
-          modelType: p.modelType,
-          maxHands: p.maxHands,
-        } as HPD.MediaPipeHandsMediaPipeModelConfig);
+        const vision = (await import('@mediapipe/tasks-vision')) as unknown as TasksVisionModule;
+        const fileset = await vision.FilesetResolver.forVisionTasks(WASM_BASE);
+        try {
+          landmarker = await vision.HandLandmarker.createFromOptions(fileset, optionsFor('GPU'));
+        } catch (gpuErr) {
+          // GPU/WebGL unavailable on this client → fall back to the CPU delegate.
+          console.warn('[thoremin] hand model GPU delegate failed; falling back to CPU', gpuErr);
+          landmarker = await vision.HandLandmarker.createFromOptions(fileset, optionsFor('CPU'));
+        }
+        if (disposed) {
+          // Unmounted while loading — don't resurrect.
+          landmarker.close();
+          landmarker = null;
+          return;
+        }
         raf = requestAnimationFrame(loop);
       },
       process() {
@@ -85,8 +158,8 @@ export const webcamHandsNode = defineNode<Params>({
       dispose() {
         disposed = true;
         if (raf !== null) cancelAnimationFrame(raf);
-        detector?.dispose();
-        detector = null;
+        landmarker?.close();
+        landmarker = null;
       },
     };
   },

--- a/src/settings/schema.ts
+++ b/src/settings/schema.ts
@@ -12,10 +12,16 @@
 import { z } from 'zod';
 import { SCALE_TYPES, type ScaleTypeId } from '@/music/theory';
 import { INSTRUMENT_IDS, type InstrumentId } from '@/music/instruments';
+import { FACE_MAPPINGS, legacyFaceToMapping, type FaceMapping } from '@/nodes/domain';
 import { OverlayParamsSchema } from '@/nodes/output/canvas_overlay';
 
 const ScaleTypeEnum = z.enum(Object.keys(SCALE_TYPES) as [ScaleTypeId, ...ScaleTypeId[]]);
 const InstrumentEnum = z.enum(INSTRUMENT_IDS as [InstrumentId, ...InstrumentId[]]);
+
+/** What the player's facial expression controls (none / timbre / chord). */
+export const FaceMappingSchema = z.enum(
+  FACE_MAPPINGS as unknown as [FaceMapping, ...FaceMapping[]],
+);
 
 /** One hand's musical settings — mirrors VoiceControl in src/app/store.ts. */
 export const VoiceSettingsSchema = z.object({
@@ -33,12 +39,28 @@ export const SettingsSchema = z.object({
   left: VoiceSettingsSchema,
   syncHands: z.boolean(),
   masterVolume: z.number().min(0).max(1),
-  // `.default(false)` keeps presets saved before face control was added valid
+  // `.default('none')` keeps presets saved before the face-mapping chooser valid
   // (the field is filled in on parse rather than failing validation).
-  faceEnabled: z.boolean().default(false),
+  faceMapping: FaceMappingSchema.default('none'),
   overlay: OverlayParamsSchema,
 });
 export type Settings = z.infer<typeof SettingsSchema>;
+
+/**
+ * Migrate a raw settings blob saved with the old boolean `faceEnabled` (pre-#64):
+ * a saved `faceEnabled: true` becomes `faceMapping: 'timbre'` so a returning
+ * player keeps face control on rather than silently reverting to off. New blobs
+ * (which already carry `faceMapping`) pass through untouched.
+ */
+function migrateLegacyFace(raw: unknown): unknown {
+  if (raw && typeof raw === 'object') {
+    const r = raw as Record<string, unknown>;
+    if (r.faceMapping === undefined && r.faceEnabled !== undefined) {
+      return { ...r, faceMapping: legacyFaceToMapping(r.faceEnabled as boolean | undefined) };
+    }
+  }
+  return raw;
+}
 
 /** A named, persisted settings snapshot (one record in the presets collection). */
 export const PresetSchema = z.object({
@@ -48,7 +70,8 @@ export const PresetSchema = z.object({
   name: z.string(),
   /** Creation/last-save time (ms since epoch), for "most recent first" ordering. */
   createdAt: z.number(),
-  settings: SettingsSchema,
+  // Preprocess migrates pre-#64 presets (boolean faceEnabled → faceMapping) on load.
+  settings: z.preprocess(migrateLegacyFace, SettingsSchema),
 });
 export type Preset = z.infer<typeof PresetSchema>;
 

--- a/test/app_graph.test.ts
+++ b/test/app_graph.test.ts
@@ -15,15 +15,20 @@ describe('production app graph', () => {
   it('builds with a valid topology', () => {
     const engine = new Engine(defaultGraph(), createAppRegistry());
     const order = engine.evaluationOrder();
-    // sources must precede mapping which must precede synth
+    // sources must precede mapping which (via the merge) must precede synth
     expect(order.indexOf('cam')).toBeLessThan(order.indexOf('feat'));
     expect(order.indexOf('feat')).toBeLessThan(order.indexOf('map'));
-    expect(order.indexOf('map')).toBeLessThan(order.indexOf('synth'));
+    expect(order.indexOf('map')).toBeLessThan(order.indexOf('merge'));
+    expect(order.indexOf('merge')).toBeLessThan(order.indexOf('synth'));
     expect(order.indexOf('kbd')).toBeLessThan(order.indexOf('kctrl'));
-    // face branch: webcam-face → face-features → voice-mapping
+    // face timbre branch: webcam-face → face-features → voice-mapping
     expect(order.indexOf('camFace')).toBeLessThan(order.indexOf('faceFeat'));
     expect(order.indexOf('faceFeat')).toBeLessThan(order.indexOf('map'));
-    expect(order).toHaveLength(10);
+    // face chord branch: webcam-face → face-expression → expression-chord → merge
+    expect(order.indexOf('camFace')).toBeLessThan(order.indexOf('faceExpr'));
+    expect(order.indexOf('faceExpr')).toBeLessThan(order.indexOf('exprChord'));
+    expect(order.indexOf('exprChord')).toBeLessThan(order.indexOf('merge'));
+    expect(order).toHaveLength(13);
   });
 
   it('ticks cleanly with no host resources (everything no-ops or idles)', () => {
@@ -42,5 +47,13 @@ describe('production app graph', () => {
     // No hands present → both voices silent.
     expect(params[0].voices.every((v) => !v.present)).toBe(true);
     expect(params[0].voices).toHaveLength(2);
+
+    // The synth's actual input is the merge of hand voices (0,1) + the 3 stable
+    // chord voices (2,3,4) — distinct ids, all silent while the face chord is idle.
+    const merged = recorder.values('merge.params') as SynthParams[];
+    const ids = merged[0].voices.map((v) => v.id);
+    expect(ids).toEqual([0, 1, 2, 3, 4]);
+    expect(new Set(ids).size).toBe(5); // no id collision between hands and chord
+    expect(merged[0].voices.every((v) => !v.present)).toBe(true);
   });
 });

--- a/test/app_store.test.ts
+++ b/test/app_store.test.ts
@@ -7,7 +7,7 @@
  * audio. (The full graph's topology + clean tick are covered by app_graph.test.)
  */
 import { describe, it, expect, beforeEach } from 'vitest';
-import { useControls, toSettings } from '@/app/store';
+import { useControls, toSettings, migrateControls, mergeControls } from '@/app/store';
 import { storeControlsNode } from '@/nodes/browser';
 import { generateScale } from '@/music/theory';
 import { DEFAULT_INSTRUMENT_RIGHT, DEFAULT_INSTRUMENT_LEFT } from '@/music/instruments';
@@ -28,6 +28,14 @@ describe('control store', () => {
     expect(s.left.type).toBe('pentatonic');
     expect(s.syncHands).toBe(true);
     expect(s.masterVolume).toBeCloseTo(0.4, 6);
+    expect(s.faceMapping).toBe('none'); // face control off by default
+  });
+
+  it('setFaceMapping switches the face mapping mode', () => {
+    useControls.getState().setFaceMapping('chord');
+    expect(useControls.getState().faceMapping).toBe('chord');
+    useControls.getState().setFaceMapping('none');
+    expect(useControls.getState().faceMapping).toBe('none');
   });
 
   it('setVoice with sync ON mirrors both hands but keeps instruments distinct', () => {
@@ -102,11 +110,13 @@ describe('control store', () => {
     useControls.getState().setSync(false);
     useControls.getState().setVoice('right', { root: 3, instrument: 'bell' });
     useControls.getState().setMasterVolume(0.6);
+    useControls.getState().setFaceMapping('chord');
     useControls.getState().setOverlayElement('indexGuide', { show: true });
     const snap = toSettings(useControls.getState());
 
     // Mutate away, then restore from the snapshot.
     useControls.getState().setMasterVolume(0.1);
+    useControls.getState().setFaceMapping('none');
     useControls.getState().setOverlayElement('indexGuide', { show: false });
     useControls.getState().applySettings(snap);
 
@@ -114,7 +124,33 @@ describe('control store', () => {
     expect(s.masterVolume).toBeCloseTo(0.6);
     expect(s.right.instrument).toBe('bell');
     expect(s.syncHands).toBe(false);
+    expect(s.faceMapping).toBe('chord');
     expect(s.overlay.indexGuide.show).toBe(true);
+  });
+});
+
+describe('persist migration (v1 → v2, returning users)', () => {
+  it('migrateControls maps the legacy faceEnabled flag onto faceMapping', () => {
+    const on = migrateControls({ masterVolume: 0.5, faceEnabled: true }, 1) as unknown as Record<string, unknown>;
+    expect(on.faceMapping).toBe('timbre');
+    expect(on.faceEnabled).toBeUndefined();
+    expect(
+      (migrateControls({ faceEnabled: false }, 1) as unknown as Record<string, unknown>).faceMapping,
+    ).toBe('none');
+  });
+
+  it('mergeControls heals a stale overlay (missing chordGuide) so it cannot crash readers', () => {
+    const initial = useControls.getInitialState();
+    // A v1-style overlay blob written before the chordGuide element existed.
+    const legacyOverlay = { video: { show: true, alpha: 0.35 }, scaleGuide: { show: true, showLabels: true } };
+    const merged = mergeControls({ overlay: legacyOverlay }, initial);
+    expect(typeof merged.overlay.chordGuide?.show).toBe('boolean'); // default filled in, no crash
+  });
+
+  it('mergeControls clamps an unknown faceMapping to a safe value', () => {
+    const initial = useControls.getInitialState();
+    expect(mergeControls({ faceMapping: 'rainbow' as never }, initial).faceMapping).toBe('none');
+    expect(mergeControls({ faceMapping: 'chord' }, initial).faceMapping).toBe('chord');
   });
 });
 
@@ -131,6 +167,7 @@ describe('store-controls node reads the store', () => {
     useControls.getState().setVoice('right', { root: 2, type: 'minor', instrument: 'square' });
     useControls.getState().setVoice('left', { root: 9, instrument: 'sawtooth' });
 
+    useControls.getState().setFaceMapping('chord');
     const node = storeControlsNode.make(storeControlsNode.params.parse({}));
     const out = node.process({}, ctxWith({ controls: () => useControls.getState() }));
 
@@ -140,6 +177,9 @@ describe('store-controls node reads the store', () => {
     expect(out.scaleRight).toEqual(generateScale(s.right));
     expect(out.scaleLeft).toEqual(generateScale(s.left));
     expect((out.scaleRight as number[]).length).toBeGreaterThan(0);
+    // The chord-path ports: the right voice's scale spec + the face mode.
+    expect(out.faceMapping).toBe('chord');
+    expect(out.rightSpec).toMatchObject({ root: 2, type: 'minor' });
   });
 
   it('emits nothing when no controls getter is injected (safe before host wires it)', () => {

--- a/test/expression_map.test.ts
+++ b/test/expression_map.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Tests the pure expression layer (issue #64): the diatonic-triad builder
+ * (theory.ts), the blendshape→expression classifier, and the confusion-aware
+ * expression→scale-degree assignment + its brute-force optimizer.
+ */
+import { describe, it, expect } from 'vitest';
+import { diatonicTriad, isSevenNoteScale, type ScaleSpec } from '@/music/theory';
+import {
+  EXPRESSIONS,
+  blendshapesToExpression,
+  triadDegreeSet,
+  sharedTriadNotes,
+  assignmentObjective,
+  optimalExpressionToDegree,
+  RECOMMENDED_EXPRESSION_TO_DEGREE,
+  CONFUSION_FER2013,
+  type ExpressionLabel,
+} from '@/music/expression';
+
+const cMajor: ScaleSpec = { root: 0, type: 'major', octaves: 2, baseOctave: 3 };
+
+describe('diatonicTriad', () => {
+  it('builds the tonic triad (I) as stacked thirds', () => {
+    // C major, baseOctave 3 → C3=48, E3=52, G3=55.
+    expect(diatonicTriad(cMajor, 0)).toEqual([48, 52, 55]);
+  });
+
+  it('builds the dominant (V) wrapping the octave to stay ascending', () => {
+    // G3=55, B3=59, D4=62.
+    expect(diatonicTriad(cMajor, 4)).toEqual([55, 59, 62]);
+  });
+
+  it('builds the diminished leading-tone triad (vii°)', () => {
+    // B3=59, D4=62, F4=65.
+    expect(diatonicTriad(cMajor, 6)).toEqual([59, 62, 65]);
+  });
+
+  it('respects harmonic minor (irregular qualities) via scale-thirds', () => {
+    // A harmonic minor degrees: A B C D E F G#. iii (C) is augmented: C E G#.
+    const aHarm: ScaleSpec = { root: 9, type: 'minorHarmonic', octaves: 2, baseOctave: 3 };
+    const triad = diatonicTriad(aHarm, 2);
+    // pitch classes C(0), E(4), G#(8) — an augmented triad.
+    expect(triad.map((m) => ((m % 12) + 12) % 12).sort((a, b) => a - b)).toEqual([0, 4, 8]);
+  });
+
+  it('returns [] for non-seven-note scales', () => {
+    expect(isSevenNoteScale('pentatonic')).toBe(false);
+    expect(diatonicTriad({ ...cMajor, type: 'pentatonic' }, 0)).toEqual([]);
+    expect(diatonicTriad({ ...cMajor, type: 'blues' }, 0)).toEqual([]);
+  });
+});
+
+describe('blendshapesToExpression', () => {
+  const classify = (bs: Record<string, number>) => blendshapesToExpression(bs);
+
+  it('reads a smile as happy', () => {
+    expect(classify({ mouthSmileLeft: 1, mouthSmileRight: 1 }).label).toBe('happy');
+  });
+
+  it('reads furrowed brows as angry (not disgust)', () => {
+    expect(classify({ browDownLeft: 1, browDownRight: 1 }).label).toBe('angry');
+  });
+
+  it('reads a sneer + raised upper lip as disgusted', () => {
+    expect(
+      classify({ noseSneerLeft: 1, noseSneerRight: 1, mouthUpperUpLeft: 0.8, mouthUpperUpRight: 0.8 })
+        .label,
+    ).toBe('disgusted');
+  });
+
+  it('reads a wide-eyed open jaw with outer-brow raise as surprised', () => {
+    expect(
+      classify({
+        jawOpen: 1,
+        eyeWideLeft: 0.8,
+        eyeWideRight: 0.8,
+        browOuterUpLeft: 0.7,
+        browOuterUpRight: 0.7,
+      }).label,
+    ).toBe('surprised');
+  });
+
+  it('distinguishes fear from surprise by the inner-brow raise', () => {
+    expect(
+      classify({ jawOpen: 0.7, eyeWideLeft: 0.9, eyeWideRight: 0.9, browInnerUp: 0.9 }).label,
+    ).toBe('fearful');
+  });
+
+  it('reads a frown + inner-brow raise as sad', () => {
+    expect(classify({ mouthFrownLeft: 1, mouthFrownRight: 1, browInnerUp: 0.7 }).label).toBe('sad');
+  });
+
+  it('falls back to neutral on a resting face', () => {
+    expect(classify({}).label).toBe('neutral');
+    expect(classify({ _neutral: 0.95 }).label).toBe('neutral');
+  });
+
+  it('returns a valid softmax distribution', () => {
+    const r = classify({ mouthSmileLeft: 1, mouthSmileRight: 1 });
+    expect(r.probs).toHaveLength(EXPRESSIONS.length);
+    expect(r.probs.reduce((a, b) => a + b, 0)).toBeCloseTo(1, 5);
+    for (const p of r.probs) expect(p).toBeGreaterThanOrEqual(0);
+    expect(r.confidence).toBeCloseTo(Math.max(...r.probs), 10);
+  });
+});
+
+describe('triad note-sharing graph', () => {
+  it('a triad is its root plus two stacked scale-thirds', () => {
+    expect(triadDegreeSet(0)).toEqual([0, 2, 4]);
+    expect(triadDegreeSet(6)).toEqual([6, 1, 3]);
+  });
+
+  it('thirds-apart triads share 2 notes, fifths 1, steps 0', () => {
+    expect(sharedTriadNotes(0, 0)).toBe(3);
+    expect(sharedTriadNotes(0, 2)).toBe(2); // I ↔ iii (mediant)
+    expect(sharedTriadNotes(0, 4)).toBe(1); // I ↔ V (dominant)
+    expect(sharedTriadNotes(0, 1)).toBe(0); // I ↔ ii (step)
+  });
+});
+
+describe('confusion-aware assignment', () => {
+  const distinct = (a: Record<ExpressionLabel, number>) =>
+    new Set(Object.values(a)).size === EXPRESSIONS.length;
+
+  it('the recommended seed is a valid bijection over degrees 0..6', () => {
+    expect(distinct(RECOMMENDED_EXPRESSION_TO_DEGREE)).toBe(true);
+    expect(new Set(Object.values(RECOMMENDED_EXPRESSION_TO_DEGREE))).toEqual(
+      new Set([0, 1, 2, 3, 4, 5, 6]),
+    );
+  });
+
+  it('places all five non-trivial confusion pairs on 2-note-sharing triads, happy on the tonic', () => {
+    const a = RECOMMENDED_EXPRESSION_TO_DEGREE;
+    expect(sharedTriadNotes(a.disgusted, a.angry)).toBe(2);
+    expect(sharedTriadNotes(a.angry, a.fearful)).toBe(2);
+    expect(sharedTriadNotes(a.fearful, a.sad)).toBe(2);
+    expect(sharedTriadNotes(a.sad, a.neutral)).toBe(2);
+    expect(sharedTriadNotes(a.happy, a.neutral)).toBe(2);
+    expect(a.happy).toBe(0); // happy → tonic (the resting "home" chord)
+  });
+
+  it('the shipped assignment IS the objective maximum of the shipped matrix', () => {
+    // Non-tautological: pins that RECOMMENDED equals the brute-force optimum
+    // (a regression in the matrix or shared-note math moves one of these).
+    const optimal = optimalExpressionToDegree(CONFUSION_FER2013);
+    expect(distinct(optimal)).toBe(true);
+    expect(optimal).toEqual(RECOMMENDED_EXPRESSION_TO_DEGREE);
+    expect(assignmentObjective(optimal)).toBeCloseTo(2.11, 5);
+  });
+
+  it('recomputes from a custom (measured) matrix without throwing', () => {
+    // A trivial matrix: only happy↔neutral confused → they should land on a
+    // 2-note-sharing pair in the optimum.
+    const idx = Object.fromEntries(EXPRESSIONS.map((e, i) => [e, i]));
+    const m = Array.from({ length: 7 }, () => new Array(7).fill(0));
+    m[idx.happy][idx.neutral] = 1;
+    m[idx.neutral][idx.happy] = 1;
+    const opt = optimalExpressionToDegree(m);
+    expect(sharedTriadNotes(opt.happy, opt.neutral)).toBe(2);
+  });
+});

--- a/test/face_chord_nodes.test.ts
+++ b/test/face_chord_nodes.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Tests the three new DAG nodes for the face-mapping chooser (issues #64/#65):
+ *   - `face-expression`  : blendshapes → smoothed/held 7-class expression
+ *   - `expression-chord` : expression + scale → diatonic triad voices (chord mode)
+ *   - `synth-merge`      : union two synth-params streams
+ * All pure + headless via replayNode.
+ */
+import { describe, it, expect } from 'vitest';
+import { replayNode } from '@/dag';
+import type { NodeContext } from '@/dag';
+import { faceExpressionNode, expressionChordNode, synthMergeNode, voiceMappingNode } from '@/nodes';
+import { CHORD_VOICE_ID_BASE, ABSENT_HAND, ABSENT_FACE } from '@/nodes';
+import type { ExpressionScores } from '@/music/expression';
+import { DEFAULT_EXPRESSION_TO_DEGREE } from '@/music/expression';
+import { diatonicTriad, midiToFreq, type ScaleSpec } from '@/music/theory';
+import type { FaceFrame, FaceFeatures, HandFeatures, SynthParams } from '@/nodes';
+
+const frame = (blendshapes: Record<string, number>): FaceFrame => ({ present: true, blendshapes });
+const ABSENT_FRAME: FaceFrame = { present: false, blendshapes: {} };
+const cMajor: ScaleSpec = { root: 0, type: 'major', octaves: 2, baseOctave: 3 };
+
+async function classify(frames: FaceFrame[], params: Record<string, unknown> = {}) {
+  const node = faceExpressionNode.make(faceExpressionNode.params.parse(params));
+  const out = await replayNode(node, { face: frames });
+  return out.map((o) => o.expression as ExpressionScores);
+}
+
+describe('face-expression node', () => {
+  it('classifies a smile as happy once smoothing settles', async () => {
+    const smile = frame({ mouthSmileLeft: 1, mouthSmileRight: 1 });
+    const out = await classify(Array(12).fill(smile), { smoothing: 0.4 });
+    expect(out[out.length - 1].label).toBe('happy');
+    expect(out[out.length - 1].present).toBe(true);
+  });
+
+  it('reports absent + neutral on an absent face', async () => {
+    const out = await classify([ABSENT_FRAME]);
+    expect(out[0].present).toBe(false);
+    expect(out[0].label).toBe('neutral');
+  });
+
+  it('keeps the smoothed distribution a valid simplex every tick', async () => {
+    const seq = [
+      frame({ mouthSmileLeft: 1, mouthSmileRight: 1 }),
+      frame({ jawOpen: 1, eyeWideLeft: 0.8, eyeWideRight: 0.8, browOuterUpLeft: 0.7, browOuterUpRight: 0.7 }),
+      ABSENT_FRAME,
+      frame({ browDownLeft: 1, browDownRight: 1 }),
+    ];
+    const out = await classify(seq, { smoothing: 0.5 });
+    for (const o of out) {
+      expect(o.probs.reduce((a, b) => a + b, 0)).toBeCloseTo(1, 5);
+    }
+  });
+
+  it('hysteresis holds the current label against a sub-margin challenger', async () => {
+    // With a large hold margin, a single off-frame should not flip the label.
+    const happy = frame({ mouthSmileLeft: 1, mouthSmileRight: 1 });
+    const blip = frame({ mouthSmileLeft: 0.5, mouthSmileRight: 0.5, browDownLeft: 0.55, browDownRight: 0.55 });
+    const out = await classify([...Array(10).fill(happy), blip], { smoothing: 0.6, holdMargin: 0.9 });
+    expect(out[out.length - 1].label).toBe('happy');
+  });
+});
+
+async function chordVoices(
+  expr: ExpressionScores,
+  faceMapping: string,
+  spec: ScaleSpec | undefined = cMajor,
+  params: Record<string, unknown> = {},
+) {
+  const node = expressionChordNode.make(expressionChordNode.params.parse(params));
+  const out = await replayNode(node, {
+    expression: [expr],
+    spec: [spec],
+    faceMapping: [faceMapping],
+  });
+  return out[0];
+}
+
+const happyExpr: ExpressionScores = {
+  present: true,
+  probs: [1, 0, 0, 0, 0, 0, 0],
+  label: 'happy',
+  confidence: 1,
+};
+
+describe('expression-chord node', () => {
+  it('plays the diatonic triad of the expression-mapped degree in chord mode', async () => {
+    const out = await chordVoices(happyExpr, 'chord');
+    const params = out.params as SynthParams;
+    const degree = DEFAULT_EXPRESSION_TO_DEGREE.happy; // 0 = tonic
+    const expected = diatonicTriad(cMajor, degree);
+    expect(out.triad).toEqual(expected);
+    const present = params.voices.filter((v) => v.present);
+    expect(present.map((v) => v.id)).toEqual([
+      CHORD_VOICE_ID_BASE,
+      CHORD_VOICE_ID_BASE + 1,
+      CHORD_VOICE_ID_BASE + 2,
+    ]);
+    expect(present.map((v) => Math.round(v.freq))).toEqual(expected.map((m) => Math.round(midiToFreq(m))));
+  });
+
+  it('emits three stable-id but silent voices when not in chord mode', async () => {
+    for (const mode of ['none', 'timbre']) {
+      const out = await chordVoices(happyExpr, mode);
+      const params = out.params as SynthParams;
+      expect(out.triad).toEqual([]);
+      expect(params.voices).toHaveLength(3); // stable ids, so the synth can release them
+      expect(params.voices.every((v) => !v.present && v.gain === 0)).toBe(true);
+      expect(params.voices.map((v) => v.id)).toEqual([2, 3, 4]);
+    }
+  });
+
+  it('stays silent on a non-seven-note scale even in chord mode', async () => {
+    const out = await chordVoices(happyExpr, 'chord', { ...cMajor, type: 'pentatonic' });
+    expect(out.triad).toEqual([]);
+    expect((out.params as SynthParams).voices.every((v) => !v.present)).toBe(true);
+  });
+
+  it('stays silent when the face is absent', async () => {
+    const absent: ExpressionScores = { present: false, probs: [0, 0, 0, 0, 0, 0, 1], label: 'neutral', confidence: 1 };
+    const out = await chordVoices(absent, 'chord');
+    expect((out.params as SynthParams).voices.every((v) => !v.present)).toBe(true);
+  });
+
+  it('follows the keyboard octave shift in audio while keeping the overlay triad un-shifted', async () => {
+    const node = expressionChordNode.make(expressionChordNode.params.parse({}));
+    const out = await replayNode(node, {
+      expression: [happyExpr],
+      spec: [cMajor],
+      faceMapping: ['chord'],
+      octaveShift: [1],
+    });
+    const rawTriad = diatonicTriad(cMajor, DEFAULT_EXPRESSION_TO_DEGREE.happy);
+    expect(out[0].triad).toEqual(rawTriad); // overlay triad stays at scale pitch (un-shifted)
+    const present = (out[0].params as SynthParams).voices.filter((v) => v.present);
+    // ...but the sounding pitch is an octave up, tracking the hand melody.
+    expect(present.map((v) => Math.round(v.freq))).toEqual(rawTriad.map((m) => Math.round(midiToFreq(m + 12))));
+  });
+});
+
+// A present right hand (openness 0 → baseline brightness 0.3) and an expressive
+// face — so smile→brightness and mouthOpen→vibrato are measurable when applied.
+const presentHand: HandFeatures = {
+  right: { ...ABSENT_HAND, present: true, x: 0.5, y: 0.3, openness: 0, pinch: 0 },
+  left: { ...ABSENT_HAND },
+};
+const expressiveFace: FaceFeatures = { ...ABSENT_FACE, present: true, smile: 1, mouthOpen: 1 };
+
+function rightVoiceUnderMode(faceMapping?: string) {
+  const node = voiceMappingNode.make(voiceMappingNode.params.parse({}));
+  const ctx = {
+    tick: 0,
+    time: 0,
+    dt: 0,
+    resources: faceMapping === undefined ? {} : { controls: () => ({ faceMapping }) },
+  } as unknown as NodeContext;
+  const out = node.process({ features: presentHand, face: expressiveFace }, ctx);
+  return (out.params as SynthParams).voices[0];
+}
+
+describe('voice-mapping face→timbre suppression (#64 chord mode)', () => {
+  it('applies face→timbre in timbre mode AND when no mode is set (back-compat)', () => {
+    for (const mode of ['timbre', undefined]) {
+      const v = rightVoiceUnderMode(mode);
+      expect(v.vibrato).toBeCloseTo(0.6, 5); // mouthOpen → vibrato
+      expect(v.brightness).toBeCloseTo(0.8, 5); // smile → brightness (0.3 base + 0.5)
+    }
+  });
+
+  it('suppresses face→timbre in chord mode (the face drives chords instead)', () => {
+    const v = rightVoiceUnderMode('chord');
+    expect(v.vibrato).toBeCloseTo(0, 5);
+    expect(v.brightness).toBeCloseTo(0.3, 5); // baseline only, no face contribution
+  });
+});
+
+describe('synth-merge node', () => {
+  it('concatenates voices from both inputs', async () => {
+    const node = synthMergeNode.make(synthMergeNode.params.parse({}));
+    const a: SynthParams = { voices: [{ id: 0, present: true, freq: 440, gain: 0.5, instrument: 'sine' }] };
+    const b: SynthParams = { voices: [{ id: 2, present: true, freq: 550, gain: 0.2, instrument: 'triangle' }] };
+    const out = await replayNode(node, { a: [a], b: [b] });
+    const merged = out[0].params as SynthParams;
+    expect(merged.voices.map((v) => v.id)).toEqual([0, 2]);
+  });
+
+  it('treats a missing input as no voices (hand voices pass through when chord idle)', async () => {
+    const node = synthMergeNode.make(synthMergeNode.params.parse({}));
+    const a: SynthParams = { voices: [{ id: 0, present: true, freq: 440, gain: 0.5, instrument: 'sine' }] };
+    const out = await replayNode(node, { a: [a] });
+    expect((out[0].params as SynthParams).voices).toHaveLength(1);
+  });
+});

--- a/test/overlay_elements.test.ts
+++ b/test/overlay_elements.test.ts
@@ -177,6 +177,60 @@ describe('canvas-overlay composable elements', () => {
     expect(noNotes.count('fillText')).toBe(0); // but no note labels
   });
 
+  it('chordGuide: highlights the chord tones that fall on the scale guide', () => {
+    const rc = makeRecordingCanvas();
+    const onlyChord = {
+      video: { show: false },
+      scaleGuide: { show: false },
+      indexGuide: { show: false },
+      landmarks: { show: false },
+      markers: { show: false },
+    };
+    const handlers = canvasOverlayNode.make(canvasOverlayNode.params.parse(onlyChord));
+    const ctx: NodeContext = { tick: 0, time: 0, dt: 0, resources: { canvas: rc.canvas, video: rc.video } };
+    // Three chord tones, all present in the scale [48,50,52,55,57,60] → 3 bands.
+    handlers.process({ ...fullInputs(), chord: [48, 52, 57] }, ctx);
+    expect(rc.count('stroke')).toBe(3);
+    expect(rc.count('moveTo')).toBe(3);
+  });
+
+  it('chordGuide: draws nothing with no chord, off, or out-of-range tones', () => {
+    const base = {
+      video: { show: false },
+      scaleGuide: { show: false },
+      indexGuide: { show: false },
+      landmarks: { show: false },
+      markers: { show: false },
+    };
+    const run = (params: unknown, chord?: number[]) => {
+      const rc = makeRecordingCanvas();
+      const handlers = canvasOverlayNode.make(canvasOverlayNode.params.parse(params));
+      const ctx: NodeContext = { tick: 0, time: 0, dt: 0, resources: { canvas: rc.canvas, video: rc.video } };
+      handlers.process({ ...fullInputs(), chord }, ctx);
+      return rc;
+    };
+    expect(run(base).count('stroke')).toBe(0); // no chord input → idle
+    expect(run({ ...base, chordGuide: { show: false } }, [48, 52, 57]).count('stroke')).toBe(0); // toggled off
+    // C# (pitch class 1) is not in the scale [48,50,52,55,57,60] = {C,D,E,G,A} → no match.
+    expect(run(base, [49]).count('stroke')).toBe(0);
+  });
+
+  it('chordGuide: folds an above-range tone to its pitch class so it still highlights', () => {
+    const rc = makeRecordingCanvas();
+    const onlyChord = {
+      video: { show: false },
+      scaleGuide: { show: false },
+      indexGuide: { show: false },
+      landmarks: { show: false },
+      markers: { show: false },
+    };
+    const handlers = canvasOverlayNode.make(canvasOverlayNode.params.parse(onlyChord));
+    const ctx: NodeContext = { tick: 0, time: 0, dt: 0, resources: { canvas: rc.canvas, video: rc.video } };
+    // 72 = C5 is above the displayed scale [48..60] but C (pitch class 0) is in it.
+    handlers.process({ ...fullInputs(), chord: [72] }, ctx);
+    expect(rc.count('stroke')).toBe(1);
+  });
+
   it('a live overlayConfig input overrides the static params', () => {
     const rc = makeRecordingCanvas();
     // Static params: index guide OFF, video ON. Live config flips both.

--- a/test/settings_presets.test.ts
+++ b/test/settings_presets.test.ts
@@ -7,7 +7,7 @@
 import { describe, it, expect } from 'vitest';
 import { createInMemoryProvider } from '@zodal/store';
 import { createPresetStore, presetId } from '@/settings/presets';
-import { SettingsSchema, type Preset, type Settings } from '@/settings/schema';
+import { PresetSchema, SettingsSchema, type Preset, type Settings } from '@/settings/schema';
 
 function sampleSettings(overrides: Partial<Settings> = {}): Settings {
   return SettingsSchema.parse({
@@ -88,5 +88,32 @@ describe('preset persistence', () => {
     expect(() =>
       SettingsSchema.parse({ ...sampleSettings(), right: { ...sampleSettings().right, instrument: 'bogus' } }),
     ).toThrow();
+  });
+
+  it('defaults faceMapping to none when omitted', () => {
+    expect(sampleSettings().faceMapping).toBe('none');
+  });
+
+  it('migrates a pre-#64 preset (boolean faceEnabled) to faceMapping on load', () => {
+    const legacy = {
+      id: 'legacy',
+      name: 'Legacy',
+      createdAt: 1,
+      settings: {
+        right: { root: 0, type: 'pentatonic', octaves: 2, baseOctave: 3, instrument: 'warmPad' },
+        left: { root: 0, type: 'pentatonic', octaves: 2, baseOctave: 3, instrument: 'glass' },
+        syncHands: true,
+        masterVolume: 0.4,
+        faceEnabled: true, // the old boolean flag
+        overlay: {},
+      },
+    };
+    const parsed = PresetSchema.parse(legacy);
+    expect(parsed.settings.faceMapping).toBe('timbre');
+    expect((parsed.settings as Record<string, unknown>).faceEnabled).toBeUndefined();
+
+    // The false branch maps to 'none'.
+    const off = { ...legacy, settings: { ...legacy.settings, faceEnabled: false } };
+    expect(PresetSchema.parse(off).settings.faceMapping).toBe('none');
   });
 });

--- a/test/webcam_face.test.ts
+++ b/test/webcam_face.test.ts
@@ -50,6 +50,18 @@ const ctx = (faceEnabled?: boolean, video?: unknown): NodeContext =>
 // A truthy <video> stand-in; never "ready" so the inference loop never fires.
 const fakeVideo = () => ({ readyState: 0, videoWidth: 0, currentTime: 0 }) as unknown;
 
+/** Context whose controls snapshot carries the new tri-state face mapping. */
+const ctxMode = (faceMapping: string, video?: unknown): NodeContext =>
+  ({
+    tick: 0,
+    time: 0,
+    dt: 0,
+    resources: {
+      controls: () => ({ faceMapping }),
+      ...(video === undefined ? {} : { video }),
+    },
+  }) as unknown as NodeContext;
+
 // The node starts a requestAnimationFrame loop once the (mocked) model loads.
 // Force a no-op rAF (and restore it after) so the loop never schedules real work
 // and we don't pollute the shared global for other test files.
@@ -105,15 +117,15 @@ describe('webcam-face node gating', () => {
     const inst = webcamFaceNode.make({ delegate: 'GPU' });
     // No controls getter (headless / pre-wired) and explicitly disabled, both
     // with a video present — the loader must not be reached either way.
-    expect(inst.process({}, ctx(undefined, fakeVideo()))).toEqual(ABSENT);
-    expect(inst.process({}, ctx(false, fakeVideo()))).toEqual(ABSENT);
+    expect(inst.process({}, ctx(undefined, fakeVideo()))).toMatchObject(ABSENT);
+    expect(inst.process({}, ctx(false, fakeVideo()))).toMatchObject(ABSENT);
     expect(createFromOptions).not.toHaveBeenCalled();
     expect(forVisionTasks).not.toHaveBeenCalled();
   });
 
   it('does not load the model when enabled but no camera <video> is present', () => {
     const inst = webcamFaceNode.make({ delegate: 'GPU' });
-    expect(inst.process({}, ctx(true))).toEqual(ABSENT);
+    expect(inst.process({}, ctx(true))).toMatchObject(ABSENT);
     expect(createFromOptions).not.toHaveBeenCalled();
   });
 
@@ -125,19 +137,86 @@ describe('webcam-face node gating', () => {
     (live.resources as Record<string, unknown>).controls = () => ({ faceEnabled });
 
     // Enable + video → loader kicks off (loading set synchronously); absent this tick.
-    expect(inst.process({}, live)).toEqual(ABSENT);
+    expect(inst.process({}, live)).toMatchObject(ABSENT);
     // Disable while still loading → offload() runs via the `loading` branch.
     faceEnabled = false;
-    expect(inst.process({}, live)).toEqual(ABSENT);
+    expect(inst.process({}, live)).toMatchObject(ABSENT);
     // Re-enable → no throw, still absent.
     faceEnabled = true;
-    expect(inst.process({}, live)).toEqual(ABSENT);
+    expect(inst.process({}, live)).toMatchObject(ABSENT);
     expect(() => {
       inst.dispose?.();
       inst.dispose?.();
     }).not.toThrow();
-    expect(inst.process({}, live)).toEqual(ABSENT);
+    expect(inst.process({}, live)).toMatchObject(ABSENT);
     await flush(); // let the dangling mocked load settle (it self-closes)
+  });
+});
+
+/**
+ * Drive the node until its fire-and-forget loader reaches a terminal phase
+ * ('ready' or 'error'), so the load FULLY completes inside the calling test under
+ * any scheduler load — never straggling a late createFromOptions into a sibling
+ * test's mock (the root of a cross-test flake). Returns the terminal phase.
+ */
+const drainLoad = async (inst: ReturnType<typeof webcamFaceNode.make>, ctxArg: NodeContext) => {
+  for (let i = 0; i < 200; i++) {
+    const phase = (inst.process({}, ctxArg) as { status: { phase: string } }).status.phase;
+    if (phase === 'ready' || phase === 'error') return phase;
+    await flush();
+  }
+  return 'loading';
+};
+
+describe('webcam-face mapping-mode gating (#64)', () => {
+  it('enters the load path for timbre and chord, idle for none', async () => {
+    for (const mode of ['timbre', 'chord']) {
+      const inst = webcamFaceNode.make({ delegate: 'GPU' });
+      // `loading` (set synchronously in ensureLoaded) proves the enabled path ran.
+      const out = inst.process({}, ctxMode(mode, fakeVideo())) as { status: { phase: string } };
+      expect(out.status.phase).toBe('loading');
+      await drainLoad(inst, ctxMode(mode, fakeVideo())); // complete the load here, don't leak it
+      inst.dispose?.();
+    }
+    createFromOptions.mockClear();
+    const off = webcamFaceNode.make({ delegate: 'GPU' });
+    const out = off.process({}, ctxMode('none', fakeVideo())) as { status: { phase: string } };
+    expect(out.status.phase).toBe('idle');
+    expect(createFromOptions).not.toHaveBeenCalled();
+  });
+});
+
+describe('webcam-face status port (#65)', () => {
+  it('reports idle when off and loading once a mode + video are present', async () => {
+    const inst = webcamFaceNode.make({ delegate: 'GPU' });
+    expect((inst.process({}, ctxMode('none', fakeVideo())) as { status: unknown }).status).toEqual({
+      phase: 'idle',
+      faceDetected: false,
+    });
+    expect(
+      (inst.process({}, ctxMode('chord', fakeVideo())) as { status: { phase: string } }).status.phase,
+    ).toBe('loading');
+    await drainLoad(inst, ctxMode('chord', fakeVideo())); // complete the load here, don't leak it
+    inst.dispose?.();
+  });
+
+  it('reports ready once the model loads', async () => {
+    const inst = webcamFaceNode.make({ delegate: 'GPU' }); // default mock resolves fakeLandmarker
+    inst.process({}, ctxMode('timbre', fakeVideo())); // kick the load
+    expect(await drainLoad(inst, ctxMode('timbre', fakeVideo()))).toBe('ready');
+    inst.dispose?.();
+  });
+
+  it('reports error when model creation fails on both delegates', async () => {
+    // Persistent throw for this test only; drainLoad completes the failed load
+    // here, and beforeEach restores the resolving default for the next test.
+    createFromOptions.mockImplementation(async () => {
+      throw new Error('no gpu, no cpu');
+    });
+    const inst = webcamFaceNode.make({ delegate: 'GPU' });
+    inst.process({}, ctxMode('chord', fakeVideo())); // kick the load (both delegates reject)
+    expect(await drainLoad(inst, ctxMode('chord', fakeVideo()))).toBe('error');
+    inst.dispose?.();
   });
 });
 

--- a/test/webcam_hands.test.ts
+++ b/test/webcam_hands.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Tests the pure `resultToHandsFrame` converter of the `webcam-hands` node — the
+ * tasks-vision HandLandmarker result (normalized landmarks) → a HandsFrame with
+ * pixel keypoints in MediaPipe's 21-point order. The live inference is
+ * browser-only; this verifies the headless conversion (coords + handedness).
+ */
+import { describe, it, expect } from 'vitest';
+import { resultToHandsFrame, type HandLandmarkerResultLike } from '@/nodes/sources/webcam_hands';
+
+describe('resultToHandsFrame', () => {
+  it('scales normalized landmarks to pixels and keeps the 21-point order', () => {
+    const landmarks = Array.from({ length: 21 }, (_, i) => ({ x: i / 20, y: 0.5, z: 0 }));
+    const res: HandLandmarkerResultLike = { landmarks: [landmarks], handedness: [[{ categoryName: 'Left' }]] };
+    const frame = resultToHandsFrame(res, 640, 480);
+    expect(frame.width).toBe(640);
+    expect(frame.hands).toHaveLength(1);
+    expect(frame.hands[0].keypoints).toHaveLength(21);
+    // index 0 → x 0; index 20 → x = 640 (full width); y always 240.
+    expect(frame.hands[0].keypoints[0]).toMatchObject({ x: 0, y: 240 });
+    expect(frame.hands[0].keypoints[20].x).toBeCloseTo(640, 5);
+    expect(frame.hands[0].handedness).toBe('Left');
+  });
+
+  it('maps each detected hand and defaults missing handedness to Right', () => {
+    const one = [{ x: 0.5, y: 0.5, z: 0 }];
+    const res: HandLandmarkerResultLike = { landmarks: [one, one], handedness: [[{ categoryName: 'Right' }]] };
+    const frame = resultToHandsFrame(res, 100, 100);
+    expect(frame.hands).toHaveLength(2);
+    expect(frame.hands[0].handedness).toBe('Right');
+    expect(frame.hands[1].handedness).toBe('Right'); // no handedness entry → default
+  });
+
+  it('returns an empty hand list when nothing is detected', () => {
+    const frame = resultToHandsFrame({ landmarks: [], handedness: [] }, 640, 480);
+    expect(frame.hands).toEqual([]);
+  });
+});


### PR DESCRIPTION
Builds **#64** (face-mapping chooser + expression→chord) and **#65** (status/feedback) together, plus the fix that makes face detection actually load on a real webcam.

## #64 — face-mapping chooser
- Replaces the binary face on/off toggle with **None / Expression→timbre / Expression→chord**.
- **Chord mode** classifies the 52 MediaPipe blendshapes into one of 7 expressions (cosine-to-FACS-prototype → softmax, zero new model bytes) and plays the diatonic triad on a **confusion-aware** scale degree of the current 7-note scale. Confused expression pairs map to note-sharing triads, so a misclassification is a soft harmonic slip. The shipped map is the brute-force objective optimum of the seeded confusion matrix (happy on the tonic; all five non-trivial confusion pairs on 2-note-sharing triads).
- Hand melody and face chord sound **together** (a new `synth-merge` node unions voices, sidestepping the engine's single-`params`-input rule). Timbre is suppressed in chord mode; the chord tracks the keyboard octave-shift.
- New CORE nodes: `face-expression`, `expression-chord`, `synth-merge`.

## #65 — feedback
- `webcam-face` gains a `status` output port (idle/loading/ready/error + faceDetected); `useEngine` bridges it (throttled) to a `useFaceStatus` store driving a ControlsPanel readout, an App face chip, and a once-per-failure toast; a `chordGuide` overlay element highlights the played triad on the pitch guides.

## Model-load fix (the blocker)
- The lazy FaceLandmarker load aborted on a real device: hand tracking's `runtime: 'mediapipe'` loaded `@mediapipe/hands`, whose Emscripten global `Module` collided with the face model's `@mediapipe/tasks-vision`. Rewrote `webcam-hands` to use tasks-vision's own `HandLandmarker` (same runtime as the face model) so they coexist; same hand model + quality, pure unit-tested converter.

## Persistence
- `faceMapping` is a shared Zod enum on the musical-preset side; a persist v1→v2 migrate + preset preprocess map legacy `faceEnabled:true → 'timbre'`; `mergeControls` re-parses the rehydrated overlay so older saves gain the new element instead of crashing.

## Tests / quality
- 169 → **217 tests**, green and verified deterministic. Typecheck + build + catalog clean. Went through a multi-agent mapping pass and a 46-agent adversarial review (18 confirmed findings fixed, incl. a returning-user crash, a flaky test, and an octave-shift desync). Verified live on a real webcam (hands track, face loads, chords play).

Closes #64. Closes #65.

https://claude.ai/code/session_01JEoe7y1hA5KdEAvvpQXxxt
