### PR TITLE
Expression help panel + reachability tuning + silence as a chord choice

### DIFF
--- a/src/app/ControlsPanel.tsx
+++ b/src/app/ControlsPanel.tsx
@@ -13,11 +13,12 @@ import { useState, type ReactNode } from 'react';
 import { NOTES, SCALE_TYPES, isSevenNoteScale, diatonicTriad, type ScaleTypeId } from '@/music/theory';
 import { INSTRUMENTS, INSTRUMENT_IDS } from '@/music/instruments';
 import { VOICINGS, RENDERINGS, isTempoRendering, voiceTriad, type VoicingId, type RenderingId } from '@/music/voicing';
-import { EXPRESSIONS, EMOTIONS, DEFAULT_EXPRESSION_TO_DEGREE } from '@/music/expression';
+import { EXPRESSIONS, EMOTIONS, DEFAULT_EXPRESSION_TO_DEGREE, SILENCE_DEGREE } from '@/music/expression';
 import { OVERLAY_ELEMENTS, OVERLAY_CATEGORIES, type OverlayParams } from '@/nodes/output/canvas_overlay';
 import type { FaceMapping } from '@/nodes';
 import { useControls, type VoiceControl } from './store';
 import { OVERLAY_CONTROLS, type OverlayControlDesc } from './overlayControls';
+import { ExpressionHelpButton } from './ExpressionHelpPanel';
 import { useFaceStatus } from './faceStatus';
 import { usePresets } from './usePresets';
 import { RECORDING_FORMATS } from './recording/formats';
@@ -378,6 +379,7 @@ function ExpressionMapping({ chordMode }: { chordMode: boolean }) {
   const voicing = useControls((s) => s.faceChord.voicing);
 
   const chordMidi = (degree: number): number[] => {
+    if (degree < 0) return []; // SILENCE_DEGREE → no chord
     const triad = diatonicTriad(
       { root: right.root, type: right.type, octaves: right.octaves, baseOctave: right.baseOctave },
       degree,
@@ -426,18 +428,23 @@ function ExpressionMapping({ chordMode }: { chordMode: boolean }) {
                   <select
                     className={selectCls}
                     value={degree}
-                    title="Scale degree this expression plays"
+                    title="Which chord this expression plays (or silence)"
                     onChange={(e) => setDegree(label, Number(e.target.value))}
                   >
+                    <option value={SILENCE_DEGREE}>Silence</option>
                     {[0, 1, 2, 3, 4, 5, 6].map((d) => (
-                      <option key={d} value={d}>{d + 1}</option>
+                      <option key={d} value={d}>{`Degree ${d + 1}`}</option>
                     ))}
                   </select>
                 )}
               </div>
               {chordMode && (
                 <div className="pl-16 font-mono text-[10px] text-white/40">
-                  {midi.length ? midi.join(' ') : '— (needs a 7-note scale)'}
+                  {degree < 0
+                    ? 'silence (no chord)'
+                    : midi.length
+                      ? midi.join(' ')
+                      : '— (needs a 7-note scale)'}
                 </div>
               )}
             </div>
@@ -471,7 +478,10 @@ function FaceControls() {
           ))}
         </select>
       </label>
