### PR TITLE
Overlay categories: data-driven grouping + face mesh + output cues

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -240,7 +240,7 @@ _Audio + the captured video with overlaid guides._
 Mirrored video + composable overlay elements (guides, landmarks, markers).
 
 - **roles:** overlay
-- **in:** hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], chord:number[], octaveShift:number, overlayConfig:overlay-config
+- **in:** hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], chord:number[], faceFrame:face-frame, expression:face-expression, octaveShift:number, overlayConfig:overlay-config
 - **out:** —
-- **params:** video (object={}), scaleGuide (object={}), chordGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={})
+- **params:** video (object={}), scaleGuide (object={}), chordGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={}), faceLandmarks (object={}), faceExpression (object={}), timbreLevels (object={})
 

--- a/public/catalog.json
+++ b/public/catalog.json
@@ -32,6 +32,14 @@
         "kind": "number[]"
       },
       {
+        "name": "faceFrame",
+        "kind": "face-frame"
+      },
+      {
+        "name": "expression",
+        "kind": "face-expression"
+      },
+      {
         "name": "octaveShift",
         "kind": "number",
         "default": 0
@@ -70,6 +78,21 @@
       },
       {
         "name": "markers",
+        "type": "object",
+        "default": {}
+      },
+      {
+        "name": "faceLandmarks",
+        "type": "object",
+        "default": {}
+      },
+      {
+        "name": "faceExpression",
+        "type": "object",
+        "default": {}
+      },
+      {
+        "name": "timbreLevels",
         "type": "object",
         "default": {}
       }

--- a/public/manual.html
+++ b/public/manual.html
@@ -279,9 +279,9 @@
       <p>Mirrored video + composable overlay elements (guides, landmarks, markers).</p>
       <dl>
         <dt>roles</dt><dd>overlay</dd>
-        <dt>in</dt><dd>hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], chord:number[], octaveShift:number, overlayConfig:overlay-config</dd>
+        <dt>in</dt><dd>hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], chord:number[], faceFrame:face-frame, expression:face-expression, octaveShift:number, overlayConfig:overlay-config</dd>
         <dt>out</dt><dd>—</dd>
-        <dt>params</dt><dd>video (object={}), scaleGuide (object={}), chordGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={})</dd>
+        <dt>params</dt><dd>video (object={}), scaleGuide (object={}), chordGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={}), faceLandmarks (object={}), faceExpression (object={}), timbreLevels (object={})</dd>
       </dl>
     </div></div></section>
 </div></body></html>

--- a/src/app/ControlsPanel.tsx
+++ b/src/app/ControlsPanel.tsx
@@ -13,8 +13,10 @@ import { useState, type ReactNode } from 'react';
 import { NOTES, SCALE_TYPES, isSevenNoteScale, type ScaleTypeId } from '@/music/theory';
 import { INSTRUMENTS, INSTRUMENT_IDS } from '@/music/instruments';
 import { VOICINGS, RENDERINGS, isTempoRendering, type VoicingId, type RenderingId } from '@/music/voicing';
+import { OVERLAY_ELEMENTS, OVERLAY_CATEGORIES, type OverlayParams } from '@/nodes/output/canvas_overlay';
 import type { FaceMapping } from '@/nodes';
 import { useControls, type VoiceControl } from './store';
+import { OVERLAY_CONTROLS, type OverlayControlDesc } from './overlayControls';
 import { useFaceStatus } from './faceStatus';
 import { usePresets } from './usePresets';
 import { RECORDING_FORMATS } from './recording/formats';
