### PR TITLE
Expression: neutral abstention + per-class sensitivity + per-expression chord editor

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -55,7 +55,7 @@ Reads the live UI control store → scale + instrument + overlay port values.
 
 - **roles:** source, control
 - **in:** —
-- **out:** scaleRight:number[], scaleLeft:number[], instrumentRight:instrument, instrumentLeft:instrument, overlay:overlay-config, rightSpec:scale-spec, faceMapping:face-mapping, chordConfig:chord-config
+- **out:** scaleRight:number[], scaleLeft:number[], instrumentRight:instrument, instrumentLeft:instrument, overlay:overlay-config, rightSpec:scale-spec, faceMapping:face-mapping, chordConfig:chord-config, expressionSensitivity:expression-sensitivity, expressionDegrees:expression-degrees
 - **params:** —
 
 #### `synthetic-hands` — Synthetic Hands
@@ -94,12 +94,12 @@ Face blendshapes → normalized expression controls (smile, mouthOpen, brow, bli
 - **params:** gain (number=1), smoothing (number=0)
 
 #### `face-expression` — Face Expression
-Face blendshapes → softmax over 7 expressions (happy/sad/angry/surprised/fearful/disgusted/neutral) with smoothing + hysteresis.
+Face blendshapes → one of 6 emotions or neutral (per-class thresholds + neutral abstention, smoothing, enter/exit hysteresis, dwell).
 
 - **roles:** feature
-- **in:** face:face-frame
+- **in:** face:face-frame, sensitivity:expression-sensitivity
 - **out:** expression:face-expression
-- **params:** smoothing (number=0.4), temperature (number=0.12), holdMargin (number=0.06)
+- **params:** smoothing (number=0.4), dwellFrames (number=2)
 
 #### `gesture-classifier` — Gesture Classifier
 Hand features → discrete poses (fist/open/pinch) + enter/exit edge events.
@@ -183,7 +183,7 @@ Roman-numeral progression in a key + position (0..1) → current chord symbol.
 Facial expression → a voiced, rendered diatonic chord on the current seven-note scale (active only in face "chord" mode).
 
 - **roles:** music
-- **in:** expression:face-expression, spec:scale-spec, faceMapping:face-mapping, octaveShift:number, chordConfig:chord-config
+- **in:** expression:face-expression, spec:scale-spec, faceMapping:face-mapping, octaveShift:number, chordConfig:chord-config, degrees:expression-degrees
 - **out:** params:synth-params, triad:number[]
 - **params:** gain (number=0.22), instrument (enum(sine | triangle | square | sawtooth | warmPad | glass | bell | organ | voice | softLead | strings | flute | brass | choir)="triangle"), voicing (enum(spread | bassTriad | close | shell | power)="spread"), rendering (enum(sustained | strum | arpUp | arpDown | arpUpDown | pulse | alberti)="sustained"), bpm (number=100)
 

--- a/public/catalog.json
+++ b/public/catalog.json
@@ -170,6 +170,10 @@
       {
         "name": "chordConfig",
         "kind": "chord-config"
+      },
+      {
+        "name": "degrees",
+        "kind": "expression-degrees"
       }
     ],
     "outputs": [
@@ -213,7 +217,7 @@
   {
     "type": "face-expression",
     "title": "Face Expression",
-    "description": "Face blendshapes → softmax over 7 expressions (happy/sad/angry/surprised/fearful/disgusted/neutral) with smoothing + hysteresis.",
+    "description": "Face blendshapes → one of 6 emotions or neutral (per-class thresholds + neutral abstention, smoothing, enter/exit hysteresis, dwell).",
     "roles": [
       "feature"
     ],
@@ -221,6 +225,10 @@
       {
         "name": "face",
         "kind": "face-frame"
+      },
+      {
+        "name": "sensitivity",
+        "kind": "expression-sensitivity"
       }
     ],
     "outputs": [
@@ -236,14 +244,9 @@
         "default": 0.4
       },
       {
-        "name": "temperature",
+        "name": "dwellFrames",
         "type": "number",
-        "default": 0.12
-      },
-      {
-        "name": "holdMargin",
-        "type": "number",
-        "default": 0.06
+        "default": 2
       }
     ]
   },
@@ -838,6 +841,14 @@
       {
         "name": "chordConfig",
         "kind": "chord-config"
+      },
+      {
+        "name": "expressionSensitivity",
+        "kind": "expression-sensitivity"
+      },
+      {
+        "name": "expressionDegrees",
+        "kind": "expression-degrees"
       }
     ],
     "params": []

--- a/public/manual.html
+++ b/public/manual.html
@@ -64,7 +64,7 @@
       <dl>
         <dt>roles</dt><dd>source, control</dd>
         <dt>in</dt><dd>—</dd>
-        <dt>out</dt><dd>scaleRight:number[], scaleLeft:number[], instrumentRight:instrument, instrumentLeft:instrument, overlay:overlay-config, rightSpec:scale-spec, faceMapping:face-mapping, chordConfig:chord-config</dd>
+        <dt>out</dt><dd>scaleRight:number[], scaleLeft:number[], instrumentRight:instrument, instrumentLeft:instrument, overlay:overlay-config, rightSpec:scale-spec, faceMapping:face-mapping, chordConfig:chord-config, expressionSensitivity:expression-sensitivity, expressionDegrees:expression-degrees</dd>
         <dt>params</dt><dd>—</dd>
       </dl>
     </div>
@@ -111,12 +111,12 @@
     </div>
     <div class="node">
       <h4><code>face-expression</code> <span class="title">Face Expression</span></h4>
-      <p>Face blendshapes → softmax over 7 expressions (happy/sad/angry/surprised/fearful/disgusted/neutral) with smoothing + hysteresis.</p>
+      <p>Face blendshapes → one of 6 emotions or neutral (per-class thresholds + neutral abstention, smoothing, enter/exit hysteresis, dwell).</p>
       <dl>
         <dt>roles</dt><dd>feature</dd>
-        <dt>in</dt><dd>face:face-frame</dd>
+        <dt>in</dt><dd>face:face-frame, sensitivity:expression-sensitivity</dd>
         <dt>out</dt><dd>expression:face-expression</dd>
-        <dt>params</dt><dd>smoothing (number=0.4), temperature (number=0.12), holdMargin (number=0.06)</dd>
+        <dt>params</dt><dd>smoothing (number=0.4), dwellFrames (number=2)</dd>
       </dl>
     </div>
     <div class="node">
@@ -216,7 +216,7 @@
       <p>Facial expression → a voiced, rendered diatonic chord on the current seven-note scale (active only in face "chord" mode).</p>
       <dl>
         <dt>roles</dt><dd>music</dd>
-        <dt>in</dt><dd>expression:face-expression, spec:scale-spec, faceMapping:face-mapping, octaveShift:number, chordConfig:chord-config</dd>
+        <dt>in</dt><dd>expression:face-expression, spec:scale-spec, faceMapping:face-mapping, octaveShift:number, chordConfig:chord-config, degrees:expression-degrees</dd>
         <dt>out</dt><dd>params:synth-params, triad:number[]</dd>
         <dt>params</dt><dd>gain (number=0.22), instrument (enum(sine | triangle | square | sawtooth | warmPad | glass | bell | organ | voice | softLead | strings | flute | brass | choir)="triangle"), voicing (enum(spread | bassTriad | close | shell | power)="spread"), rendering (enum(sustained | strum | arpUp | arpDown | arpUpDown | pulse | alberti)="sustained"), bpm (number=100)</dd>
       </dl>

--- a/src/app/ControlsPanel.tsx
+++ b/src/app/ControlsPanel.tsx
@@ -10,9 +10,10 @@
  * in a collapsible translucent overlay so the video stays the focus.
  */
 import { useState, type ReactNode } from 'react';
-import { NOTES, SCALE_TYPES, isSevenNoteScale, type ScaleTypeId } from '@/music/theory';
+import { NOTES, SCALE_TYPES, isSevenNoteScale, diatonicTriad, type ScaleTypeId } from '@/music/theory';
 import { INSTRUMENTS, INSTRUMENT_IDS } from '@/music/instruments';
-import { VOICINGS, RENDERINGS, isTempoRendering, type VoicingId, type RenderingId } from '@/music/voicing';
+import { VOICINGS, RENDERINGS, isTempoRendering, voiceTriad, type VoicingId, type RenderingId } from '@/music/voicing';
+import { EXPRESSIONS, DEFAULT_EXPRESSION_TO_DEGREE } from '@/music/expression';
 import { OVERLAY_ELEMENTS, OVERLAY_CATEGORIES, type OverlayParams } from '@/nodes/output/canvas_overlay';
 import type { FaceMapping } from '@/nodes';
 import { useControls, type VoiceControl } from './store';
@@ -64,6 +65,31 @@ function CollapsibleSection({
         {label}
       </summary>
       <div className="mt-2 space-y-2 pl-1">{children}</div>
+    </details>
+  );
+}
+
+/**
+ * A top-level collapsible group (Sound / Face / Overlay / …) — the accordion that
+ * keeps the panel from overwhelming as settings grow. More prominent than the
+ * inner {@link CollapsibleSection}; a ▸/▾ marker and a divider above.
+ */
+function TopSection({
+  label,
+  defaultOpen = false,
+  children,
+}: {
+  label: string;
+  defaultOpen?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <details open={defaultOpen} className="group border-t border-white/10 pt-3 [&[open]>summary>span.mk]:rotate-90">
+      <summary className="flex cursor-pointer select-none items-center gap-1.5 text-[11px] font-bold uppercase tracking-widest text-white/70 transition hover:text-white">
+        <span className="mk inline-block transition-transform">▸</span>
+        {label}
+      </summary>
+      <div className="mt-3 space-y-3">{children}</div>
     </details>
   );
 }