-      <FaceStatusReadout active={faceMapping !== 'none'} />
+      <div className="flex items-center justify-between gap-2">
+        <FaceStatusReadout active={faceMapping !== 'none'} />
+        {faceMapping !== 'none' && <ExpressionHelpButton />}
+      </div>
       {faceMapping === 'chord' && !sevenNote && (
         <p className="text-[10px] leading-relaxed text-amber-300/80">
           Chord mode needs a 7-note scale (Major / Natural Minor / Harmonic Minor) on the right hand.

--- a/src/app/ExpressionHelpPanel.tsx
+++ b/src/app/ExpressionHelpPanel.tsx
@@ -6,6 +6,7 @@
  * classifier prototypes). A plain React overlay — not a native dialog.
  */
 import { useState, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import { EXPRESSION_HELP, HELP_REFERENCES, MODEL_ORIGIN } from './expressionHelp';
 
 export function ExpressionHelpButton() {
@@ -31,11 +32,16 @@ export function ExpressionHelpButton() {
       >
         i
       </button>
-      {open && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
-          onClick={() => setOpen(false)}
-        >
+      {open &&
+        createPortal(
+          // Portal to <body>: the controls panel uses backdrop-blur (which makes it
+          // the containing block for fixed descendants) + overflow-hidden, so an
+          // in-tree `fixed inset-0` overlay would be clipped to the panel, not the
+          // viewport. The portal lets the modal cover and dim the whole screen.
+          <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+            onClick={() => setOpen(false)}
+          >
           <div
             role="dialog"
             aria-modal="true"
@@ -117,8 +123,9 @@ export function ExpressionHelpButton() {
               slider (in Expression sensitivity / mapping) — that lowers its trigger bar.
             </p>
           </div>
-        </div>
-      )}
+        </div>,
+          document.body,
+        )}
     </>
   );
 }

--- a/src/app/ExpressionHelpPanel.tsx
+++ b/src/app/ExpressionHelpPanel.tsx
@@ -1,0 +1,124 @@
+/**
+ * ExpressionHelpButton — a small info (ⓘ) icon for the facial-expression detector
+ * that opens a help panel: where the model comes from, how to trigger each emotion
+ * (especially the model's hard-to-detect ones), what channels it reads, and links
+ * to reference imagery. Content lives in expressionHelp.ts (grounded in the actual
+ * classifier prototypes). A plain React overlay — not a native dialog.
+ */
+import { useState, useEffect } from 'react';
+import { EXPRESSION_HELP, HELP_REFERENCES, MODEL_ORIGIN } from './expressionHelp';
+
+export function ExpressionHelpButton() {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open]);
+
+  return (
+    <>
+      <button
+        type="button"
+        className="inline-flex h-4 w-4 items-center justify-center rounded-full border border-white/30 text-[9px] font-bold italic text-white/60 transition hover:border-white/70 hover:text-white"
+        title="How to trigger each expression"
+        aria-label="Expression detector help"
+        onClick={() => setOpen(true)}
+      >
+        i
+      </button>
+      {open && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+          onClick={() => setOpen(false)}
+        >
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-label="Expression detector help"
+            className="max-h-[85vh] w-full max-w-md overflow-y-auto rounded-lg border border-white/15 bg-neutral-900/95 p-4 text-white shadow-2xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="mb-2 flex items-start justify-between gap-2">
+              <h2 className="text-sm font-bold uppercase tracking-widest text-white/80">
+                Reading your expression
+              </h2>
+              <button
+                type="button"
+                className="-mt-1 px-1 text-lg leading-none text-white/50 hover:text-white"
+                aria-label="Close help"
+                onClick={() => setOpen(false)}
+              >
+                ×
+              </button>
+            </div>
+
+            <p className="mb-3 text-[11px] leading-relaxed text-white/55">{MODEL_ORIGIN}</p>
+
+            <div className="space-y-2.5">
+              {EXPRESSION_HELP.map((e) => (
+                <div key={e.name} className="rounded border border-white/10 p-2.5">
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs font-bold capitalize text-cyan-300">{e.name}</span>
+                    {e.hardToDetect && (
+                      <span className="rounded bg-amber-400/15 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wide text-amber-300/90">
+                        harder to detect
+                      </span>
+                    )}
+                  </div>
+                  <p className="mt-1 text-[11px] font-semibold text-white/80">{e.keyAction}</p>
+                  <p className="mt-1 text-[11px] leading-relaxed text-white/55">{e.howTo}</p>
+                  <p className="mt-1 text-[10px] leading-relaxed text-white/40">
+                    <span className="text-white/55">Common slip:</span> {e.commonMistake}
+                  </p>
+                  {e.avoidConfusion && (
+                    <p className="mt-0.5 text-[10px] leading-relaxed text-white/40">
+                      <span className="text-white/55">Tell apart:</span> {e.avoidConfusion}
+                    </p>
+                  )}
+                  <div className="mt-1.5 flex flex-wrap gap-1">
+                    {e.blendshapes.map((b) => (
+                      <span key={b} className="rounded bg-white/10 px-1.5 py-0.5 font-mono text-[9px] text-white/45">
+                        {b}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-3 border-t border-white/10 pt-2">
+              <p className="mb-1 text-[10px] font-bold uppercase tracking-widest text-white/50">
+                See the faces
+              </p>
+              <ul className="space-y-1">
+                {HELP_REFERENCES.map((r) => (
+                  <li key={r.url} className="text-[10px] leading-snug">
+                    <a
+                      href={r.url}
+                      target="_blank"
+                      rel="noreferrer noopener"
+                      className="text-cyan-300/90 underline hover:text-cyan-200"
+                    >
+                      {r.title}
+                    </a>
+                    <span className="text-white/35"> — {r.shows}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <p className="mt-3 text-[10px] leading-relaxed text-white/40">
+              Tip: if an expression won’t trigger, raise its <span className="text-white/60">sensitivity</span>{' '}
+              slider (in Expression sensitivity / mapping) — that lowers its trigger bar.
+            </p>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/app/expressionHelp.ts
+++ b/src/app/expressionHelp.ts
@@ -72,7 +72,7 @@ export const EXPRESSION_HELP: EmotionHelp[] = [
     howTo: 'Open the eyes as wide as you can, knit the inner brows up-and-together, and drop the jaw — all at once, near-maximal. This is the hardest one.',
     commonMistake: 'A moderate, realistic fear face. Eye-widen and inner-brow barely register, so a non-maximal attempt lands just under the bar.',
     avoidConfusion: 'Vs surprised: knit the inner brows up-and-together and stretch the mouth, rather than a calm open-mouth lift.',
-    blendshapes: ['jawOpen', 'eyeWideLeft', 'eyeWideRight', 'browInnerUp', 'mouthStretchLeft', 'mouthStretchRight'],
+    blendshapes: ['jawOpen', 'eyeWideLeft', 'eyeWideRight', 'browInnerUp', 'browOuterUpLeft', 'browOuterUpRight', 'mouthStretchLeft', 'mouthStretchRight'],
     hardToDetect: true,
   },
   {

--- a/src/app/expressionHelp.ts
+++ b/src/app/expressionHelp.ts
@@ -1,0 +1,106 @@
+/**
+ * Help content for the facial-expression detector — how to trigger each emotion,
+ * what the classifier looks for, and where the model comes from. Rendered by the
+ * info-icon panel (ExpressionHelp.tsx).
+ *
+ * The per-emotion guidance is grounded in the actual classifier prototypes
+ * (music/expression.ts `EXPRESSION_PROTOTYPES`) and a research pass on how readily
+ * MediaPipe's blendshape channels activate: several (noseSneer, mouthFrown,
+ * browInnerUp, eyeWide) are under-reported by the model, which is exactly why
+ * `sad`, `disgusted`, and `fearful` are the hard ones (flagged `hardToDetect`).
+ */
+import type { Emotion } from '@/music/expression';
+
+export interface EmotionHelp {
+  name: Emotion;
+  /** The single most important action, one line. */
+  keyAction: string;
+  /** 1-3 short, achievable steps. */
+  howTo: string;
+  /** Why an attempt commonly fails. */
+  commonMistake: string;
+  /** How to disambiguate from a confusable neighbour. */
+  avoidConfusion: string;
+  /** The ARKit blendshape channels the classifier scores for this emotion. */
+  blendshapes: string[];
+  /** True when the model under-reports this emotion's channels (the hard ones). */
+  hardToDetect?: boolean;
+}
+
+/** Where the model + the blendshape categories come from (for the panel header). */
+export const MODEL_ORIGIN =
+  'Expressions are read by Google’s MediaPipe Face Landmarker — it tracks 478 face points and outputs 52 “blendshape” values (named after Apple’s ARKit face shapes, e.g. jawOpen, browInnerUp). Your face is matched against a per-emotion template of expected blendshapes, and an emotion fires when it’s activated enough. These are AR-entertainment-grade signals: a few channels (nose-wrinkle, frown, inner-brow, eye-widen) read weakly, so the emotions that rely on them take more effort — those are marked “harder to detect” below, and you can lower their sensitivity bar in Expression sensitivity / mapping.';
+
+/** Per-emotion how-to, in EMOTIONS order (happy, sad, angry, surprised, fearful, disgusted). */
+export const EXPRESSION_HELP: EmotionHelp[] = [
+  {
+    name: 'happy',
+    keyAction: 'Smile broadly with both mouth corners.',
+    howTo: 'Pull both lip corners up and back into a clear, symmetric smile and let your cheeks lift. The model reads this one reliably.',
+    commonMistake: 'A faint, closed-lip half-smile — the model wants a definite smile, not a polite one.',
+    avoidConfusion: 'If your jaw drops open you may read as surprised — keep the mouth in a smile shape, not gaping.',
+    blendshapes: ['mouthSmileLeft', 'mouthSmileRight', 'cheekSquintLeft', 'cheekSquintRight'],
+  },
+  {
+    name: 'sad',
+    keyAction: 'Turn both mouth corners down and drop the lower lip.',
+    howTo: 'Pull both lip corners down into a frown and let the lower lip drop, while raising the inner brows. Exaggerate — the model under-reports frowns.',
+    commonMistake: 'A subtle frown. A mild sad face barely moves the frown/inner-brow channels and never fires.',
+    avoidConfusion: 'Don’t lower/furrow the brows (that reads angry) — keep them raised and knit inward.',
+    blendshapes: ['mouthFrownLeft', 'mouthFrownRight', 'mouthLowerDownLeft', 'mouthLowerDownRight', 'browInnerUp'],
+    hardToDetect: true,
+  },
+  {
+    name: 'angry',
+    keyAction: 'Furrow and lower both brows hard.',
+    howTo: 'Pull both eyebrows down and together into a strong furrow; optionally tense the lips. The brow-down channel is reliable, so a firm scowl fires cleanly.',
+    commonMistake: 'Only squinting or pressing the lips without driving the brows down — the lowered brow is what carries it.',
+    avoidConfusion: 'Don’t wrinkle the nose (that pushes toward disgust); lead with the lowered brow.',
+    blendshapes: ['browDownLeft', 'browDownRight', 'noseSneerLeft', 'noseSneerRight', 'mouthPressLeft', 'mouthPressRight'],
+  },
+  {
+    name: 'surprised',
+    keyAction: 'Drop your jaw open and raise your brows.',
+    howTo: 'Open your mouth (drop the jaw), widen your eyes, and raise your eyebrows. The open jaw is the strongest signal.',
+    commonMistake: 'Raising brows with a closed mouth — without the jaw-open the score stays low.',
+    avoidConfusion: 'If you knit the inner brows inward and tense up it tips toward fearful — keep it open and lifted.',
+    blendshapes: ['jawOpen', 'eyeWideLeft', 'eyeWideRight', 'browOuterUpLeft', 'browOuterUpRight', 'browInnerUp'],
+  },
+  {
+    name: 'fearful',
+    keyAction: 'Widen the eyes AND drop the jaw together.',
+    howTo: 'Open the eyes as wide as you can, knit the inner brows up-and-together, and drop the jaw — all at once, near-maximal. This is the hardest one.',
+    commonMistake: 'A moderate, realistic fear face. Eye-widen and inner-brow barely register, so a non-maximal attempt lands just under the bar.',
+    avoidConfusion: 'Vs surprised: knit the inner brows up-and-together and stretch the mouth, rather than a calm open-mouth lift.',
+    blendshapes: ['jawOpen', 'eyeWideLeft', 'eyeWideRight', 'browInnerUp', 'mouthStretchLeft', 'mouthStretchRight'],
+    hardToDetect: true,
+  },
+  {
+    name: 'disgusted',
+    keyAction: 'Wrinkle your nose and raise your upper lip.',
+    howTo: 'Scrunch the nose and pull the upper lip up — a “something stinks” sneer — with a slight brow-lower. Drive the upper-lip raise strongly.',
+    commonMistake: 'Relying on the nose wrinkle alone — the model pins noseSneer near zero, so without a strong upper-lip raise it’s too weak to fire.',
+    avoidConfusion: 'Vs angry: lead with the nose/upper-lip sneer, not the lowered brow.',
+    blendshapes: ['noseSneerLeft', 'noseSneerRight', 'mouthUpperUpLeft', 'mouthUpperUpRight', 'browDownLeft', 'browDownRight'],
+    hardToDetect: true,
+  },
+];
+
+/** Authoritative reference links (the model + visual blendshape/emotion catalogs). */
+export const HELP_REFERENCES: { title: string; url: string; shows: string }[] = [
+  {
+    title: 'MediaPipe Face Landmarker (Google AI Edge)',
+    url: 'https://developers.google.com/edge/mediapipe/solutions/vision/face_landmarker',
+    shows: 'The model: 478 landmarks + 52 blendshapes, and its model card.',
+  },
+  {
+    title: 'ARKit face blendshapes — visual reference',
+    url: 'https://arkit-face-blendshapes.com/',
+    shows: 'A rendered face for each of the 52 blendshape channels by name.',
+  },
+  {
+    title: 'The 7 universal expressions (Wikimedia, CC BY)',
+    url: 'https://commons.wikimedia.org/wiki/File:Universal_emotions7.JPG',
+    shows: 'Photographs of each target face, including sad, fear, disgust.',
+  },
+];

--- a/src/music/expression.ts
+++ b/src/music/expression.ts
@@ -84,14 +84,18 @@ function clamp01(x: number): number {
 export const EXPRESSION_PROTOTYPES: Record<Emotion, BlendshapeWeights> = {
   happy: { mouthSmileLeft: 1, mouthSmileRight: 1, cheekSquintLeft: 0.4, cheekSquintRight: 0.4 },
   sad: {
-    // Rebalanced off the under-reported mouthFrown/browInnerUp onto the reliable
-    // lower-lip drop (den 3.0): the old all-hard-weight prototype was effectively
-    // unreachable on this model however hard the face was performed.
+    // Rebalanced off the under-reported mouthFrown/browInnerUp onto the more
+    // reliable lower-lip drop (den 2.7). The lower-lip weight is CAPPED so it can't
+    // satisfy sad on its own — an open mouth (yawn / loud vowel) drives
+    // mouthLowerDown high via jawOpen, and at 0.45 each it tops out at 0.9/2.7 =
+    // 0.33, below the 0.375 firing bar, so a non-frowning open mouth stays neutral;
+    // a real frown + lip-drop still clears. (Old all-hard-weight prototype was
+    // unreachable; 0.6 each let a yawn false-fire sad — see review.)
     mouthFrownLeft: 0.7,
     mouthFrownRight: 0.7,
     browInnerUp: 0.4,
-    mouthLowerDownLeft: 0.6,
-    mouthLowerDownRight: 0.6,
+    mouthLowerDownLeft: 0.45,
+    mouthLowerDownRight: 0.45,
   },
   angry: {
     browDownLeft: 1,

--- a/src/music/expression.ts
+++ b/src/music/expression.ts
@@ -73,15 +73,25 @@ function clamp01(x: number): number {
  * units carry weight 1; supporting units less. Seeded from the ARKit-blendshape
  * emotion literature (issue #64 refs [1][2]); swap for a calibrated set. (Neutral
  * has no prototype — it is the abstention fallback, not a scored class.)
+ *
+ * NOTE on `sad`/`disgusted`: the MediaPipe Blendshape model **under-reports**
+ * several channels — `noseSneer`, `mouthFrown`, `browInnerUp`, `eyeWide` cap near
+ * zero even on a strong genuine expression (model card: AR-entertainment grade;
+ * MediaPipe issues #5329, #4450). So these two prototypes deliberately lean on the
+ * RELIABLE neighbouring units (the lower-lip drop for sad, the upper-lip raise for
+ * disgust) rather than the weak primary AU, so a real expression can clear the bar.
  */
 export const EXPRESSION_PROTOTYPES: Record<Emotion, BlendshapeWeights> = {
   happy: { mouthSmileLeft: 1, mouthSmileRight: 1, cheekSquintLeft: 0.4, cheekSquintRight: 0.4 },
   sad: {
-    mouthFrownLeft: 1,
-    mouthFrownRight: 1,
-    browInnerUp: 0.7,
-    mouthLowerDownLeft: 0.2,
-    mouthLowerDownRight: 0.2,
+    // Rebalanced off the under-reported mouthFrown/browInnerUp onto the reliable
+    // lower-lip drop (den 3.0): the old all-hard-weight prototype was effectively
+    // unreachable on this model however hard the face was performed.
+    mouthFrownLeft: 0.7,
+    mouthFrownRight: 0.7,
+    browInnerUp: 0.4,
+    mouthLowerDownLeft: 0.6,
+    mouthLowerDownRight: 0.6,
   },
   angry: {
     browDownLeft: 1,
@@ -110,10 +120,12 @@ export const EXPRESSION_PROTOTYPES: Record<Emotion, BlendshapeWeights> = {
     mouthStretchRight: 0.3,
   },
   disgusted: {
-    noseSneerLeft: 1,
-    noseSneerRight: 1,
-    mouthUpperUpLeft: 0.8,
-    mouthUpperUpRight: 0.8,
+    // Weighted toward the reliable upper-lip raise (the model pins noseSneer near
+    // zero), so a strong sneer fires. den 4.2.
+    noseSneerLeft: 0.7,
+    noseSneerRight: 0.7,
+    mouthUpperUpLeft: 1,
+    mouthUpperUpRight: 1,
     browDownLeft: 0.4,
     browDownRight: 0.4,
   },
@@ -163,7 +175,9 @@ export const EXPRESSION_THRESHOLD_BOUNDS: Record<Emotion, ExpressionThresholdBou
   sad: { min: 0.15, max: 0.6, delta: 0.06 },
   angry: { min: 0.2, max: 0.65, delta: 0.06 },
   surprised: { min: 0.15, max: 0.6, delta: 0.06 },
-  fearful: { min: 0.2, max: 0.65, delta: 0.06 },
+  // Lower max (→ default firing bar 0.40) — a realistic fear face barely clears it
+  // because the eyeWide/browInnerUp channels read weakly on this model.
+  fearful: { min: 0.2, max: 0.6, delta: 0.06 },
   disgusted: { min: 0.15, max: 0.6, delta: 0.06 },
 };
 
@@ -397,5 +411,23 @@ export const RECOMMENDED_EXPRESSION_TO_DEGREE: ExpressionToDegree = {
   angry: 6,
 };
 
-/** The expression→degree assignment the chord mapping ships with. */
-export const DEFAULT_EXPRESSION_TO_DEGREE = RECOMMENDED_EXPRESSION_TO_DEGREE;
+/**
+ * Sentinel degree meaning "play nothing" — an expression mapped to {@link
+ * SILENCE_DEGREE} contributes no chord (an empty note set). Any expression can be
+ * assigned to it; `neutral` defaults to it (a resting face is silence). A negative
+ * value so it survives `?? default` lookups (unlike `null`, which `??` would
+ * replace) and is trivially distinguished from a real scale degree (0..6).
+ */
+export const SILENCE_DEGREE = -1;
+
+/**
+ * The expression→degree assignment the chord mapping ships with: the confusion-aware
+ * {@link RECOMMENDED_EXPRESSION_TO_DEGREE} for the six emotions, but `neutral`
+ * defaults to {@link SILENCE_DEGREE} (silence) — a resting face plays nothing
+ * unless the player assigns it a degree. (RECOMMENDED itself stays the pure 0..6
+ * bijection the optimizer produces, for the confusion-assignment tests.)
+ */
+export const DEFAULT_EXPRESSION_TO_DEGREE: ExpressionToDegree = {
+  ...RECOMMENDED_EXPRESSION_TO_DEGREE,
+  neutral: SILENCE_DEGREE,
+};

--- a/src/music/theory.ts
+++ b/src/music/theory.ts
@@ -92,9 +92,12 @@ export function isSevenNoteScale(type: ScaleTypeId): boolean {
  * octave wrap up by 12 semitones, keeping the triad ascending.
  *
  * Returns `[]` for non-seven-note scales (see {@link isSevenNoteScale}) so callers
- * degrade gracefully (no chord) rather than indexing out of range.
+ * degrade gracefully (no chord) rather than indexing out of range. A NEGATIVE
+ * degree (the silence sentinel) also returns `[]`, so the sentinel is self-enforcing
+ * — a caller that forgets to gate it gets silence, not a wrong (wrapped) chord.
  */
 export function diatonicTriad(spec: ScaleSpec, degree: number): number[] {
+  if (degree < 0) return [];
   const intervals = SCALE_TYPES[spec.type].intervals;
   if (intervals.length !== 7) return [];
   const baseNote = (spec.baseOctave + 1) * 12 + spec.root;

--- a/src/nodes/music/expression_chord.ts
+++ b/src/nodes/music/expression_chord.ts
@@ -30,7 +30,12 @@ import { defineNode } from '@/dag';
 import type { NodeContext } from '@/dag';
 import { diatonicTriad, midiToFreq, type ScaleSpec } from '@/music/theory';
 import { InstrumentSchema } from '@/music/instruments';
-import { DEFAULT_EXPRESSION_TO_DEGREE, type ExpressionScores, type ExpressionLabel } from '@/music/expression';
+import {
+  DEFAULT_EXPRESSION_TO_DEGREE,
+  SILENCE_DEGREE,
+  type ExpressionScores,
+  type ExpressionLabel,
+} from '@/music/expression';
 import { VOICINGS, RENDERINGS, voiceTriad, renderGains, type VoicingId, type RenderingId } from '@/music/voicing';
 import type { VoiceParams } from '../domain';
 
@@ -117,12 +122,14 @@ export const expressionChordNode = defineNode<Params>({
 
         // Which scale degree the expression plays — the live per-expression map
         // (from the store), falling back to the confusion-aware default per label.
+        // A negative degree (SILENCE_DEGREE) means "play nothing" (e.g. neutral).
         const degrees = inputs.degrees as Partial<Record<ExpressionLabel, number>> | undefined;
         const degreeFor = (label: ExpressionLabel) =>
           degrees?.[label] ?? DEFAULT_EXPRESSION_TO_DEGREE[label];
-        // The un-voiced scale triad (3 tones) for the overlay highlight; [] off a
-        // seven-note scale or when idle.
-        const triad = active ? diatonicTriad(spec!, degreeFor(expr!.label)) : [];
+        const degree = active ? degreeFor(expr!.label) : SILENCE_DEGREE;
+        // The un-voiced scale triad (3 tones) for the overlay highlight; [] when
+        // idle, off a seven-note scale, or when the expression maps to silence.
+        const triad = degree >= 0 ? diatonicTriad(spec!, degree) : [];
         // Voice the chord, then sort ascending by pitch so arpeggios traverse
         // low→high by actual pitch (some voicings stack out of pitch order). The
         // ids stay stable (one per array slot), so the synth still releases all.

--- a/src/settings/schema.ts
+++ b/src/settings/schema.ts
@@ -57,8 +57,9 @@ export const FaceExprSchema = z
     sensitivity: z
       .record(z.string(), z.number().min(0).max(1))
       .default({ ...DEFAULT_EXPRESSION_SENSITIVITY }),
+    // -1 = silence (SILENCE_DEGREE, play nothing); 0..6 = a scale degree.
     degrees: z
-      .record(z.string(), z.number().int().min(0).max(6))
+      .record(z.string(), z.number().int().min(-1).max(6))
       .default({ ...DEFAULT_EXPRESSION_TO_DEGREE }),
   })
   .default({

--- a/test/app_store.test.ts
+++ b/test/app_store.test.ts
@@ -58,7 +58,7 @@ describe('control store', () => {
     expect(fe.sensitivity.angry).toBe(0.2);
     expect(fe.sensitivity.happy).toBe(0.5); // sibling sensitivity untouched (default)
     expect(fe.degrees.happy).toBe(4);
-    expect(fe.degrees.neutral).toBe(5); // sibling degree untouched (confusion-aware default)
+    expect(fe.degrees.neutral).toBe(-1); // sibling untouched — neutral's default is silence (-1)
   });
 
   it('setVoice with sync ON mirrors both hands but keeps instruments distinct', () => {
@@ -254,7 +254,8 @@ describe('store-controls node reads the store', () => {
     expect(out.chordConfig).toMatchObject({ voicing: 'spread', gain: 0.22, bpm: 100 });
     // The expression-mapping ports: per-emotion sensitivity + per-expression degrees.
     expect(out.expressionSensitivity).toMatchObject({ happy: 0.5, angry: 0.45 });
-    expect((out.expressionDegrees as Record<string, number>).neutral).toBe(5);
+    expect((out.expressionDegrees as Record<string, number>).neutral).toBe(-1); // silence default
+    expect((out.expressionDegrees as Record<string, number>).happy).toBe(0);
   });
 
   it('emits nothing when no controls getter is injected (safe before host wires it)', () => {

--- a/test/expression_map.test.ts
+++ b/test/expression_map.test.ts
@@ -12,6 +12,7 @@ import {
   decideExpression,
   sensitivityToThreshold,
   expressionThresholds,
+  EXPRESSION_PROTOTYPES,
   EXPRESSION_THRESHOLD_BOUNDS,
   DEFAULT_EXPRESSION_SENSITIVITY,
   triadDegreeSet,
@@ -143,7 +144,7 @@ describe('reachability: sad / disgusted / fearful fire after the prototype/thres
       mouthFrownLeft: 0.25, mouthFrownRight: 0.25, browInnerUp: 0.2,
       mouthLowerDownLeft: 0.8, mouthLowerDownRight: 0.8,
     });
-    expect(a.sad).toBeGreaterThan(0.375);
+    expect(a.sad).toBeGreaterThan(expressionThresholds().sad); // clears its own firing bar
     expect(decideExpression(a).label).toBe('sad');
   });
 
@@ -151,8 +152,9 @@ describe('reachability: sad / disgusted / fearful fire after the prototype/thres
     const a = expressionActivations({
       noseSneerLeft: 0.1, noseSneerRight: 0.1, mouthUpperUpLeft: 0.8, mouthUpperUpRight: 0.8,
     });
-    expect(a.disgusted).toBeGreaterThan(0.375);
+    expect(a.disgusted).toBeGreaterThan(expressionThresholds().disgusted);
     expect(decideExpression(a).label).toBe('disgusted');
+    expect(a.angry).toBeLessThan(expressionThresholds().angry); // the browDown component stays under angry
   });
 
   it('fearful wins at the relaxed 0.40 bar on a wide-eyed, open-jaw, lip-stretched face', () => {
@@ -161,6 +163,14 @@ describe('reachability: sad / disgusted / fearful fire after the prototype/thres
       mouthStretchLeft: 0.5, mouthStretchRight: 0.5,
     });
     expect(decideExpression(a).label).toBe('fearful');
+  });
+
+  it('does NOT false-fire on non-emotional faces (open mouth → neutral, smile → not disgusted)', () => {
+    // An open mouth drives mouthLowerDown high via jawOpen, but with no frown it
+    // must stay neutral (the lower-lip weight is capped below the bar).
+    expect(decideExpression(expressionActivations({ jawOpen: 1, mouthLowerDownLeft: 1, mouthLowerDownRight: 1 })).label).toBe('neutral');
+    // A broad smile must not leak into disgusted via any upper-lip movement.
+    expect(decideExpression(expressionActivations({ mouthSmileLeft: 1, mouthSmileRight: 1 })).label).not.toBe('disgusted');
   });
 });
 
@@ -251,7 +261,10 @@ describe('expression help content', () => {
     for (const h of EXPRESSION_HELP) {
       expect(h.keyAction.length).toBeGreaterThan(0);
       expect(h.blendshapes.length).toBeGreaterThan(0);
-      for (const b of h.blendshapes) expect(b).toMatch(/^[a-zA-Z]+$/); // real ARKit channel names
+      // The channels named in each help card are exactly the ones the classifier
+      // scores for that emotion (catches a typo or drift after a prototype retune).
+      const protoKeys = new Set(Object.keys(EXPRESSION_PROTOTYPES[h.name]));
+      for (const b of h.blendshapes) expect(protoKeys.has(b)).toBe(true);
     }
     // The model's under-reported emotions are flagged as harder to detect.
     const hard = new Set(EXPRESSION_HELP.filter((h) => h.hardToDetect).map((h) => h.name));

--- a/test/expression_map.test.ts
+++ b/test/expression_map.test.ts
@@ -23,6 +23,7 @@ import {
   type Emotion,
   type ExpressionLabel,
 } from '@/music/expression';
+import { EXPRESSION_HELP } from '@/app/expressionHelp';
 
 const zeroActs = (): Record<Emotion, number> =>
   Object.fromEntries(EMOTIONS.map((e) => [e, 0])) as Record<Emotion, number>;
@@ -133,6 +134,36 @@ describe('decideExpression (per-class thresholds + neutral abstention)', () => {
   });
 });
 
+describe('reachability: sad / disgusted / fearful fire after the prototype/threshold tuning', () => {
+  // The MediaPipe model under-reports mouthFrown / noseSneer / browInnerUp / eyeWide;
+  // the prototypes were rebalanced onto the reliable neighbour channels so a real
+  // (partial on the weak channels) expression clears the bar. These pin that.
+  it('sad fires on a strong frown even with the weak channels only partial', () => {
+    const a = expressionActivations({
+      mouthFrownLeft: 0.25, mouthFrownRight: 0.25, browInnerUp: 0.2,
+      mouthLowerDownLeft: 0.8, mouthLowerDownRight: 0.8,
+    });
+    expect(a.sad).toBeGreaterThan(0.375);
+    expect(decideExpression(a).label).toBe('sad');
+  });
+
+  it('disgusted fires on a strong upper-lip raise even with noseSneer near zero', () => {
+    const a = expressionActivations({
+      noseSneerLeft: 0.1, noseSneerRight: 0.1, mouthUpperUpLeft: 0.8, mouthUpperUpRight: 0.8,
+    });
+    expect(a.disgusted).toBeGreaterThan(0.375);
+    expect(decideExpression(a).label).toBe('disgusted');
+  });
+
+  it('fearful wins at the relaxed 0.40 bar on a wide-eyed, open-jaw, lip-stretched face', () => {
+    const a = expressionActivations({
+      jawOpen: 0.5, eyeWideLeft: 0.7, eyeWideRight: 0.7, browInnerUp: 0.3,
+      mouthStretchLeft: 0.5, mouthStretchRight: 0.5,
+    });
+    expect(decideExpression(a).label).toBe('fearful');
+  });
+});
+
 describe('sensitivity ↔ threshold', () => {
   it('sensitivityToThreshold is monotone DECREASING (more sensitive = lower bar)', () => {
     const b = EXPRESSION_THRESHOLD_BOUNDS.happy;
@@ -210,5 +241,20 @@ describe('confusion-aware assignment', () => {
     m[idx.neutral][idx.happy] = 1;
     const opt = optimalExpressionToDegree(m);
     expect(sharedTriadNotes(opt.happy, opt.neutral)).toBe(2);
+  });
+});
+
+describe('expression help content', () => {
+  it('covers every emotion with a key action + real blendshape channels; flags the hard ones', () => {
+    const helpNames = new Set(EXPRESSION_HELP.map((h) => h.name));
+    for (const e of EMOTIONS) expect(helpNames.has(e)).toBe(true); // one card per emotion
+    for (const h of EXPRESSION_HELP) {
+      expect(h.keyAction.length).toBeGreaterThan(0);
+      expect(h.blendshapes.length).toBeGreaterThan(0);
+      for (const b of h.blendshapes) expect(b).toMatch(/^[a-zA-Z]+$/); // real ARKit channel names
+    }
+    // The model's under-reported emotions are flagged as harder to detect.
+    const hard = new Set(EXPRESSION_HELP.filter((h) => h.hardToDetect).map((h) => h.name));
+    expect(hard).toEqual(new Set(['sad', 'fearful', 'disgusted']));
   });
 });

--- a/test/face_chord_nodes.test.ts
+++ b/test/face_chord_nodes.test.ts
@@ -175,6 +175,33 @@ describe('expression-chord node', () => {
     expect(out[0].triad).toEqual(diatonicTriad(cMajor, 4)); // V triad, not the default tonic
   });
 
+  it('plays nothing when the expression maps to silence (SILENCE_DEGREE = -1)', async () => {
+    const node = expressionChordNode.make(expressionChordNode.params.parse({}));
+    const out = await replayNode(node, {
+      expression: [happyExpr],
+      spec: [cMajor],
+      faceMapping: ['chord'],
+      degrees: [{ ...DEFAULT_EXPRESSION_TO_DEGREE, happy: -1 }], // happy → silence
+    });
+    expect(out[0].triad).toEqual([]); // no chord
+    expect((out[0].params as SynthParams).voices.every((v) => !v.present)).toBe(true);
+  });
+
+  it('neutral defaults to silence — a neutral face plays no chord', async () => {
+    const neutralExpr: ExpressionScores = {
+      present: true,
+      label: 'neutral',
+      scores: [0, 0, 0, 0, 0, 0],
+      thresholds: [0.4, 0.4, 0.45, 0.4, 0.45, 0.4],
+      fired: [false, false, false, false, false, false],
+    };
+    // No `degrees` input → falls back to DEFAULT_EXPRESSION_TO_DEGREE (neutral = -1).
+    const out = await chordVoices(neutralExpr, 'chord');
+    expect(out.triad).toEqual([]);
+    expect((out.params as SynthParams).voices.every((v) => !v.present)).toBe(true);
+    expect(DEFAULT_EXPRESSION_TO_DEGREE.neutral).toBe(-1); // pin the silence default
+  });
+
   it('stays silent on a non-seven-note scale even in chord mode', async () => {
     const out = await chordVoices(happyExpr, 'chord', { ...cMajor, type: 'pentatonic' });
     expect(out.triad).toEqual([]);

--- a/test/settings_presets.test.ts
+++ b/test/settings_presets.test.ts
@@ -101,7 +101,8 @@ describe('preset persistence', () => {
   it('defaults faceExpr when omitted (pre-expression-mapping presets)', () => {
     const fe = sampleSettings().faceExpr;
     expect(fe.sensitivity.angry).toBe(0.45); // DEFAULT_EXPRESSION_SENSITIVITY.angry
-    expect(fe.degrees.neutral).toBe(5); // the confusion-aware default (RECOMMENDED…neutral)
+    expect(fe.degrees.neutral).toBe(-1); // SILENCE_DEGREE — a resting face plays nothing by default
+    expect(fe.degrees.happy).toBe(0); // emotions keep the confusion-aware default (happy → tonic)
   });
 
   it('migrates a pre-#64 preset (boolean faceEnabled) to faceMapping on load', () => {

--- a/test/settings_presets.test.ts
+++ b/test/settings_presets.test.ts
@@ -105,6 +105,15 @@ describe('preset persistence', () => {
     expect(fe.degrees.happy).toBe(0); // emotions keep the confusion-aware default (happy → tonic)
   });
 
+  it('persists a player-set silence assignment and rejects an out-of-range degree', () => {
+    // A non-neutral expression assigned to silence (-1) must survive the schema.
+    const parsed = SettingsSchema.parse({ ...sampleSettings(), faceExpr: { degrees: { happy: -1 } } });
+    expect(parsed.faceExpr.degrees.happy).toBe(-1);
+    // The new lower bound (min -1) still rejects -2 and the max still rejects 7.
+    expect(SettingsSchema.safeParse({ ...sampleSettings(), faceExpr: { degrees: { happy: -2 } } }).success).toBe(false);
+    expect(SettingsSchema.safeParse({ ...sampleSettings(), faceExpr: { degrees: { happy: 7 } } }).success).toBe(false);
+  });
+
   it('migrates a pre-#64 preset (boolean faceEnabled) to faceMapping on load', () => {
     const legacy = {
       id: 'legacy',


### PR DESCRIPTION
Addresses two requests: a help system for the expression detector, and making silence a first-class chord assignment. Plus a model-grounded fix for the three emotions that wouldn't trigger.

## Reachability (sad / disgusted / fearful)
A research pass confirmed this wasn't just a how-to gap: **MediaPipe genuinely under-reports** the channels these lean on (noseSneer, mouthFrown, browInnerUp, eyeWide cap near zero even on a strong genuine expression — MediaPipe issues [#5329](https://github.com/google-ai-edge/mediapipe/issues/5329), [#4450](https://github.com/google/mediapipe/issues/4450)). The audit found **sad literally unreachable** (100% hard-weight). So:
- Rebalanced the sad + disgusted prototypes onto the reliable neighbour channels (lower-lip drop; upper-lip raise); relaxed fearful's firing bar 0.425→0.40.
- The lower-lip weight is **capped** so an open mouth (yawn / loud singing) can't false-fire sad on its own — caught in adversarial review.
- happy/angry/surprised untouched; rest-state still abstains. Reachability + false-positive guards tested.

## Help panel (ⓘ)
An info icon by the face-status readout opens a panel: where the model comes from, per-emotion how-to (key action, common slip, how to tell apart confusable pairs, the exact channels it reads), the three hard ones flagged, and links to authoritative reference imagery (MediaPipe docs, ARKit blendshape catalog, the Ekman expression chart). Content is grounded in the actual classifier prototypes (a test enforces the channels match). **Verified in-browser** the modal portals full-screen (it was being clipped inside the backdrop-blur panel — a critical review find, fixed with a portal).

## Silence as a chord choice
`SILENCE_DEGREE` (-1): an expression can map to "play nothing". **Neutral now defaults to silence** (a resting face is quiet) — but any expression can be set to silence, and neutral can be assigned a degree. The degree dropdown gains a "Silence" option.

## Process
Multi-agent adversarial review (4 dimensions, double-verified): **9 confirmed, all fixed** — a critical modal-portal layout bug and a major sad false-positive among them. **273 tests**, deterministic; typecheck + build + catalog clean; modal verified live in Chrome.

https://claude.ai/code/session_01JEoe7y1hA5KdEAvvpQXxxt