@@ -129,60 +131,69 @@ function VoiceControls({ side }: { side: 'right' | 'left' }) {
 }
 
 /**
- * Overlay settings, grouped by the element {@link OVERLAY_CATEGORIES} into
- * collapsible sections — the "target space of the mapping" framing: Input
- * features (what the camera detected), Output features (what gestures map to),
- * Guides, and the Backdrop. New overlay elements slot into their category here.
+ * Overlay settings, DATA-DRIVEN by the element categories: a collapsible section
+ * per {@link OVERLAY_CATEGORIES} entry (Input features / Output features / Guides /
+ * Backdrop — the "target space of the mapping" framing), and within each, one
+ * control per element whose {@link OVERLAY_ELEMENTS}.category matches, rendered
+ * from its {@link OVERLAY_CONTROLS} descriptor. Adding an overlay element makes it
+ * appear here automatically (a test enforces every element has a descriptor), so
+ * this is a general framework, not a hand-maintained list.
  */
 function OverlayControls() {
   const overlay = useControls((s) => s.overlay);
-  const set = useControls((s) => s.setOverlayElement);
+  const setEl = useControls((s) => s.setOverlayElement);
   const faceActive = useControls((s) => s.faceMapping) !== 'none';
+  const categoryOf = new Map(OVERLAY_ELEMENTS.map((e) => [e.name, e.category]));
+  // The React layer isn't strict-typechecked; a runtime element key loses the
+  // setOverlayElement generic narrowing, so patch with a loose cast.
+  const patch = (name: keyof OverlayParams, p: object) => setEl(name, p as never);
+
+  const renderControl = (d: OverlayControlDesc) => {
+    const elt = overlay[d.name] as { show: boolean } & Record<string, unknown>;
+    const off = !!d.needsFace && !faceActive;
+    return (
+      <div key={d.name} className="space-y-1.5">
+        <Toggle label={d.label} checked={elt.show} onChange={(v) => patch(d.name, { show: v })} disabled={off} />
+        {off && (
+          <p className="pl-5 text-[10px] leading-relaxed text-white/30">Appears once a face mapping is on.</p>
+        )}
+        {d.toggles?.map((t) => (
+          <div key={t.key} className="pl-5">
+            <Toggle
+              label={t.label}
+              checked={elt[t.key] as boolean}
+              onChange={(v) => patch(d.name, { [t.key]: v })}
+              disabled={off || !elt.show}
+            />
+          </div>
+        ))}
+        {d.slider && (
+          <label className={`flex items-center justify-between gap-2 pl-5 text-xs ${elt.show ? '' : 'opacity-40'}`}>
+            {d.slider.label}
+            <input
+              type="range" min={0} max={1} step={0.01}
+              value={elt[d.slider.key] as number}
+              disabled={!elt.show}
+              onChange={(e) => patch(d.name, { [d.slider!.key]: Number(e.target.value) })}
+            />
+          </label>
+        )}
+      </div>
+    );
+  };
 
   return (
     <div className="space-y-3">
       <h3 className="text-[11px] font-bold uppercase tracking-widest text-white/70">Overlay</h3>
-
-      <CollapsibleSection label="Input features">
-        <Toggle label="Hand landmarks" checked={overlay.landmarks.show} onChange={(v) => set('landmarks', { show: v })} />
-        <Toggle
-          label="Face mesh"
-          checked={overlay.faceLandmarks.show}
-          onChange={(v) => set('faceLandmarks', { show: v })}
-          disabled={!faceActive}
-        />
-        {!faceActive && (
-          <p className="text-[10px] leading-relaxed text-white/30">
-            Face mesh appears once a face mapping is on (the model loads then).
-          </p>
-        )}
-      </CollapsibleSection>
-
-      <CollapsibleSection label="Output features">
-        <Toggle label="Note names" checked={overlay.markers.showNotes} onChange={(v) => set('markers', { showNotes: v })} />
-        <Toggle label="Control markers" checked={overlay.markers.show} onChange={(v) => set('markers', { show: v })} />
-        <Toggle label="Face expression" checked={overlay.faceExpression.show} onChange={(v) => set('faceExpression', { show: v })} />
-        <Toggle label="Timbre levels" checked={overlay.timbreLevels.show} onChange={(v) => set('timbreLevels', { show: v })} />
-        <Toggle label="Chord highlight" checked={overlay.chordGuide.show} onChange={(v) => set('chordGuide', { show: v })} />
-      </CollapsibleSection>
-
-      <CollapsibleSection label="Guides">
-        <Toggle label="Scale guide" checked={overlay.scaleGuide.show} onChange={(v) => set('scaleGuide', { show: v })} />
-        <Toggle label="Scale guide labels" checked={overlay.scaleGuide.showLabels} onChange={(v) => set('scaleGuide', { showLabels: v })} />
-        <Toggle label="Index-finger guide" checked={overlay.indexGuide.show} onChange={(v) => set('indexGuide', { show: v })} />
-        <Toggle label="Index guide dashed" checked={overlay.indexGuide.dashed} onChange={(v) => set('indexGuide', { dashed: v })} />
-      </CollapsibleSection>
-
-      <CollapsibleSection label="Backdrop" defaultOpen={false}>
-        <Toggle label="Video backdrop" checked={overlay.video.show} onChange={(v) => set('video', { show: v })} />
-        <label className="flex items-center justify-between gap-2 text-xs">
-          Background opacity
-          <input
-            type="range" min={0} max={1} step={0.01} value={overlay.video.alpha}
-            onChange={(e) => set('video', { alpha: Number(e.target.value) })}
-          />
-        </label>
-      </CollapsibleSection>
+      {OVERLAY_CATEGORIES.map((cat) => {
+        const descs = OVERLAY_CONTROLS.filter((d) => categoryOf.get(d.name) === cat.id);
+        if (descs.length === 0) return null;
+        return (
+          <CollapsibleSection key={cat.id} label={cat.label} defaultOpen={cat.id !== 'backdrop'}>
+            {descs.map(renderControl)}
+          </CollapsibleSection>
+        );
+      })}
     </div>
   );
 }

--- a/src/app/ControlsPanel.tsx
+++ b/src/app/ControlsPanel.tsx
@@ -9,7 +9,7 @@
  * Renders just the controls *content* (no outer card); the host (App) wraps it
  * in a collapsible translucent overlay so the video stays the focus.
  */
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 import { NOTES, SCALE_TYPES, isSevenNoteScale, type ScaleTypeId } from '@/music/theory';
 import { INSTRUMENTS, INSTRUMENT_IDS } from '@/music/instruments';
 import { VOICINGS, RENDERINGS, isTempoRendering, type VoicingId, type RenderingId } from '@/music/voicing';
@@ -25,16 +25,44 @@ function Toggle({
   label,
   checked,
   onChange,
+  disabled,
 }: {
   label: string;
   checked: boolean;
   onChange: (v: boolean) => void;
+  disabled?: boolean;
 }) {
   return (
-    <label className="flex items-center gap-2 text-xs">
-      <input type="checkbox" checked={checked} onChange={(e) => onChange(e.target.checked)} />
+    <label className={`flex items-center gap-2 text-xs ${disabled ? 'opacity-40' : ''}`}>
+      <input
+        type="checkbox"
+        checked={checked}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.checked)}
+      />
       {label}
     </label>
+  );
+}
+
+/** A collapsible settings group (native <details>), used to group the overlay
+ * elements by their category (Input features / Output features / Guides / …). */
+function CollapsibleSection({
+  label,
+  defaultOpen = true,
+  children,
+}: {
+  label: string;
+  defaultOpen?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <details open={defaultOpen}>
+      <summary className="cursor-pointer select-none text-[10px] font-bold uppercase tracking-widest text-white/60 transition hover:text-white/90">
+        {label}
+      </summary>
+      <div className="mt-2 space-y-2 pl-1">{children}</div>
+    </details>
   );
 }
 
@@ -100,29 +128,61 @@ function VoiceControls({ side }: { side: 'right' | 'left' }) {
   );
 }
 
