### PR TITLE
Chord voicings + tempo renderings + chord controls (face #64 follow-up)

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -55,7 +55,7 @@ Reads the live UI control store → scale + instrument + overlay port values.
 
 - **roles:** source, control
 - **in:** —
-- **out:** scaleRight:number[], scaleLeft:number[], instrumentRight:instrument, instrumentLeft:instrument, overlay:overlay-config, rightSpec:scale-spec, faceMapping:face-mapping
+- **out:** scaleRight:number[], scaleLeft:number[], instrumentRight:instrument, instrumentLeft:instrument, overlay:overlay-config, rightSpec:scale-spec, faceMapping:face-mapping, chordConfig:chord-config
 - **params:** —
 
 #### `synthetic-hands` — Synthetic Hands
@@ -180,12 +180,12 @@ Roman-numeral progression in a key + position (0..1) → current chord symbol.
 - **params:** key (string="C"), romanNumerals (array=["I","IV","V","vi"])
 
 #### `expression-chord` — Expression Chord
-Facial expression → the diatonic triad on its confusion-aware scale degree (active only in face "chord" mode on seven-note scales).
+Facial expression → a voiced, rendered diatonic chord on the current seven-note scale (active only in face "chord" mode).
 
 - **roles:** music
-- **in:** expression:face-expression, spec:scale-spec, faceMapping:face-mapping, octaveShift:number
+- **in:** expression:face-expression, spec:scale-spec, faceMapping:face-mapping, octaveShift:number, chordConfig:chord-config
 - **out:** params:synth-params, triad:number[]
-- **params:** gain (number=0.22), instrument (enum(sine | triangle | square | sawtooth | warmPad | glass | bell | organ | voice | softLead | strings | flute | brass | choir)="triangle")
+- **params:** gain (number=0.22), instrument (enum(sine | triangle | square | sawtooth | warmPad | glass | bell | organ | voice | softLead | strings | flute | brass | choir)="triangle"), voicing (enum(spread | bassTriad | close | shell | power)="spread"), rendering (enum(sustained | strum | arpUp | arpDown | arpUpDown | pulse | alberti)="sustained"), bpm (number=100)
 
 ### Conductor mode
 _Direct a fixed piece with gesture (tempo + dynamics)._

--- a/public/catalog.json
+++ b/public/catalog.json
@@ -121,7 +121,7 @@
   {
     "type": "expression-chord",
     "title": "Expression Chord",
-    "description": "Facial expression → the diatonic triad on its confusion-aware scale degree (active only in face \"chord\" mode on seven-note scales).",
+    "description": "Facial expression → a voiced, rendered diatonic chord on the current seven-note scale (active only in face \"chord\" mode).",
     "roles": [
       "music"
     ],
@@ -143,6 +143,10 @@
         "name": "octaveShift",
         "kind": "number",
         "default": 0
+      },
+      {
+        "name": "chordConfig",
+        "kind": "chord-config"
       }
     ],
     "outputs": [
@@ -165,6 +169,21 @@
         "name": "instrument",
         "type": "enum(sine | triangle | square | sawtooth | warmPad | glass | bell | organ | voice | softLead | strings | flute | brass | choir)",
         "default": "triangle"
+      },
+      {
+        "name": "voicing",
+        "type": "enum(spread | bassTriad | close | shell | power)",
+        "default": "spread"
+      },
+      {
+        "name": "rendering",
+        "type": "enum(sustained | strum | arpUp | arpDown | arpUpDown | pulse | alberti)",
+        "default": "sustained"
+      },
+      {
+        "name": "bpm",
+        "type": "number",
+        "default": 100
       }
     ]
   },
@@ -792,6 +811,10 @@
       {
         "name": "faceMapping",
         "kind": "face-mapping"
+      },
+      {
+        "name": "chordConfig",
+        "kind": "chord-config"
       }
     ],
     "params": []

--- a/public/manual.html
+++ b/public/manual.html
@@ -64,7 +64,7 @@
       <dl>
         <dt>roles</dt><dd>source, control</dd>
         <dt>in</dt><dd>—</dd>
-        <dt>out</dt><dd>scaleRight:number[], scaleLeft:number[], instrumentRight:instrument, instrumentLeft:instrument, overlay:overlay-config, rightSpec:scale-spec, faceMapping:face-mapping</dd>
+        <dt>out</dt><dd>scaleRight:number[], scaleLeft:number[], instrumentRight:instrument, instrumentLeft:instrument, overlay:overlay-config, rightSpec:scale-spec, faceMapping:face-mapping, chordConfig:chord-config</dd>
         <dt>params</dt><dd>—</dd>
       </dl>
     </div>
@@ -213,12 +213,12 @@
     </div>
     <div class="node">
       <h4><code>expression-chord</code> <span class="title">Expression Chord</span></h4>
-      <p>Facial expression → the diatonic triad on its confusion-aware scale degree (active only in face "chord" mode on seven-note scales).</p>
+      <p>Facial expression → a voiced, rendered diatonic chord on the current seven-note scale (active only in face "chord" mode).</p>
       <dl>
         <dt>roles</dt><dd>music</dd>
-        <dt>in</dt><dd>expression:face-expression, spec:scale-spec, faceMapping:face-mapping, octaveShift:number</dd>
+        <dt>in</dt><dd>expression:face-expression, spec:scale-spec, faceMapping:face-mapping, octaveShift:number, chordConfig:chord-config</dd>
         <dt>out</dt><dd>params:synth-params, triad:number[]</dd>
-        <dt>params</dt><dd>gain (number=0.22), instrument (enum(sine | triangle | square | sawtooth | warmPad | glass | bell | organ | voice | softLead | strings | flute | brass | choir)="triangle")</dd>
+        <dt>params</dt><dd>gain (number=0.22), instrument (enum(sine | triangle | square | sawtooth | warmPad | glass | bell | organ | voice | softLead | strings | flute | brass | choir)="triangle"), voicing (enum(spread | bassTriad | close | shell | power)="spread"), rendering (enum(sustained | strum | arpUp | arpDown | arpUpDown | pulse | alberti)="sustained"), bpm (number=100)</dd>
       </dl>
     </div></div></section>
 <section><h3>Conductor mode</h3><p class="blurb">Direct a fixed piece with gesture (tempo + dynamics).</p><div class="grid">

--- a/src/app/ControlsPanel.tsx
+++ b/src/app/ControlsPanel.tsx
@@ -255,6 +255,12 @@ function ChordControls() {
           onChange={(e) => set({ bpm: Number(e.target.value) })}
         />
       </label>
+      {tempoRelevant && (
+        <p className="text-[10px] leading-relaxed text-white/40">
+          Tempo modes articulate best with a crisp instrument (organ / glass / bell); a slow-attack
+          pad blurs fast arpeggios into a wash.
+        </p>
+      )}
     </div>
   );
 }

--- a/src/app/ControlsPanel.tsx
+++ b/src/app/ControlsPanel.tsx
@@ -12,6 +12,7 @@
 import { useState } from 'react';
 import { NOTES, SCALE_TYPES, isSevenNoteScale, type ScaleTypeId } from '@/music/theory';
 import { INSTRUMENTS, INSTRUMENT_IDS } from '@/music/instruments';
+import { VOICINGS, RENDERINGS, isTempoRendering, type VoicingId, type RenderingId } from '@/music/voicing';
 import type { FaceMapping } from '@/nodes';
 import { useControls, type VoiceControl } from './store';
 import { useFaceStatus } from './faceStatus';
@@ -177,6 +178,87 @@ function FaceStatusReadout({ active }: { active: boolean }) {
   );
 }
 
+const VOICING_LABELS: Record<VoicingId, string> = {
+  spread: 'Open (spread)',
+  bassTriad: 'Bass + triad',
+  close: 'Close',
+  shell: 'Shell (sparse)',
+  power: 'Power (5ths)',
+};
+
+const RENDERING_LABELS: Record<RenderingId, string> = {
+  sustained: 'Sustained pad',
+  strum: 'Strum',
+  arpUp: 'Arpeggio ↑',
+  arpDown: 'Arpeggio ↓',
+  arpUpDown: 'Arpeggio ↑↓',
+  pulse: 'Pulse',
+  alberti: 'Alberti',
+};
+
+/** Sound settings for the face chord — shown when chord mapping is active. */
+function ChordControls() {
+  const chord = useControls((s) => s.faceChord);
+  const set = useControls((s) => s.setFaceChord);
+  const tempoRelevant = isTempoRendering(chord.rendering);
+
+  return (
+    <div className="space-y-2 border-l-2 border-amber-300/30 pl-3">
+      <h4 className="text-[10px] font-bold uppercase tracking-widest text-amber-300/70">Chord sound</h4>
+      <label className="flex items-center justify-between gap-2 text-xs">
+        Instrument
+        <select
+          className={selectCls}
+          value={chord.instrument}
+          onChange={(e) => set({ instrument: e.target.value as VoiceControl['instrument'] })}
+        >
+          {INSTRUMENT_IDS.map((id) => (
+            <option key={id} value={id}>{INSTRUMENTS[id].name}</option>
+          ))}
+        </select>
+      </label>
+      <label className="flex items-center justify-between gap-2 text-xs">
+        Volume
+        <input
+          type="range" min={0} max={1} step={0.01} value={chord.volume}
+          onChange={(e) => set({ volume: Number(e.target.value) })}
+        />
+      </label>
+      <label className="flex items-center justify-between gap-2 text-xs">
+        Voicing
+        <select
+          className={selectCls}
+          value={chord.voicing}
+          onChange={(e) => set({ voicing: e.target.value as VoicingId })}
+        >
+          {VOICINGS.map((v) => (
+            <option key={v} value={v}>{VOICING_LABELS[v]}</option>
+          ))}
+        </select>
+      </label>
+      <label className="flex items-center justify-between gap-2 text-xs">
+        Rendering
+        <select
+          className={selectCls}
+          value={chord.rendering}
+          onChange={(e) => set({ rendering: e.target.value as RenderingId })}
+        >
+          {RENDERINGS.map((r) => (
+            <option key={r} value={r}>{RENDERING_LABELS[r]}</option>
+          ))}
+        </select>
+      </label>
+      <label className={`flex items-center justify-between gap-2 text-xs ${tempoRelevant ? '' : 'opacity-40'}`}>
+        Tempo {chord.bpm} bpm
+        <input
+          type="range" min={40} max={200} step={1} value={chord.bpm}
+          onChange={(e) => set({ bpm: Number(e.target.value) })}
+        />
+      </label>
+    </div>
+  );
+}
+
 function FaceControls() {
   const faceMapping = useControls((s) => s.faceMapping);
   const setFaceMapping = useControls((s) => s.setFaceMapping);
@@ -208,6 +290,7 @@ function FaceControls() {
         </p>
       )}
       <p className="text-[10px] leading-relaxed text-white/40">{FACE_MODE_HINT[faceMapping]}</p>
