### PR TITLE
Add 'kiss' as a 7th expression + hand-picked chord map (all 7 chords)

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -94,7 +94,7 @@ Face blendshapes → normalized expression controls (smile, mouthOpen, brow, bli
 - **params:** gain (number=1), smoothing (number=0)
 
 #### `face-expression` — Face Expression
-Face blendshapes → one of 6 emotions or neutral (per-class thresholds + neutral abstention, smoothing, enter/exit hysteresis, dwell).
+Face blendshapes → one of 7 emotions or neutral (per-class thresholds + neutral abstention, smoothing, enter/exit hysteresis, dwell).
 
 - **roles:** feature
 - **in:** face:face-frame, sensitivity:expression-sensitivity

--- a/public/catalog.json
+++ b/public/catalog.json
@@ -217,7 +217,7 @@
   {
     "type": "face-expression",
     "title": "Face Expression",
-    "description": "Face blendshapes → one of 6 emotions or neutral (per-class thresholds + neutral abstention, smoothing, enter/exit hysteresis, dwell).",
+    "description": "Face blendshapes → one of 7 emotions or neutral (per-class thresholds + neutral abstention, smoothing, enter/exit hysteresis, dwell).",
     "roles": [
       "feature"
     ],

--- a/public/manual.html
+++ b/public/manual.html
@@ -111,7 +111,7 @@
     </div>
     <div class="node">
       <h4><code>face-expression</code> <span class="title">Face Expression</span></h4>
-      <p>Face blendshapes → one of 6 emotions or neutral (per-class thresholds + neutral abstention, smoothing, enter/exit hysteresis, dwell).</p>
+      <p>Face blendshapes → one of 7 emotions or neutral (per-class thresholds + neutral abstention, smoothing, enter/exit hysteresis, dwell).</p>
       <dl>
         <dt>roles</dt><dd>feature</dd>
         <dt>in</dt><dd>face:face-frame, sensitivity:expression-sensitivity</dd>

--- a/src/app/expressionHelp.ts
+++ b/src/app/expressionHelp.ts
@@ -31,7 +31,7 @@ export interface EmotionHelp {
 export const MODEL_ORIGIN =
   'Expressions are read by Google’s MediaPipe Face Landmarker — it tracks 478 face points and outputs 52 “blendshape” values (named after Apple’s ARKit face shapes, e.g. jawOpen, browInnerUp). Your face is matched against a per-emotion template of expected blendshapes, and an emotion fires when it’s activated enough. These are AR-entertainment-grade signals: a few channels (nose-wrinkle, frown, inner-brow, eye-widen) read weakly, so the emotions that rely on them take more effort — those are marked “harder to detect” below, and you can lower their sensitivity bar in Expression sensitivity / mapping.';
 
-/** Per-emotion how-to, in EMOTIONS order (happy, sad, angry, surprised, fearful, disgusted). */
+/** Per-emotion how-to, in EMOTIONS order (happy, sad, angry, surprised, fearful, disgusted, kiss). */
 export const EXPRESSION_HELP: EmotionHelp[] = [
   {
     name: 'happy',

--- a/src/app/expressionHelp.ts
+++ b/src/app/expressionHelp.ts
@@ -84,6 +84,14 @@ export const EXPRESSION_HELP: EmotionHelp[] = [
     blendshapes: ['noseSneerLeft', 'noseSneerRight', 'mouthUpperUpLeft', 'mouthUpperUpRight', 'browDownLeft', 'browDownRight'],
     hardToDetect: true,
   },
+  {
+    name: 'kiss',
+    keyAction: 'Push your lips forward into an “ooo” / kiss.',
+    howTo: 'Funnel your lips forward into a rounded “ooo” or kiss shape — push them outward, don’t just squeeze flat — and hold briefly. The model reads this one reliably.',
+    commonMistake: 'Pressing the lips flat instead of funneling them FORWARD; the forward “ooo” shape (mouthFunnel) is what registers.',
+    avoidConfusion: 'Keep the jaw closed and don’t smile — a wide-open or smiling mouth reads as surprised or happy instead.',
+    blendshapes: ['mouthFunnel', 'mouthPucker'],
+  },
 ];
 
 /** Authoritative reference links (the model + visual blendshape/emotion catalogs). */

--- a/src/music/expression.ts
+++ b/src/music/expression.ts
@@ -23,7 +23,9 @@
  * swap them for a model-specific calibration without touching the algorithms.
  */
 
-/** The seven canonical expressions, in a stable index order. */
+/** The canonical expressions, in a stable index order: the scored {@link EMOTIONS}
+ *  followed by `neutral` (the abstention fallback). `kiss` (lips funneled forward)
+ *  is the 7th scored emotion — a reliable, distinct face for the diminished vii. */
 export const EXPRESSIONS = [
   'happy',
   'sad',
@@ -31,20 +33,21 @@ export const EXPRESSIONS = [
   'surprised',
   'fearful',
   'disgusted',
+  'kiss',
   'neutral',
 ] as const;
 
 export type ExpressionLabel = (typeof EXPRESSIONS)[number];
 
 /**
- * The six *scored* emotions. Neutral is the abstention FALLBACK (the decision when
- * no emotion clears its threshold), not a scored class — for a prototype/cosine
- * classifier without a strong neutral exemplar, abstention is far more robust than
- * asking a neutral prototype to out-score everything (Bishop, reject option;
- * open-set recognition bounds the acceptance region instead of partitioning all of
- * feature space among the known classes).
+ * The *scored* emotions. Neutral is the abstention FALLBACK (the decision when no
+ * emotion clears its threshold), not a scored class — for a prototype classifier
+ * without a strong neutral exemplar, abstention is far more robust than asking a
+ * neutral prototype to out-score everything (Bishop, reject option; open-set
+ * recognition bounds the acceptance region instead of partitioning all of feature
+ * space among the known classes).
  */
-export const EMOTIONS = ['happy', 'sad', 'angry', 'surprised', 'fearful', 'disgusted'] as const;
+export const EMOTIONS = ['happy', 'sad', 'angry', 'surprised', 'fearful', 'disgusted', 'kiss'] as const;
 export type Emotion = (typeof EMOTIONS)[number];
 
 /** A sparse weighting over blendshape names (missing keys = 0). */
@@ -133,6 +136,14 @@ export const EXPRESSION_PROTOTYPES: Record<Emotion, BlendshapeWeights> = {
     browDownLeft: 0.4,
     browDownRight: 0.4,
   },
+  kiss: {
+    // Lips funneled forward into an "ooo"/kiss. mouthFunnel is the reliable,
+    // load-bearing channel; mouthPucker is noisier so it only assists. These touch
+    // NONE of the other prototypes' channels, so kiss neither cross-trips nor is
+    // cross-tripped by the six emotions. den 1.0.
+    mouthFunnel: 0.7,
+    mouthPucker: 0.3,
+  },
 };
 
 /**
@@ -183,6 +194,8 @@ export const EXPRESSION_THRESHOLD_BOUNDS: Record<Emotion, ExpressionThresholdBou
   // because the eyeWide/browInnerUp channels read weakly on this model.
   fearful: { min: 0.2, max: 0.6, delta: 0.06 },
   disgusted: { min: 0.15, max: 0.6, delta: 0.06 },
+  // Reliable channel → normal bounds.
+  kiss: { min: 0.15, max: 0.6, delta: 0.06 },
 };
 
 export type ExpressionSensitivity = Record<Emotion, number>;
@@ -195,6 +208,7 @@ export const DEFAULT_EXPRESSION_SENSITIVITY: ExpressionSensitivity = {
   surprised: 0.5,
   fearful: 0.5,
   disgusted: 0.5,
+  kiss: 0.5,
 };
 
 /** A per-emotion sensitivity in [0,1] → its firing threshold, monotone DECREASING
@@ -272,6 +286,21 @@ export const ABSENT_EXPRESSION: ExpressionScores = {
 };
 
 // ---- Confusion-aware expression → scale-degree assignment -----------------
+//
+// This is the ORIGINAL confusion-aware auto-assignment (issue #64). The shipped
+// DEFAULT_EXPRESSION_TO_DEGREE is now a hand-picked map (below), so this machinery
+// is a reference/optimizer kept over its original 7-label set — `kiss` (the later
+// 7th emotion) is NOT part of it.
+export const CONFUSION_EXPRESSIONS = [
+  'happy',
+  'sad',
+  'angry',
+  'surprised',
+  'fearful',
+  'disgusted',
+  'neutral',
+] as const;
+type ConfusionLabel = (typeof CONFUSION_EXPRESSIONS)[number];
 
 /**
  * The three scale-degree indices (0..6) of the diatonic triad rooted on
@@ -297,7 +326,7 @@ export function sharedTriadNotes(degreeA: number, degreeB: number): number {
  * FER literature/human studies (issue #64 refs [6]-[9]): higher = more often
  * mistaken for one another. The negative cluster {anger, disgust, fear, sad} +
  * neutral is the confusable core; happy is the most distinct, surprise second.
- * Indexed by {@link EXPRESSIONS} order; only the listed pairs are non-zero.
+ * Indexed by {@link CONFUSION_EXPRESSIONS} order; only the listed pairs are non-zero.
  * Override with a *measured* matrix and re-run {@link optimalExpressionToDegree}.
  */
 export const CONFUSION_FER2013: number[][] = buildConfusionMatrix({
@@ -317,11 +346,11 @@ export const CONFUSION_FER2013: number[][] = buildConfusionMatrix({
 });
 
 function buildConfusionMatrix(pairs: Record<string, number>): number[][] {
-  const idx = new Map(EXPRESSIONS.map((e, i) => [e, i]));
-  const n = EXPRESSIONS.length;
+  const idx = new Map(CONFUSION_EXPRESSIONS.map((e, i) => [e, i]));
+  const n = CONFUSION_EXPRESSIONS.length;
   const m = Array.from({ length: n }, () => new Array(n).fill(0));
   for (const [pair, w] of Object.entries(pairs)) {
-    const [a, b] = pair.split('|') as ExpressionLabel[];
+    const [a, b] = pair.split('|') as ConfusionLabel[];
     const i = idx.get(a);
     const j = idx.get(b);
     if (i === undefined || j === undefined) throw new Error(`unknown expression in pair: ${pair}`);
@@ -331,8 +360,11 @@ function buildConfusionMatrix(pairs: Record<string, number>): number[][] {
   return m;
 }
 
-/** An expression→degree bijection, keyed by {@link ExpressionLabel}. */
-export type ExpressionToDegree = Record<ExpressionLabel, number>;
+/** An expression→scale-degree map, keyed by expression label. (A degree of
+ *  {@link SILENCE_DEGREE} means silence.) The confusion optimizer below produces
+ *  one over the original 7 labels; {@link DEFAULT_EXPRESSION_TO_DEGREE} is the full
+ *  hand-picked map over all {@link EXPRESSIONS}. */
+export type ExpressionToDegree = Record<string, number>;
 
 /**
  * The assignment objective: total confusion-weighted shared-note mass. Higher is
@@ -343,11 +375,11 @@ export function assignmentObjective(
   confusion: number[][] = CONFUSION_FER2013,
 ): number {
   let total = 0;
-  for (let i = 0; i < EXPRESSIONS.length; i++) {
-    for (let j = i + 1; j < EXPRESSIONS.length; j++) {
+  for (let i = 0; i < CONFUSION_EXPRESSIONS.length; i++) {
+    for (let j = i + 1; j < CONFUSION_EXPRESSIONS.length; j++) {
       const w = confusion[i][j];
       if (w === 0) continue;
-      total += w * sharedTriadNotes(assignment[EXPRESSIONS[i]], assignment[EXPRESSIONS[j]]);
+      total += w * sharedTriadNotes(assignment[CONFUSION_EXPRESSIONS[i]], assignment[CONFUSION_EXPRESSIONS[j]]);
     }
   }
   return total;
@@ -365,7 +397,7 @@ export function optimalExpressionToDegree(
   let bestScore = -Infinity;
   for (const perm of permutations([0, 1, 2, 3, 4, 5, 6])) {
     const assignment = Object.fromEntries(
-      EXPRESSIONS.map((e, i) => [e, perm[i]]),
+      CONFUSION_EXPRESSIONS.map((e, i) => [e, perm[i]]),
     ) as ExpressionToDegree;
     const score = assignmentObjective(assignment, confusion);
     if (score > bestScore) {
@@ -425,13 +457,25 @@ export const RECOMMENDED_EXPRESSION_TO_DEGREE: ExpressionToDegree = {
 export const SILENCE_DEGREE = -1;
 
 /**
- * The expression→degree assignment the chord mapping ships with: the confusion-aware
- * {@link RECOMMENDED_EXPRESSION_TO_DEGREE} for the six emotions, but `neutral`
- * defaults to {@link SILENCE_DEGREE} (silence) — a resting face plays nothing
- * unless the player assigns it a degree. (RECOMMENDED itself stays the pure 0..6
- * bijection the optimizer produces, for the confusion-assignment tests.)
+ * The expression→degree assignment the chord mapping ships with — a HAND-PICKED map
+ * (each emotion to a distinct scale degree, covering all of I..vii°), superseding
+ * the confusion-aware auto-assignment ({@link RECOMMENDED_EXPRESSION_TO_DEGREE},
+ * kept as a reference). In C major:
+ *
+ *   happy→I(0)·C    fearful→ii(1)·Dm   disgusted→iii(2)·Em   surprised→IV(3)·F
+ *   angry→V(4)·G    sad→vi(5)·Am       kiss→vii°(6)·B°       neutral→silence
+ *
+ * Happy sits on the tonic (home); the new `kiss` covers the tense diminished vii°;
+ * `neutral` defaults to {@link SILENCE_DEGREE} (a resting face plays nothing). All
+ * editable per-expression in the UI.
  */
 export const DEFAULT_EXPRESSION_TO_DEGREE: ExpressionToDegree = {
-  ...RECOMMENDED_EXPRESSION_TO_DEGREE,
-  neutral: SILENCE_DEGREE,
+  happy: 0, // I
+  fearful: 1, // ii
+  disgusted: 2, // iii
+  surprised: 3, // IV
+  angry: 4, // V
+  sad: 5, // vi
+  kiss: 6, // vii°
+  neutral: SILENCE_DEGREE, // silence
 };

--- a/src/music/expression.ts
+++ b/src/music/expression.ts
@@ -57,7 +57,7 @@ export type BlendshapeWeights = Record<string, number>;
  * The classifier's per-frame result (flows on the DAG edge). `scores` are the
  * per-emotion activations and `thresholds` their effective firing thresholds (both
  * aligned to {@link EMOTIONS}, for the readout); `fired` is score ≥ threshold; and
- * `label` is the decided expression — one of the six emotions or `neutral`.
+ * `label` is the decided expression — one of the seven emotions or `neutral`.
  */
 export interface ExpressionScores {
   present: boolean;
@@ -140,7 +140,7 @@ export const EXPRESSION_PROTOTYPES: Record<Emotion, BlendshapeWeights> = {
     // Lips funneled forward into an "ooo"/kiss. mouthFunnel is the reliable,
     // load-bearing channel; mouthPucker is noisier so it only assists. These touch
     // NONE of the other prototypes' channels, so kiss neither cross-trips nor is
-    // cross-tripped by the six emotions. den 1.0.
+    // cross-tripped by the other six emotions. den 1.0.
     mouthFunnel: 0.7,
     mouthPucker: 0.3,
   },

--- a/src/nodes/features/face_expression.ts
+++ b/src/nodes/features/face_expression.ts
@@ -51,7 +51,7 @@ export const faceExpressionNode = defineNode<Params>({
   roles: ['feature'],
   title: 'Face Expression',
   description:
-    'Face blendshapes → one of 6 emotions or neutral (per-class thresholds + neutral abstention, smoothing, enter/exit hysteresis, dwell).',
+    'Face blendshapes → one of 7 emotions or neutral (per-class thresholds + neutral abstention, smoothing, enter/exit hysteresis, dwell).',
   inputs: [
     { name: 'face', kind: 'face-frame' },
     // Live per-emotion sensitivities [0,1] (from the store); optional → defaults.

--- a/src/nodes/features/face_expression.ts
+++ b/src/nodes/features/face_expression.ts
@@ -1,6 +1,6 @@
 /**
  * `face-expression` node — turns the 52 MediaPipe/ARKit blendshapes of a
- * {@link FaceFrame} into a decided expression (one of six emotions or `neutral`),
+ * {@link FaceFrame} into a decided expression (one of seven emotions or `neutral`),
  * the sibling of `face-features`. No extra model, no extra bytes: it scores the
  * blendshapes against FACS-grounded prototypes ({@link expressionActivations}) and
  * applies the research-grounded decision + stabilization stack:

--- a/src/settings/schema.ts
+++ b/src/settings/schema.ts
@@ -69,7 +69,7 @@ export const FaceExprSchema = z
 export type FaceExpr = z.infer<typeof FaceExprSchema>;
 
 /** The shipped defaults for the expression mapping (research-grounded sensitivity
- *  + the confusion-aware degree assignment). */
+ *  + the hand-picked degree assignment — one diatonic degree per emotion). */
 export const DEFAULT_FACE_EXPR: FaceExpr = {
   sensitivity: { ...DEFAULT_EXPRESSION_SENSITIVITY },
   degrees: { ...DEFAULT_EXPRESSION_TO_DEGREE },

--- a/test/app_store.test.ts
+++ b/test/app_store.test.ts
@@ -197,6 +197,10 @@ describe('persist migration (v1 → v2, returning users)', () => {
     expect(merged.faceExpr.sensitivity.angry).toBe(0.1); // kept
     expect(merged.faceExpr.sensitivity.happy).toBe(0.5); // filled from default
     expect(typeof merged.faceExpr.degrees.happy).toBe('number'); // degree map filled too
+    // A pre-kiss blob lacks the `kiss` key entirely — it must materialize from the
+    // defaults (else its sensitivity slider / degree would bind undefined).
+    expect(merged.faceExpr.sensitivity.kiss).toBe(0.5);
+    expect(merged.faceExpr.degrees.kiss).toBe(6); // vii°
   });
 
   it('mergeControls clamps an unknown faceMapping to a safe value', () => {

--- a/test/expression_map.test.ts
+++ b/test/expression_map.test.ts
@@ -6,8 +6,9 @@
 import { describe, it, expect } from 'vitest';
 import { diatonicTriad, isSevenNoteScale, type ScaleSpec } from '@/music/theory';
 import {
-  EXPRESSIONS,
   EMOTIONS,
+  CONFUSION_EXPRESSIONS,
+  DEFAULT_EXPRESSION_TO_DEGREE,
   expressionActivations,
   decideExpression,
   sensitivityToThreshold,
@@ -22,7 +23,6 @@ import {
   RECOMMENDED_EXPRESSION_TO_DEGREE,
   CONFUSION_FER2013,
   type Emotion,
-  type ExpressionLabel,
 } from '@/music/expression';
 import { EXPRESSION_HELP } from '@/app/expressionHelp';
 
@@ -165,6 +165,15 @@ describe('reachability: sad / disgusted / fearful fire after the prototype/thres
     expect(decideExpression(a).label).toBe('fearful');
   });
 
+  it('kiss: funneled-lips "ooo" fires kiss, and kiss does not cross-trip happy/surprise', () => {
+    const a = expressionActivations({ mouthFunnel: 0.8, mouthPucker: 0.5 }); // kiss = 0.71
+    expect(a.kiss).toBeGreaterThan(expressionThresholds().kiss);
+    expect(decideExpression(a).label).toBe('kiss');
+    // A smile or an open-mouth surprise (no mouthFunnel) must not read as kiss.
+    expect(decideExpression(expressionActivations({ mouthSmileLeft: 1, mouthSmileRight: 1 })).label).not.toBe('kiss');
+    expect(decideExpression(expressionActivations({ jawOpen: 1, eyeWideLeft: 0.8, eyeWideRight: 0.8 })).label).not.toBe('kiss');
+  });
+
   it('does NOT false-fire on non-emotional faces (open mouth → neutral, smile → not disgusted)', () => {
     // An open mouth drives mouthLowerDown high via jawOpen, but with no frown it
     // must stay neutral (the lower-lip weight is capped below the bar).
@@ -212,9 +221,27 @@ describe('triad note-sharing graph', () => {
   });
 });
 
+describe('shipped default expression→degree map (hand-picked)', () => {
+  it('covers I..vii° once each, kiss on vii°, neutral silent', () => {
+    const d = DEFAULT_EXPRESSION_TO_DEGREE;
+    expect(d.happy).toBe(0); // I
+    expect(d.fearful).toBe(1); // ii
+    expect(d.disgusted).toBe(2); // iii
+    expect(d.surprised).toBe(3); // IV
+    expect(d.angry).toBe(4); // V
+    expect(d.sad).toBe(5); // vi
+    expect(d.kiss).toBe(6); // vii°
+    expect(d.neutral).toBe(-1); // silence
+    // The seven scored emotions cover degrees 0..6 exactly once (all 7 chords).
+    expect(EMOTIONS.map((e) => d[e]).sort((a, b) => a - b)).toEqual([0, 1, 2, 3, 4, 5, 6]);
+  });
+});
+
 describe('confusion-aware assignment', () => {
-  const distinct = (a: Record<ExpressionLabel, number>) =>
-    new Set(Object.values(a)).size === EXPRESSIONS.length;
+  // The confusion optimizer is a bijection over the ORIGINAL 7 labels (it predates
+  // the later `kiss` emotion), so size against CONFUSION_EXPRESSIONS, not EXPRESSIONS.
+  const distinct = (a: Record<string, number>) =>
+    new Set(Object.values(a)).size === CONFUSION_EXPRESSIONS.length;
 
   it('the recommended seed is a valid bijection over degrees 0..6', () => {
     expect(distinct(RECOMMENDED_EXPRESSION_TO_DEGREE)).toBe(true);
@@ -245,7 +272,7 @@ describe('confusion-aware assignment', () => {
   it('recomputes from a custom (measured) matrix without throwing', () => {
     // A trivial matrix: only happy↔neutral confused → they should land on a
     // 2-note-sharing pair in the optimum.
-    const idx = Object.fromEntries(EXPRESSIONS.map((e, i) => [e, i]));
+    const idx = Object.fromEntries(CONFUSION_EXPRESSIONS.map((e, i) => [e, i]));
     const m = Array.from({ length: 7 }, () => new Array(7).fill(0));
     m[idx.happy][idx.neutral] = 1;
     m[idx.neutral][idx.happy] = 1;

--- a/test/expression_map.test.ts
+++ b/test/expression_map.test.ts
@@ -172,6 +172,9 @@ describe('reachability: sad / disgusted / fearful fire after the prototype/thres
     // A smile or an open-mouth surprise (no mouthFunnel) must not read as kiss.
     expect(decideExpression(expressionActivations({ mouthSmileLeft: 1, mouthSmileRight: 1 })).label).not.toBe('kiss');
     expect(decideExpression(expressionActivations({ jawOpen: 1, eyeWideLeft: 0.8, eyeWideRight: 0.8 })).label).not.toBe('kiss');
+    // When kiss CO-FIRES with a weakly-firing emotion, the bigger margin wins —
+    // kiss (0.71, margin 0.335) beats a just-firing happy (0.40, margin 0.025).
+    expect(decideExpression({ ...a, happy: 0.4 }).label).toBe('kiss');
   });
 
   it('does NOT false-fire on non-emotional faces (open mouth → neutral, smile → not disgusted)', () => {

--- a/test/face_chord_nodes.test.ts
+++ b/test/face_chord_nodes.test.ts
@@ -40,6 +40,19 @@ describe('face-expression node', () => {
     expect(out[0].label).toBe('neutral');
   });
 
+  it('classifies a funneled-lips kiss as kiss', async () => {
+    const kiss = frame({ mouthFunnel: 0.8, mouthPucker: 0.5 });
+    const out = await classify(Array(12).fill(kiss), { smoothing: 0.4 });
+    expect(out[out.length - 1].label).toBe('kiss');
+  });
+
+  it('emits one score/threshold/fired per scored emotion (7, incl kiss)', async () => {
+    const out = await classify([frame({ mouthSmileLeft: 1, mouthSmileRight: 1 })]);
+    expect(out[0].scores).toHaveLength(7);
+    expect(out[0].thresholds).toHaveLength(7);
+    expect(out[0].fired).toHaveLength(7);
+  });
+
   it('keeps the smoothed activation scores in [0,1] every tick', async () => {
     const seq = [
       frame({ mouthSmileLeft: 1, mouthSmileRight: 1 }),
@@ -133,9 +146,10 @@ async function chordVoices(
 const happyExpr: ExpressionScores = {
   present: true,
   label: 'happy',
-  scores: [1, 0, 0, 0, 0, 0],
-  thresholds: [0.375, 0.375, 0.4475, 0.375, 0.4475, 0.375],
-  fired: [true, false, false, false, false, false],
+  // Aligned to EMOTIONS: happy, sad, angry, surprised, fearful, disgusted, kiss.
+  scores: [1, 0, 0, 0, 0, 0, 0],
+  thresholds: [0.375, 0.375, 0.4475, 0.375, 0.4, 0.375, 0.375],
+  fired: [true, false, false, false, false, false, false],
 };
 
 describe('expression-chord node', () => {
@@ -191,9 +205,9 @@ describe('expression-chord node', () => {
     const neutralExpr: ExpressionScores = {
       present: true,
       label: 'neutral',
-      scores: [0, 0, 0, 0, 0, 0],
-      thresholds: [0.4, 0.4, 0.45, 0.4, 0.45, 0.4],
-      fired: [false, false, false, false, false, false],
+      scores: [0, 0, 0, 0, 0, 0, 0],
+      thresholds: [0.4, 0.4, 0.45, 0.4, 0.4, 0.4, 0.375],
+      fired: [false, false, false, false, false, false, false],
     };
     // No `degrees` input → falls back to DEFAULT_EXPRESSION_TO_DEGREE (neutral = -1).
     const out = await chordVoices(neutralExpr, 'chord');
@@ -212,9 +226,9 @@ describe('expression-chord node', () => {
     const absent: ExpressionScores = {
       present: false,
       label: 'neutral',
-      scores: [0, 0, 0, 0, 0, 0],
-      thresholds: [0, 0, 0, 0, 0, 0],
-      fired: [false, false, false, false, false, false],
+      scores: [0, 0, 0, 0, 0, 0, 0],
+      thresholds: [0, 0, 0, 0, 0, 0, 0],
+      fired: [false, false, false, false, false, false, false],
     };
     const out = await chordVoices(absent, 'chord');
     expect((out.params as SynthParams).voices.every((v) => !v.present)).toBe(true);

--- a/test/overlay_elements.test.ts
+++ b/test/overlay_elements.test.ts
@@ -275,14 +275,14 @@ describe('canvas-overlay composable elements', () => {
     const expression = {
       present: true,
       label: 'happy',
-      scores: [0.7, 0.1, 0.1, 0.1, 0.1, 0.1],
-      thresholds: [0.4, 0.4, 0.45, 0.4, 0.45, 0.4],
-      fired: [true, false, false, false, false, false],
+      scores: [0.7, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1],
+      thresholds: [0.4, 0.4, 0.45, 0.4, 0.4, 0.4, 0.375],
+      fired: [true, false, false, false, false, false, false],
     };
     const rc = drawWith(onlyElement('faceExpression'), { expression });
     expect(rc.count('fillText')).toBe(1); // the label
     const strokes = rc.calls.filter((c) => c.m === 'stroke');
-    expect(strokes).toHaveLength(12); // 6 emotions × (activation bar + threshold tick)
+    expect(strokes).toHaveLength(14); // 7 emotions × (activation bar + threshold tick)
     expect(strokes[0].stroke).toBe('#f5d142'); // happy bar — the winner glows gold
     expect(strokes[1].stroke).toBe('#ffffff'); // happy's threshold tick is white
     expect(strokes[2].stroke).toBe('#22d3ee'); // sad bar — face cyan (not the winner)
@@ -294,14 +294,14 @@ describe('canvas-overlay composable elements', () => {
     const expression = {
       present: true,
       label: 'neutral',
-      scores: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1],
-      thresholds: [0.4, 0.4, 0.45, 0.4, 0.45, 0.4],
-      fired: [false, false, false, false, false, false],
+      scores: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1],
+      thresholds: [0.4, 0.4, 0.45, 0.4, 0.4, 0.4, 0.375],
+      fired: [false, false, false, false, false, false, false],
     };
     const rc = drawWith(onlyElement('faceExpression'), { expression });
     expect(rc.count('fillText')).toBe(1); // 'neutral' label still renders
     const strokes = rc.calls.filter((c) => c.m === 'stroke');
-    expect(strokes).toHaveLength(12);
+    expect(strokes).toHaveLength(14);
     // No activation bar (even indices) uses the gold winner colour.
     expect(strokes.filter((_, i) => i % 2 === 0).every((s) => s.stroke !== '#f5d142')).toBe(true);
   });
@@ -316,9 +316,9 @@ describe('canvas-overlay composable elements', () => {
     const expression = {
       present: true,
       label: 'happy',
-      scores: [1, 0, 0, 0, 0, 0],
-      thresholds: [0.4, 0.4, 0.45, 0.4, 0.45, 0.4],
-      fired: [true, false, false, false, false, false],
+      scores: [1, 0, 0, 0, 0, 0, 0],
+      thresholds: [0.4, 0.4, 0.45, 0.4, 0.4, 0.4, 0.375],
+      fired: [true, false, false, false, false, false, false],
     };
     expect(drawWith({ ...onlyElement('faceExpression'), faceExpression: { show: false } }, { expression }).count('stroke')).toBe(0);
   });

--- a/test/settings_presets.test.ts
+++ b/test/settings_presets.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect } from 'vitest';
 import { createInMemoryProvider } from '@zodal/store';
 import { createPresetStore, presetId } from '@/settings/presets';
 import { PresetSchema, SettingsSchema, DEFAULT_FACE_CHORD, type Preset, type Settings } from '@/settings/schema';
+import { expressionThresholds, DEFAULT_EXPRESSION_TO_DEGREE } from '@/music/expression';
 
 function sampleSettings(overrides: Partial<Settings> = {}): Settings {
   return SettingsSchema.parse({
@@ -103,6 +104,23 @@ describe('preset persistence', () => {
     expect(fe.sensitivity.angry).toBe(0.45); // DEFAULT_EXPRESSION_SENSITIVITY.angry
     expect(fe.degrees.neutral).toBe(-1); // SILENCE_DEGREE — a resting face plays nothing by default
     expect(fe.degrees.happy).toBe(0); // emotions keep the confusion-aware default (happy → tonic)
+  });
+
+  it('a pre-kiss faceExpr blob: the consumer heals the missing kiss key', () => {
+    // The preset schema (z.record.default) does NOT backfill per-key, so a blob with
+    // only the six original emotions leaves `kiss` undefined — the CONSUMERS fill it.
+    const parsed = SettingsSchema.parse({
+      ...sampleSettings(),
+      faceExpr: {
+        sensitivity: { happy: 0.5, sad: 0.5, angry: 0.5, surprised: 0.5, fearful: 0.5, disgusted: 0.5 },
+        degrees: { happy: 0, fearful: 1, disgusted: 2, surprised: 3, angry: 4, sad: 5, neutral: -1 },
+      },
+    });
+    expect(parsed.faceExpr.sensitivity.kiss).toBeUndefined(); // schema leaves it absent
+    // expressionThresholds heals via ?? DEFAULT_EXPRESSION_SENSITIVITY.kiss → bar 0.375.
+    expect(expressionThresholds(parsed.faceExpr.sensitivity as never).kiss).toBeCloseTo(0.375);
+    // expression-chord's degreeFor falls back to the kiss default (vii°) for the missing key.
+    expect(parsed.faceExpr.degrees.kiss ?? DEFAULT_EXPRESSION_TO_DEGREE.kiss).toBe(6);
   });
 
   it('persists a player-set silence assignment and rejects an out-of-range degree', () => {


### PR DESCRIPTION
The six emotions left one diatonic chord uncovered. This adds a reliably-detectable 7th expression and reassigns the map so **every degree I–vii° is covered**.

## New expression: Kiss
A "kiss" / "ooo" face (lips funneled forward): prototype `mouthFunnel` 0.7 + `mouthPucker` 0.3. Research-chosen for **reliability** — `mouthFunnel` is a well-reported MediaPipe channel (unlike the under-reported nose/frown/brow ones that made sad/disgusted hard), and its channels touch *none* of the six existing prototypes, so it neither cross-trips nor is cross-tripped by them. Rejected alternatives (smirk/contempt, wink) need a new asymmetry detector and risk reading as happy.

## Hand-picked map (in C major)
| Expression | Degree | Chord |
|---|---|---|
| Happy | I | C major |
| Fearful | ii | D minor |
| Disgusted | iii | E minor |
| Surprised | IV | F major |
| Angry | V | G major |
| Sad | vi | A minor |
| **Kiss** | vii° | B diminished |
| Neutral | — | silence |

`DEFAULT_EXPRESSION_TO_DEGREE` is now this explicit hand map; the confusion-aware optimizer is kept as a reference, decoupled onto its original 7-label set (`CONFUSION_EXPRESSIONS`) so its tests still hold. All editable per-expression in the UI.

## Process
Multi-agent adversarial review (4 dimensions, double-verified): **8 confirmed, all addressed** — the review explicitly verified the classifier is correct end-to-end (kiss math, no cross-trip, indices aligned, returning-user heal); findings were doc staleness + test-coverage gaps (now closed, incl. the pre-kiss faceExpr blob healing the kiss key). **278 tests**, deterministic; typecheck + build + catalog clean.

https://claude.ai/code/session_01JEoe7y1hA5KdEAvvpQXxxt
