### PR TITLE
Migrate thoremin to Zod 4 (prerequisite for zodal-dials)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "react-dom": "^19.0.0",
         "tonal": "^6.4.0",
         "vite": "^6.2.0",
-        "zod": "^3.24.1",
+        "zod": "^4.4.3",
         "zustand": "^5.0.14"
       },
       "devDependencies": {
@@ -4922,9 +4922,9 @@
       "license": "ISC"
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react-dom": "^19.0.0",
     "tonal": "^6.4.0",
     "vite": "^6.2.0",
-    "zod": "^3.24.1",
+    "zod": "^4.4.3",
     "zustand": "^5.0.14"
   },
   "devDependencies": {

--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -83,6 +83,8 @@ function paramInfo(name: string, field: any): ParamInfo {
       f = f._def.innerType;
     } else if (t === 'optional' || t === 'nullable') {
       f = f._def.innerType;
+    } else if (t === 'pipe') {
+      f = f._def.in ?? f._def.out; // symmetry with unwrapToObject (a future .pipe()/.transform() field)
     } else {
       break;
     }

--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -42,52 +42,56 @@ const portInfo = (p: PortSpec): PortInfo => ({
 });
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const TYPE_NAMES: Record<string, string> = {
-  ZodNumber: 'number',
-  ZodString: 'string',
-  ZodBoolean: 'boolean',
-  ZodArray: 'array',
-  ZodObject: 'object',
-  ZodAny: 'any',
-  ZodUnknown: 'unknown',
+// Zod 4 introspection: `_def.type` is a lowercase tag ('number'|'string'|'object'|
+// 'enum'|'default'|'optional'|…). Wrapper types expose `.innerType`; a `.refine()`/
+// `.superRefine()` on an object stays `type: 'object'` (no ZodEffects wrapper in v4).
+const TYPE_TAGS: Record<string, string> = {
+  number: 'number',
+  string: 'string',
+  boolean: 'boolean',
+  array: 'array',
+  object: 'object',
+  any: 'any',
+  unknown: 'unknown',
 };
 
-/** Unwrap wrapper Zod types (effects/optional/default/nullable) to the inner ZodObject. */
+/** Unwrap wrapper Zod types (default/optional/nullable/prefault/pipe) to the inner ZodObject. */
 function unwrapToObject(schema: any): any | null {
   let s = schema;
   for (let i = 0; i < 6 && s && s._def; i++) {
-    const tn = s._def.typeName;
-    if (tn === 'ZodObject') return s;
-    if (tn === 'ZodEffects') s = s._def.schema;
-    else if (tn === 'ZodDefault' || tn === 'ZodOptional' || tn === 'ZodNullable') s = s._def.innerType;
+    const t = s._def.type;
+    if (t === 'object') return s;
+    if (t === 'pipe') s = s._def.in ?? s._def.out;
+    else if (t === 'default' || t === 'optional' || t === 'nullable' || t === 'prefault') s = s._def.innerType;
     else break;
   }
-  return s && s._def && s._def.typeName === 'ZodObject' ? s : null;
+  return s && s._def && s._def.type === 'object' ? s : null;
 }
 
 function paramInfo(name: string, field: any): ParamInfo {
   let f = field;
   let def: unknown;
   for (let i = 0; i < 6 && f && f._def; i++) {
-    const tn = f._def.typeName;
-    if (tn === 'ZodDefault') {
+    const t = f._def.type;
+    if (t === 'default' || t === 'prefault') {
+      const dv = f._def.defaultValue;
       try {
-        def = f._def.defaultValue();
+        def = typeof dv === 'function' ? dv() : dv;
       } catch {
         /* ignore */
       }
       f = f._def.innerType;
-    } else if (tn === 'ZodOptional' || tn === 'ZodNullable') {
+    } else if (t === 'optional' || t === 'nullable') {
       f = f._def.innerType;
     } else {
       break;
     }
   }
-  const tn = f && f._def ? f._def.typeName : 'unknown';
-  let type = TYPE_NAMES[tn] ?? String(tn).replace(/^Zod/, '').toLowerCase();
-  if (tn === 'ZodEnum') {
-    const values = (f._def.values as string[]) ?? [];
-    type = `enum(${values.join(' | ')})`;
+  const t = f && f._def ? f._def.type : 'unknown';
+  let type = TYPE_TAGS[t] ?? String(t);
+  if (t === 'enum') {
+    const values = (f.options as string[] | undefined) ?? Object.values(f._def.entries ?? {});
+    type = `enum(${(values as string[]).join(' | ')})`;
   }
   return { name, type, default: def };
 }
@@ -96,7 +100,7 @@ function paramsOf(def: NodeDef): ParamInfo[] {
   try {
     const obj = unwrapToObject(def.params as any);
     if (!obj) return [];
-    const shape = typeof obj._def.shape === 'function' ? obj._def.shape() : obj.shape;
+    const shape = obj.shape;
     return Object.entries(shape).map(([name, field]) => paramInfo(name, field));
   } catch {
     return [];

--- a/src/nodes/output/canvas_overlay.ts
+++ b/src/nodes/output/canvas_overlay.ts
@@ -44,7 +44,7 @@ const Params = z.object({
       show: z.boolean().default(true),
       alpha: z.number().min(0).max(1).default(0.35),
     })
-    .default({}),
+    .prefault({}),
   /** Faint vertical guide at each scale note (a "fretboard"), with note labels. */
   scaleGuide: z
     .object({
@@ -52,26 +52,26 @@ const Params = z.object({
       /** Draw the note-name labels (split from the lines so each toggles alone). */
       showLabels: z.boolean().default(true),
     })
-    .default({}),
+    .prefault({}),
   /** Highlight the face-driven chord's tones on the pitch guide (face chord mode). */
   chordGuide: z
     .object({
       show: z.boolean().default(true),
     })
-    .default({}),
+    .prefault({}),
   /** Dashed vertical line from each index fingertip to the frame edge. Opt-in. */
   indexGuide: z
     .object({
       show: z.boolean().default(false),
       dashed: z.boolean().default(true),
     })
-    .default({}),
+    .prefault({}),
   /** Hand landmark dots + a ring around each index fingertip. */
   landmarks: z
     .object({
       show: z.boolean().default(true),
     })
-    .default({}),
+    .prefault({}),
   /** Per-hand control marker (openness = ring size, pinch = fill). */
   markers: z
     .object({
@@ -79,25 +79,25 @@ const Params = z.object({
       /** Show the note name each hand is sounding, above its marker. */
       showNotes: z.boolean().default(true),
     })
-    .default({}),
+    .prefault({}),
   /** The detected face mesh (input feature) — available when a face mapping is on. */
   faceLandmarks: z
     .object({
       show: z.boolean().default(true),
     })
-    .default({}),
+    .prefault({}),
   /** Live readout of the classified facial expression (output feature). */
   faceExpression: z
     .object({
       show: z.boolean().default(true),
     })
-    .default({}),
+    .prefault({}),
   /** Per-hand brightness/vibrato level bars (output feature). Opt-in. */
   timbreLevels: z
     .object({
       show: z.boolean().default(false),
     })
-    .default({}),
+    .prefault({}),
 });
 type Params = z.infer<typeof Params>;
 


### PR DESCRIPTION
Foundation for the zodal-dials "instruments" work: `zodal-dials` requires Zod 4 (`>=4.1.13`, built on Zod 4's `.meta()` API), but thoremin was on Zod 3 (`3.25.76`). This bumps `zod 3 → 4.4.3` and fixes the two breaking-change spots.

## Changes
- **`zod ^3.24.1 → ^4`.** `@zodal/core` + `@zodal/store` already declare `zod ^3 || ^4`, so they keep working.
- **`canvas_overlay` overlay params: `z.object({...}).default({})` → `.prefault({})`.** In Zod 4 `.default()` no longer re-parses the default (so the inner field defaults wouldn't fill, and `{}` fails the output type). `.prefault()` re-parses it, preserving the v3 behavior that `OverlayParamsSchema.parse({})` / `defaultOverlay()` rely on. (The other `.default({...})` sites provide complete values, so they were correctly left as-is.)
- **`catalog.ts` schema introspection rewritten for Zod 4 internals:** `_def.type` (lowercase tags) not `_def.typeName`; `_def.defaultValue` is the value not a getter; enums via `.options`; refined objects stay `type:'object'` (Zod 4 dropped the `ZodEffects` wrapper). Plus a `pipe`-unwrap for symmetry (review nit).

## Verification
The regenerated catalog (`CATALOG.md`/`catalog.json`/`manual.html`) is **byte-identical** to before — the introspection extracts the same `{type, default}` under Zod 4. **278 tests** pass deterministically; typecheck + build clean. No user-visible behavior change.

Multi-agent adversarial review (runtime-semantics + catalog-introspection, double-verified): **0 real defects** — verifiers independently exercised the persist/heal paths (`.prefault` heals returning-user blobs), the error-shape/coercion paths (no code reads `ZodError` internals; no `z.coerce`), and the introspection across all 25 nodes.

https://claude.ai/code/session_01JEoe7y1hA5KdEAvvpQXxxt