+      {faceMapping === 'chord' && <ChordControls />}
     </div>
   );
 }

--- a/src/app/graph.ts
+++ b/src/app/graph.ts
@@ -145,6 +145,8 @@ export function defaultGraph(selection?: SlotSelection, registry?: NodeRegistry)
       { from: { node: 'faceExpr', port: 'expression' }, to: { node: 'exprChord', port: 'expression' } },
       { from: { node: 'ui', port: 'rightSpec' }, to: { node: 'exprChord', port: 'spec' } },
       { from: { node: 'ui', port: 'faceMapping' }, to: { node: 'exprChord', port: 'faceMapping' } },
+      // Live chord settings (instrument / volume / voicing / rendering / tempo).
+      { from: { node: 'ui', port: 'chordConfig' }, to: { node: 'exprChord', port: 'chordConfig' } },
       // Keep the face chord in the same register as the hand melody (octave shift).
       { from: { node: 'kctrl', port: 'octaveShift' }, to: { node: 'exprChord', port: 'octaveShift' } },
       { from: { node: 'feat', port: 'features' }, to: { node: 'map', port: 'features' } },

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -19,7 +19,7 @@ import type { ScaleTypeId } from '@/music/theory';
 import { DEFAULT_INSTRUMENT_RIGHT, DEFAULT_INSTRUMENT_LEFT } from '@/music/instruments';
 import { OverlayParamsSchema, type OverlayParams } from '@/nodes/output/canvas_overlay';
 import { FACE_MAPPINGS, legacyFaceToMapping, type VoiceParams, type FaceMapping } from '@/nodes';
-import { DEFAULT_FACE_CHORD, type Settings, type FaceChord } from '@/settings/schema';
+import { DEFAULT_FACE_CHORD, FaceChordSchema, type Settings, type FaceChord } from '@/settings/schema';
 import { DEFAULT_RECORDING_FORMATS } from './recording/formats';
 
 export interface VoiceControl {
@@ -129,10 +129,20 @@ export function mergeControls(persisted: unknown, current: ControlState): Contro
       overlay = current.overlay;
     }
   }
+  // Re-parse faceChord: complete a partial blob from the defaults, then validate,
+  // so a UI control never binds to an undefined/corrupt field (parity with overlay).
+  let faceChord = current.faceChord;
+  if (p.faceChord) {
+    try {
+      faceChord = FaceChordSchema.parse({ ...DEFAULT_FACE_CHORD, ...p.faceChord });
+    } catch {
+      faceChord = current.faceChord;
+    }
+  }
   const faceMapping = (FACE_MAPPINGS as readonly string[]).includes(p.faceMapping as string)
     ? (p.faceMapping as FaceMapping)
     : legacyFaceToMapping(p.faceEnabled);
-  return { ...current, ...p, overlay, faceMapping };
+  return { ...current, ...p, overlay, faceMapping, faceChord };
 }
 
 // localStorage in the browser; a no-op elsewhere (Node test runtime) so the