@@ -184,7 +210,6 @@ function OverlayControls() {
 
   return (
     <div className="space-y-3">
-      <h3 className="text-[11px] font-bold uppercase tracking-widest text-white/70">Overlay</h3>
       {OVERLAY_CATEGORIES.map((cat) => {
         const descs = OVERLAY_CONTROLS.filter((d) => categoryOf.get(d.name) === cat.id);
         if (descs.length === 0) return null;
@@ -336,6 +361,77 @@ function ChordControls() {
   );
 }
 
+/**
+ * Per-expression mapping editor (advanced): for each expression — sensitivity
+ * (how easily it triggers), the scale degree it plays, and that chord's live MIDI
+ * notes — all editable. The (global) rendering lives in ChordControls above.
+ * Neutral is the rest/fallback (no sensitivity). Shown in chord mode.
+ */
+function ExpressionMapping() {
+  const degrees = useControls((s) => s.faceExpr.degrees);
+  const sensitivity = useControls((s) => s.faceExpr.sensitivity);
+  const setDegree = useControls((s) => s.setExpressionDegree);
+  const setSens = useControls((s) => s.setExpressionSensitivity);
+  const right = useControls((s) => s.right);
+  const voicing = useControls((s) => s.faceChord.voicing);
+
+  const chordMidi = (degree: number): number[] => {
+    const triad = diatonicTriad(
+      { root: right.root, type: right.type, octaves: right.octaves, baseOctave: right.baseOctave },
+      degree,
+    );
+    return triad.length ? voiceTriad(triad, voicing, 0).slice().sort((a, b) => a - b) : [];
+  };
+
+  return (
+    <CollapsibleSection label="Expression mapping" defaultOpen={false}>
+      <p className="text-[10px] leading-relaxed text-white/40">
+        Per expression: how easily it triggers (sensitivity), the scale degree it plays, and the
+        chord’s MIDI notes. <span className="text-white/60">Neutral</span> plays when no expression
+        is detected.
+      </p>
+      <div className="space-y-2">
+        {EXPRESSIONS.map((label) => {
+          const degree = degrees[label] ?? DEFAULT_EXPRESSION_TO_DEGREE[label];
+          const midi = chordMidi(degree);
+          const isEmotion = label !== 'neutral';
+          return (
+            <div key={label} className="space-y-1">
+              <div className="flex items-center gap-2 text-xs">
+                <span className="w-16 shrink-0 capitalize">{label}</span>
+                {isEmotion ? (
+                  <input
+                    type="range" min={0} max={1} step={0.01}
+                    value={sensitivity[label] ?? 0.5}
+                    title="Sensitivity (higher = more hits)"
+                    className="flex-1"
+                    onChange={(e) => setSens(label, Number(e.target.value))}
+                  />
+                ) : (
+                  <span className="flex-1 text-[10px] italic text-white/30">rest / fallback</span>
+                )}
+                <select
+                  className={selectCls}
+                  value={degree}
+                  title="Scale degree this expression plays"
+                  onChange={(e) => setDegree(label, Number(e.target.value))}
+                >
+                  {[0, 1, 2, 3, 4, 5, 6].map((d) => (
+                    <option key={d} value={d}>{d + 1}</option>
+                  ))}
+                </select>
+              </div>
+              <div className="pl-16 font-mono text-[10px] text-white/40">
+                {midi.length ? midi.join(' ') : '— (needs a 7-note scale)'}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </CollapsibleSection>
+  );
+}
+
 function FaceControls() {
   const faceMapping = useControls((s) => s.faceMapping);
   const setFaceMapping = useControls((s) => s.setFaceMapping);
@@ -344,7 +440,6 @@ function FaceControls() {
 
   return (
     <div className="space-y-2">
-      <h3 className="text-[11px] font-bold uppercase tracking-widest text-white/70">Face control</h3>
       <label className="flex items-center justify-between gap-2 text-xs">
         Mapping
         <select
@@ -368,6 +463,7 @@ function FaceControls() {
       )}
       <p className="text-[10px] leading-relaxed text-white/40">{FACE_MODE_HINT[faceMapping]}</p>
       {faceMapping === 'chord' && <ChordControls />}
+      {faceMapping === 'chord' && <ExpressionMapping />}
     </div>
   );
 }
@@ -378,7 +474,6 @@ function RecordingControls() {
 
   return (
     <div className="space-y-2">
-      <h3 className="text-[11px] font-bold uppercase tracking-widest text-white/70">Recording</h3>
       {RECORDING_FORMATS.map((f) => (
         <Toggle
           key={f.id}
@@ -406,7 +501,6 @@ function PresetControls() {
 
   return (
     <div className="space-y-2">
-      <h3 className="text-[11px] font-bold uppercase tracking-widest text-white/70">Presets</h3>
       <div className="flex gap-1">
         <input
           className={`${selectCls} flex-1`}
@@ -463,8 +557,9 @@ export default function ControlsPanel() {
   const setMasterVolume = useControls((s) => s.setMasterVolume);
 
   return (
-    <div className="space-y-4">
-      <div>
+    <div className="space-y-1">
+      {/* Sound — the live-performance knobs, open by default. */}
+      <TopSection label="Sound" defaultOpen>
         <label className="flex items-center justify-between gap-2 text-xs">
           Master volume
           <input
@@ -472,31 +567,37 @@ export default function ControlsPanel() {
             onChange={(e) => setMasterVolume(Number(e.target.value))}
           />
         </label>
-        <label className="mt-2 flex items-center gap-2 text-xs">
+        <label className="flex items-center gap-2 text-xs">
           <input type="checkbox" checked={syncHands} onChange={(e) => setSync(e.target.checked)} />
           Sync both hands
         </label>
-      </div>
-      <VoiceControls side="right" />
-      {!syncHands && <VoiceControls side="left" />}
-      <div className="border-t border-white/10 pt-3">
-        <OverlayControls />
-      </div>
-      <div className="border-t border-white/10 pt-3">
+        <VoiceControls side="right" />
+        {!syncHands && <VoiceControls side="left" />}
+      </TopSection>
+
+      <TopSection label="Face">
         <FaceControls />
-      </div>
-      <div className="border-t border-white/10 pt-3">
+      </TopSection>
+
+      <TopSection label="Overlay">
+        <OverlayControls />
+      </TopSection>
+
+      <TopSection label="Recording">
         <RecordingControls />
-      </div>
-      <div className="border-t border-white/10 pt-3">
+      </TopSection>
+
+      <TopSection label="Presets">
         <PresetControls />
-      </div>
-      <div className="border-t border-white/10 pt-3 text-[10px] leading-relaxed text-white/50">
-        <p className="mb-1 font-bold uppercase tracking-widest text-white/70">Keyboard</p>
-        <p>↑ / ↓ — octave shift</p>
-        <p>← / → — less / more scale-snap</p>
-        <p>m — mute</p>
-      </div>
+      </TopSection>
+
+      <TopSection label="Keyboard">
+        <div className="text-[10px] leading-relaxed text-white/50">
+          <p>↑ / ↓ — octave shift</p>
+          <p>← / → — less / more scale-snap</p>
+          <p>m — mute</p>
+        </div>
+      </TopSection>
     </div>
   );
 }

--- a/src/app/ControlsPanel.tsx
+++ b/src/app/ControlsPanel.tsx
@@ -13,7 +13,7 @@ import { useState, type ReactNode } from 'react';
 import { NOTES, SCALE_TYPES, isSevenNoteScale, diatonicTriad, type ScaleTypeId } from '@/music/theory';
 import { INSTRUMENTS, INSTRUMENT_IDS } from '@/music/instruments';
 import { VOICINGS, RENDERINGS, isTempoRendering, voiceTriad, type VoicingId, type RenderingId } from '@/music/voicing';
-import { EXPRESSIONS, DEFAULT_EXPRESSION_TO_DEGREE } from '@/music/expression';
+import { EXPRESSIONS, EMOTIONS, DEFAULT_EXPRESSION_TO_DEGREE } from '@/music/expression';
 import { OVERLAY_ELEMENTS, OVERLAY_CATEGORIES, type OverlayParams } from '@/nodes/output/canvas_overlay';
 import type { FaceMapping } from '@/nodes';
 import { useControls, type VoiceControl } from './store';
@@ -362,12 +362,14 @@ function ChordControls() {
 }
 
 /**
- * Per-expression mapping editor (advanced): for each expression — sensitivity
- * (how easily it triggers), the scale degree it plays, and that chord's live MIDI
- * notes — all editable. The (global) rendering lives in ChordControls above.
- * Neutral is the rest/fallback (no sensitivity). Shown in chord mode.
+ * Per-expression mapping editor (advanced). The per-emotion SENSITIVITY sliders
+ * apply in any active face mode (the classifier runs in timbre mode too — it
+ * feeds the readout/status there), so they show whenever a mapping is on. The
+ * scale-degree dropdown + live chord MIDI are chord-specific, so they appear only
+ * in chord mode (where `neutral` also gets a row — its rest chord). The (global)
+ * rendering lives in ChordControls above.
  */
-function ExpressionMapping() {
+function ExpressionMapping({ chordMode }: { chordMode: boolean }) {
   const degrees = useControls((s) => s.faceExpr.degrees);
   const sensitivity = useControls((s) => s.faceExpr.sensitivity);
   const setDegree = useControls((s) => s.setExpressionDegree);
@@ -383,18 +385,28 @@ function ExpressionMapping() {
     return triad.length ? voiceTriad(triad, voicing, 0).slice().sort((a, b) => a - b) : [];
   };
 
+  // Chord mode lists all 7 (incl neutral, the rest chord); timbre mode lists only
+  // the 6 scored emotions (neutral has no sensitivity / no audio effect there).
+  const rows = chordMode ? EXPRESSIONS : EMOTIONS;
+
   return (
-    <CollapsibleSection label="Expression mapping" defaultOpen={false}>
+    <CollapsibleSection label={chordMode ? 'Expression mapping' : 'Expression sensitivity'} defaultOpen={false}>
       <p className="text-[10px] leading-relaxed text-white/40">
-        Per expression: how easily it triggers (sensitivity), the scale degree it plays, and the
-        chord’s MIDI notes. <span className="text-white/60">Neutral</span> plays when no expression
-        is detected.
+        {chordMode ? (
+          <>
+            Per expression: how easily it triggers (sensitivity), the scale degree it plays, and the
+            chord’s MIDI notes. <span className="text-white/60">Neutral</span> plays when no
+            expression is detected.
+          </>
+        ) : (
+          'How easily each expression triggers (higher = more hits). Tune if a neutral face reads as an emotion, or one won’t fire.'
+        )}
       </p>
       <div className="space-y-2">
-        {EXPRESSIONS.map((label) => {
-          const degree = degrees[label] ?? DEFAULT_EXPRESSION_TO_DEGREE[label];
-          const midi = chordMidi(degree);
+        {rows.map((label) => {
           const isEmotion = label !== 'neutral';
+          const degree = degrees[label] ?? DEFAULT_EXPRESSION_TO_DEGREE[label];
+          const midi = chordMode ? chordMidi(degree) : [];
           return (
             <div key={label} className="space-y-1">
               <div className="flex items-center gap-2 text-xs">
@@ -410,20 +422,24 @@ function ExpressionMapping() {
                 ) : (
                   <span className="flex-1 text-[10px] italic text-white/30">rest / fallback</span>
                 )}
-                <select
-                  className={selectCls}
-                  value={degree}
-                  title="Scale degree this expression plays"
-                  onChange={(e) => setDegree(label, Number(e.target.value))}
-                >
-                  {[0, 1, 2, 3, 4, 5, 6].map((d) => (
-                    <option key={d} value={d}>{d + 1}</option>
-                  ))}
-                </select>
+                {chordMode && (
+                  <select
+                    className={selectCls}
+                    value={degree}
+                    title="Scale degree this expression plays"
+                    onChange={(e) => setDegree(label, Number(e.target.value))}
+                  >
+                    {[0, 1, 2, 3, 4, 5, 6].map((d) => (
+                      <option key={d} value={d}>{d + 1}</option>
+                    ))}
+                  </select>
+                )}
               </div>
-              <div className="pl-16 font-mono text-[10px] text-white/40">
-                {midi.length ? midi.join(' ') : '— (needs a 7-note scale)'}
-              </div>
+              {chordMode && (
+                <div className="pl-16 font-mono text-[10px] text-white/40">
+                  {midi.length ? midi.join(' ') : '— (needs a 7-note scale)'}
+                </div>
+              )}
             </div>
           );
         })}
@@ -463,7 +479,7 @@ function FaceControls() {
       )}
       <p className="text-[10px] leading-relaxed text-white/40">{FACE_MODE_HINT[faceMapping]}</p>
       {faceMapping === 'chord' && <ChordControls />}
-      {faceMapping === 'chord' && <ExpressionMapping />}
+      {faceMapping !== 'none' && <ExpressionMapping chordMode={faceMapping === 'chord'} />}
     </div>
   );
 }

--- a/src/app/faceStatus.ts
+++ b/src/app/faceStatus.ts
@@ -8,24 +8,22 @@
  */
 import { create } from 'zustand';
 import { ABSENT_FACE_STATUS, type FaceStatus } from '@/nodes';
-import { EXPRESSIONS, type ExpressionLabel } from '@/music/expression';
-
-const EMPTY_PROBS: number[] = EXPRESSIONS.map(() => 0);
+import { type ExpressionLabel } from '@/music/expression';
 
 export interface FaceStatusState {
   status: FaceStatus;
-  /** Latest classified expression label (null when no face / model not ready). */
+  /** Latest classified expression label (null when no face / model not ready). The
+   *  per-emotion activations/thresholds live on the DAG `expression` output and are
+   *  drawn by the overlay readout directly — this store only carries the label for
+   *  the text status line. */
   label: ExpressionLabel | null;
-  /** Softmax over {@link EXPRESSIONS} (for the live readout bars). */
-  probs: number[];
-  report(status: FaceStatus, label: ExpressionLabel | null, probs: number[]): void;
+  report(status: FaceStatus, label: ExpressionLabel | null): void;
   reset(): void;
 }
 
 export const useFaceStatus = create<FaceStatusState>((set) => ({
   status: ABSENT_FACE_STATUS,
   label: null,
-  probs: EMPTY_PROBS,
-  report: (status, label, probs) => set({ status, label, probs }),
-  reset: () => set({ status: ABSENT_FACE_STATUS, label: null, probs: EMPTY_PROBS }),
+  report: (status, label) => set({ status, label }),
+  reset: () => set({ status: ABSENT_FACE_STATUS, label: null }),
 }));

--- a/src/app/graph.ts
+++ b/src/app/graph.ts
@@ -142,8 +142,12 @@ export function defaultGraph(selection?: SlotSelection, registry?: NodeRegistry)
       // Face chord: webcam-face → face-expression → expression-chord (fed the live
       // scale spec + face mode). Emits silent voices unless mode is 'chord'.
       { from: { node: 'camFace', port: 'face' }, to: { node: 'faceExpr', port: 'face' } },
+      // Live per-emotion sensitivities steer the classifier's thresholds.
+      { from: { node: 'ui', port: 'expressionSensitivity' }, to: { node: 'faceExpr', port: 'sensitivity' } },
       { from: { node: 'faceExpr', port: 'expression' }, to: { node: 'exprChord', port: 'expression' } },
       { from: { node: 'ui', port: 'rightSpec' }, to: { node: 'exprChord', port: 'spec' } },
+      // Live per-expression scale-degree map (which triad each expression plays).
+      { from: { node: 'ui', port: 'expressionDegrees' }, to: { node: 'exprChord', port: 'degrees' } },
       { from: { node: 'ui', port: 'faceMapping' }, to: { node: 'exprChord', port: 'faceMapping' } },
       // Live chord settings (instrument / volume / voicing / rendering / tempo).
       { from: { node: 'ui', port: 'chordConfig' }, to: { node: 'exprChord', port: 'chordConfig' } },

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -19,8 +19,22 @@ import type { ScaleTypeId } from '@/music/theory';
 import { DEFAULT_INSTRUMENT_RIGHT, DEFAULT_INSTRUMENT_LEFT } from '@/music/instruments';
 import { OverlayParamsSchema, type OverlayParams } from '@/nodes/output/canvas_overlay';
 import { FACE_MAPPINGS, legacyFaceToMapping, type VoiceParams, type FaceMapping } from '@/nodes';
-import { DEFAULT_FACE_CHORD, FaceChordSchema, type Settings, type FaceChord } from '@/settings/schema';
+import {
+  DEFAULT_FACE_CHORD,
+  DEFAULT_FACE_EXPR,
+  FaceChordSchema,
+  FaceExprSchema,
+  SettingsSchema,
+  type Settings,
+  type FaceChord,
+  type FaceExpr,
+} from '@/settings/schema';
 import { DEFAULT_RECORDING_FORMATS } from './recording/formats';
+
+/** The preset keys (derived from the schema — the SSOT). Add a field to
+ *  SettingsSchema (+ the store) and it is snapshotted, persisted, and restored
+ *  automatically: no hand-edits to toSettings / applySettings / partialize. */
+const SETTINGS_KEYS = Object.keys(SettingsSchema.shape) as (keyof Settings)[];
 
 export interface VoiceControl {
   root: number; // 0..11
@@ -45,6 +59,10 @@ export interface ControlState {
   /** How the face chord sounds (instrument / volume / voicing / rendering / tempo).
    *  Read live by `expression-chord` via the `chordConfig` port. */
   faceChord: FaceChord;
+  /** The expression-mapping config: per-emotion firing sensitivity (read live by
+   *  `face-expression`) + per-expression scale-degree map (read live by
+   *  `expression-chord`). */
+  faceExpr: FaceExpr;
   /** Composable overlay element config (see canvas_overlay.ts). Live-controlled. */
   overlay: OverlayParams;
   /**
@@ -59,6 +77,10 @@ export interface ControlState {
   setFaceMapping(v: FaceMapping): void;
   /** Patch the face-chord settings (e.g. setFaceChord({ voicing: 'spread' })). */
   setFaceChord(patch: Partial<FaceChord>): void;
+  /** Set one emotion's firing sensitivity [0,1] (higher = more hits). */
+  setExpressionSensitivity(emotion: string, value: number): void;
+  /** Set the scale degree (0..6) an expression maps to. */
+  setExpressionDegree(expr: string, degree: number): void;
   /** Toggle a recording output format on/off (keeps at least one selected). */
   setRecordingFormat(id: string, on: boolean): void;
   /** Patch one overlay element's options (e.g. setOverlayElement('indexGuide', { show: true })). */
@@ -80,17 +102,16 @@ const defaultVoice = (instrument: VoiceParams['instrument']): VoiceControl => ({
 /** The overlay element defaults (all on except the opt-in index-finger guide). */
 const defaultOverlay = (): OverlayParams => OverlayParamsSchema.parse({});
 
+/** Pick exactly the preset fields ({@link SETTINGS_KEYS}) from a state-like object. */
+function pickSettings(s: Record<string, unknown>): Settings {
+  const out: Record<string, unknown> = {};
+  for (const k of SETTINGS_KEYS) out[k] = s[k];
+  return out as unknown as Settings;
+}
+
 /** Snapshot the persistable settings from the live state (for saving a preset). */
 export function toSettings(s: ControlState): Settings {
-  return {
-    right: s.right,
-    left: s.left,
-    syncHands: s.syncHands,
-    masterVolume: s.masterVolume,
-    faceMapping: s.faceMapping,
-    faceChord: s.faceChord,
-    overlay: s.overlay,
-  };
+  return pickSettings(s as unknown as Record<string, unknown>);
 }
 
 /**
@@ -139,10 +160,24 @@ export function mergeControls(persisted: unknown, current: ControlState): Contro
       faceChord = current.faceChord;
     }
   }
+  // Heal faceExpr the same way: fill the sensitivity/degrees maps from the defaults
+  // so a returning user's older blob can't leave an emotion's slider unbound.
+  let faceExpr = current.faceExpr;
+  if (p.faceExpr) {
+    try {
+      const pe = p.faceExpr as Partial<FaceExpr>;
+      faceExpr = FaceExprSchema.parse({
+        sensitivity: { ...DEFAULT_FACE_EXPR.sensitivity, ...(pe.sensitivity ?? {}) },
+        degrees: { ...DEFAULT_FACE_EXPR.degrees, ...(pe.degrees ?? {}) },
+      });
+    } catch {
+      faceExpr = current.faceExpr;
+    }
+  }
   const faceMapping = (FACE_MAPPINGS as readonly string[]).includes(p.faceMapping as string)
     ? (p.faceMapping as FaceMapping)
     : legacyFaceToMapping(p.faceEnabled);
-  return { ...current, ...p, overlay, faceMapping, faceChord };
+  return { ...current, ...p, overlay, faceMapping, faceChord, faceExpr };
 }
 
 // localStorage in the browser; a no-op elsewhere (Node test runtime) so the
@@ -164,6 +199,10 @@ export const useControls = create<ControlState>()(
       masterVolume: 0.4,
       faceMapping: 'none',
       faceChord: { ...DEFAULT_FACE_CHORD },
+      faceExpr: {
+        sensitivity: { ...DEFAULT_FACE_EXPR.sensitivity },
+        degrees: { ...DEFAULT_FACE_EXPR.degrees },
+      },
       overlay: defaultOverlay(),
       recordingFormats: [...DEFAULT_RECORDING_FORMATS],
       setVoice: (side, patch) =>
@@ -185,6 +224,14 @@ export const useControls = create<ControlState>()(
       setMasterVolume: (v) => set({ masterVolume: v }),
       setFaceMapping: (v) => set({ faceMapping: v }),
       setFaceChord: (patch) => set((s) => ({ faceChord: { ...s.faceChord, ...patch } })),
+      setExpressionSensitivity: (emotion, value) =>
+        set((s) => ({
+          faceExpr: { ...s.faceExpr, sensitivity: { ...s.faceExpr.sensitivity, [emotion]: value } },
+        })),
+      setExpressionDegree: (expr, degree) =>
+        set((s) => ({
+          faceExpr: { ...s.faceExpr, degrees: { ...s.faceExpr.degrees, [expr]: degree } },
+        })),
       setRecordingFormat: (id, on) =>
         set((s) => {
           const has = s.recordingFormats.includes(id);
@@ -200,16 +247,9 @@ export const useControls = create<ControlState>()(
         set((s) => ({
           overlay: { ...s.overlay, [key]: { ...s.overlay[key], ...patch } } as OverlayParams,
         })),
-      applySettings: (st) =>
-        set({
-          right: st.right,
-          left: st.left,
-          syncHands: st.syncHands,
-          masterVolume: st.masterVolume,
-          faceMapping: st.faceMapping,
-          faceChord: st.faceChord,
-          overlay: st.overlay,
-        }),
+      // Restore exactly the schema fields (the setters/recordingFormats are left
+      // untouched). Derived from SETTINGS_KEYS, so a new preset field needs no edit.
+      applySettings: (st) => set(pickSettings(st as unknown as Record<string, unknown>)),
     }),
     {
       name: 'thoremin-controls',
@@ -223,15 +263,10 @@ export const useControls = create<ControlState>()(
       migrate: migrateControls,
       merge: mergeControls,
       storage: createJSONStorage(controlsStorage),
-      // Persist only the control values, never the setter functions.
+      // Persist the preset fields (schema-derived) + the recordingFormats tooling
+      // pref, never the setter functions.
       partialize: (s) => ({
-        right: s.right,
-        left: s.left,
-        syncHands: s.syncHands,
-        masterVolume: s.masterVolume,
-        faceMapping: s.faceMapping,
-        faceChord: s.faceChord,
-        overlay: s.overlay,
+        ...pickSettings(s as unknown as Record<string, unknown>),
         recordingFormats: s.recordingFormats,
       }),
     },

--- a/src/app/useEngine.ts
+++ b/src/app/useEngine.ts
@@ -178,7 +178,7 @@ export function useThoreminEngine() {
           }
           const expr = engine.getOutput('faceExpr', 'expression') as ExpressionScores | undefined;
           const detected = fs.phase === 'ready' && fs.faceDetected && expr?.present;
-          useFaceStatus.getState().report(fs, detected ? expr!.label : null, expr?.probs ?? []);
+          useFaceStatus.getState().report(fs, detected ? expr!.label : null);
           lastFaceReport = now;
           lastPhase = fs.phase;
           lastDetected = fs.faceDetected;

--- a/src/music/expression.ts
+++ b/src/music/expression.ts
@@ -191,7 +191,10 @@ export function expressionThresholds(
 ): Record<Emotion, number> {
   const out = {} as Record<Emotion, number>;
   for (const e of EMOTIONS) {
-    out[e] = sensitivityToThreshold(sensitivity[e] ?? 0.5, EXPRESSION_THRESHOLD_BOUNDS[e]);
+    out[e] = sensitivityToThreshold(
+      sensitivity[e] ?? DEFAULT_EXPRESSION_SENSITIVITY[e],
+      EXPRESSION_THRESHOLD_BOUNDS[e],
+    );
   }
   return out;
 }
@@ -199,6 +202,10 @@ export function expressionThresholds(
 export interface ExpressionDecision {
   label: ExpressionLabel;
   fired: Record<Emotion, boolean>;
+  /** The effective threshold each emotion was judged against — the easier EXIT
+   *  threshold for the `held` label, the ENTER threshold otherwise. Returned so a
+   *  readout's threshold line matches `fired` (a single source of truth). */
+  thresholds: Record<Emotion, number>;
 }
 
 /**
@@ -219,12 +226,14 @@ export function decideExpression(
   held?: ExpressionLabel,
 ): ExpressionDecision {
   const fired = {} as Record<Emotion, boolean>;
+  const thresholds = {} as Record<Emotion, number>;
   let winner: Emotion | null = null;
   let bestMargin = -Infinity;
   for (const e of EMOTIONS) {
     const bounds = EXPRESSION_THRESHOLD_BOUNDS[e];
-    const enter = sensitivityToThreshold(sensitivity[e] ?? 0.5, bounds);
+    const enter = sensitivityToThreshold(sensitivity[e] ?? DEFAULT_EXPRESSION_SENSITIVITY[e], bounds);
     const threshold = e === held ? enter - bounds.delta : enter;
+    thresholds[e] = threshold;
     const margin = (activations[e] ?? 0) - threshold;
     fired[e] = margin >= 0;
     if (fired[e] && margin > bestMargin) {
@@ -232,7 +241,7 @@ export function decideExpression(
       winner = e;
     }
   }
-  return { label: winner ?? 'neutral', fired };
+  return { label: winner ?? 'neutral', fired, thresholds };
 }
 
 /** The absent/rest expression: neutral, nothing fired. */

--- a/src/music/expression.ts
+++ b/src/music/expression.ts
@@ -36,28 +36,45 @@ export const EXPRESSIONS = [
 
 export type ExpressionLabel = (typeof EXPRESSIONS)[number];
 
+/**
+ * The six *scored* emotions. Neutral is the abstention FALLBACK (the decision when
+ * no emotion clears its threshold), not a scored class — for a prototype/cosine
+ * classifier without a strong neutral exemplar, abstention is far more robust than
+ * asking a neutral prototype to out-score everything (Bishop, reject option;
+ * open-set recognition bounds the acceptance region instead of partitioning all of
+ * feature space among the known classes).
+ */
+export const EMOTIONS = ['happy', 'sad', 'angry', 'surprised', 'fearful', 'disgusted'] as const;
+export type Emotion = (typeof EMOTIONS)[number];
+
 /** A sparse weighting over blendshape names (missing keys = 0). */
 export type BlendshapeWeights = Record<string, number>;
 
-/** The classifier's result: a softmax over {@link EXPRESSIONS} + its argmax. */
+/**
+ * The classifier's per-frame result (flows on the DAG edge). `scores` are the
+ * per-emotion activations and `thresholds` their effective firing thresholds (both
+ * aligned to {@link EMOTIONS}, for the readout); `fired` is score ≥ threshold; and
+ * `label` is the decided expression — one of the six emotions or `neutral`.
+ */
 export interface ExpressionScores {
   present: boolean;
-  /** Softmax probabilities, aligned to {@link EXPRESSIONS} (sums to 1). */
-  probs: number[];
-  /** argmax label. */
   label: ExpressionLabel;
-  /** Probability of {@link label} (= max of {@link probs}); 0 when absent. */
-  confidence: number;
+  scores: number[];
+  thresholds: number[];
+  fired: boolean[];
+}
+
+function clamp01(x: number): number {
+  return x < 0 ? 0 : x > 1 ? 1 : x;
 }
 
 /**
- * FACS-grounded prototype blendshape vectors, one per expression. Primary action
- * units carry weight 1; supporting units less. Neutral is anchored on the
- * model's own `_neutral` blendshape, so a resting face scores neutral highest.
- * Seeded from the ARKit-blendshape emotion literature (issue #64 refs [1][2]);
- * override via {@link ExpressionOptions.prototypes} for a calibrated set.
+ * FACS-grounded prototype blendshape vectors, one per emotion. Primary action
+ * units carry weight 1; supporting units less. Seeded from the ARKit-blendshape
+ * emotion literature (issue #64 refs [1][2]); swap for a calibrated set. (Neutral
+ * has no prototype — it is the abstention fallback, not a scored class.)
  */
-export const EXPRESSION_PROTOTYPES: Record<ExpressionLabel, BlendshapeWeights> = {
+export const EXPRESSION_PROTOTYPES: Record<Emotion, BlendshapeWeights> = {
   happy: { mouthSmileLeft: 1, mouthSmileRight: 1, cheekSquintLeft: 0.4, cheekSquintRight: 0.4 },
   sad: {
     mouthFrownLeft: 1,
@@ -100,85 +117,131 @@ export const EXPRESSION_PROTOTYPES: Record<ExpressionLabel, BlendshapeWeights> =
     browDownLeft: 0.4,
     browDownRight: 0.4,
   },
-  neutral: { _neutral: 1 },
 };
 
-/** The blendshape dimensions the classifier scores over (union of all prototype
- * keys). Restricting cosine to these FACS-relevant dims keeps gaze/blink noise
- * out of the norm. */
-const PROTOTYPE_DIMS: string[] = (() => {
-  const dims = new Set<string>();
-  for (const proto of Object.values(EXPRESSION_PROTOTYPES)) {
-    for (const k of Object.keys(proto)) dims.add(k);
+/**
+ * Magnitude-aware activation of each emotion: the weighted-mean activation of its
+ * FACS blendshapes, in [0,1] (0 = those action units at rest, 1 = fully active).
+ * Unlike cosine similarity this is NOT scale-invariant — a faint resting brow
+ * furrow yields a tiny `angry` activation, so it cannot clear a threshold. (That
+ * scale-invariance is exactly why the old cosine classifier read a neutral face
+ * as angry: the direction matched even though the magnitude was negligible.) Pure.
+ */
+export function expressionActivations(
+  blendshapes: BlendshapeWeights,
+  prototypes: Record<Emotion, BlendshapeWeights> = EXPRESSION_PROTOTYPES,
+): Record<Emotion, number> {
+  const out = {} as Record<Emotion, number>;
+  for (const e of EMOTIONS) {
+    let num = 0;
+    let den = 0;
+    for (const k in prototypes[e]) {
+      const w = prototypes[e][k];
+      num += (blendshapes[k] ?? 0) * w;
+      den += w;
+    }
+    out[e] = den > 0 ? clamp01(num / den) : 0;
   }
-  return [...dims];
-})();
-
-export interface ExpressionOptions {
-  /** Override the prototype vectors (e.g. a calibrated set). */
-  prototypes?: Record<ExpressionLabel, BlendshapeWeights>;
-  /** Softmax temperature; lower = sharper. Default 0.12. */
-  temperature?: number;
-}
-
-function dot(a: BlendshapeWeights, b: BlendshapeWeights, dims: string[]): number {
-  let s = 0;
-  for (const k of dims) s += (a[k] ?? 0) * (b[k] ?? 0);
-  return s;
-}
-
-function norm(a: BlendshapeWeights, dims: string[]): number {
-  return Math.sqrt(dot(a, a, dims));
-}
-
-function softmax(xs: number[], temperature: number): number[] {
-  const t = temperature > 0 ? temperature : 1e-6;
-  const scaled = xs.map((x) => x / t);
-  const max = Math.max(...scaled);
-  const exps = scaled.map((x) => Math.exp(x - max));
-  const sum = exps.reduce((a, b) => a + b, 0) || 1;
-  return exps.map((e) => e / sum);
+  return out;
 }
 
 /**
- * Classify a blendshape frame into a softmax distribution over the seven
- * {@link EXPRESSIONS}. Cosine similarity to each {@link EXPRESSION_PROTOTYPES}
- * vector (over the FACS-relevant dims) is passed through a temperature softmax.
- * A near-zero face (no activation) falls back to neutral.
+ * Per-emotion operating-point bounds (calibration constants — NOT calibrated
+ * probabilities; cosine/activation "confidence" is uncalibrated, so these are
+ * tuned operating points). `sensitivity` 0 → `max` (hardest, almost nothing
+ * fires), 1 → `min` (easiest). `delta` is the hysteresis band (enter − delta =
+ * the easier exit threshold). `angry`/`fearful` start slightly stricter (they are
+ * the spurious-prone / overlapping ones).
  */
-export function blendshapesToExpression(
-  blendshapes: BlendshapeWeights,
-  opts: ExpressionOptions = {},
-): ExpressionScores {
-  const prototypes = opts.prototypes ?? EXPRESSION_PROTOTYPES;
-  const temperature = opts.temperature ?? 0.12;
-  const inputNorm = norm(blendshapes, PROTOTYPE_DIMS);
+export interface ExpressionThresholdBounds {
+  min: number;
+  max: number;
+  delta: number;
+}
+export const EXPRESSION_THRESHOLD_BOUNDS: Record<Emotion, ExpressionThresholdBounds> = {
+  happy: { min: 0.15, max: 0.6, delta: 0.06 },
+  sad: { min: 0.15, max: 0.6, delta: 0.06 },
+  angry: { min: 0.2, max: 0.65, delta: 0.06 },
+  surprised: { min: 0.15, max: 0.6, delta: 0.06 },
+  fearful: { min: 0.2, max: 0.65, delta: 0.06 },
+  disgusted: { min: 0.15, max: 0.6, delta: 0.06 },
+};
 
-  let sims: number[];
-  if (inputNorm < 1e-6) {
-    // No measurable expression → certain neutral.
-    sims = EXPRESSIONS.map((label) => (label === 'neutral' ? 1 : 0));
-  } else {
-    sims = EXPRESSIONS.map((label) => {
-      const proto = prototypes[label];
-      const pn = norm(proto, PROTOTYPE_DIMS);
-      if (pn < 1e-6) return 0;
-      return dot(blendshapes, proto, PROTOTYPE_DIMS) / (inputNorm * pn);
-    });
-  }
+export type ExpressionSensitivity = Record<Emotion, number>;
 
-  const probs = softmax(sims, temperature);
-  let argmax = 0;
-  for (let i = 1; i < probs.length; i++) if (probs[i] > probs[argmax]) argmax = i;
-  return { present: true, probs, label: EXPRESSIONS[argmax], confidence: probs[argmax] };
+/** Default per-emotion sensitivity (angry slightly stricter — spurious-prone). */
+export const DEFAULT_EXPRESSION_SENSITIVITY: ExpressionSensitivity = {
+  happy: 0.5,
+  sad: 0.5,
+  angry: 0.45,
+  surprised: 0.5,
+  fearful: 0.5,
+  disgusted: 0.5,
+};
+
+/** A per-emotion sensitivity in [0,1] → its firing threshold, monotone DECREASING
+ *  (more sensitive = lower bar = more hits). */
+export function sensitivityToThreshold(sensitivity: number, bounds: ExpressionThresholdBounds): number {
+  return bounds.max - clamp01(sensitivity) * (bounds.max - bounds.min);
 }
 
-/** The absent/rest expression: certain neutral, no probs to act on. */
+/** The effective (enter) firing threshold for each emotion at the given sensitivities. */
+export function expressionThresholds(
+  sensitivity: ExpressionSensitivity = DEFAULT_EXPRESSION_SENSITIVITY,
+): Record<Emotion, number> {
+  const out = {} as Record<Emotion, number>;
+  for (const e of EMOTIONS) {
+    out[e] = sensitivityToThreshold(sensitivity[e] ?? 0.5, EXPRESSION_THRESHOLD_BOUNDS[e]);
+  }
+  return out;
+}
+
+export interface ExpressionDecision {
+  label: ExpressionLabel;
+  fired: Record<Emotion, boolean>;
+}
+
+/**
+ * Decide the expression from per-emotion activations + per-emotion sensitivities:
+ *  - an emotion *fires* when its activation ≥ its threshold;
+ *  - if NONE fire → `neutral` (the abstention fallback, Chow's reject rule);
+ *  - among those that fire, the winner has the greatest margin OVER ITS OWN
+ *    threshold (so a more-sensitive emotion both fires more often AND wins ties —
+ *    the operating-point generalization of argmax; per-class thresholds don't move
+ *    the underlying scores, only eligibility).
+ * `held` (the currently-committed label, if any) is judged against the easier EXIT
+ * threshold (enter − delta) — a Schmitt-trigger / Canny hysteresis against chatter.
+ * Pure.
+ */
+export function decideExpression(
+  activations: Record<Emotion, number>,
+  sensitivity: ExpressionSensitivity = DEFAULT_EXPRESSION_SENSITIVITY,
+  held?: ExpressionLabel,
+): ExpressionDecision {
+  const fired = {} as Record<Emotion, boolean>;
+  let winner: Emotion | null = null;
+  let bestMargin = -Infinity;
+  for (const e of EMOTIONS) {
+    const bounds = EXPRESSION_THRESHOLD_BOUNDS[e];
+    const enter = sensitivityToThreshold(sensitivity[e] ?? 0.5, bounds);
+    const threshold = e === held ? enter - bounds.delta : enter;
+    const margin = (activations[e] ?? 0) - threshold;
+    fired[e] = margin >= 0;
+    if (fired[e] && margin > bestMargin) {
+      bestMargin = margin;
+      winner = e;
+    }
+  }
+  return { label: winner ?? 'neutral', fired };
+}
+
+/** The absent/rest expression: neutral, nothing fired. */
 export const ABSENT_EXPRESSION: ExpressionScores = {
   present: false,
-  probs: EXPRESSIONS.map((l) => (l === 'neutral' ? 1 : 0)),
   label: 'neutral',
-  confidence: 1,
+  scores: EMOTIONS.map(() => 0),
+  thresholds: EMOTIONS.map(() => 0),
+  fired: EMOTIONS.map(() => false),
 };
 
 // ---- Confusion-aware expression → scale-degree assignment -----------------

--- a/src/nodes/features/face_expression.ts
+++ b/src/nodes/features/face_expression.ts
@@ -27,7 +27,6 @@ import {
   ABSENT_EXPRESSION,
   expressionActivations,
   decideExpression,
-  expressionThresholds,
   DEFAULT_EXPRESSION_SENSITIVITY,
   type ExpressionScores,
   type ExpressionSensitivity,
@@ -63,8 +62,11 @@ export const faceExpressionNode = defineNode<Params>({
   make(p) {
     const smoothed = zeroActivations();
     let committed: ExpressionLabel = 'neutral';
-    let candidate: ExpressionLabel | null = null;
-    let candidateCount = 0;
+    // Frames the committed label has been out-voted (a *leave* counter, not a
+    // per-candidate one): so a single blip is debounced, but two emotions trading
+    // the lead can't deadlock the switch — it commits to whoever leads once the
+    // committed label has lost for dwellFrames running.
+    let leaveCount = 0;
 
     /** EMA toward the target activations (target 0 = decay toward rest). */
     const ema = (target: Record<Emotion, number>) => {
@@ -84,16 +86,16 @@ export const faceExpressionNode = defineNode<Params>({
       return out;
     };
 
-    /** Build the output record from the current smoothed state + sensitivities. */
+    /** Build the output record from the current smoothed state + sensitivities.
+     *  `thresholds` and `fired` come from the SAME decision (judged with the
+     *  committed label held), so the readout's tick can't drift from `fired`. */
     const toScores = (sensitivity: ExpressionSensitivity): ExpressionScores => {
-      const thr = expressionThresholds(sensitivity);
-      // `fired` reflects the same hysteresis the committed label uses.
       const decision = decideExpression(smoothed, sensitivity, committed);
       return {
         present: true,
         label: committed,
         scores: EMOTIONS.map((e) => smoothed[e]),
-        thresholds: EMOTIONS.map((e) => thr[e]),
+        thresholds: EMOTIONS.map((e) => decision.thresholds[e]),
         fired: EMOTIONS.map((e) => decision.fired[e]),
       };
     };
@@ -108,30 +110,22 @@ export const faceExpressionNode = defineNode<Params>({
           // freezing the last chord, and report absent.
           ema(zeroActivations());
           committed = 'neutral';
-          candidate = null;
-          candidateCount = 0;
+          leaveCount = 0;
           return { expression: { ...ABSENT_EXPRESSION } };
         }
 
         ema(expressionActivations(face.blendshapes));
 
         // Decide with hysteresis (the committed label is judged against its easier
-        // exit threshold), then commit a switch only after it persists `dwellFrames`.
+        // exit threshold). Commit a switch only after the committed label has been
+        // out-voted for `dwellFrames` running — debounces a blip without deadlocking
+        // when two emotions alternate as the winner (commit to whoever leads now).
         const proposed = decideExpression(smoothed, sensitivity, committed).label;
         if (proposed === committed) {
-          candidate = null;
-          candidateCount = 0;
-        } else {
-          if (proposed === candidate) candidateCount++;
-          else {
-            candidate = proposed;
-            candidateCount = 1;
-          }
-          if (candidateCount >= p.dwellFrames) {
-            committed = proposed;
-            candidate = null;
-            candidateCount = 0;
-          }
+          leaveCount = 0;
+        } else if (++leaveCount >= p.dwellFrames) {
+          committed = proposed;
+          leaveCount = 0;
         }
 
         return { expression: toScores(sensitivity) };

--- a/src/nodes/features/face_expression.ts
+++ b/src/nodes/features/face_expression.ts
@@ -1,94 +1,140 @@
 /**
- * `face-expression` node — classifies the 52 MediaPipe/ARKit blendshapes of a
- * {@link FaceFrame} into a softmax distribution over the seven canonical
- * expressions (happy / sad / angry / surprised / fearful / disgusted / neutral),
- * the sibling of `face-features`. It uses {@link blendshapesToExpression} (cosine
- * similarity to FACS-grounded prototypes) — no extra model, no extra bytes — and
- * adds temporal stability the raw frame lacks:
+ * `face-expression` node — turns the 52 MediaPipe/ARKit blendshapes of a
+ * {@link FaceFrame} into a decided expression (one of six emotions or `neutral`),
+ * the sibling of `face-features`. No extra model, no extra bytes: it scores the
+ * blendshapes against FACS-grounded prototypes ({@link expressionActivations}) and
+ * applies the research-grounded decision + stabilization stack:
  *
- *  - **per-class EMA smoothing** of the softmax (the simplex is preserved, since
- *    a convex blend of probability vectors is still a probability vector), so the
- *    distribution eases rather than jumps;
- *  - **argmax margin-hold hysteresis**, so the winning expression (which drives
- *    the chord in `expression-chord`) only switches when a challenger leads by a
- *    margin — preventing chord chatter at decision boundaries.
+ *  - **per-emotion EMA smoothing** of the magnitude-aware activations, so each
+ *    emotion's level eases rather than jumps;
+ *  - **per-class thresholds** (from the live, user-tunable sensitivities) with
+ *    **neutral as the abstention fallback** — if no emotion clears its bar the
+ *    decision is `neutral` (the fix for a resting face reading as `angry`);
+ *  - **enter/exit hysteresis** (the held label is judged against an easier exit
+ *    threshold) plus a small **dwell** (a switch must persist a few frames) so the
+ *    expression — which drives the chord in `expression-chord` — does not chatter.
  *
  * Pure + Node-safe (no DOM/MediaPipe): the live `webcam-face` node feeds it the
- * same `{ present, blendshapes }` frames the offline fixture replays.
+ * same `{ present, blendshapes }` frames the offline fixture replays. The live
+ * per-emotion sensitivities arrive on the optional `sensitivity` input (from the
+ * store); absent, the shipped {@link DEFAULT_EXPRESSION_SENSITIVITY} is used.
  */
 import { z } from 'zod';
 import { defineNode } from '@/dag';
 import type { FaceFrame } from '../domain';
 import {
-  EXPRESSIONS,
+  EMOTIONS,
   ABSENT_EXPRESSION,
-  blendshapesToExpression,
+  expressionActivations,
+  decideExpression,
+  expressionThresholds,
+  DEFAULT_EXPRESSION_SENSITIVITY,
   type ExpressionScores,
+  type ExpressionSensitivity,
+  type Emotion,
+  type ExpressionLabel,
 } from '@/music/expression';
 
-const NEUTRAL_INDEX = EXPRESSIONS.indexOf('neutral');
-
 const Params = z.object({
-  /** Per-class EMA smoothing 0..1 (0 = instant, higher = smoother/slower). */
+  /** Per-emotion EMA smoothing 0..1 (0 = instant, higher = smoother/slower). */
   smoothing: z.number().min(0).max(0.999).default(0.4),
-  /** Softmax temperature; lower = sharper distribution. */
-  temperature: z.number().min(0.01).max(2).default(0.12),
-  /** A challenger must lead the held expression by this probability margin
-   *  before the argmax switches (hysteresis against chord flicker). */
-  holdMargin: z.number().min(0).max(1).default(0.06),
+  /** A label switch must persist this many frames before it is committed
+   *  (dwell/debounce, on top of the per-emotion enter/exit hysteresis). */
+  dwellFrames: z.number().int().min(1).max(30).default(2),
 });
 type Params = z.infer<typeof Params>;
 
-/** Rest distribution: certain neutral. */
-const restProbs = (): number[] => EXPRESSIONS.map((l) => (l === 'neutral' ? 1 : 0));
+const zeroActivations = (): Record<Emotion, number> =>
+  Object.fromEntries(EMOTIONS.map((e) => [e, 0])) as Record<Emotion, number>;
 
 export const faceExpressionNode = defineNode<Params>({
   type: 'face-expression',
   roles: ['feature'],
   title: 'Face Expression',
   description:
-    'Face blendshapes → softmax over 7 expressions (happy/sad/angry/surprised/fearful/disgusted/neutral) with smoothing + hysteresis.',
-  inputs: [{ name: 'face', kind: 'face-frame' }],
+    'Face blendshapes → one of 6 emotions or neutral (per-class thresholds + neutral abstention, smoothing, enter/exit hysteresis, dwell).',
+  inputs: [
+    { name: 'face', kind: 'face-frame' },
+    // Live per-emotion sensitivities [0,1] (from the store); optional → defaults.
+    { name: 'sensitivity', kind: 'expression-sensitivity' },
+  ],
   outputs: [{ name: 'expression', kind: 'face-expression' }],
   params: Params,
   make(p) {
-    const smoothed = restProbs();
-    let held = NEUTRAL_INDEX;
+    const smoothed = zeroActivations();
+    let committed: ExpressionLabel = 'neutral';
+    let candidate: ExpressionLabel | null = null;
+    let candidateCount = 0;
 
-    const ema = (targets: number[]) => {
-      for (let i = 0; i < smoothed.length; i++) {
-        smoothed[i] = smoothed[i] + (1 - p.smoothing) * (targets[i] - smoothed[i]);
+    /** EMA toward the target activations (target 0 = decay toward rest). */
+    const ema = (target: Record<Emotion, number>) => {
+      for (const e of EMOTIONS) {
+        smoothed[e] = smoothed[e] + (1 - p.smoothing) * ((target[e] ?? 0) - smoothed[e]);
       }
+    };
+
+    /** Read the live sensitivities, healing any missing emotion with the default. */
+    const sensitivityFrom = (raw: unknown): ExpressionSensitivity => {
+      const s = raw as Partial<ExpressionSensitivity> | undefined;
+      if (!s) return DEFAULT_EXPRESSION_SENSITIVITY;
+      const out = {} as ExpressionSensitivity;
+      for (const e of EMOTIONS) {
+        out[e] = typeof s[e] === 'number' ? (s[e] as number) : DEFAULT_EXPRESSION_SENSITIVITY[e];
+      }
+      return out;
+    };
+
+    /** Build the output record from the current smoothed state + sensitivities. */
+    const toScores = (sensitivity: ExpressionSensitivity): ExpressionScores => {
+      const thr = expressionThresholds(sensitivity);
+      // `fired` reflects the same hysteresis the committed label uses.
+      const decision = decideExpression(smoothed, sensitivity, committed);
+      return {
+        present: true,
+        label: committed,
+        scores: EMOTIONS.map((e) => smoothed[e]),
+        thresholds: EMOTIONS.map((e) => thr[e]),
+        fired: EMOTIONS.map((e) => decision.fired[e]),
+      };
     };
 
     return {
       process(inputs) {
         const face = inputs.face as FaceFrame | undefined;
+        const sensitivity = sensitivityFrom(inputs.sensitivity);
+
         if (!face || !face.present) {
           // Decay toward rest so a lost face relaxes to neutral rather than
           // freezing the last chord, and report absent.
-          ema(restProbs());
-          held = NEUTRAL_INDEX;
+          ema(zeroActivations());
+          committed = 'neutral';
+          candidate = null;
+          candidateCount = 0;
           return { expression: { ...ABSENT_EXPRESSION } };
         }
 
-        const raw = blendshapesToExpression(face.blendshapes, { temperature: p.temperature });
-        ema(raw.probs);
+        ema(expressionActivations(face.blendshapes));
 
-        // Argmax of the SMOOTHED distribution, with margin-hold hysteresis.
-        let argmax = 0;
-        for (let i = 1; i < smoothed.length; i++) if (smoothed[i] > smoothed[argmax]) argmax = i;
-        if (argmax !== held && smoothed[argmax] - smoothed[held] < p.holdMargin) argmax = held;
-        held = argmax;
+        // Decide with hysteresis (the committed label is judged against its easier
+        // exit threshold), then commit a switch only after it persists `dwellFrames`.
+        const proposed = decideExpression(smoothed, sensitivity, committed).label;
+        if (proposed === committed) {
+          candidate = null;
+          candidateCount = 0;
+        } else {
+          if (proposed === candidate) candidateCount++;
+          else {
+            candidate = proposed;
+            candidateCount = 1;
+          }
+          if (candidateCount >= p.dwellFrames) {
+            committed = proposed;
+            candidate = null;
+            candidateCount = 0;
+          }
+        }
 
-        const probs = [...smoothed];
-        const out: ExpressionScores = {
-          present: true,
-          probs,
-          label: EXPRESSIONS[argmax],
-          confidence: probs[argmax],
-        };
-        return { expression: out };
+        return { expression: toScores(sensitivity) };
       },
     };
   },

--- a/src/nodes/music/expression_chord.ts
+++ b/src/nodes/music/expression_chord.ts
@@ -30,7 +30,7 @@ import { defineNode } from '@/dag';
 import type { NodeContext } from '@/dag';
 import { diatonicTriad, midiToFreq, type ScaleSpec } from '@/music/theory';
 import { InstrumentSchema } from '@/music/instruments';
-import { DEFAULT_EXPRESSION_TO_DEGREE, type ExpressionScores } from '@/music/expression';
+import { DEFAULT_EXPRESSION_TO_DEGREE, type ExpressionScores, type ExpressionLabel } from '@/music/expression';
 import { VOICINGS, RENDERINGS, voiceTriad, renderGains, type VoicingId, type RenderingId } from '@/music/voicing';
 import type { VoiceParams } from '../domain';
 
@@ -77,6 +77,8 @@ export const expressionChordNode = defineNode<Params>({
     { name: 'octaveShift', kind: 'number', default: 0 },
     // Live chord settings (instrument / volume / voicing / rendering / tempo).
     { name: 'chordConfig', kind: 'chord-config' },
+    // Per-expression scale-degree map (which triad each expression plays); optional.
+    { name: 'degrees', kind: 'expression-degrees' },
   ],
   outputs: [
     { name: 'params', kind: 'synth-params' },
@@ -113,9 +115,14 @@ export const expressionChordNode = defineNode<Params>({
         const shift = typeof inputs.octaveShift === 'number' ? inputs.octaveShift : 0;
         const active = inputs.faceMapping === 'chord' && !!expr && expr.present && !!spec;
 
+        // Which scale degree the expression plays — the live per-expression map
+        // (from the store), falling back to the confusion-aware default per label.
+        const degrees = inputs.degrees as Partial<Record<ExpressionLabel, number>> | undefined;
+        const degreeFor = (label: ExpressionLabel) =>
+          degrees?.[label] ?? DEFAULT_EXPRESSION_TO_DEGREE[label];
         // The un-voiced scale triad (3 tones) for the overlay highlight; [] off a
         // seven-note scale or when idle.
-        const triad = active ? diatonicTriad(spec!, DEFAULT_EXPRESSION_TO_DEGREE[expr!.label]) : [];
+        const triad = active ? diatonicTriad(spec!, degreeFor(expr!.label)) : [];
         // Voice the chord, then sort ascending by pitch so arpeggios traverse
         // low→high by actual pitch (some voicings stack out of pitch order). The
         // ids stay stable (one per array slot), so the synth still releases all.

--- a/src/nodes/output/canvas_overlay.ts
+++ b/src/nodes/output/canvas_overlay.ts
@@ -21,7 +21,7 @@ import { z } from 'zod';
 import { defineNode } from '@/dag';
 import type { NodeContext } from '@/dag';
 import { freqToMidi, midiToName, scaleGuide } from '@/music/theory';
-import { EXPRESSIONS, type ExpressionScores } from '@/music/expression';
+import { EMOTIONS, type ExpressionScores } from '@/music/expression';
 import {
   kp,
   LM,
@@ -412,9 +412,12 @@ const faceMesh: OverlayElement = {
 };
 
 /**
- * Live readout of the classified facial expression (output feature) — the argmax
- * label plus a small bar per class, so the player sees what their face is being
- * mapped to. Top-centre; absent when no face is detected.
+ * Live readout of the classified facial expression (output feature) — the decided
+ * label plus, per emotion, an activation bar with a white tick at its firing
+ * threshold, so the player SEES each emotion's level against its (user-tunable)
+ * sensitivity. A fired emotion is opaque; the winning one (driving the chord)
+ * glows gold; `neutral` shows no winner (nothing cleared its bar). Top-centre;
+ * absent when no face is detected.
  */
 const faceExpressionReadout: OverlayElement = {
   name: 'faceExpression',
@@ -422,32 +425,39 @@ const faceExpressionReadout: OverlayElement = {
   draw(g, { W, H, inputs, params }) {
     if (!params.faceExpression.show) return;
     const expr = inputs.expression;
-    if (!expr?.present || !expr.probs?.length) return;
-    // The winner glows on the *held* label (what is actually driving the chord),
-    // not the tallest bar — under the classifier's argmax hysteresis the held
-    // expression can briefly differ from the raw smoothed distribution. (Out-of-set
-    // label → -1 → nothing glows, harmless.)
-    const argmax = EXPRESSIONS.indexOf(expr.label);
+    if (!expr?.present || !expr.scores?.length) return;
+    const clamp01 = (x: number) => (x < 0 ? 0 : x > 1 ? 1 : x);
     g.save();
     g.textAlign = 'center';
     g.font = 'bold 15px monospace';
     g.fillStyle = FACE_COLOR;
     g.fillText(expr.label, W * 0.5, H * 0.05);
-    // A small bar per expression class; the winning class glows gold.
-    const n = expr.probs.length;
+    const n = expr.scores.length; // = EMOTIONS.length
     const barW = 14;
     const gap = 5;
+    const maxH = 30;
     const baseY = H * 0.05 + 30;
     const startX = W * 0.5 - (n * (barW + gap) - gap) / 2 + barW / 2;
     for (let i = 0; i < n; i++) {
-      const p = expr.probs[i];
       const cx = startX + i * (barW + gap);
-      g.globalAlpha = 0.25 + 0.65 * p;
-      g.strokeStyle = i === argmax ? CHORD_COLOR : FACE_COLOR;
+      const fired = expr.fired?.[i] ?? false;
+      const isWinner = EMOTIONS[i] === expr.label;
+      // The activation bar — opaque if it fired, dim otherwise; gold if it won.
+      g.globalAlpha = fired ? 0.9 : 0.4;
+      g.strokeStyle = isWinner ? CHORD_COLOR : FACE_COLOR;
       g.lineWidth = barW;
       g.beginPath();
       g.moveTo(cx, baseY);
-      g.lineTo(cx, baseY - (2 + p * 26));
+      g.lineTo(cx, baseY - (2 + clamp01(expr.scores[i]) * maxH));
+      g.stroke();
+      // The firing-threshold tick (lower tick = more sensitive).
+      const ty = baseY - (2 + clamp01(expr.thresholds?.[i] ?? 0) * maxH);
+      g.globalAlpha = 0.85;
+      g.strokeStyle = '#ffffff';
+      g.lineWidth = 2;
+      g.beginPath();
+      g.moveTo(cx - barW / 2, ty);
+      g.lineTo(cx + barW / 2, ty);
       g.stroke();
     }
     g.restore();

--- a/src/nodes/sources/store_controls.ts
+++ b/src/nodes/sources/store_controls.ts
@@ -13,7 +13,7 @@ import type { NodeContext } from '@/dag';
 import { generateScale, type ScaleSpec, type ScaleTypeId } from '@/music/theory';
 import type { InstrumentId } from '@/music/instruments';
 import { legacyFaceToMapping, type FaceMapping } from '@/nodes/domain';
-import type { FaceChord } from '@/settings/schema';
+import type { FaceChord, FaceExpr } from '@/settings/schema';
 import type { OverlayParams } from '@/nodes/output/canvas_overlay';
 
 export interface VoiceControlSnapshot {
@@ -36,6 +36,9 @@ export interface ControlSnapshot {
   faceMapping?: FaceMapping;
   /** How the face chord sounds; fed to `expression-chord` as the chordConfig port. */
   faceChord?: FaceChord;
+  /** Per-emotion sensitivity + per-expression degree map; the sensitivity feeds
+   *  `face-expression` and the degree map feeds `expression-chord`. */
+  faceExpr?: FaceExpr;
 }
 
 const Params = z.object({});
@@ -57,6 +60,10 @@ export const storeControlsNode = defineNode<Record<string, never>>({
     { name: 'faceMapping', kind: 'face-mapping' },
     // Live chord settings (instrument / volume / voicing / rendering / tempo).
     { name: 'chordConfig', kind: 'chord-config' },
+    // Per-emotion firing sensitivity (→ face-expression) and the per-expression
+    // scale-degree map (→ expression-chord).
+    { name: 'expressionSensitivity', kind: 'expression-sensitivity' },
+    { name: 'expressionDegrees', kind: 'expression-degrees' },
   ],
   params: Params,
   make() {
@@ -87,6 +94,10 @@ export const storeControlsNode = defineNode<Record<string, never>>({
             rendering: c.faceChord.rendering,
             bpm: c.faceChord.bpm,
           };
+        }
+        if (c.faceExpr) {
+          out.expressionSensitivity = c.faceExpr.sensitivity;
+          out.expressionDegrees = c.faceExpr.degrees;
         }
         if (c.overlay) out.overlay = c.overlay;
         return out;

--- a/src/settings/schema.ts
+++ b/src/settings/schema.ts
@@ -15,6 +15,7 @@ import { INSTRUMENT_IDS, type InstrumentId } from '@/music/instruments';
 import { VOICINGS, RENDERINGS, type VoicingId, type RenderingId } from '@/music/voicing';
 import { FACE_MAPPINGS, legacyFaceToMapping, type FaceMapping } from '@/nodes/domain';
 import { OverlayParamsSchema } from '@/nodes/output/canvas_overlay';
+import { DEFAULT_EXPRESSION_SENSITIVITY, DEFAULT_EXPRESSION_TO_DEGREE } from '@/music/expression';
 
 const ScaleTypeEnum = z.enum(Object.keys(SCALE_TYPES) as [ScaleTypeId, ...ScaleTypeId[]]);
 const InstrumentEnum = z.enum(INSTRUMENT_IDS as [InstrumentId, ...InstrumentId[]]);
@@ -44,6 +45,35 @@ export const DEFAULT_FACE_CHORD: FaceChord = {
   bpm: 100,
 };
 
+/**
+ * The face-expression mapping config: per-emotion firing `sensitivity` [0,1] (more
+ * sensitive = more hits — see the classifier in music/expression.ts) and a
+ * per-expression scale-`degrees` override (0..6) selecting which diatonic triad
+ * each expression — including `neutral` — plays. Loose `record` shape + full
+ * defaults; consumers heal any missing key, so a partial blob can't crash a reader.
+ */
+export const FaceExprSchema = z
+  .object({
+    sensitivity: z
+      .record(z.string(), z.number().min(0).max(1))
+      .default({ ...DEFAULT_EXPRESSION_SENSITIVITY }),
+    degrees: z
+      .record(z.string(), z.number().int().min(0).max(6))
+      .default({ ...DEFAULT_EXPRESSION_TO_DEGREE }),
+  })
+  .default({
+    sensitivity: { ...DEFAULT_EXPRESSION_SENSITIVITY },
+    degrees: { ...DEFAULT_EXPRESSION_TO_DEGREE },
+  });
+export type FaceExpr = z.infer<typeof FaceExprSchema>;
+
+/** The shipped defaults for the expression mapping (research-grounded sensitivity
+ *  + the confusion-aware degree assignment). */
+export const DEFAULT_FACE_EXPR: FaceExpr = {
+  sensitivity: { ...DEFAULT_EXPRESSION_SENSITIVITY },
+  degrees: { ...DEFAULT_EXPRESSION_TO_DEGREE },
+};
+
 /** One hand's musical settings — mirrors VoiceControl in src/app/store.ts. */
 export const VoiceSettingsSchema = z.object({
   root: z.number().int().min(0).max(11),
@@ -65,6 +95,9 @@ export const SettingsSchema = z.object({
   faceMapping: FaceMappingSchema.default('none'),
   // `.default(...)` keeps presets saved before the chord settings existed valid.
   faceChord: FaceChordSchema.default(DEFAULT_FACE_CHORD),
+  // Per-emotion sensitivity + per-expression degree map; `.default(...)` keeps
+  // presets saved before the expression-mapping editor valid.
+  faceExpr: FaceExprSchema,
   overlay: OverlayParamsSchema,
 });
 export type Settings = z.infer<typeof SettingsSchema>;

--- a/test/app_store.test.ts
+++ b/test/app_store.test.ts
@@ -51,6 +51,16 @@ describe('control store', () => {
     expect(c.rendering).toBe('sustained'); // untouched
   });
 
+  it('setExpressionSensitivity / setExpressionDegree patch one entry, leaving siblings', () => {
+    useControls.getState().setExpressionSensitivity('angry', 0.2);
+    useControls.getState().setExpressionDegree('happy', 4);
+    const fe = useControls.getState().faceExpr;
+    expect(fe.sensitivity.angry).toBe(0.2);
+    expect(fe.sensitivity.happy).toBe(0.5); // sibling sensitivity untouched (default)
+    expect(fe.degrees.happy).toBe(4);
+    expect(fe.degrees.neutral).toBe(5); // sibling degree untouched (confusion-aware default)
+  });
+
   it('setVoice with sync ON mirrors both hands but keeps instruments distinct', () => {
     useControls.getState().setVoice('right', { root: 7, octaves: 4 });
     const s = useControls.getState();
@@ -144,6 +154,19 @@ describe('control store', () => {
     expect(s.faceChord.bpm).toBe(140);
     expect(s.overlay.indexGuide.show).toBe(true);
   });
+
+  it('toSettings → applySettings round-trips faceExpr (schema-derived persistence)', () => {
+    useControls.getState().setExpressionSensitivity('angry', 0.2);
+    useControls.getState().setExpressionDegree('neutral', 1);
+    const snap = toSettings(useControls.getState());
+    // Mutate away, then restore from the snapshot.
+    useControls.getState().setExpressionSensitivity('angry', 0.9);
+    useControls.getState().setExpressionDegree('neutral', 6);
+    useControls.getState().applySettings(snap);
+    const fe = useControls.getState().faceExpr;
+    expect(fe.sensitivity.angry).toBe(0.2);
+    expect(fe.degrees.neutral).toBe(1);
+  });
 });
 
 describe('persist migration (v1 → v2, returning users)', () => {
@@ -166,6 +189,14 @@ describe('persist migration (v1 → v2, returning users)', () => {
       expect(typeof merged.overlay[k]?.show).toBe('boolean');
     }
     expect(merged.overlay.timbreLevels.show).toBe(false); // opt-in default survives the heal
+  });
+
+  it('mergeControls heals a partial faceExpr (missing emotions/degrees filled from defaults)', () => {
+    const initial = useControls.getInitialState();
+    const merged = mergeControls({ faceExpr: { sensitivity: { angry: 0.1 } } } as never, initial);
+    expect(merged.faceExpr.sensitivity.angry).toBe(0.1); // kept
+    expect(merged.faceExpr.sensitivity.happy).toBe(0.5); // filled from default
+    expect(typeof merged.faceExpr.degrees.happy).toBe('number'); // degree map filled too
   });
 
   it('mergeControls clamps an unknown faceMapping to a safe value', () => {
@@ -221,6 +252,9 @@ describe('store-controls node reads the store', () => {
     expect(out.rightSpec).toMatchObject({ root: 2, type: 'minor' });
     // chordConfig maps the store's faceChord (volume → gain) for expression-chord.
     expect(out.chordConfig).toMatchObject({ voicing: 'spread', gain: 0.22, bpm: 100 });
+    // The expression-mapping ports: per-emotion sensitivity + per-expression degrees.
+    expect(out.expressionSensitivity).toMatchObject({ happy: 0.5, angry: 0.45 });
+    expect((out.expressionDegrees as Record<string, number>).neutral).toBe(5);
   });
 
   it('emits nothing when no controls getter is injected (safe before host wires it)', () => {

--- a/test/expression_map.test.ts
+++ b/test/expression_map.test.ts
@@ -7,15 +7,25 @@ import { describe, it, expect } from 'vitest';
 import { diatonicTriad, isSevenNoteScale, type ScaleSpec } from '@/music/theory';
 import {
   EXPRESSIONS,
-  blendshapesToExpression,
+  EMOTIONS,
+  expressionActivations,
+  decideExpression,
+  sensitivityToThreshold,
+  expressionThresholds,
+  EXPRESSION_THRESHOLD_BOUNDS,
+  DEFAULT_EXPRESSION_SENSITIVITY,
   triadDegreeSet,
   sharedTriadNotes,
   assignmentObjective,
   optimalExpressionToDegree,
   RECOMMENDED_EXPRESSION_TO_DEGREE,
   CONFUSION_FER2013,
+  type Emotion,
   type ExpressionLabel,
 } from '@/music/expression';
+
+const zeroActs = (): Record<Emotion, number> =>
+  Object.fromEntries(EMOTIONS.map((e) => [e, 0])) as Record<Emotion, number>;
 
 const cMajor: ScaleSpec = { root: 0, type: 'major', octaves: 2, baseOctave: 3 };
 
@@ -50,57 +60,100 @@ describe('diatonicTriad', () => {
   });
 });
 
-describe('blendshapesToExpression', () => {
-  const classify = (bs: Record<string, number>) => blendshapesToExpression(bs);
-
-  it('reads a smile as happy', () => {
-    expect(classify({ mouthSmileLeft: 1, mouthSmileRight: 1 }).label).toBe('happy');
+describe('expressionActivations (magnitude-aware, [0,1])', () => {
+  it('a full smile activates happy strongly and the rest near zero', () => {
+    const a = expressionActivations({ mouthSmileLeft: 1, mouthSmileRight: 1 });
+    expect(a.happy).toBeGreaterThan(0.6);
+    expect(a.angry).toBeLessThan(0.1);
+    expect(a.sad).toBeLessThan(0.1);
   });
 
+  it('a FAINT brow furrow barely activates angry (the fix for cosine scale-invariance)', () => {
+    // The old cosine classifier read this tiny resting furrow as a confident
+    // angry; the magnitude-aware score keeps it near zero so it cannot fire.
+    const a = expressionActivations({ browDownLeft: 0.08, browDownRight: 0.08 });
+    expect(a.angry).toBeLessThan(0.1);
+  });
+
+  it('every emotion scores within [0,1]', () => {
+    const a = expressionActivations({ jawOpen: 1, eyeWideLeft: 1, eyeWideRight: 1, browInnerUp: 1 });
+    for (const e of EMOTIONS) {
+      expect(a[e]).toBeGreaterThanOrEqual(0);
+      expect(a[e]).toBeLessThanOrEqual(1);
+    }
+  });
+});
+
+describe('decideExpression (per-class thresholds + neutral abstention)', () => {
+  const decide = (bs: Record<string, number>) => decideExpression(expressionActivations(bs)).label;
+
+  it('reads a clear smile as happy', () => {
+    expect(decide({ mouthSmileLeft: 1, mouthSmileRight: 1 })).toBe('happy');
+  });
   it('reads furrowed brows as angry (not disgust)', () => {
-    expect(classify({ browDownLeft: 1, browDownRight: 1 }).label).toBe('angry');
+    expect(decide({ browDownLeft: 1, browDownRight: 1 })).toBe('angry');
   });
-
   it('reads a sneer + raised upper lip as disgusted', () => {
-    expect(
-      classify({ noseSneerLeft: 1, noseSneerRight: 1, mouthUpperUpLeft: 0.8, mouthUpperUpRight: 0.8 })
-        .label,
-    ).toBe('disgusted');
+    expect(decide({ noseSneerLeft: 1, noseSneerRight: 1, mouthUpperUpLeft: 0.8, mouthUpperUpRight: 0.8 })).toBe('disgusted');
   });
-
   it('reads a wide-eyed open jaw with outer-brow raise as surprised', () => {
-    expect(
-      classify({
-        jawOpen: 1,
-        eyeWideLeft: 0.8,
-        eyeWideRight: 0.8,
-        browOuterUpLeft: 0.7,
-        browOuterUpRight: 0.7,
-      }).label,
-    ).toBe('surprised');
+    expect(decide({ jawOpen: 1, eyeWideLeft: 0.8, eyeWideRight: 0.8, browOuterUpLeft: 0.7, browOuterUpRight: 0.7, browInnerUp: 0.4 })).toBe('surprised');
   });
-
   it('distinguishes fear from surprise by the inner-brow raise', () => {
-    expect(
-      classify({ jawOpen: 0.7, eyeWideLeft: 0.9, eyeWideRight: 0.9, browInnerUp: 0.9 }).label,
-    ).toBe('fearful');
+    expect(decide({ jawOpen: 0.7, eyeWideLeft: 0.9, eyeWideRight: 0.9, browInnerUp: 0.9, mouthStretchLeft: 0.3, mouthStretchRight: 0.3 })).toBe('fearful');
   });
-
   it('reads a frown + inner-brow raise as sad', () => {
-    expect(classify({ mouthFrownLeft: 1, mouthFrownRight: 1, browInnerUp: 0.7 }).label).toBe('sad');
+    expect(decide({ mouthFrownLeft: 1, mouthFrownRight: 1, browInnerUp: 0.7 })).toBe('sad');
   });
 
-  it('falls back to neutral on a resting face', () => {
-    expect(classify({}).label).toBe('neutral');
-    expect(classify({ _neutral: 0.95 }).label).toBe('neutral');
+  it('falls back to neutral on a resting OR faintly-active face (the angry-bug fix)', () => {
+    expect(decide({})).toBe('neutral');
+    expect(decide({ _neutral: 0.95 })).toBe('neutral'); // a stray model key, no FACS units
+    expect(decide({ browDownLeft: 0.1, browDownRight: 0.1 })).toBe('neutral'); // faint furrow
   });
 
-  it('returns a valid softmax distribution', () => {
-    const r = classify({ mouthSmileLeft: 1, mouthSmileRight: 1 });
-    expect(r.probs).toHaveLength(EXPRESSIONS.length);
-    expect(r.probs.reduce((a, b) => a + b, 0)).toBeCloseTo(1, 5);
-    for (const p of r.probs) expect(p).toBeGreaterThanOrEqual(0);
-    expect(r.confidence).toBeCloseTo(Math.max(...r.probs), 10);
+  it('a higher sensitivity makes an otherwise-neutral faint expression fire', () => {
+    const faint = expressionActivations({ mouthSmileLeft: 0.25, mouthSmileRight: 0.25 });
+    expect(decideExpression(faint, DEFAULT_EXPRESSION_SENSITIVITY).label).toBe('neutral');
+    expect(decideExpression(faint, { ...DEFAULT_EXPRESSION_SENSITIVITY, happy: 1 }).label).toBe('happy');
+  });
+
+  it('breaks ties by margin over each class’s own threshold', () => {
+    // happy at 0.5, sad at 0.5 — both clear; the more-sensitive one (lower bar →
+    // bigger margin) wins, exercising the operating-point tie-break.
+    const acts = { ...zeroActs(), happy: 0.5, sad: 0.5 };
+    expect(decideExpression(acts, { ...DEFAULT_EXPRESSION_SENSITIVITY, happy: 0.9, sad: 0.5 }).label).toBe('happy');
+    expect(decideExpression(acts, { ...DEFAULT_EXPRESSION_SENSITIVITY, happy: 0.5, sad: 0.9 }).label).toBe('sad');
+  });
+
+  it('marks fired flags for the emotions that cleared their bar', () => {
+    const d = decideExpression(expressionActivations({ mouthSmileLeft: 1, mouthSmileRight: 1 }));
+    expect(d.fired.happy).toBe(true);
+    expect(d.fired.angry).toBe(false);
+  });
+});
+
+describe('sensitivity ↔ threshold', () => {
+  it('sensitivityToThreshold is monotone DECREASING (more sensitive = lower bar)', () => {
+    const b = EXPRESSION_THRESHOLD_BOUNDS.happy;
+    expect(sensitivityToThreshold(0, b)).toBeCloseTo(b.max);
+    expect(sensitivityToThreshold(1, b)).toBeCloseTo(b.min);
+    expect(sensitivityToThreshold(0.3, b)).toBeGreaterThan(sensitivityToThreshold(0.7, b));
+  });
+  it('expressionThresholds returns one threshold per emotion', () => {
+    const thr = expressionThresholds(DEFAULT_EXPRESSION_SENSITIVITY);
+    for (const e of EMOTIONS) expect(typeof thr[e]).toBe('number');
+  });
+});
+
+describe('decideExpression hysteresis', () => {
+  it('judges the held label against an easier exit threshold (sticky, anti-chatter)', () => {
+    const b = EXPRESSION_THRESHOLD_BOUNDS.happy;
+    const enter = sensitivityToThreshold(0.5, b);
+    const between = enter - b.delta * 0.5; // below enter, above the exit (enter − delta)
+    const acts = { ...zeroActs(), happy: between };
+    expect(decideExpression(acts, DEFAULT_EXPRESSION_SENSITIVITY).label).toBe('neutral'); // not held
+    expect(decideExpression(acts, DEFAULT_EXPRESSION_SENSITIVITY, 'happy').label).toBe('happy'); // held → sticky
   });
 });
 

--- a/test/face_chord_nodes.test.ts
+++ b/test/face_chord_nodes.test.ts
@@ -65,6 +65,40 @@ describe('face-expression node', () => {
     expect(out[out.length - 1].label).toBe('happy');
   });
 
+  it('commits a sustained different expression after the dwell (the positive switch)', async () => {
+    const happy = frame({ mouthSmileLeft: 1, mouthSmileRight: 1 });
+    const sad = frame({ mouthFrownLeft: 1, mouthFrownRight: 1, browInnerUp: 0.7 });
+    const out = await classify([...Array(8).fill(happy), ...Array(8).fill(sad)], { smoothing: 0.3, dwellFrames: 2 });
+    expect(out[7].label).toBe('happy');
+    expect(out[out.length - 1].label).toBe('sad'); // the switch was committed
+  });
+
+  it('does NOT deadlock when two emotions alternate as winner (leave-counter, not per-candidate)', async () => {
+    // Regression for the dwell bug: after happy decays out, sad and angry trade the
+    // lead frame-to-frame. A per-candidate dwell counter never accumulates and stays
+    // stuck on happy; the leave-counter must commit away from it.
+    const happy = frame({ mouthSmileLeft: 1, mouthSmileRight: 1 });
+    const sadF = frame({ mouthFrownLeft: 1, mouthFrownRight: 1, browInnerUp: 0.7 });
+    const angryF = frame({ browDownLeft: 1, browDownRight: 1 });
+    const alt: FaceFrame[] = Array.from({ length: 14 }, (_, i) => (i % 2 ? sadF : angryF));
+    const out = await classify([...Array(8).fill(happy), ...alt], { smoothing: 0.3, dwellFrames: 2 });
+    expect(out[7].label).toBe('happy');
+    expect(out[out.length - 1].label).not.toBe('happy'); // not stuck on the stale label
+  });
+
+  it('resets on an absent frame: relaxes to neutral, then re-commits cleanly after the gap', async () => {
+    const happy = frame({ mouthSmileLeft: 1, mouthSmileRight: 1 });
+    const angry = frame({ browDownLeft: 1, browDownRight: 1 });
+    const out = await classify(
+      [...Array(8).fill(happy), ABSENT_FRAME, ...Array(8).fill(angry)],
+      { smoothing: 0.3, dwellFrames: 2 },
+    );
+    expect(out[7].label).toBe('happy');
+    expect(out[8].present).toBe(false);
+    expect(out[8].label).toBe('neutral'); // absent → neutral immediately (state reset)
+    expect(out[out.length - 1].label).toBe('angry'); // re-commits after the gap
+  });
+
   it('respects the live per-emotion sensitivity input (a strict bar abstains to neutral)', async () => {
     const smile = frame({ mouthSmileLeft: 0.7, mouthSmileRight: 0.7 }); // a clear-ish smile
     const run = async (sensitivity?: Record<string, number>) => {

--- a/test/face_chord_nodes.test.ts
+++ b/test/face_chord_nodes.test.ts
@@ -11,7 +11,7 @@ import type { NodeContext } from '@/dag';
 import { faceExpressionNode, expressionChordNode, synthMergeNode, voiceMappingNode } from '@/nodes';
 import { MAX_CHORD_VOICES, ABSENT_HAND, ABSENT_FACE } from '@/nodes';
 import type { ExpressionScores } from '@/music/expression';
-import { DEFAULT_EXPRESSION_TO_DEGREE } from '@/music/expression';
+import { DEFAULT_EXPRESSION_TO_DEGREE, DEFAULT_EXPRESSION_SENSITIVITY } from '@/music/expression';
 import { voiceTriad } from '@/music/voicing';
 import { diatonicTriad, midiToFreq, type ScaleSpec } from '@/music/theory';
 import type { FaceFrame, FaceFeatures, HandFeatures, SynthParams } from '@/nodes';
@@ -40,7 +40,7 @@ describe('face-expression node', () => {
     expect(out[0].label).toBe('neutral');
   });
 
-  it('keeps the smoothed distribution a valid simplex every tick', async () => {
+  it('keeps the smoothed activation scores in [0,1] every tick', async () => {
     const seq = [
       frame({ mouthSmileLeft: 1, mouthSmileRight: 1 }),
       frame({ jawOpen: 1, eyeWideLeft: 0.8, eyeWideRight: 0.8, browOuterUpLeft: 0.7, browOuterUpRight: 0.7 }),
@@ -49,16 +49,35 @@ describe('face-expression node', () => {
     ];
     const out = await classify(seq, { smoothing: 0.5 });
     for (const o of out) {
-      expect(o.probs.reduce((a, b) => a + b, 0)).toBeCloseTo(1, 5);
+      for (const s of o.scores) {
+        expect(s).toBeGreaterThanOrEqual(0);
+        expect(s).toBeLessThanOrEqual(1);
+      }
     }
   });
 
-  it('hysteresis holds the current label against a sub-margin challenger', async () => {
-    // With a large hold margin, a single off-frame should not flip the label.
+  it('a single off-frame does not flip the committed label (EMA + dwell hysteresis)', async () => {
+    // After settling on happy, one angry blip should not switch the chord: the
+    // slow EMA + the dwell (a switch must persist dwellFrames) both resist it.
     const happy = frame({ mouthSmileLeft: 1, mouthSmileRight: 1 });
-    const blip = frame({ mouthSmileLeft: 0.5, mouthSmileRight: 0.5, browDownLeft: 0.55, browDownRight: 0.55 });
-    const out = await classify([...Array(10).fill(happy), blip], { smoothing: 0.6, holdMargin: 0.9 });
+    const blip = frame({ browDownLeft: 1, browDownRight: 1 });
+    const out = await classify([...Array(10).fill(happy), blip], { smoothing: 0.6, dwellFrames: 3 });
     expect(out[out.length - 1].label).toBe('happy');
+  });
+
+  it('respects the live per-emotion sensitivity input (a strict bar abstains to neutral)', async () => {
+    const smile = frame({ mouthSmileLeft: 0.7, mouthSmileRight: 0.7 }); // a clear-ish smile
+    const run = async (sensitivity?: Record<string, number>) => {
+      const node = faceExpressionNode.make(faceExpressionNode.params.parse({ smoothing: 0.3 }));
+      const inputs: Record<string, unknown[]> = { face: Array(12).fill(smile) };
+      if (sensitivity) inputs.sensitivity = Array(12).fill(sensitivity);
+      const out = await replayNode(node, inputs);
+      return (out[out.length - 1].expression as ExpressionScores).label;
+    };
+    // Default sensitivity → the smile clears happy's bar.
+    expect(await run()).toBe('happy');
+    // Sensitivity 0 for happy raises its threshold above the smile → abstains to neutral.
+    expect(await run({ ...DEFAULT_EXPRESSION_SENSITIVITY, happy: 0 })).toBe('neutral');
   });
 });
 
@@ -79,9 +98,10 @@ async function chordVoices(
 
 const happyExpr: ExpressionScores = {
   present: true,
-  probs: [1, 0, 0, 0, 0, 0, 0],
   label: 'happy',
-  confidence: 1,
+  scores: [1, 0, 0, 0, 0, 0],
+  thresholds: [0.375, 0.375, 0.4475, 0.375, 0.4475, 0.375],
+  fired: [true, false, false, false, false, false],
 };
 
 describe('expression-chord node', () => {
@@ -110,6 +130,17 @@ describe('expression-chord node', () => {
     }
   });
 
+  it('follows the live per-expression degree override (happy → V instead of the default I)', async () => {
+    const node = expressionChordNode.make(expressionChordNode.params.parse({}));
+    const out = await replayNode(node, {
+      expression: [happyExpr],
+      spec: [cMajor],
+      faceMapping: ['chord'],
+      degrees: [{ ...DEFAULT_EXPRESSION_TO_DEGREE, happy: 4 }], // override happy → degree 4 (V)
+    });
+    expect(out[0].triad).toEqual(diatonicTriad(cMajor, 4)); // V triad, not the default tonic
+  });
+
   it('stays silent on a non-seven-note scale even in chord mode', async () => {
     const out = await chordVoices(happyExpr, 'chord', { ...cMajor, type: 'pentatonic' });
     expect(out.triad).toEqual([]);
@@ -117,7 +148,13 @@ describe('expression-chord node', () => {
   });
 
   it('stays silent when the face is absent', async () => {
-    const absent: ExpressionScores = { present: false, probs: [0, 0, 0, 0, 0, 0, 1], label: 'neutral', confidence: 1 };
+    const absent: ExpressionScores = {
+      present: false,
+      label: 'neutral',
+      scores: [0, 0, 0, 0, 0, 0],
+      thresholds: [0, 0, 0, 0, 0, 0],
+      fired: [false, false, false, false, false, false],
+    };
     const out = await chordVoices(absent, 'chord');
     expect((out.params as SynthParams).voices.every((v) => !v.present)).toBe(true);
   });

--- a/test/overlay_elements.test.ts
+++ b/test/overlay_elements.test.ts
@@ -288,6 +288,24 @@ describe('canvas-overlay composable elements', () => {
     expect(strokes[2].stroke).toBe('#22d3ee'); // sad bar — face cyan (not the winner)
   });
 
+  it('faceExpression: abstention (present but neutral) draws bars but glows NONE gold', () => {
+    // The classifier's central new state: a present face that cleared no emotion's
+    // bar → label 'neutral'. 'neutral' is not in EMOTIONS, so no bar should glow.
+    const expression = {
+      present: true,
+      label: 'neutral',
+      scores: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1],
+      thresholds: [0.4, 0.4, 0.45, 0.4, 0.45, 0.4],
+      fired: [false, false, false, false, false, false],
+    };
+    const rc = drawWith(onlyElement('faceExpression'), { expression });
+    expect(rc.count('fillText')).toBe(1); // 'neutral' label still renders
+    const strokes = rc.calls.filter((c) => c.m === 'stroke');
+    expect(strokes).toHaveLength(12);
+    // No activation bar (even indices) uses the gold winner colour.
+    expect(strokes.filter((_, i) => i % 2 === 0).every((s) => s.stroke !== '#f5d142')).toBe(true);
+  });
+
   it('faceExpression: nothing when the expression is absent or toggled off', () => {
     expect(drawWith(onlyElement('faceExpression'), {}).count('fillText')).toBe(0); // no expression
     expect(

--- a/test/overlay_elements.test.ts
+++ b/test/overlay_elements.test.ts
@@ -271,23 +271,37 @@ describe('canvas-overlay composable elements', () => {
       { present: true, blendshapes: {}, landmarks: [{ x: 0.5, y: 0.5 }] })).toBe(0); // off
   });
 
-  it('faceExpression (Output): label + a bar per class; the winning class glows gold', () => {
-    const expression = { present: true, probs: [0.7, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05], label: 'happy', confidence: 0.7 };
+  it('faceExpression (Output): an activation bar + threshold tick per emotion; the winner glows gold', () => {
+    const expression = {
+      present: true,
+      label: 'happy',
+      scores: [0.7, 0.1, 0.1, 0.1, 0.1, 0.1],
+      thresholds: [0.4, 0.4, 0.45, 0.4, 0.45, 0.4],
+      fired: [true, false, false, false, false, false],
+    };
     const rc = drawWith(onlyElement('faceExpression'), { expression });
     expect(rc.count('fillText')).toBe(1); // the label
-    const bars = rc.calls.filter((c) => c.m === 'stroke');
-    expect(bars).toHaveLength(7); // one bar per expression class
-    // 'happy' (argmax index 0) glows gold; the rest are the face cyan.
-    expect(bars[0].stroke).toBe('#f5d142');
-    expect(bars[1].stroke).toBe('#22d3ee');
+    const strokes = rc.calls.filter((c) => c.m === 'stroke');
+    expect(strokes).toHaveLength(12); // 6 emotions × (activation bar + threshold tick)
+    expect(strokes[0].stroke).toBe('#f5d142'); // happy bar — the winner glows gold
+    expect(strokes[1].stroke).toBe('#ffffff'); // happy's threshold tick is white
+    expect(strokes[2].stroke).toBe('#22d3ee'); // sad bar — face cyan (not the winner)
   });
 
   it('faceExpression: nothing when the expression is absent or toggled off', () => {
     expect(drawWith(onlyElement('faceExpression'), {}).count('fillText')).toBe(0); // no expression
     expect(
-      drawWith(onlyElement('faceExpression'), { expression: { present: false, probs: [], label: 'neutral', confidence: 1 } }).count('fillText'),
+      drawWith(onlyElement('faceExpression'), {
+        expression: { present: false, label: 'neutral', scores: [], thresholds: [], fired: [] },
+      }).count('fillText'),
     ).toBe(0);
-    const expression = { present: true, probs: [1, 0, 0, 0, 0, 0, 0], label: 'happy', confidence: 1 };
+    const expression = {
+      present: true,
+      label: 'happy',
+      scores: [1, 0, 0, 0, 0, 0],
+      thresholds: [0.4, 0.4, 0.45, 0.4, 0.45, 0.4],
+      fired: [true, false, false, false, false, false],
+    };
     expect(drawWith({ ...onlyElement('faceExpression'), faceExpression: { show: false } }, { expression }).count('stroke')).toBe(0);
   });
 

--- a/test/settings_presets.test.ts
+++ b/test/settings_presets.test.ts
@@ -98,6 +98,12 @@ describe('preset persistence', () => {
     expect(sampleSettings().faceChord).toEqual(DEFAULT_FACE_CHORD);
   });
 
+  it('defaults faceExpr when omitted (pre-expression-mapping presets)', () => {
+    const fe = sampleSettings().faceExpr;
+    expect(fe.sensitivity.angry).toBe(0.45); // DEFAULT_EXPRESSION_SENSITIVITY.angry
+    expect(fe.degrees.neutral).toBe(5); // the confusion-aware default (RECOMMENDED…neutral)
+  });
+
   it('migrates a pre-#64 preset (boolean faceEnabled) to faceMapping on load', () => {
     const legacy = {
       id: 'legacy',


### PR DESCRIPTION
Reworks the facial-expression classifier and the settings around it. Grounded in a research pass on **multi-class classification with a reject option + per-class thresholds** (full synthesis with Vancouver references is in the session; key sources: Bishop PRML §1.5.3–1.5.4 on the reject option / inference-vs-decision, Chow's rule, Rifkin & Klautau on argmax selection, Canny/Schmitt hysteresis, Guo et al. on calibration).

## The "neutral reads as angry" fix
The old classifier used **cosine** similarity to FACS prototypes — *scale-invariant*, so a faint resting brow-furrow had the right *direction* for "angry" and won despite negligible magnitude. Replaced with:
- a **magnitude-aware** activation per emotion (weighted-mean of its blendshapes, [0,1]);
- **neutral as the abstention fallback** — an emotion fires only if it clears its threshold; if none do → neutral (no neutral prototype to out-score);
- **per-emotion sensitivity** [0,1] → threshold (monotone: more sensitive = more hits); ties break by margin-over-threshold;
- stabilized by EMA + enter/exit **hysteresis** + a **dwell** debounce.

The expression readout now shows each emotion's activation bar against a **white threshold tick** (you *see* the sensitivity), winner glowing gold.

## Per-expression chord editor + settings architecture
You asked where this is going — the answer is an **in-house declarative + accordion** organization (not a one-off):
- ControlsPanel reorganized into a top-level accordion (Sound / Face / Overlay / Recording / Presets / Keyboard) with progressive disclosure.
- A per-expression **mapping editor**: per expression a sensitivity slider, the scale degree it plays (editable), and the chord's **live MIDI notes**. Sensitivity shows in any face mode; the degree + MIDI are chord-specific. Rendering stays global.
- **Persistence is now schema-derived**: `toSettings` / `applySettings` / `partialize` pick the keys from `SettingsSchema.shape`, so a new preset field is added once (schema + store), not in six places.

## Process
Multi-agent adversarial review (6 dimensions, each finding double-verified): **15 confirmed, all fixed** — chiefly a **dwell deadlock** (two emotions alternating could lock the label), sensitivity being hidden in timbre mode, and a stale `expr.probs` read that survived both CI gates. **265 tests**, deterministic; typecheck + build + catalog clean.

https://claude.ai/code/session_01JEoe7y1hA5KdEAvvpQXxxt