+/**
+ * Overlay settings, grouped by the element {@link OVERLAY_CATEGORIES} into
+ * collapsible sections — the "target space of the mapping" framing: Input
+ * features (what the camera detected), Output features (what gestures map to),
+ * Guides, and the Backdrop. New overlay elements slot into their category here.
+ */
 function OverlayControls() {
   const overlay = useControls((s) => s.overlay);
   const set = useControls((s) => s.setOverlayElement);
+  const faceActive = useControls((s) => s.faceMapping) !== 'none';
 
   return (
-    <div className="space-y-2">
+    <div className="space-y-3">
       <h3 className="text-[11px] font-bold uppercase tracking-widest text-white/70">Overlay</h3>
-      <Toggle label="Video backdrop" checked={overlay.video.show} onChange={(v) => set('video', { show: v })} />
-      <label className="flex items-center justify-between gap-2 text-xs">
-        Background opacity
-        <input
-          type="range" min={0} max={1} step={0.01} value={overlay.video.alpha}
-          onChange={(e) => set('video', { alpha: Number(e.target.value) })}
+
+      <CollapsibleSection label="Input features">
+        <Toggle label="Hand landmarks" checked={overlay.landmarks.show} onChange={(v) => set('landmarks', { show: v })} />
+        <Toggle
+          label="Face mesh"
+          checked={overlay.faceLandmarks.show}
+          onChange={(v) => set('faceLandmarks', { show: v })}
+          disabled={!faceActive}
         />
-      </label>
-      <Toggle label="Scale guide" checked={overlay.scaleGuide.show} onChange={(v) => set('scaleGuide', { show: v })} />
-      <Toggle label="Scale guide labels" checked={overlay.scaleGuide.showLabels} onChange={(v) => set('scaleGuide', { showLabels: v })} />
-      <Toggle label="Face chord highlight" checked={overlay.chordGuide.show} onChange={(v) => set('chordGuide', { show: v })} />
-      <Toggle label="Index-finger guide" checked={overlay.indexGuide.show} onChange={(v) => set('indexGuide', { show: v })} />
-      <Toggle label="Index guide dashed" checked={overlay.indexGuide.dashed} onChange={(v) => set('indexGuide', { dashed: v })} />
-      <Toggle label="Hand landmarks" checked={overlay.landmarks.show} onChange={(v) => set('landmarks', { show: v })} />
-      <Toggle label="Control markers" checked={overlay.markers.show} onChange={(v) => set('markers', { show: v })} />
-      <Toggle label="Note names" checked={overlay.markers.showNotes} onChange={(v) => set('markers', { showNotes: v })} />
+        {!faceActive && (
+          <p className="text-[10px] leading-relaxed text-white/30">
+            Face mesh appears once a face mapping is on (the model loads then).
+          </p>
+        )}
+      </CollapsibleSection>
+
+      <CollapsibleSection label="Output features">
+        <Toggle label="Note names" checked={overlay.markers.showNotes} onChange={(v) => set('markers', { showNotes: v })} />
+        <Toggle label="Control markers" checked={overlay.markers.show} onChange={(v) => set('markers', { show: v })} />
+        <Toggle label="Face expression" checked={overlay.faceExpression.show} onChange={(v) => set('faceExpression', { show: v })} />
+        <Toggle label="Timbre levels" checked={overlay.timbreLevels.show} onChange={(v) => set('timbreLevels', { show: v })} />
+        <Toggle label="Chord highlight" checked={overlay.chordGuide.show} onChange={(v) => set('chordGuide', { show: v })} />
+      </CollapsibleSection>
+
+      <CollapsibleSection label="Guides">
+        <Toggle label="Scale guide" checked={overlay.scaleGuide.show} onChange={(v) => set('scaleGuide', { show: v })} />
+        <Toggle label="Scale guide labels" checked={overlay.scaleGuide.showLabels} onChange={(v) => set('scaleGuide', { showLabels: v })} />
+        <Toggle label="Index-finger guide" checked={overlay.indexGuide.show} onChange={(v) => set('indexGuide', { show: v })} />
+        <Toggle label="Index guide dashed" checked={overlay.indexGuide.dashed} onChange={(v) => set('indexGuide', { dashed: v })} />
+      </CollapsibleSection>
+
+      <CollapsibleSection label="Backdrop" defaultOpen={false}>
+        <Toggle label="Video backdrop" checked={overlay.video.show} onChange={(v) => set('video', { show: v })} />
+        <label className="flex items-center justify-between gap-2 text-xs">
+          Background opacity
+          <input
+            type="range" min={0} max={1} step={0.01} value={overlay.video.alpha}
+            onChange={(e) => set('video', { alpha: Number(e.target.value) })}
+          />
+        </label>
+      </CollapsibleSection>
     </div>
   );
 }

--- a/src/app/graph.ts
+++ b/src/app/graph.ts
@@ -171,6 +171,9 @@ export function defaultGraph(selection?: SlotSelection, registry?: NodeRegistry)
       { from: { node: 'kctrl', port: 'octaveShift' }, to: { node: 'overlay', port: 'octaveShift' } },
       // The face chord's tones, so the overlay can highlight them on the guide.
       { from: { node: 'exprChord', port: 'triad' }, to: { node: 'overlay', port: 'chord' } },
+      // The raw face frame (mesh) + classified expression, for the face overlays.
+      { from: { node: 'camFace', port: 'face' }, to: { node: 'overlay', port: 'faceFrame' } },
+      { from: { node: 'faceExpr', port: 'expression' }, to: { node: 'overlay', port: 'expression' } },
       // Live overlay element config from the UI store (toggle elements without rebuild).
       { from: { node: 'ui', port: 'overlay' }, to: { node: 'overlay', port: 'overlayConfig' } },
     ],

--- a/src/app/overlayControls.ts
+++ b/src/app/overlayControls.ts
@@ -1,0 +1,42 @@
+/**
+ * UI descriptors for the overlay settings panel — the data that drives the
+ * grouped, collapsible Overlay controls (see ControlsPanel `OverlayControls`).
+ *
+ * Each descriptor names an overlay element (the key into the overlay params) and
+ * declares its controls: a primary `show` toggle, optional dependent sub-toggles
+ * (disabled when `show` is off), an optional 0..1 slider, and whether it requires
+ * an active face mapping. The panel renders these grouped by each element's
+ * {@link OverlayElement.category} (from {@link OVERLAY_CATEGORIES}) — so adding a
+ * new overlay element is: register it in `OVERLAY_ELEMENTS` (with a category) +
+ * its params sub-object + one descriptor here. A test asserts every element has a
+ * descriptor, so an element can never be silently un-toggleable in the UI.
+ *
+ * Kept out of the .tsx so it is importable in plain Node tests without React.
+ */
+import type { OverlayParams } from '@/nodes/output/canvas_overlay';
+
+export interface OverlayControlDesc {
+  /** The overlay element / params key this descriptor controls. */
+  name: keyof OverlayParams;
+  /** Label for the primary on/off toggle. */
+  label: string;
+  /** Dependent boolean sub-toggles (disabled when the element's `show` is off). */
+  toggles?: { key: string; label: string }[];
+  /** A 0..1 slider param (disabled when the element's `show` is off). */
+  slider?: { key: string; label: string };
+  /** Only meaningful with an active face mapping (the model must be loaded). */
+  needsFace?: boolean;
+}
+
+/** Per-element control descriptors, in within-category display order. */
+export const OVERLAY_CONTROLS: OverlayControlDesc[] = [
+  { name: 'landmarks', label: 'Hand landmarks' },
+  { name: 'faceLandmarks', label: 'Face mesh', needsFace: true },
+  { name: 'markers', label: 'Control markers', toggles: [{ key: 'showNotes', label: 'Note names' }] },
+  { name: 'faceExpression', label: 'Face expression' },
+  { name: 'timbreLevels', label: 'Timbre levels' },
+  { name: 'chordGuide', label: 'Chord highlight' },
+  { name: 'scaleGuide', label: 'Scale guide', toggles: [{ key: 'showLabels', label: 'Note labels' }] },
+  { name: 'indexGuide', label: 'Index-finger guide', toggles: [{ key: 'dashed', label: 'Dashed' }] },
+  { name: 'video', label: 'Video backdrop', slider: { key: 'alpha', label: 'Opacity' } },
+];