@@ -205,7 +215,10 @@ export const useControls = create<ControlState>()(
       name: 'thoremin-controls',
       // Version 2: the face-mapping chooser (#64) replaced the boolean
       // `faceEnabled` with the tri-state `faceMapping`. See migrateControls (field
-      // rename) and mergeControls (heals a stale `overlay` + clamps `faceMapping`).
+      // rename) and mergeControls (heals a stale `overlay`/`faceChord` + clamps
+      // `faceMapping`). The later `faceChord` field is additive and default-safe
+      // (the initializer + mergeControls supply it for a v2 blob that predates it),
+      // so it intentionally needs no version bump or migrate branch.
       version: 2,
       migrate: migrateControls,
       merge: mergeControls,

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -19,7 +19,7 @@ import type { ScaleTypeId } from '@/music/theory';
 import { DEFAULT_INSTRUMENT_RIGHT, DEFAULT_INSTRUMENT_LEFT } from '@/music/instruments';
 import { OverlayParamsSchema, type OverlayParams } from '@/nodes/output/canvas_overlay';
 import { FACE_MAPPINGS, legacyFaceToMapping, type VoiceParams, type FaceMapping } from '@/nodes';
-import type { Settings } from '@/settings/schema';
+import { DEFAULT_FACE_CHORD, type Settings, type FaceChord } from '@/settings/schema';
 import { DEFAULT_RECORDING_FORMATS } from './recording/formats';
 
 export interface VoiceControl {
@@ -42,6 +42,9 @@ export interface ControlState {
    * by the nodes each tick via `ctx.resources.controls`.
    */
   faceMapping: FaceMapping;
+  /** How the face chord sounds (instrument / volume / voicing / rendering / tempo).
+   *  Read live by `expression-chord` via the `chordConfig` port. */
+  faceChord: FaceChord;
   /** Composable overlay element config (see canvas_overlay.ts). Live-controlled. */
   overlay: OverlayParams;
   /**
@@ -54,6 +57,8 @@ export interface ControlState {
   setSync(v: boolean): void;
   setMasterVolume(v: number): void;
   setFaceMapping(v: FaceMapping): void;
+  /** Patch the face-chord settings (e.g. setFaceChord({ voicing: 'spread' })). */
+  setFaceChord(patch: Partial<FaceChord>): void;
   /** Toggle a recording output format on/off (keeps at least one selected). */
   setRecordingFormat(id: string, on: boolean): void;
   /** Patch one overlay element's options (e.g. setOverlayElement('indexGuide', { show: true })). */
@@ -83,6 +88,7 @@ export function toSettings(s: ControlState): Settings {
     syncHands: s.syncHands,
     masterVolume: s.masterVolume,
     faceMapping: s.faceMapping,
+    faceChord: s.faceChord,
     overlay: s.overlay,
   };
 }
@@ -147,6 +153,7 @@ export const useControls = create<ControlState>()(
       syncHands: true,
       masterVolume: 0.4,
       faceMapping: 'none',
+      faceChord: { ...DEFAULT_FACE_CHORD },
       overlay: defaultOverlay(),
       recordingFormats: [...DEFAULT_RECORDING_FORMATS],
       setVoice: (side, patch) =>
@@ -167,6 +174,7 @@ export const useControls = create<ControlState>()(
       setSync: (v) => set({ syncHands: v }),
       setMasterVolume: (v) => set({ masterVolume: v }),
       setFaceMapping: (v) => set({ faceMapping: v }),
+      setFaceChord: (patch) => set((s) => ({ faceChord: { ...s.faceChord, ...patch } })),
       setRecordingFormat: (id, on) =>
         set((s) => {
           const has = s.recordingFormats.includes(id);
@@ -189,6 +197,7 @@ export const useControls = create<ControlState>()(
           syncHands: st.syncHands,
           masterVolume: st.masterVolume,
           faceMapping: st.faceMapping,
+          faceChord: st.faceChord,
           overlay: st.overlay,
         }),
     }),
@@ -208,6 +217,7 @@ export const useControls = create<ControlState>()(
         syncHands: s.syncHands,
         masterVolume: s.masterVolume,
         faceMapping: s.faceMapping,
+        faceChord: s.faceChord,
         overlay: s.overlay,
         recordingFormats: s.recordingFormats,
       }),

--- a/src/music/voicing.ts
+++ b/src/music/voicing.ts
@@ -1,0 +1,137 @@
+/**
+ * Chord voicing + tempo-based rendering for the face chord (issue #64 follow-up).
+ *
+ * Two pure, dependency-free pieces (no DOM, no audio):
+ *
+ *  1. {@link voiceTriad} — arrange a root-position triad (3 ascending scale tones)
+ *     into a tasteful chord with a clear low bass fundamental. The voicings are
+ *     researched arranging idioms (close, bass+triad, open/spread, shell, power);
+ *     they are *view-independent* (anchored an octave below the scale-degree root)
+ *     and *quality-agnostic* (the third/fifth intervals are read from the triad,
+ *     so the same recipe works for major / minor / diminished / augmented).
+ *
+ *  2. {@link renderGains} — per-voice gain factors (0..1) for an articulation
+ *     pattern at a given beat position: a sustained pad plus tempo-based arpeggios,
+ *     a re-articulated pulse, an Alberti pattern, and a strum. These say "which
+ *     voices sound right now"; the synth's own envelope smooths the edges.
+ */
+
+/** Voicing idioms (how a triad's tones are stacked into a chord with a low bass). */
+export const VOICINGS = ['spread', 'bassTriad', 'close', 'shell', 'power'] as const;
+export type VoicingId = (typeof VOICINGS)[number];
+
+/** Articulation patterns (how a voiced chord is played over time). */
+export const RENDERINGS = ['sustained', 'strum', 'arpUp', 'arpDown', 'arpUpDown', 'pulse', 'alberti'] as const;
+export type RenderingId = (typeof RENDERINGS)[number];
+
+/** Renderings that march to the tempo clock (the rest ignore BPM). */
+export function isTempoRendering(r: RenderingId): boolean {
+  return r === 'arpUp' || r === 'arpDown' || r === 'arpUpDown' || r === 'pulse' || r === 'alberti';
+}
+
+/**
+ * Voice a root-position triad `[root, third, fifth]` (ascending MIDI scale tones)
+ * into a chord with a low bass fundamental. The bass is anchored an octave below
+ * the scale-degree root (plus the live `octaveShift`, so the chord tracks the
+ * melody's register) — deliberately *below* the playing range, since the chord is
+ * an accompaniment, not part of the visible scale. Returns ascending-ish MIDI.
+ * Returns `[]` for a malformed (non-triad) input.
+ */
+export function voiceTriad(triad: number[], voicing: VoicingId, octaveShift = 0): number[] {
+  if (triad.length < 3) return [];
+  const [r, third, fifth] = triad;
+  const T = third - r; // 3 (minor/dim) or 4 (major/aug) — read from the triad
+  const F = fifth - r; // 6 (dim) / 7 (perfect) / 8 (aug)
+  const b = r - 12 + 12 * octaveShift; // low bass = the fundamental
+  switch (voicing) {
+    case 'close':
+      return [b, b + T, b + F];
+    case 'bassTriad':
+      return [b, b + 12, b + 12 + T, b + 12 + F];
+    case 'spread':
+      // root, fifth, third-up-an-octave, root-up — the classic wide piano voicing.
+      return [b, b + F, b + 12 + T, b + 12];
+    case 'shell':
+      // root + third + a far-flung fifth: sparse, transparent.
+      return [b, b + T, b + 12 + F];
+    case 'power':
+      // root + fifth + octave: bold, quality-neutral.
+      return [b, b + F, b + 12];
+    default:
+      return [b, b + F, b + 12 + T, b + 12];
+  }
+}
+
+export interface RenderOpts {
+  /** Steps per beat (2 = eighth notes, the default grid). */
+  subdiv?: number;
+  /** Per-voice strum delay in seconds (default 25 ms). */
+  strumSec?: number;
+  /** Fraction of each step the pulse sounds before re-articulating (default 0.85). */
+  pulseGate?: number;
+}
+
+/**
+ * Per-voice gain factors (0..1) for `n` voices under `rendering`.
+ *  - `beat` is the running beat position (quarter notes) for tempo patterns.
+ *  - `timeSinceChange` (seconds since the chord last changed) drives the strum
+ *    stagger and resets the roll on each new chord.
+ * Pure: the same inputs always give the same gains (so it replays deterministically).
+ */
+export function renderGains(
+  n: number,
+  rendering: RenderingId,
+  beat: number,
+  timeSinceChange: number,
+  opts: RenderOpts = {},
+): number[] {
+  if (n <= 0) return [];
+  const subdiv = opts.subdiv ?? 2;
+  const strumSec = opts.strumSec ?? 0.025;
+  const pulseGate = opts.pulseGate ?? 0.85;
+
+  const ones = () => new Array<number>(n).fill(1);
+  const zeros = () => new Array<number>(n).fill(0);
+  const only = (idx: number) => {
+    const g = zeros();
+    g[((idx % n) + n) % n] = 1;
+    return g;
+  };
+
+  const stepF = beat * subdiv;
+  const step = Math.floor(stepF);
+
+  switch (rendering) {
+    case 'sustained':
+      return ones();
+    case 'arpUp':
+      return only(step);
+    case 'arpDown':
+      return only(-step);
+    case 'arpUpDown': {
+      if (n === 1) return ones();
+      const cyc = 2 * (n - 1);
+      const pos = ((step % cyc) + cyc) % cyc;
+      return only(pos < n ? pos : cyc - pos);
+    }
+    case 'pulse': {
+      // Re-articulate the whole chord each step: on for the first `pulseGate` of
+      // the step, off for the tail (so the synth release leaves an audible pulse).
+      const frac = stepF - step;
+      return frac < pulseGate ? ones() : zeros();
+    }
+    case 'alberti': {
+      // low, high, mid, high — the classic broken-chord pattern, generalized.
+      const order = n <= 1 ? [0] : n === 2 ? [0, 1] : [0, n - 1, 1, n - 1];
+      return only(order[((step % order.length) + order.length) % order.length]);
+    }
+    case 'strum': {
+      // Staggered onsets from the chord change, then sustain (a roll into a pad).
+      const g = zeros();
+      for (let j = 0; j < n; j++) g[j] = timeSinceChange >= j * strumSec ? 1 : 0;
+      return g;
+    }
+    default:
+      return ones();
+  }
+}

--- a/src/music/voicing.ts
+++ b/src/music/voicing.ts
@@ -77,6 +77,14 @@ export interface RenderOpts {
  *  - `timeSinceChange` (seconds since the chord last changed) drives the strum
  *    stagger and resets the roll on each new chord.
  * Pure: the same inputs always give the same gains (so it replays deterministically).
+ *
+ * These gains say *which voices sound right now*; the synth's per-voice envelope
+ * shapes the edges. NOTE the tradeoff: crisp articulation of the tempo renderings
+ * (arpeggios / pulse / alberti) needs the instrument's attack AND release to be
+ * short relative to the step length (≈ 60 / bpm / subdiv seconds). A long-attack
+ * pad (e.g. `warmPad`) will smear a fast arpeggio into a sustained wash — by
+ * design, not a bug — so pair tempo renderings with a crisp preset (organ / glass
+ * / bell) for clear articulation.
  */
 export function renderGains(
   n: number,
@@ -98,7 +106,7 @@ export function renderGains(
     return g;
   };
 
-  const stepF = beat * subdiv;
+  const stepF = (Number.isFinite(beat) ? beat : 0) * subdiv;
   const step = Math.floor(stepF);
 
   switch (rendering) {

--- a/src/nodes/index.ts
+++ b/src/nodes/index.ts
@@ -43,7 +43,7 @@ export { pickNode } from './mapping/pick';
 export { oneEuroNode } from './mapping/one_euro';
 export { lyriaNode } from './output/lyria';
 export { chordNode, voiceChord } from './music/chord';
-export { expressionChordNode, CHORD_VOICE_ID_BASE } from './music/expression_chord';
+export { expressionChordNode, CHORD_VOICE_ID_BASE, MAX_CHORD_VOICES } from './music/expression_chord';
 export { progressionNode } from './music/progression';
 export { transportNode } from './music/transport';
 export { scoreNode } from './music/score';

--- a/src/nodes/music/expression_chord.ts
+++ b/src/nodes/music/expression_chord.ts
@@ -50,7 +50,7 @@ const Params = z.object({
   /** How the voiced chord is played over time. */
   rendering: z.enum(RENDERINGS).default('sustained'),
   /** Tempo (BPM) for the tempo-based renderings. */
-  bpm: z.number().min(20).max(300).default(100),
+  bpm: z.number().min(40).max(200).default(100),
 });
 type Params = z.infer<typeof Params>;
 
@@ -116,12 +116,19 @@ export const expressionChordNode = defineNode<Params>({
         // The un-voiced scale triad (3 tones) for the overlay highlight; [] off a
         // seven-note scale or when idle.
         const triad = active ? diatonicTriad(spec!, DEFAULT_EXPRESSION_TO_DEGREE[expr!.label]) : [];
-        const voiced = triad.length ? voiceTriad(triad, voicing, shift) : [];
+        // Voice the chord, then sort ascending by pitch so arpeggios traverse
+        // low→high by actual pitch (some voicings stack out of pitch order). The
+        // ids stay stable (one per array slot), so the synth still releases all.
+        const voiced = (triad.length ? voiceTriad(triad, voicing, shift) : []).sort((a, b) => a - b);
 
-        // Beat clock + chord-change detection (a new chord restarts the strum).
-        const dt = typeof ctx?.dt === 'number' ? ctx.dt : 0;
+        // Beat clock (NaN-guarded so a degenerate dt can't poison it) + chord-change
+        // detection. The key is the actual sounding pitches, so ANY genuine chord
+        // change (expression, scale root/type/baseOctave, octave shift, voicing)
+        // restarts the strum. (Switching rendering mid-chord does NOT re-roll — a
+        // live strum re-rolls on a new chord, not on a control tweak.)
+        const dt = typeof ctx?.dt === 'number' && Number.isFinite(ctx.dt) ? ctx.dt : 0;
         beat += (bpm / 60) * dt;
-        const key = voiced.length ? `${expr!.label}:${voicing}:${shift}` : '';
+        const key = voiced.length ? voiced.join(',') : '';
         if (key !== lastKey) {
           timeSinceChange = 0;
           lastKey = key;
@@ -135,7 +142,8 @@ export const expressionChordNode = defineNode<Params>({
         const voices: VoiceParams[] = [];
         for (let i = 0; i < MAX_CHORD_VOICES; i++) {
           const midi = voiced[i];
-          const g = midi !== undefined ? gain * (gains[i] ?? 0) : 0;
+          const raw = gains[i];
+          const g = midi !== undefined && Number.isFinite(raw) ? gain * raw : 0;
           voices.push({
             id: CHORD_VOICE_ID_BASE + i,
             present: g > 0,

--- a/src/nodes/music/expression_chord.ts
+++ b/src/nodes/music/expression_chord.ts
@@ -1,90 +1,151 @@
 /**
- * `expression-chord` node — turns a classified facial expression into the
- * diatonic triad on its confusion-aware scale degree (issue #64). It is the
- * "expression → chord" half of the face-mapping chooser: the player's expression
- * (from `face-expression`) selects a scale degree via
- * {@link DEFAULT_EXPRESSION_TO_DEGREE}, and the triad is built on the active
- * seven-note scale ({@link diatonicTriad}).
+ * `expression-chord` node — turns a classified facial expression into a played
+ * chord (issue #64 + the voicing/rendering follow-up). The expression (from
+ * `face-expression`) selects a scale degree via {@link DEFAULT_EXPRESSION_TO_DEGREE};
+ * the diatonic triad on the active seven-note scale ({@link diatonicTriad}) is then
+ * VOICED (a tasteful arrangement with a low bass fundamental — {@link voiceTriad})
+ * and RENDERED over time (sustained pad or a tempo-based arpeggio/pulse/strum —
+ * {@link renderGains}).
  *
- * It emits chord voices on ids ≥ {@link CHORD_VOICE_ID_BASE}, so they never
- * collide with the two hand voices (0, 1) and can be unioned into the synth
- * alongside the hand melody (see `synth-merge`). The node is the live gate for
- * the chord mode: it emits voices ONLY when `faceMapping === 'chord'`, the
- * expression is present, and the current scale has seven notes — otherwise it
- * emits nothing (silent), so timbre/none modes and pentatonic-style scales
- * degrade gracefully.
+ * It emits chord voices on ids ≥ {@link CHORD_VOICE_ID_BASE}, so they never collide
+ * with the two hand voices (0, 1) and can be unioned into the synth alongside the
+ * hand melody (see `synth-merge`). It is the live gate for chord mode: voices sound
+ * ONLY when `faceMapping === 'chord'`, the expression is present, and the current
+ * scale has seven notes — otherwise all voices are silent.
  *
- * Pure + deterministic — testable from canned expression frames via `replayNode`.
+ * It ALWAYS emits {@link MAX_CHORD_VOICES} voices on stable ids: the synth releases
+ * voices it still sees in the array, so a vanishing voice would leave a chord stuck
+ * sounding. Stable ids also let the synth glide/re-articulate cleanly.
+ *
+ * Live config (instrument / volume / voicing / rendering / tempo) arrives on the
+ * `chordConfig` input (from the UI store via `store-controls`), so changing it
+ * never rebuilds the graph. The `triad` output is the un-voiced scale triad (three
+ * tones), used by the overlay to highlight the chord's pitch classes on the guide.
+ *
+ * Stateful (a beat clock + a strum re-trigger), but deterministic given the tick
+ * timing — so it replays exactly.
  */
 import { z } from 'zod';
 import { defineNode } from '@/dag';
+import type { NodeContext } from '@/dag';
 import { diatonicTriad, midiToFreq, type ScaleSpec } from '@/music/theory';
 import { InstrumentSchema } from '@/music/instruments';
 import { DEFAULT_EXPRESSION_TO_DEGREE, type ExpressionScores } from '@/music/expression';
+import { VOICINGS, RENDERINGS, voiceTriad, renderGains, type VoicingId, type RenderingId } from '@/music/voicing';
 import type { VoiceParams } from '../domain';
 
 /** Chord voices start at this id, above the two hand voices (0 = right, 1 = left). */
 export const CHORD_VOICE_ID_BASE = 2;
 
-/** A diatonic triad has three tones; we always emit exactly this many voices. */
-const TRIAD_SIZE = 3;
+/** The largest voicing is four notes; we always emit this many voices on stable ids. */
+export const MAX_CHORD_VOICES = 4;
 
 const Params = z.object({
-  /** Gain of each chord voice (0..1) — gentle by default so the triad supports,
-   *  rather than overpowers, the hand melody. */
+  /** Volume of the chord (0..1) — gentle by default so it supports the melody. */
   gain: z.number().min(0).max(1).default(0.22),
   /** Instrument timbre for the chord voices. */
   instrument: InstrumentSchema.default('triangle'),
+  /** How the triad is arranged (low bass + upper structure). */
+  voicing: z.enum(VOICINGS).default('spread'),
+  /** How the voiced chord is played over time. */
+  rendering: z.enum(RENDERINGS).default('sustained'),
+  /** Tempo (BPM) for the tempo-based renderings. */
+  bpm: z.number().min(20).max(300).default(100),
 });
 type Params = z.infer<typeof Params>;
+
+/** Live chord settings from the UI store (override the static params each tick). */
+interface ChordConfig {
+  instrument?: VoiceParams['instrument'];
+  gain?: number;
+  voicing?: VoicingId;
+  rendering?: RenderingId;
+  bpm?: number;
+}
 
 export const expressionChordNode = defineNode<Params>({
   type: 'expression-chord',
   roles: ['music'],
   title: 'Expression Chord',
   description:
-    'Facial expression → the diatonic triad on its confusion-aware scale degree (active only in face "chord" mode on seven-note scales).',
+    'Facial expression → a voiced, rendered diatonic chord on the current seven-note scale (active only in face "chord" mode).',
   inputs: [
     { name: 'expression', kind: 'face-expression' },
     { name: 'spec', kind: 'scale-spec' },
     { name: 'faceMapping', kind: 'face-mapping', default: 'none' },
-    // Live keyboard octave shift, so the chord tracks the same register as the
-    // hand melody (which also applies it). Unconnected → 0 (no shift).
+    // Live keyboard octave shift, so the chord tracks the melody's register.
     { name: 'octaveShift', kind: 'number', default: 0 },
+    // Live chord settings (instrument / volume / voicing / rendering / tempo).
+    { name: 'chordConfig', kind: 'chord-config' },
   ],
   outputs: [
     { name: 'params', kind: 'synth-params' },
-    // The chosen triad as *un-shifted* scale MIDI notes, so the overlay highlight
-    // matches the raw scale-guide lines (whose labels already include the shift —
-    // so the highlighted line, its label, and the sounding pitch all agree).
+    // The un-voiced scale triad (three tones), for the overlay to highlight the
+    // chord's pitch classes on the pitch guide — independent of the voicing.
     { name: 'triad', kind: 'number[]' },
   ],
   params: Params,
-  process(inputs, p) {
-    const expr = inputs.expression as ExpressionScores | undefined;
-    const spec = inputs.spec as ScaleSpec | undefined;
-    const active = inputs.faceMapping === 'chord' && !!expr && expr.present && !!spec;
-    const shift = typeof inputs.octaveShift === 'number' ? inputs.octaveShift : 0;
-    // diatonicTriad returns 3 notes for seven-note scales, [] otherwise. These are
-    // the un-shifted scale tones (the `triad` output the overlay highlights).
-    const triad = active ? diatonicTriad(spec!, DEFAULT_EXPRESSION_TO_DEGREE[expr!.label]) : [];
-    // ALWAYS emit TRIAD_SIZE voices on stable ids: a present/sounding voice when
-    // active, an absent (gain 0) voice when idle. The synth releases voices it
-    // still sees in the array — so a vanishing voice would leave a chord stuck
-    // sounding. Keeping the ids stable lets it fade the triad out cleanly. The
-    // sounding pitch applies the octave shift so it stays in the melody's register.
-    const voices: VoiceParams[] = [];
-    for (let i = 0; i < TRIAD_SIZE; i++) {
-      const midi = triad[i];
-      const present = midi !== undefined;
-      voices.push({
+  make(p) {
+    let beat = 0;
+    let timeSinceChange = 0;
+    let lastKey = '';
+
+    const silent = (): VoiceParams[] =>
+      Array.from({ length: MAX_CHORD_VOICES }, (_, i) => ({
         id: CHORD_VOICE_ID_BASE + i,
-        present,
-        freq: midiToFreq((present ? midi : 60) + 12 * shift),
-        gain: present ? p.gain : 0,
+        present: false,
+        freq: midiToFreq(60),
+        gain: 0,
         instrument: p.instrument,
-      });
-    }
-    return { params: { voices }, triad };
+      }));
+
+    return {
+      process(inputs, ctx: NodeContext) {
+        const cfg = (inputs.chordConfig as ChordConfig | undefined) ?? {};
+        const instrument = cfg.instrument ?? p.instrument;
+        const gain = cfg.gain ?? p.gain;
+        const voicing = cfg.voicing ?? p.voicing;
+        const rendering = cfg.rendering ?? p.rendering;
+        const bpm = cfg.bpm ?? p.bpm;
+
+        const expr = inputs.expression as ExpressionScores | undefined;
+        const spec = inputs.spec as ScaleSpec | undefined;
+        const shift = typeof inputs.octaveShift === 'number' ? inputs.octaveShift : 0;
+        const active = inputs.faceMapping === 'chord' && !!expr && expr.present && !!spec;
+
+        // The un-voiced scale triad (3 tones) for the overlay highlight; [] off a
+        // seven-note scale or when idle.
+        const triad = active ? diatonicTriad(spec!, DEFAULT_EXPRESSION_TO_DEGREE[expr!.label]) : [];
+        const voiced = triad.length ? voiceTriad(triad, voicing, shift) : [];
+
+        // Beat clock + chord-change detection (a new chord restarts the strum).
+        const dt = typeof ctx?.dt === 'number' ? ctx.dt : 0;
+        beat += (bpm / 60) * dt;
+        const key = voiced.length ? `${expr!.label}:${voicing}:${shift}` : '';
+        if (key !== lastKey) {
+          timeSinceChange = 0;
+          lastKey = key;
+        } else {
+          timeSinceChange += dt;
+        }
+
+        if (voiced.length === 0) return { params: { voices: silent() }, triad: [] };
+
+        const gains = renderGains(voiced.length, rendering, beat, timeSinceChange);
+        const voices: VoiceParams[] = [];
+        for (let i = 0; i < MAX_CHORD_VOICES; i++) {
+          const midi = voiced[i];
+          const g = midi !== undefined ? gain * (gains[i] ?? 0) : 0;
+          voices.push({
+            id: CHORD_VOICE_ID_BASE + i,
+            present: g > 0,
+            freq: midiToFreq(midi ?? 60),
+            gain: g,
+            instrument,
+          });
+        }
+        return { params: { voices }, triad };
+      },
+    };
   },
 });

--- a/src/nodes/output/canvas_overlay.ts
+++ b/src/nodes/output/canvas_overlay.ts
@@ -189,10 +189,12 @@ const scaleGuideElement: OverlayElement = {
 
 /**
  * Highlights the face-driven chord (issue #64): when the player is in face "chord"
- * mode, each tone of the chosen diatonic triad lights up on the existing pitch
- * guide, so the player sees which notes their expression is playing. The triad
- * tones are scale notes, so they align exactly with the scaleGuide lines; this
- * draws a brighter/thicker band over them. Idle (no chord) → draws nothing.
+ * mode, the chord's tones light up on the existing pitch guide so the player sees
+ * which notes their expression is playing. The highlight reflects the chord's
+ * PITCH CLASSES (with octave repetition) — for a C chord {C, E, G}, every visible
+ * C, E and G guide line lights up — NOT the specific rendered voicing (which may
+ * add a bass octave, doublings, etc.). It is a subtle tint over the guide lines.
+ * Idle (no chord) → draws nothing.
  */
 const CHORD_COLOR = '#f5d142'; // warm gold, distinct from the white/blue scale guides
 const chordGuideElement: OverlayElement = {
@@ -203,19 +205,15 @@ const chordGuideElement: OverlayElement = {
     const scale = inputs.scale;
     if (!Array.isArray(chord) || chord.length === 0) return;
     if (!Array.isArray(scale) || scale.length <= 1) return;
-    const guide = scaleGuide(scale);
+    const pitchClass = (m: number) => (((m % 12) + 12) % 12);
+    const chordPcs = new Set(chord.map(pitchClass));
     g.save();
-    g.globalAlpha = 0.55;
+    g.globalAlpha = 0.28; // subtle: a visible tint, not a hard band
     g.strokeStyle = CHORD_COLOR;
-    g.lineWidth = 3;
-    const samePitchClass = (a: number, b: number) => (((a - b) % 12) + 12) % 12 === 0;
-    for (const midi of chord) {
-      // Prefer the exact guide line; when the tone is above the displayed range
-      // (e.g. the V/vii° top note in a 1-octave scale) fall back to its pitch
-      // class so it still lights up rather than silently dropping.
-      const entry = guide.find((e) => e.midi === midi) ?? guide.find((e) => samePitchClass(e.midi, midi));
-      if (!entry) continue;
-      const sx = entry.x * W;
+    g.lineWidth = 2;
+    for (const { midi, x } of scaleGuide(scale)) {
+      if (!chordPcs.has(pitchClass(midi))) continue;
+      const sx = x * W;
       g.beginPath();
       g.moveTo(sx, H * 0.12);
       g.lineTo(sx, H * 0.86);

--- a/src/nodes/sources/store_controls.ts
+++ b/src/nodes/sources/store_controls.ts
@@ -13,6 +13,7 @@ import type { NodeContext } from '@/dag';
 import { generateScale, type ScaleSpec, type ScaleTypeId } from '@/music/theory';
 import type { InstrumentId } from '@/music/instruments';
 import { legacyFaceToMapping, type FaceMapping } from '@/nodes/domain';
+import type { FaceChord } from '@/settings/schema';
 import type { OverlayParams } from '@/nodes/output/canvas_overlay';
 
 export interface VoiceControlSnapshot {
@@ -33,6 +34,8 @@ export interface ControlSnapshot {
   /** What the face controls: none / timbre / chord. Read by `webcam-face` (model
    *  gating) and fed to `expression-chord` (chord-mode gating) as a port. */
   faceMapping?: FaceMapping;
+  /** How the face chord sounds; fed to `expression-chord` as the chordConfig port. */
+  faceChord?: FaceChord;
 }
 
 const Params = z.object({});
@@ -52,6 +55,8 @@ export const storeControlsNode = defineNode<Record<string, never>>({
     // The right voice's scale spec + the face mode, for the expression→chord path.
     { name: 'rightSpec', kind: 'scale-spec' },
     { name: 'faceMapping', kind: 'face-mapping' },
+    // Live chord settings (instrument / volume / voicing / rendering / tempo).
+    { name: 'chordConfig', kind: 'chord-config' },
   ],
   params: Params,
   make() {
@@ -74,6 +79,15 @@ export const storeControlsNode = defineNode<Record<string, never>>({
           rightSpec,
           faceMapping: c.faceMapping ?? legacyFaceToMapping(c.faceEnabled),
         };
+        if (c.faceChord) {
+          out.chordConfig = {
+            instrument: c.faceChord.instrument,
+            gain: c.faceChord.volume,
+            voicing: c.faceChord.voicing,
+            rendering: c.faceChord.rendering,
+            bpm: c.faceChord.bpm,
+          };
+        }
         if (c.overlay) out.overlay = c.overlay;
         return out;
       },

--- a/src/settings/schema.ts
+++ b/src/settings/schema.ts
@@ -30,7 +30,8 @@ export const FaceChordSchema = z.object({
   volume: z.number().min(0).max(1),
   voicing: z.enum(VOICINGS as unknown as [VoicingId, ...VoicingId[]]),
   rendering: z.enum(RENDERINGS as unknown as [RenderingId, ...RenderingId[]]),
-  bpm: z.number().min(20).max(300),
+  // 40..200 matches the Tempo slider (one source of truth for the bounds).
+  bpm: z.number().min(40).max(200),
 });
 export type FaceChord = z.infer<typeof FaceChordSchema>;
 

--- a/src/settings/schema.ts
+++ b/src/settings/schema.ts
@@ -12,6 +12,7 @@
 import { z } from 'zod';
 import { SCALE_TYPES, type ScaleTypeId } from '@/music/theory';
 import { INSTRUMENT_IDS, type InstrumentId } from '@/music/instruments';
+import { VOICINGS, RENDERINGS, type VoicingId, type RenderingId } from '@/music/voicing';
 import { FACE_MAPPINGS, legacyFaceToMapping, type FaceMapping } from '@/nodes/domain';
 import { OverlayParamsSchema } from '@/nodes/output/canvas_overlay';
 
@@ -22,6 +23,25 @@ const InstrumentEnum = z.enum(INSTRUMENT_IDS as [InstrumentId, ...InstrumentId[]
 export const FaceMappingSchema = z.enum(
   FACE_MAPPINGS as unknown as [FaceMapping, ...FaceMapping[]],
 );
+
+/** How the face chord sounds: instrument, volume, voicing, rendering, tempo. */
+export const FaceChordSchema = z.object({
+  instrument: InstrumentEnum,
+  volume: z.number().min(0).max(1),
+  voicing: z.enum(VOICINGS as unknown as [VoicingId, ...VoicingId[]]),
+  rendering: z.enum(RENDERINGS as unknown as [RenderingId, ...RenderingId[]]),
+  bpm: z.number().min(20).max(300),
+});
+export type FaceChord = z.infer<typeof FaceChordSchema>;
+
+/** The shipped defaults for the face chord (open voicing, sustained pad, 100 BPM). */
+export const DEFAULT_FACE_CHORD: FaceChord = {
+  instrument: 'warmPad',
+  volume: 0.22,
+  voicing: 'spread',
+  rendering: 'sustained',
+  bpm: 100,
+};
 
 /** One hand's musical settings — mirrors VoiceControl in src/app/store.ts. */
 export const VoiceSettingsSchema = z.object({
@@ -42,6 +62,8 @@ export const SettingsSchema = z.object({
   // `.default('none')` keeps presets saved before the face-mapping chooser valid
   // (the field is filled in on parse rather than failing validation).
   faceMapping: FaceMappingSchema.default('none'),
+  // `.default(...)` keeps presets saved before the chord settings existed valid.
+  faceChord: FaceChordSchema.default(DEFAULT_FACE_CHORD),
   overlay: OverlayParamsSchema,
 });
 export type Settings = z.infer<typeof SettingsSchema>;

--- a/test/app_graph.test.ts
+++ b/test/app_graph.test.ts
@@ -48,12 +48,12 @@ describe('production app graph', () => {
     expect(params[0].voices.every((v) => !v.present)).toBe(true);
     expect(params[0].voices).toHaveLength(2);
 
-    // The synth's actual input is the merge of hand voices (0,1) + the 3 stable
-    // chord voices (2,3,4) — distinct ids, all silent while the face chord is idle.
+    // The synth's actual input is the merge of hand voices (0,1) + the 4 stable
+    // chord voices (2..5) — distinct ids, all silent while the face chord is idle.
     const merged = recorder.values('merge.params') as SynthParams[];
     const ids = merged[0].voices.map((v) => v.id);
-    expect(ids).toEqual([0, 1, 2, 3, 4]);
-    expect(new Set(ids).size).toBe(5); // no id collision between hands and chord
+    expect(ids).toEqual([0, 1, 2, 3, 4, 5]);
+    expect(new Set(ids).size).toBe(6); // no id collision between hands and chord
     expect(merged[0].voices.every((v) => !v.present)).toBe(true);
   });
 });

--- a/test/app_store.test.ts
+++ b/test/app_store.test.ts
@@ -8,6 +8,7 @@
  */
 import { describe, it, expect, beforeEach } from 'vitest';
 import { useControls, toSettings, migrateControls, mergeControls } from '@/app/store';
+import { DEFAULT_FACE_CHORD } from '@/settings/schema';
 import { storeControlsNode } from '@/nodes/browser';
 import { generateScale } from '@/music/theory';
 import { DEFAULT_INSTRUMENT_RIGHT, DEFAULT_INSTRUMENT_LEFT } from '@/music/instruments';
@@ -123,12 +124,14 @@ describe('control store', () => {
     useControls.getState().setVoice('right', { root: 3, instrument: 'bell' });
     useControls.getState().setMasterVolume(0.6);
     useControls.getState().setFaceMapping('chord');
+    useControls.getState().setFaceChord({ voicing: 'power', bpm: 140 });
     useControls.getState().setOverlayElement('indexGuide', { show: true });
     const snap = toSettings(useControls.getState());
 
     // Mutate away, then restore from the snapshot.
     useControls.getState().setMasterVolume(0.1);
     useControls.getState().setFaceMapping('none');
+    useControls.getState().setFaceChord({ voicing: 'close', bpm: 90 });
     useControls.getState().setOverlayElement('indexGuide', { show: false });
     useControls.getState().applySettings(snap);
 
@@ -137,6 +140,8 @@ describe('control store', () => {
     expect(s.right.instrument).toBe('bell');
     expect(s.syncHands).toBe(false);
     expect(s.faceMapping).toBe('chord');
+    expect(s.faceChord.voicing).toBe('power'); // faceChord survives toSettings → applySettings
+    expect(s.faceChord.bpm).toBe(140);
     expect(s.overlay.indexGuide.show).toBe(true);
   });
 });
@@ -163,6 +168,24 @@ describe('persist migration (v1 → v2, returning users)', () => {
     const initial = useControls.getInitialState();
     expect(mergeControls({ faceMapping: 'rainbow' as never }, initial).faceMapping).toBe('none');
     expect(mergeControls({ faceMapping: 'chord' }, initial).faceMapping).toBe('chord');
+  });
+
+  it('mergeControls fills the default faceChord for a returning v2 user (blob lacks it)', () => {
+    const initial = useControls.getInitialState();
+    const merged = mergeControls({ masterVolume: 0.5 }, initial); // no faceChord key
+    expect(merged.faceChord).toEqual(DEFAULT_FACE_CHORD);
+  });
+
+  it('mergeControls completes/heals a partial or corrupt faceChord so no UI control binds undefined', () => {
+    const initial = useControls.getInitialState();
+    // A hand-edited partial blob: only volume set.
+    const partial = mergeControls({ faceChord: { volume: 0.5 } as never }, initial).faceChord;
+    expect(partial.volume).toBe(0.5); // kept
+    expect(partial.voicing).toBe(DEFAULT_FACE_CHORD.voicing); // filled from default
+    expect(typeof partial.rendering).toBe('string');
+    expect(typeof partial.instrument).toBe('string');
+    // A corrupt value (out of range) falls back to the default whole.
+    expect(mergeControls({ faceChord: { volume: 99 } as never }, initial).faceChord).toEqual(DEFAULT_FACE_CHORD);
   });
 });
 

--- a/test/app_store.test.ts
+++ b/test/app_store.test.ts
@@ -29,6 +29,10 @@ describe('control store', () => {
     expect(s.syncHands).toBe(true);
     expect(s.masterVolume).toBeCloseTo(0.4, 6);
     expect(s.faceMapping).toBe('none'); // face control off by default
+    // Chord-sound defaults (open voicing, sustained pad, 100 BPM).
+    expect(s.faceChord.voicing).toBe('spread');
+    expect(s.faceChord.rendering).toBe('sustained');
+    expect(s.faceChord.bpm).toBe(100);
   });
 
   it('setFaceMapping switches the face mapping mode', () => {
@@ -36,6 +40,14 @@ describe('control store', () => {
     expect(useControls.getState().faceMapping).toBe('chord');
     useControls.getState().setFaceMapping('none');
     expect(useControls.getState().faceMapping).toBe('none');
+  });
+
+  it('setFaceChord patches chord settings without touching the rest', () => {
+    useControls.getState().setFaceChord({ voicing: 'power', bpm: 120 });
+    const c = useControls.getState().faceChord;
+    expect(c.voicing).toBe('power');
+    expect(c.bpm).toBe(120);
+    expect(c.rendering).toBe('sustained'); // untouched
   });
 
   it('setVoice with sync ON mirrors both hands but keeps instruments distinct', () => {
@@ -177,9 +189,11 @@ describe('store-controls node reads the store', () => {
     expect(out.scaleRight).toEqual(generateScale(s.right));
     expect(out.scaleLeft).toEqual(generateScale(s.left));
     expect((out.scaleRight as number[]).length).toBeGreaterThan(0);
-    // The chord-path ports: the right voice's scale spec + the face mode.
+    // The chord-path ports: the right voice's scale spec + the face mode + config.
     expect(out.faceMapping).toBe('chord');
     expect(out.rightSpec).toMatchObject({ root: 2, type: 'minor' });
+    // chordConfig maps the store's faceChord (volume → gain) for expression-chord.
+    expect(out.chordConfig).toMatchObject({ voicing: 'spread', gain: 0.22, bpm: 100 });
   });
 
   it('emits nothing when no controls getter is injected (safe before host wires it)', () => {

--- a/test/face_chord_nodes.test.ts
+++ b/test/face_chord_nodes.test.ts
@@ -91,8 +91,8 @@ describe('expression-chord node', () => {
     const triad = diatonicTriad(cMajor, DEFAULT_EXPRESSION_TO_DEGREE.happy); // [48,52,55]
     // The `triad` output is the un-voiced scale triad (for the overlay highlight).
     expect(out.triad).toEqual(triad);
-    // The sounding voices are the spread voicing of that triad (4 notes, low bass).
-    const voiced = voiceTriad(triad, 'spread', 0); // [36,43,52,48]
+    // The sounding voices are the spread voicing, emitted ascending by pitch.
+    const voiced = voiceTriad(triad, 'spread', 0).sort((a, b) => a - b);
     const present = params.voices.filter((v) => v.present);
     expect(present.map((v) => v.id)).toEqual([2, 3, 4, 5]); // 4 stable ids
     expect(present.map((v) => Math.round(v.freq))).toEqual(voiced.map((m) => Math.round(midiToFreq(m))));
@@ -133,7 +133,7 @@ describe('expression-chord node', () => {
     const triad = diatonicTriad(cMajor, DEFAULT_EXPRESSION_TO_DEGREE.happy);
     expect(out[0].triad).toEqual(triad); // overlay triad stays at scale pitch (un-shifted)
     // ...but the voiced chord is an octave up, tracking the hand melody.
-    const voicedShifted = voiceTriad(triad, 'spread', 1);
+    const voicedShifted = voiceTriad(triad, 'spread', 1).sort((a, b) => a - b);
     const present = (out[0].params as SynthParams).voices.filter((v) => v.present);
     expect(present.map((v) => Math.round(v.freq))).toEqual(voicedShifted.map((m) => Math.round(midiToFreq(m))));
   });
@@ -151,6 +151,58 @@ describe('expression-chord node', () => {
     const present = (out[0].params as SynthParams).voices.filter((v) => v.present);
     expect(present).toHaveLength(voiced.length);
     expect(present.every((v) => Math.abs(v.gain - 0.5) < 1e-9)).toBe(true); // live gain
+  });
+});
+
+describe('expression-chord rendering over time (stateful)', () => {
+  const node = () => expressionChordNode.make(expressionChordNode.params.parse({}));
+  const ctx = (dt: number) => ({ tick: 0, time: 0, dt, resources: {} }) as unknown as NodeContext;
+  const aMinor: ScaleSpec = { root: 9, type: 'minor', octaves: 2, baseOctave: 3 };
+  const presentCount = (out: Record<string, unknown>) =>
+    (out.params as SynthParams).voices.filter((v) => v.present).length;
+
+  it('always emits MAX stable-id voices regardless of mode/rendering (no stuck voices)', () => {
+    const n = node();
+    for (const rendering of ['sustained', 'arpUp', 'strum'] as const) {
+      for (const faceMapping of ['none', 'chord']) {
+        const out = n.process(
+          { expression: happyExpr, spec: cMajor, faceMapping, chordConfig: { rendering } },
+          ctx(1 / 60),
+        );
+        expect((out.params as SynthParams).voices.map((v) => v.id)).toEqual([2, 3, 4, 5]);
+      }
+    }
+  });
+
+  it('the beat clock advances an arpeggio through the node (one voice at a time)', () => {
+    const n = node();
+    const ids = new Set<number>();
+    for (let i = 0; i < 40; i++) {
+      const out = n.process(
+        { expression: happyExpr, spec: cMajor, faceMapping: 'chord', chordConfig: { rendering: 'arpUp', bpm: 180 } },
+        ctx(1 / 60),
+      );
+      const present = (out.params as SynthParams).voices.filter((v) => v.present);
+      expect(present.length).toBeLessThanOrEqual(1); // arpeggio = one voice at a time
+      if (present.length === 1) ids.add(present[0].id);
+    }
+    expect(ids.size).toBeGreaterThan(1); // the active voice advanced over time
+  });
+
+  it('strum re-rolls on a real chord change — including a scale change at a fixed expression', () => {
+    const n = node();
+    const strum = (spec: ScaleSpec) =>
+      n.process(
+        { expression: happyExpr, spec, faceMapping: 'chord', chordConfig: { rendering: 'strum' } },
+        ctx(1 / 60),
+      );
+    // Hold the first chord; the strum rolls voices in over a few ticks.
+    let out = strum(cMajor);
+    for (let i = 0; i < 7; i++) out = strum(cMajor);
+    expect(presentCount(out)).toBeGreaterThan(1);
+    // Same expression but a DIFFERENT scale = a genuinely different chord → re-roll.
+    out = strum(aMinor);
+    expect(presentCount(out)).toBe(1); // only the bass at the restart
   });
 });
 

--- a/test/face_chord_nodes.test.ts
+++ b/test/face_chord_nodes.test.ts
@@ -9,9 +9,10 @@ import { describe, it, expect } from 'vitest';
 import { replayNode } from '@/dag';
 import type { NodeContext } from '@/dag';
 import { faceExpressionNode, expressionChordNode, synthMergeNode, voiceMappingNode } from '@/nodes';
-import { CHORD_VOICE_ID_BASE, ABSENT_HAND, ABSENT_FACE } from '@/nodes';
+import { MAX_CHORD_VOICES, ABSENT_HAND, ABSENT_FACE } from '@/nodes';
 import type { ExpressionScores } from '@/music/expression';
 import { DEFAULT_EXPRESSION_TO_DEGREE } from '@/music/expression';
+import { voiceTriad } from '@/music/voicing';
 import { diatonicTriad, midiToFreq, type ScaleSpec } from '@/music/theory';
 import type { FaceFrame, FaceFeatures, HandFeatures, SynthParams } from '@/nodes';
 
@@ -84,29 +85,28 @@ const happyExpr: ExpressionScores = {
 };
 
 describe('expression-chord node', () => {
-  it('plays the diatonic triad of the expression-mapped degree in chord mode', async () => {
+  it('voices the diatonic triad with a low bass (default spread voicing, sustained)', async () => {
     const out = await chordVoices(happyExpr, 'chord');
     const params = out.params as SynthParams;
-    const degree = DEFAULT_EXPRESSION_TO_DEGREE.happy; // 0 = tonic
-    const expected = diatonicTriad(cMajor, degree);
-    expect(out.triad).toEqual(expected);
+    const triad = diatonicTriad(cMajor, DEFAULT_EXPRESSION_TO_DEGREE.happy); // [48,52,55]
+    // The `triad` output is the un-voiced scale triad (for the overlay highlight).
+    expect(out.triad).toEqual(triad);
+    // The sounding voices are the spread voicing of that triad (4 notes, low bass).
+    const voiced = voiceTriad(triad, 'spread', 0); // [36,43,52,48]
     const present = params.voices.filter((v) => v.present);
-    expect(present.map((v) => v.id)).toEqual([
-      CHORD_VOICE_ID_BASE,
-      CHORD_VOICE_ID_BASE + 1,
-      CHORD_VOICE_ID_BASE + 2,
-    ]);
-    expect(present.map((v) => Math.round(v.freq))).toEqual(expected.map((m) => Math.round(midiToFreq(m))));
+    expect(present.map((v) => v.id)).toEqual([2, 3, 4, 5]); // 4 stable ids
+    expect(present.map((v) => Math.round(v.freq))).toEqual(voiced.map((m) => Math.round(midiToFreq(m))));
+    expect(Math.min(...voiced)).toBeLessThan(Math.min(...triad)); // bass is below the scale triad
   });
 
-  it('emits three stable-id but silent voices when not in chord mode', async () => {
+  it('emits MAX silent voices on stable ids when not in chord mode', async () => {
     for (const mode of ['none', 'timbre']) {
       const out = await chordVoices(happyExpr, mode);
       const params = out.params as SynthParams;
       expect(out.triad).toEqual([]);
-      expect(params.voices).toHaveLength(3); // stable ids, so the synth can release them
+      expect(params.voices).toHaveLength(MAX_CHORD_VOICES); // stable ids → synth releases them
       expect(params.voices.every((v) => !v.present && v.gain === 0)).toBe(true);
-      expect(params.voices.map((v) => v.id)).toEqual([2, 3, 4]);
+      expect(params.voices.map((v) => v.id)).toEqual([2, 3, 4, 5]);
     }
   });
 
@@ -130,11 +130,27 @@ describe('expression-chord node', () => {
       faceMapping: ['chord'],
       octaveShift: [1],
     });
-    const rawTriad = diatonicTriad(cMajor, DEFAULT_EXPRESSION_TO_DEGREE.happy);
-    expect(out[0].triad).toEqual(rawTriad); // overlay triad stays at scale pitch (un-shifted)
+    const triad = diatonicTriad(cMajor, DEFAULT_EXPRESSION_TO_DEGREE.happy);
+    expect(out[0].triad).toEqual(triad); // overlay triad stays at scale pitch (un-shifted)
+    // ...but the voiced chord is an octave up, tracking the hand melody.
+    const voicedShifted = voiceTriad(triad, 'spread', 1);
     const present = (out[0].params as SynthParams).voices.filter((v) => v.present);
-    // ...but the sounding pitch is an octave up, tracking the hand melody.
-    expect(present.map((v) => Math.round(v.freq))).toEqual(rawTriad.map((m) => Math.round(midiToFreq(m + 12))));
+    expect(present.map((v) => Math.round(v.freq))).toEqual(voicedShifted.map((m) => Math.round(midiToFreq(m))));
+  });
+
+  it('respects a live chordConfig (volume, voicing) over the static params', async () => {
+    const node = expressionChordNode.make(expressionChordNode.params.parse({}));
+    const out = await replayNode(node, {
+      expression: [happyExpr],
+      spec: [cMajor],
+      faceMapping: ['chord'],
+      chordConfig: [{ gain: 0.5, voicing: 'power' }],
+    });
+    const triad = diatonicTriad(cMajor, DEFAULT_EXPRESSION_TO_DEGREE.happy);
+    const voiced = voiceTriad(triad, 'power', 0); // 3 notes
+    const present = (out[0].params as SynthParams).voices.filter((v) => v.present);
+    expect(present).toHaveLength(voiced.length);
+    expect(present.every((v) => Math.abs(v.gain - 0.5) < 1e-9)).toBe(true); // live gain
   });
 });
 

--- a/test/overlay_elements.test.ts
+++ b/test/overlay_elements.test.ts
@@ -177,58 +177,40 @@ describe('canvas-overlay composable elements', () => {
     expect(noNotes.count('fillText')).toBe(0); // but no note labels
   });
 
-  it('chordGuide: highlights the chord tones that fall on the scale guide', () => {
+  const onlyChord = {
+    video: { show: false },
+    scaleGuide: { show: false },
+    indexGuide: { show: false },
+    landmarks: { show: false },
+    markers: { show: false },
+  };
+  const drawChord = (chord: number[] | undefined, paramsOverride: unknown = onlyChord) => {
     const rc = makeRecordingCanvas();
-    const onlyChord = {
-      video: { show: false },
-      scaleGuide: { show: false },
-      indexGuide: { show: false },
-      landmarks: { show: false },
-      markers: { show: false },
-    };
-    const handlers = canvasOverlayNode.make(canvasOverlayNode.params.parse(onlyChord));
+    const handlers = canvasOverlayNode.make(canvasOverlayNode.params.parse(paramsOverride));
     const ctx: NodeContext = { tick: 0, time: 0, dt: 0, resources: { canvas: rc.canvas, video: rc.video } };
-    // Three chord tones, all present in the scale [48,50,52,55,57,60] → 3 bands.
-    handlers.process({ ...fullInputs(), chord: [48, 52, 57] }, ctx);
-    expect(rc.count('stroke')).toBe(3);
-    expect(rc.count('moveTo')).toBe(3);
+    handlers.process({ ...fullInputs(), chord }, ctx);
+    return rc;
+  };
+
+  it('chordGuide: highlights every visible guide line of the chord pitch classes (with octave repetition)', () => {
+    // Scale [48,50,52,55,57,60] = C,D,E,G,A,C → C appears twice (48 and 60).
+    // A C chord {C,E,A} = pcs {0,4,9} lights up 48(C), 52(E), 57(A) AND 60(C) = 4 lines.
+    const rc = drawChord([48, 52, 57]);
+    expect(rc.count('stroke')).toBe(4);
+    expect(rc.count('moveTo')).toBe(4);
   });
 
-  it('chordGuide: draws nothing with no chord, off, or out-of-range tones', () => {
-    const base = {
-      video: { show: false },
-      scaleGuide: { show: false },
-      indexGuide: { show: false },
-      landmarks: { show: false },
-      markers: { show: false },
-    };
-    const run = (params: unknown, chord?: number[]) => {
-      const rc = makeRecordingCanvas();
-      const handlers = canvasOverlayNode.make(canvasOverlayNode.params.parse(params));
-      const ctx: NodeContext = { tick: 0, time: 0, dt: 0, resources: { canvas: rc.canvas, video: rc.video } };
-      handlers.process({ ...fullInputs(), chord }, ctx);
-      return rc;
-    };
-    expect(run(base).count('stroke')).toBe(0); // no chord input → idle
-    expect(run({ ...base, chordGuide: { show: false } }, [48, 52, 57]).count('stroke')).toBe(0); // toggled off
-    // C# (pitch class 1) is not in the scale [48,50,52,55,57,60] = {C,D,E,G,A} → no match.
-    expect(run(base, [49]).count('stroke')).toBe(0);
+  it('chordGuide: lights every octave of a chord pitch class regardless of the rendered octave', () => {
+    // 72 = C5 (pitch class 0) — highlights BOTH C guide lines (48=C3, 60=C4),
+    // independent of the rendered voicing's octave.
+    expect(drawChord([72]).count('stroke')).toBe(2);
   });
 
-  it('chordGuide: folds an above-range tone to its pitch class so it still highlights', () => {
-    const rc = makeRecordingCanvas();
-    const onlyChord = {
-      video: { show: false },
-      scaleGuide: { show: false },
-      indexGuide: { show: false },
-      landmarks: { show: false },
-      markers: { show: false },
-    };
-    const handlers = canvasOverlayNode.make(canvasOverlayNode.params.parse(onlyChord));
-    const ctx: NodeContext = { tick: 0, time: 0, dt: 0, resources: { canvas: rc.canvas, video: rc.video } };
-    // 72 = C5 is above the displayed scale [48..60] but C (pitch class 0) is in it.
-    handlers.process({ ...fullInputs(), chord: [72] }, ctx);
-    expect(rc.count('stroke')).toBe(1);
+  it('chordGuide: draws nothing with no chord, off, or pitch classes absent from the scale', () => {
+    expect(drawChord(undefined).count('stroke')).toBe(0); // no chord input → idle
+    expect(drawChord([48, 52, 57], { ...onlyChord, chordGuide: { show: false } }).count('stroke')).toBe(0); // off
+    // C# (pitch class 1) is not in the scale {C,D,E,G,A} → no match.
+    expect(drawChord([49]).count('stroke')).toBe(0);
   });
 
   it('a live overlayConfig input overrides the static params', () => {

--- a/test/settings_presets.test.ts
+++ b/test/settings_presets.test.ts
@@ -7,7 +7,7 @@
 import { describe, it, expect } from 'vitest';
 import { createInMemoryProvider } from '@zodal/store';
 import { createPresetStore, presetId } from '@/settings/presets';
-import { PresetSchema, SettingsSchema, type Preset, type Settings } from '@/settings/schema';
+import { PresetSchema, SettingsSchema, DEFAULT_FACE_CHORD, type Preset, type Settings } from '@/settings/schema';
 
 function sampleSettings(overrides: Partial<Settings> = {}): Settings {
   return SettingsSchema.parse({
@@ -92,6 +92,10 @@ describe('preset persistence', () => {
 
   it('defaults faceMapping to none when omitted', () => {
     expect(sampleSettings().faceMapping).toBe('none');
+  });
+
+  it('defaults faceChord when omitted (pre-chord-feature presets)', () => {
+    expect(sampleSettings().faceChord).toEqual(DEFAULT_FACE_CHORD);
   });
 
   it('migrates a pre-#64 preset (boolean faceEnabled) to faceMapping on load', () => {

--- a/test/voicing.test.ts
+++ b/test/voicing.test.ts
@@ -50,10 +50,20 @@ describe('renderGains', () => {
     expect(renderGains(4, 'arpUp', 2.0, 0)).toEqual([1, 0, 0, 0]); // step 4 wraps
   });
 
+  it('arpDown walks downward (negative-modulo index)', () => {
+    const idx = (beat: number) => renderGains(4, 'arpDown', beat, 0).indexOf(1);
+    // index 0,3,2,1 then wraps — the descent from the bass through the negative modulo.
+    expect([0, 0.5, 1.0, 1.5, 2.0].map(idx)).toEqual([0, 3, 2, 1, 0]);
+  });
+
   it('arpUpDown ping-pongs without doubling the endpoints', () => {
     const idx = (beat: number) => renderGains(4, 'arpUpDown', beat, 0).indexOf(1);
     // steps 0..5 over a 4-voice ping-pong cycle (length 6): 0,1,2,3,2,1
     expect([0, 0.5, 1.0, 1.5, 2.0, 2.5].map(idx)).toEqual([0, 1, 2, 3, 2, 1]);
+  });
+
+  it('a NaN beat is guarded to step 0 (no crash, no phantom index)', () => {
+    expect(renderGains(4, 'arpUp', NaN, 0)).toEqual([1, 0, 0, 0]);
   });
 
   it('pulse re-articulates: on early in the step, off in the tail', () => {

--- a/test/voicing.test.ts
+++ b/test/voicing.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Tests the pure chord voicing + rendering engine (src/music/voicing.ts):
+ * researched triad voicings (low bass, quality-agnostic, view-independent) and the
+ * tempo-based articulation gain patterns.
+ */
+import { describe, it, expect } from 'vitest';
+import { voiceTriad, renderGains, isTempoRendering } from '@/music/voicing';
+
+// C major triad as ascending scale tones: C3, E3, G3.
+const cMaj = [48, 52, 55];
+
+describe('voiceTriad', () => {
+  it('anchors a low bass an octave below the root and stacks each voicing', () => {
+    // bass b = 48 - 12 = 36 (C2); third T = 4, fifth F = 7.
+    expect(voiceTriad(cMaj, 'close')).toEqual([36, 40, 43]); // C2 E2 G2
+    expect(voiceTriad(cMaj, 'bassTriad')).toEqual([36, 48, 52, 55]); // C2 + C3 E3 G3
+    expect(voiceTriad(cMaj, 'spread')).toEqual([36, 43, 52, 48]); // root, 5th, 3rd+oct, root+oct
+    expect(voiceTriad(cMaj, 'shell')).toEqual([36, 40, 55]); // root, 3rd, high 5th
+    expect(voiceTriad(cMaj, 'power')).toEqual([36, 43, 48]); // root, 5th, octave
+  });
+
+  it('is quality-agnostic — reads the third/fifth from the triad', () => {
+    // A minor triad A3 C4 E4: third = 3 (minor), fifth = 7. bass = 57 - 12 = 45.
+    expect(voiceTriad([57, 60, 64], 'close')).toEqual([45, 48, 52]);
+    // B diminished B3 D4 F4: third = 3, fifth = 6.
+    expect(voiceTriad([59, 62, 65], 'close')).toEqual([47, 50, 53]);
+  });
+
+  it('tracks the keyboard octave shift', () => {
+    expect(voiceTriad(cMaj, 'close', 1)).toEqual([48, 52, 55]); // +12 everywhere
+    expect(voiceTriad(cMaj, 'close', -1)).toEqual([24, 28, 31]);
+  });
+
+  it('returns [] for a non-triad input', () => {
+    expect(voiceTriad([], 'spread')).toEqual([]);
+    expect(voiceTriad([60, 64], 'spread')).toEqual([]);
+  });
+});
+
+describe('renderGains', () => {
+  it('sustained holds all voices', () => {
+    expect(renderGains(4, 'sustained', 0, 0)).toEqual([1, 1, 1, 1]);
+    expect(renderGains(4, 'sustained', 3.7, 5)).toEqual([1, 1, 1, 1]);
+  });
+
+  it('arpUp lights one voice per eighth-note step, cycling', () => {
+    expect(renderGains(4, 'arpUp', 0, 0)).toEqual([1, 0, 0, 0]);
+    expect(renderGains(4, 'arpUp', 0.5, 0)).toEqual([0, 1, 0, 0]); // step 1
+    expect(renderGains(4, 'arpUp', 1.0, 0)).toEqual([0, 0, 1, 0]); // step 2
+    expect(renderGains(4, 'arpUp', 2.0, 0)).toEqual([1, 0, 0, 0]); // step 4 wraps
+  });
+
+  it('arpUpDown ping-pongs without doubling the endpoints', () => {
+    const idx = (beat: number) => renderGains(4, 'arpUpDown', beat, 0).indexOf(1);
+    // steps 0..5 over a 4-voice ping-pong cycle (length 6): 0,1,2,3,2,1
+    expect([0, 0.5, 1.0, 1.5, 2.0, 2.5].map(idx)).toEqual([0, 1, 2, 3, 2, 1]);
+  });
+
+  it('pulse re-articulates: on early in the step, off in the tail', () => {
+    expect(renderGains(3, 'pulse', 0, 0)).toEqual([1, 1, 1]); // frac 0 < gate
+    // beat 0.45 → stepF 0.9 → frac 0.9 ≥ 0.85 gate → silent tail
+    expect(renderGains(3, 'pulse', 0.45, 0)).toEqual([0, 0, 0]);
+  });
+
+  it('alberti plays low, high, mid, high', () => {
+    const idx = (beat: number) => renderGains(4, 'alberti', beat, 0).indexOf(1);
+    expect([0, 0.5, 1.0, 1.5].map(idx)).toEqual([0, 3, 1, 3]);
+  });
+
+  it('strum staggers onsets from the chord change, then sustains', () => {
+    expect(renderGains(4, 'strum', 0, 0)).toEqual([1, 0, 0, 0]); // only the bass at t=0
+    expect(renderGains(4, 'strum', 0, 0.025)).toEqual([1, 1, 0, 0]); // 2nd voice in
+    expect(renderGains(4, 'strum', 0, 0.1)).toEqual([1, 1, 1, 1]); // fully rolled
+  });
+
+  it('classifies tempo vs non-tempo renderings', () => {
+    expect(isTempoRendering('sustained')).toBe(false);
+    expect(isTempoRendering('strum')).toBe(false);
+    expect(isTempoRendering('arpUp')).toBe(true);
+    expect(isTempoRendering('pulse')).toBe(true);
+  });
+});


### PR DESCRIPTION
Makes the face chord musical and configurable (follow-up to #64/#65, PR #66).

## What it adds
- **Voicings** (`src/music/voicing.ts`, pure): `voiceTriad` arranges the diatonic triad into a chord with a **low bass fundamental**, view-independent (anchored below the playing range) and quality-agnostic (third/fifth read from the triad). Modes: **spread** (open/cinematic, default), bassTriad, close, shell, power.
- **Renderings**: `renderGains` plays the voiced chord over time — sustained pad + tempo-based arpeggios (up/down/up-down), pulse, alberti, and a strum (staggered onsets rolling into a pad). Arps traverse low→high by actual pitch.
- **expression-chord** is now stateful + time-aware (its own beat clock; strum re-rolls on each genuine chord change — keyed off the sounding pitches). Always emits 4 stable-id voices so the synth never sticks. Live settings arrive on a `chordConfig` port (no graph rebuild).
- **Chord controls** UI (instrument / volume / voicing / rendering / tempo), shown in chord mode, with a hint that tempo modes want a crisp instrument.
- **Highlight** now reflects the chord's **pitch classes with octave repetition** (every visible C/E/G line for a C chord), independent of the voicing, and is more subtle.
- Persistence: `faceChord` is a musical preset field; `mergeControls` heals a partial/corrupt blob (parity with overlay).

## Process
Researched voicings + articulation patterns (Vancouver-cited), then a 46-agent adversarial review (6 dimensions, each finding verified by 2 skeptics): **19 confirmed findings fixed** — incl. the strum-key scale-change gap, arpeggios following array order instead of pitch, and the faceChord merge-heal. **238 tests**, deterministic; typecheck + build + catalog clean.

https://claude.ai/code/session_01JEoe7y1hA5KdEAvvpQXxxt