--- a/src/nodes/domain.ts
+++ b/src/nodes/domain.ts
@@ -118,6 +118,9 @@ export function legacyFaceToMapping(faceEnabled: boolean | undefined): FaceMappi
 export interface FaceFrame {
   present: boolean;
   blendshapes: Record<string, number>;
+  /** Normalized (0..1) face landmark points in the source frame, for drawing the
+   *  face mesh overlay. Optional — the feature/expression nodes ignore it. */
+  landmarks?: { x: number; y: number }[];
 }
 
 /** Normalized expression controls derived from blendshapes, all 0..1. */

--- a/src/nodes/output/canvas_overlay.ts
+++ b/src/nodes/output/canvas_overlay.ts
@@ -423,6 +423,10 @@ const faceExpressionReadout: OverlayElement = {
     if (!params.faceExpression.show) return;
     const expr = inputs.expression;
     if (!expr?.present || !expr.probs?.length) return;
+    // The winner glows on the *held* label (what is actually driving the chord),
+    // not the tallest bar — under the classifier's argmax hysteresis the held
+    // expression can briefly differ from the raw smoothed distribution. (Out-of-set
+    // label → -1 → nothing glows, harmless.)
     const argmax = EXPRESSIONS.indexOf(expr.label);
     g.save();
     g.textAlign = 'center';
@@ -469,8 +473,11 @@ const timbreLevels: OverlayElement = {
       if (!v) return;
       const sx = f.x * W;
       const sy = f.y * H;
+      // Place the bars toward screen-centre so a hand near the right edge doesn't
+      // push them off-canvas.
+      const side = f.x > 0.5 ? -1 : 1;
       const bar = (offset: number, value: number, c: string) => {
-        const bx = sx + 32 + offset;
+        const bx = sx + side * (32 + offset);
         g.globalAlpha = 0.8;
         g.strokeStyle = c;
         g.lineWidth = 5;

--- a/src/nodes/output/canvas_overlay.ts
+++ b/src/nodes/output/canvas_overlay.ts
@@ -21,9 +21,11 @@ import { z } from 'zod';
 import { defineNode } from '@/dag';
 import type { NodeContext } from '@/dag';
 import { freqToMidi, midiToName, scaleGuide } from '@/music/theory';
+import { EXPRESSIONS, type ExpressionScores } from '@/music/expression';
 import {
   kp,
   LM,
+  type FaceFrame,
   type HandFeatures,
   type HandsFrame,
   type SingleHandFeatures,
@@ -78,6 +80,24 @@ const Params = z.object({
       showNotes: z.boolean().default(true),
     })
     .default({}),
+  /** The detected face mesh (input feature) — available when a face mapping is on. */
+  faceLandmarks: z
+    .object({
+      show: z.boolean().default(true),
+    })
+    .default({}),
+  /** Live readout of the classified facial expression (output feature). */
+  faceExpression: z
+    .object({
+      show: z.boolean().default(true),
+    })
+    .default({}),
+  /** Per-hand brightness/vibrato level bars (output feature). Opt-in. */
+  timbreLevels: z
+    .object({
+      show: z.boolean().default(false),
+    })
+    .default({}),
 });
 type Params = z.infer<typeof Params>;
 
@@ -110,17 +130,42 @@ export interface OverlayView {
     octaveShift: number;
     /** The face-driven chord's tones (MIDI), to highlight on the pitch guide. */
     chord?: number[];
+    /** The raw face frame (blendshapes + landmark geometry), for the face mesh. */
+    faceFrame?: FaceFrame;
+    /** The classified facial expression, for the live expression readout. */
+    expression?: ExpressionScores;
   };
   params: Params;
 }
 
 /**
+ * The category an overlay element belongs to — the "target space" framing the
+ * settings panel groups by (extensible; add more as the mapping space grows):
+ *  - `input`    : raw features the camera detected (hand/face landmarks).
+ *  - `output`   : what those inputs are mapped to (sounding note, chord, expression,
+ *                 timbre levels).
+ *  - `guide`    : reference overlays (the pitch fretboard, finger guides).
+ *  - `backdrop` : the video itself.
+ */
+export type OverlayCategory = 'input' | 'output' | 'guide' | 'backdrop';
+
+/** Category display order + labels for the settings panel (the grouping UI). */
+export const OVERLAY_CATEGORIES: { id: OverlayCategory; label: string; blurb: string }[] = [
+  { id: 'input', label: 'Input features', blurb: 'What the camera detected.' },
+  { id: 'output', label: 'Output features', blurb: 'What your gestures are mapped to.' },
+  { id: 'guide', label: 'Guides', blurb: 'Reference overlays.' },
+  { id: 'backdrop', label: 'Backdrop', blurb: 'The video feed.' },
+];
+
+/**
  * One composable piece of the overlay. `draw` is responsible for honoring its
- * own `view.params.<name>.show` toggle. Elements are plain functions held inside
+ * own `view.params.<name>.show` toggle. `category` groups it in the settings
+ * panel (see {@link OVERLAY_CATEGORIES}). Elements are plain functions held inside
  * this node — deliberately NOT DAG nodes (see the module docstring).
  */
 export interface OverlayElement {
   name: string;
+  category: OverlayCategory;
   draw(g: CanvasRenderingContext2D, view: OverlayView): void;
 }
 
@@ -136,6 +181,7 @@ function isDisplayedRight(handedness: string): boolean {
 
 const videoBackdrop: OverlayElement = {
   name: 'video',
+  category: 'backdrop',
   draw(g, { W, H, video, params }) {
     if (!params.video.show) return;
     if (!video || video.readyState < 2) return;
@@ -153,6 +199,7 @@ const arrEq = (a?: number[], b?: number[]) =>
 
 const scaleGuideElement: OverlayElement = {
   name: 'scaleGuide',
+  category: 'guide',
   draw(g, { W, H, inputs, params }) {
     if (!params.scaleGuide.show) return;
     const scaleR = inputs.scale;
@@ -199,6 +246,7 @@ const scaleGuideElement: OverlayElement = {
 const CHORD_COLOR = '#f5d142'; // warm gold, distinct from the white/blue scale guides
 const chordGuideElement: OverlayElement = {
   name: 'chordGuide',
+  category: 'output',
   draw(g, { W, H, inputs, params }) {
     if (!params.chordGuide.show) return;
     const chord = inputs.chord;
@@ -232,6 +280,7 @@ const chordGuideElement: OverlayElement = {
  */
 const indexFingerGuide: OverlayElement = {
   name: 'indexGuide',
+  category: 'guide',
   draw(g, { W, H, inputs, params }) {
     if (!params.indexGuide.show) return;
     const frame = inputs.hands;
@@ -258,6 +307,7 @@ const indexFingerGuide: OverlayElement = {
 
 const landmarkDots: OverlayElement = {
   name: 'landmarks',
+  category: 'input',
   draw(g, { W, H, inputs, params }) {
     if (!params.landmarks.show) return;
     const frame = inputs.hands;
@@ -288,6 +338,7 @@ const landmarkDots: OverlayElement = {
 
 const controlMarkers: OverlayElement = {
   name: 'markers',
+  category: 'output',
   draw(g, { W, H, inputs, params }) {
     if (!params.markers.show) return;
     const feats = inputs.features;
@@ -327,17 +378,132 @@ const controlMarkers: OverlayElement = {
   },
 };
 
+const FACE_COLOR = '#22d3ee'; // cyan — distinct from hands (emerald/blue) + chord (gold)
+
 /**
- * The overlay elements, in draw (z) order. Append here to add a new element;
- * give it a `<name>` sub-object in `Params` with at least a `show` toggle.
+ * The detected face mesh (input feature) — the raw face landmarks, drawn as dots,
+ * so the player can SEE that face detection is working. Only present when a face
+ * mapping is active (the model is loaded); otherwise the face frame is absent.
+ */
+const faceMesh: OverlayElement = {
+  name: 'faceLandmarks',
+  category: 'input',
+  draw(g, { W, H, inputs, params }) {
+    if (!params.faceLandmarks.show) return;
+    const face = inputs.faceFrame;
+    if (!face?.present || !face.landmarks?.length) return;
+    g.save();
+    g.globalAlpha = 0.45;
+    g.fillStyle = FACE_COLOR;
+    // One path for all ~478 dots, filled once (moveTo separates the sub-paths so
+    // they don't connect) — far cheaper than a fill per landmark each frame.
+    const r = 1.1;
+    g.beginPath();
+    for (const lm of face.landmarks) {
+      // Landmarks are normalized (0..1) in the source frame; mirror x like the video.
+      const sx = (1 - lm.x) * W;
+      const sy = lm.y * H;
+      g.moveTo(sx + r, sy);
+      g.arc(sx, sy, r, 0, Math.PI * 2);
+    }
+    g.fill();
+    g.restore();
+  },
+};
+
+/**
+ * Live readout of the classified facial expression (output feature) — the argmax
+ * label plus a small bar per class, so the player sees what their face is being
+ * mapped to. Top-centre; absent when no face is detected.
+ */
+const faceExpressionReadout: OverlayElement = {
+  name: 'faceExpression',
+  category: 'output',
+  draw(g, { W, H, inputs, params }) {
+    if (!params.faceExpression.show) return;
+    const expr = inputs.expression;
+    if (!expr?.present || !expr.probs?.length) return;
+    const argmax = EXPRESSIONS.indexOf(expr.label);
+    g.save();
+    g.textAlign = 'center';
+    g.font = 'bold 15px monospace';
+    g.fillStyle = FACE_COLOR;
+    g.fillText(expr.label, W * 0.5, H * 0.05);
+    // A small bar per expression class; the winning class glows gold.
+    const n = expr.probs.length;
+    const barW = 14;
+    const gap = 5;
+    const baseY = H * 0.05 + 30;
+    const startX = W * 0.5 - (n * (barW + gap) - gap) / 2 + barW / 2;
+    for (let i = 0; i < n; i++) {
+      const p = expr.probs[i];
+      const cx = startX + i * (barW + gap);
+      g.globalAlpha = 0.25 + 0.65 * p;
+      g.strokeStyle = i === argmax ? CHORD_COLOR : FACE_COLOR;
+      g.lineWidth = barW;
+      g.beginPath();
+      g.moveTo(cx, baseY);
+      g.lineTo(cx, baseY - (2 + p * 26));
+      g.stroke();
+    }
+    g.restore();
+  },
+};
+
+/**
+ * Per-hand brightness/vibrato level bars (output feature) — the timbre values the
+ * hand (and, in timbre mode, the face) maps to. NOT the index x/y, which the
+ * marker already cues. Opt-in. Drawn as two thin bars beside each hand's marker.
+ */
+const timbreLevels: OverlayElement = {
+  name: 'timbreLevels',
+  category: 'output',
+  draw(g, { W, H, inputs, params }) {
+    if (!params.timbreLevels.show) return;
+    const sp = inputs.params;
+    const feats = inputs.features;
+    if (!sp || !feats) return;
+    const drawLevels = (f: SingleHandFeatures, voiceId: number, color: string) => {
+      if (!f.present) return;
+      const v = sp.voices?.[voiceId];
+      if (!v) return;
+      const sx = f.x * W;
+      const sy = f.y * H;
+      const bar = (offset: number, value: number, c: string) => {
+        const bx = sx + 32 + offset;
+        g.globalAlpha = 0.8;
+        g.strokeStyle = c;
+        g.lineWidth = 5;
+        g.beginPath();
+        g.moveTo(bx, sy + 18);
+        g.lineTo(bx, sy + 18 - (3 + Math.max(0, Math.min(1, value)) * 32));
+        g.stroke();
+      };
+      bar(0, v.brightness ?? 1, color); // brightness (from openness / smile)
+      bar(9, v.vibrato ?? 0, CHORD_COLOR); // vibrato (from pinch / open mouth)
+    };
+    g.save();
+    drawLevels(feats.right, 0, RIGHT_COLOR);
+    drawLevels(feats.left, 1, LEFT_COLOR);
+    g.restore();
+  },
+};
+
+/**
+ * The overlay elements, in draw (z) order (backdrop first, readouts on top). Each
+ * has a `category` (the settings panel groups by it) and a `<name>` sub-object in
+ * `Params` with at least a `show` toggle. Append here to add an element.
  */
 export const OVERLAY_ELEMENTS: readonly OverlayElement[] = [
   videoBackdrop,
   scaleGuideElement,
   chordGuideElement,
   indexFingerGuide,
+  faceMesh,
   landmarkDots,
   controlMarkers,
+  timbreLevels,
+  faceExpressionReadout,
 ];
 
 export const canvasOverlayNode = defineNode<Params>({
@@ -357,6 +523,10 @@ export const canvasOverlayNode = defineNode<Params>({
     { name: 'scaleLeft', kind: 'number[]' },
     // Optional: the face-driven chord's tones (MIDI), highlighted on the guide.
     { name: 'chord', kind: 'number[]' },
+    // Optional: the raw face frame (blendshapes + landmarks), for the face mesh.
+    { name: 'faceFrame', kind: 'face-frame' },
+    // Optional: the classified expression, for the live expression readout.
+    { name: 'expression', kind: 'face-expression' },
     // Optional: the live octave shift, so guide labels match the sounding pitch.
     { name: 'octaveShift', kind: 'number', default: 0 },
     // Optional: a live overlay element config (from the UI store) that overrides
@@ -394,6 +564,8 @@ export const canvasOverlayNode = defineNode<Params>({
             scaleLeft: inputs.scaleLeft as number[] | undefined,
             octaveShift: typeof inputs.octaveShift === 'number' ? inputs.octaveShift : 0,
             chord: inputs.chord as number[] | undefined,
+            faceFrame: inputs.faceFrame as FaceFrame | undefined,
+            expression: inputs.expression as ExpressionScores | undefined,
           },
         };
 

--- a/src/nodes/sources/webcam_face.ts
+++ b/src/nodes/sources/webcam_face.ts
@@ -50,19 +50,25 @@ const ABSENT_FRAME: FaceFrame = { present: false, blendshapes: {} };
 /** The minimal slice of a `FaceLandmarkerResult` this node reads. */
 export interface FaceLandmarkerResultLike {
   faceBlendshapes?: Array<{ categories: Array<{ categoryName: string; score: number }> }>;
+  /** Normalized (0..1) landmark points per detected face, for the face-mesh overlay. */
+  faceLandmarks?: Array<Array<{ x: number; y: number }>>;
 }
 
 /**
- * Pure converter: a MediaPipe FaceLandmarker result → a {@link FaceFrame}.
- * Exported so it can be unit-tested headlessly (the live inference itself is
- * browser-only). Returns the absent frame when no face was detected.
+ * Pure converter: a MediaPipe FaceLandmarker result → a {@link FaceFrame} (the 52
+ * blendshapes plus the normalized landmark points, when present). Exported so it
+ * can be unit-tested headlessly (the live inference itself is browser-only).
+ * Returns the absent frame when no face was detected.
  */
 export function blendshapesToFaceFrame(result: FaceLandmarkerResultLike): FaceFrame {
   const categories = result.faceBlendshapes?.[0]?.categories;
   if (!categories || categories.length === 0) return ABSENT_FRAME;
   const blendshapes: Record<string, number> = {};
   for (const c of categories) blendshapes[c.categoryName] = c.score;
-  return { present: true, blendshapes };
+  const frame: FaceFrame = { present: true, blendshapes };
+  const pts = result.faceLandmarks?.[0];
+  if (pts && pts.length) frame.landmarks = pts.map((p) => ({ x: p.x, y: p.y }));
+  return frame;
 }
 
 /** The minimal runtime surface of MediaPipe used here (browser-only, lazy). */

--- a/test/app_graph.test.ts
+++ b/test/app_graph.test.ts
@@ -31,6 +31,14 @@ describe('production app graph', () => {
     expect(order).toHaveLength(13);
   });
 
+  it('wires the face overlays (mesh + expression readout)', () => {
+    const edges = defaultGraph().edges;
+    const has = (fn: string, fp: string, tn: string, tp: string) =>
+      edges.some((e) => e.from.node === fn && e.from.port === fp && e.to.node === tn && e.to.port === tp);
+    expect(has('camFace', 'face', 'overlay', 'faceFrame')).toBe(true); // face mesh data
+    expect(has('faceExpr', 'expression', 'overlay', 'expression')).toBe(true); // expression readout
+  });
+
   it('ticks cleanly with no host resources (everything no-ops or idles)', () => {
     const recorder = new StreamRecorder();
     // No resources: webcam has no video (emits empty frame), synth has no

--- a/test/app_store.test.ts
+++ b/test/app_store.test.ts
@@ -156,12 +156,16 @@ describe('persist migration (v1 → v2, returning users)', () => {
     ).toBe('none');
   });
 
-  it('mergeControls heals a stale overlay (missing chordGuide) so it cannot crash readers', () => {
+  it('mergeControls heals a stale overlay (missing later elements) so it cannot crash readers', () => {
     const initial = useControls.getInitialState();
-    // A v1-style overlay blob written before the chordGuide element existed.
+    // A legacy overlay blob written before chordGuide / face / timbre elements existed.
     const legacyOverlay = { video: { show: true, alpha: 0.35 }, scaleGuide: { show: true, showLabels: true } };
     const merged = mergeControls({ overlay: legacyOverlay }, initial);
-    expect(typeof merged.overlay.chordGuide?.show).toBe('boolean'); // default filled in, no crash
+    // Every element added since the blob was written gets its default (no undefined read).
+    for (const k of ['chordGuide', 'faceLandmarks', 'faceExpression', 'timbreLevels'] as const) {
+      expect(typeof merged.overlay[k]?.show).toBe('boolean');
+    }
+    expect(merged.overlay.timbreLevels.show).toBe(false); // opt-in default survives the heal
   });
 
   it('mergeControls clamps an unknown faceMapping to a safe value', () => {

--- a/test/overlay_elements.test.ts
+++ b/test/overlay_elements.test.ts
@@ -13,6 +13,7 @@ import type { NodeContext } from '@/dag';
 import { createAppRegistry } from '@/nodes/browser';
 import { defaultGraph } from '@/app/graph';
 import { canvasOverlayNode, OVERLAY_ELEMENTS, OVERLAY_CATEGORIES } from '@/nodes/output/canvas_overlay';
+import { OVERLAY_CONTROLS } from '@/app/overlayControls';
 import {
   makeHandKeypoints,
   type HandFeatures,
@@ -24,6 +25,8 @@ interface Call {
   m: string;
   args: unknown[];
   alpha: number;
+  stroke: string;
+  fill: string;
 }
 
 function makeRecordingCanvas(width = 1280, height = 720) {
@@ -40,7 +43,13 @@ function makeRecordingCanvas(width = 1280, height = 720) {
   const rec =
     (m: string) =>
     (...args: unknown[]) => {
-      calls.push({ m, args, alpha: ctx.globalAlpha as number });
+      calls.push({
+        m,
+        args,
+        alpha: ctx.globalAlpha as number,
+        stroke: ctx.strokeStyle as string,
+        fill: ctx.fillStyle as string,
+      });
     };
   for (const m of [
     'clearRect', 'save', 'restore', 'beginPath', 'arc', 'fill', 'stroke',
@@ -133,6 +142,12 @@ describe('canvas-overlay composable elements', () => {
     }
     expect(names[0]).toBe('video'); // backdrop drawn first (bottom)
     expect(names[names.length - 1]).toBe('faceExpression'); // readout on top
+  });
+
+  it('every overlay element has a UI control descriptor (the panel is data-driven, no silent drop)', () => {
+    const elementNames = new Set(OVERLAY_ELEMENTS.map((e) => e.name));
+    const descNames = new Set(OVERLAY_CONTROLS.map((d) => d.name as string));
+    expect(descNames).toEqual(elementNames); // descriptors ↔ elements, exactly
   });
 
   it('defaults: clears once, draws the video, guide, and markers; index-guide OFF', () => {
@@ -238,6 +253,15 @@ describe('canvas-overlay composable elements', () => {
     expect(rc.count('fill')).toBe(1); // ...all filled in a single path (perf)
   });
 
+  it('faceLandmarks: mirrors x and keeps y (asymmetric landmark pins the geometry)', () => {
+    const rc = drawWith(onlyElement('faceLandmarks'), {
+      faceFrame: { present: true, blendshapes: {}, landmarks: [{ x: 0.1, y: 0.25 }] },
+    });
+    const arc = rc.calls.find((c) => c.m === 'arc')!;
+    expect(arc.args[0] as number).toBeCloseTo((1 - 0.1) * 1280); // x mirrored (matches the video)
+    expect(arc.args[1] as number).toBeCloseTo(0.25 * 720); // y un-mirrored
+  });
+
   it('faceLandmarks: nothing with no face / no landmarks / absent / toggled off', () => {
     const arcs = (params: unknown, faceFrame?: unknown) => drawWith(params, { faceFrame }).count('arc');
     expect(arcs(onlyElement('faceLandmarks'))).toBe(0); // no face frame
@@ -247,11 +271,15 @@ describe('canvas-overlay composable elements', () => {
       { present: true, blendshapes: {}, landmarks: [{ x: 0.5, y: 0.5 }] })).toBe(0); // off
   });
 
-  it('faceExpression (Output): draws the label + a bar per class when present', () => {
+  it('faceExpression (Output): label + a bar per class; the winning class glows gold', () => {
     const expression = { present: true, probs: [0.7, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05], label: 'happy', confidence: 0.7 };
     const rc = drawWith(onlyElement('faceExpression'), { expression });
     expect(rc.count('fillText')).toBe(1); // the label
-    expect(rc.count('stroke')).toBe(7); // one bar per expression class
+    const bars = rc.calls.filter((c) => c.m === 'stroke');
+    expect(bars).toHaveLength(7); // one bar per expression class
+    // 'happy' (argmax index 0) glows gold; the rest are the face cyan.
+    expect(bars[0].stroke).toBe('#f5d142');
+    expect(bars[1].stroke).toBe('#22d3ee');
   });
 
   it('faceExpression: nothing when the expression is absent or toggled off', () => {

--- a/test/overlay_elements.test.ts
+++ b/test/overlay_elements.test.ts
@@ -12,7 +12,7 @@ import { Engine } from '@/dag';
 import type { NodeContext } from '@/dag';
 import { createAppRegistry } from '@/nodes/browser';
 import { defaultGraph } from '@/app/graph';
-import { canvasOverlayNode, OVERLAY_ELEMENTS } from '@/nodes/output/canvas_overlay';
+import { canvasOverlayNode, OVERLAY_ELEMENTS, OVERLAY_CATEGORIES } from '@/nodes/output/canvas_overlay';
 import {
   makeHandKeypoints,
   type HandFeatures,
@@ -107,14 +107,32 @@ function draw(paramsPartial: unknown, resourcesExtra: Record<string, unknown> = 
   return rc;
 }
 
+/** Draw with extra input-port values merged in (e.g. a faceFrame / expression). */
+function drawWith(paramsPartial: unknown, extraInputs: Record<string, unknown> = {}) {
+  const rc = makeRecordingCanvas();
+  const handlers = canvasOverlayNode.make(canvasOverlayNode.params.parse(paramsPartial ?? {}));
+  const ctx: NodeContext = { tick: 0, time: 0, dt: 0, resources: { canvas: rc.canvas, video: rc.video } };
+  handlers.process({ ...fullInputs(), ...extraInputs }, ctx);
+  return rc;
+}
+
+/** Everything off except the named element, so we can count its draws in isolation. */
+const onlyElement = (name: string) =>
+  Object.fromEntries(
+    OVERLAY_ELEMENTS.map((e) => [e.name, { show: e.name === name }]),
+  ) as Record<string, { show: boolean }>;
+
 describe('canvas-overlay composable elements', () => {
-  it('the element list and the params schema agree on names', () => {
+  it('every element has a params key and a known category; z-order is sane', () => {
     const names = OVERLAY_ELEMENTS.map((e) => e.name);
     const paramKeys = Object.keys(canvasOverlayNode.params.parse({}) as Record<string, unknown>);
-    for (const n of names) expect(paramKeys).toContain(n);
-    // z-order: video first, markers last.
-    expect(names[0]).toBe('video');
-    expect(names[names.length - 1]).toBe('markers');
+    const categories = new Set(OVERLAY_CATEGORIES.map((c) => c.id));
+    for (const el of OVERLAY_ELEMENTS) {
+      expect(paramKeys).toContain(el.name); // toggleable via its own params sub-object
+      expect(categories.has(el.category)).toBe(true); // grouped under a known category
+    }
+    expect(names[0]).toBe('video'); // backdrop drawn first (bottom)
+    expect(names[names.length - 1]).toBe('faceExpression'); // readout on top
   });
 
   it('defaults: clears once, draws the video, guide, and markers; index-guide OFF', () => {
@@ -211,6 +229,46 @@ describe('canvas-overlay composable elements', () => {
     expect(drawChord([48, 52, 57], { ...onlyChord, chordGuide: { show: false } }).count('stroke')).toBe(0); // off
     // C# (pitch class 1) is not in the scale {C,D,E,G,A} → no match.
     expect(drawChord([49]).count('stroke')).toBe(0);
+  });
+
+  it('faceLandmarks (Input): one dot per landmark when a present face frame has them', () => {
+    const faceFrame = { present: true, blendshapes: {}, landmarks: [{ x: 0.5, y: 0.5 }, { x: 0.4, y: 0.6 }, { x: 0.6, y: 0.4 }] };
+    const rc = drawWith(onlyElement('faceLandmarks'), { faceFrame });
+    expect(rc.count('arc')).toBe(3); // one arc per landmark
+    expect(rc.count('fill')).toBe(1); // ...all filled in a single path (perf)
+  });
+
+  it('faceLandmarks: nothing with no face / no landmarks / absent / toggled off', () => {
+    const arcs = (params: unknown, faceFrame?: unknown) => drawWith(params, { faceFrame }).count('arc');
+    expect(arcs(onlyElement('faceLandmarks'))).toBe(0); // no face frame
+    expect(arcs(onlyElement('faceLandmarks'), { present: false, blendshapes: {} })).toBe(0); // absent
+    expect(arcs(onlyElement('faceLandmarks'), { present: true, blendshapes: {} })).toBe(0); // no landmarks
+    expect(arcs({ ...onlyElement('faceLandmarks'), faceLandmarks: { show: false } },
+      { present: true, blendshapes: {}, landmarks: [{ x: 0.5, y: 0.5 }] })).toBe(0); // off
+  });
+
+  it('faceExpression (Output): draws the label + a bar per class when present', () => {
+    const expression = { present: true, probs: [0.7, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05], label: 'happy', confidence: 0.7 };
+    const rc = drawWith(onlyElement('faceExpression'), { expression });
+    expect(rc.count('fillText')).toBe(1); // the label
+    expect(rc.count('stroke')).toBe(7); // one bar per expression class
+  });
+
+  it('faceExpression: nothing when the expression is absent or toggled off', () => {
+    expect(drawWith(onlyElement('faceExpression'), {}).count('fillText')).toBe(0); // no expression
+    expect(
+      drawWith(onlyElement('faceExpression'), { expression: { present: false, probs: [], label: 'neutral', confidence: 1 } }).count('fillText'),
+    ).toBe(0);
+    const expression = { present: true, probs: [1, 0, 0, 0, 0, 0, 0], label: 'happy', confidence: 1 };
+    expect(drawWith({ ...onlyElement('faceExpression'), faceExpression: { show: false } }, { expression }).count('stroke')).toBe(0);
+  });
+
+  it('timbreLevels (Output): two bars per present hand; nothing when off', () => {
+    // fullInputs has two present hands + synth voices 0/1.
+    expect(drawWith(onlyElement('timbreLevels')).count('stroke')).toBe(4); // 2 hands × (brightness + vibrato)
+    expect(drawWith({ ...onlyElement('timbreLevels'), timbreLevels: { show: false } }).count('stroke')).toBe(0);
+    // Default is off (opt-in).
+    expect((canvasOverlayNode.params.parse({}) as { timbreLevels: { show: boolean } }).timbreLevels.show).toBe(false);
   });
 
   it('a live overlayConfig input overrides the static params', () => {

--- a/test/webcam_face.test.ts
+++ b/test/webcam_face.test.ts
@@ -110,6 +110,16 @@ describe('blendshapesToFaceFrame', () => {
     expect(blendshapesToFaceFrame({ faceBlendshapes: [] })).toEqual(absent);
     expect(blendshapesToFaceFrame({ faceBlendshapes: [{ categories: [] }] })).toEqual(absent);
   });
+
+  it('includes the normalized face landmark points when present (for the face mesh)', () => {
+    const frame = blendshapesToFaceFrame({
+      faceBlendshapes: [{ categories: [{ categoryName: 'jawOpen', score: 0.3 }] }],
+      faceLandmarks: [[{ x: 0.1, y: 0.2 }, { x: 0.3, y: 0.4 }]],
+    });
+    expect(frame.landmarks).toEqual([{ x: 0.1, y: 0.2 }, { x: 0.3, y: 0.4 }]);
+    // No landmarks in the result → the field is omitted (not an empty array).
+    expect(blendshapesToFaceFrame({ faceBlendshapes: [{ categories: [{ categoryName: 'jawOpen', score: 0.3 }] }] }).landmarks).toBeUndefined();
+  });
 });
 
 describe('webcam-face node gating', () => {


### PR DESCRIPTION
Generalizes the canvas-overlay settings into an extensible, grouped framework (the user's "target space of the mapping" idea) and adds the face-detection + output cues.

## Framework
- Every `OverlayElement` gains a `category` (input / output / guide / backdrop). The settings panel is **data-driven**: a collapsible section per `OVERLAY_CATEGORIES`, and within each, one control per element (grouped by its category) rendered from per-element descriptors (`src/app/overlayControls.ts`). Adding an overlay element makes it appear in the UI automatically — a test asserts the descriptors cover every element.

## New elements
- **Input — Face mesh** (`faceLandmarks`): `webcam-face` now also emits the normalized landmark geometry; the overlay draws the ~478 dots in one filled path (cheap), mirrored, shown only when a face mapping is active — so you can *see* detection working.
- **Output — Face expression**: argmax label + a bar per class (winner glows gold; follows the held/chord-driving label).
- **Output — Timbre levels** (opt-in): per-hand brightness/vibrato bars from the synth params (not the index x/y, which the marker already cues; bars flip toward centre so edge hands don't clip).
- Wiring: overlay gains `faceFrame` + `expression` input ports (fan-out from `camFace` / `faceExpr`, no rebuild); new elements auto-persist via `OverlayParamsSchema` + `mergeControls`.

## Process
Multi-agent adversarial review (5 dimensions, each finding verified by 2 skeptics): **10 confirmed findings fixed** — chiefly making the "framework" actually data-driven (it was dead JSDoc data), plus the face-mesh mirror test, the expression winner-color test, the merge-heal coverage, and the timbre-bar clipping. **247 tests**, deterministic; typecheck + build + catalog clean.

https://claude.ai/code/session_01JEoe7y1hA5KdEAvvpQXxxt
