### PR TITLE
Phase 3: render the settings panel from zodal-dials

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -14,7 +14,7 @@ import { Settings, X, Play, BookOpen, Circle, Square } from 'lucide-react';
 import { useThoreminEngine } from './useEngine';
 import { useControls } from './store';
 import { useFaceStatus } from './faceStatus';
-import ControlsPanel from './ControlsPanel';
+import DialsControlsPanel from './dials/DialsControlsPanel';
 import Toaster from './Toaster';
 
 /** A compact face-status chip, visible even when the controls panel is collapsed
@@ -123,7 +123,7 @@ export default function App() {
             </button>
           </div>
           <div className="overflow-auto p-4">
-            <ControlsPanel />
+            <DialsControlsPanel />
           </div>
         </div>
       ) : (

--- a/src/app/dials/DialsControlsPanel.tsx
+++ b/src/app/dials/DialsControlsPanel.tsx
@@ -1,13 +1,19 @@
 /**
- * ControlsPanel — schema-light UI bound to the Zustand control store. Changing
- * any value updates the store; the `store-controls` DAG node reads it on the
- * next tick, so edits take effect live without rebuilding the graph.
+ * DialsControlsPanel — the settings panel, rendered FROM the zodal-dials surface
+ * ({@link thoreminDials}) instead of straight off the zustand control store. Visually
+ * identical to the old hand-wired panel: the same sections, widgets, and conditional
+ * disclosure — but every control now reads its value from the dials store
+ * ({@link useDialsSettings}) and writes back with `set(key, value)`. A subscription in
+ * {@link settingsStore} mirrors each edit into the synchronous hot `useControls` store
+ * the DAG reads each tick, so audio still responds live.
  *
- * Sections: per-hand voice, master/sync, the composable Overlay elements, and
- * named Presets (save/load/delete via the zodal-backed preset store).
+ * What is dials-driven: master volume / sync, both voices, the face-mapping chooser +
+ * chord sound, the expression-mapping table, and the overlay element config. What is
+ * NOT (kept verbatim, reading their own stores): Recording formats (a tooling pref),
+ * named Presets (the older zodal preset collection), and the Keyboard cheat-sheet.
  *
- * Renders just the controls *content* (no outer card); the host (App) wraps it
- * in a collapsible translucent overlay so the video stays the focus.
+ * Renders just the controls *content* (no outer card); the host (App) wraps it in a
+ * collapsible translucent overlay so the video stays the focus.
  */
 import { useState, type ReactNode } from 'react';
 import { NOTES, SCALE_TYPES, isSevenNoteScale, diatonicTriad, type ScaleTypeId } from '@/music/theory';
@@ -16,12 +22,14 @@ import { VOICINGS, RENDERINGS, isTempoRendering, voiceTriad, type VoicingId, typ
 import { EXPRESSIONS, EMOTIONS, DEFAULT_EXPRESSION_TO_DEGREE, SILENCE_DEGREE } from '@/music/expression';
 import { OVERLAY_ELEMENTS, OVERLAY_CATEGORIES, type OverlayParams } from '@/nodes/output/canvas_overlay';
 import type { FaceMapping } from '@/nodes';
-import { useControls, type VoiceControl } from './store';
-import { OVERLAY_CONTROLS, type OverlayControlDesc } from './overlayControls';
-import { ExpressionHelpButton } from './ExpressionHelpPanel';
-import { useFaceStatus } from './faceStatus';
-import { usePresets } from './usePresets';
-import { RECORDING_FORMATS } from './recording/formats';
+import { useControls } from '../store';
+import { OVERLAY_CONTROLS, type OverlayControlDesc } from '../overlayControls';
+import { ExpressionHelpButton } from '../ExpressionHelpPanel';
+import { useFaceStatus } from '../faceStatus';
+import { usePresets } from '../usePresets';
+import { RECORDING_FORMATS } from '../recording/formats';
+import { useDialsSettings } from './useDialsSettings';
+import { voiceEditWrites, type VoiceField } from './settingsStore';
 
 const selectCls = 'rounded bg-white/10 px-2 py-1 text-xs outline-none focus:bg-white/20';
 
@@ -95,10 +103,23 @@ function TopSection({
   );
 }
 
+/**
+ * One hand's voice (sound / root / scale / octaves / base octave), read from and
+ * written to the dials store. Mirrors `setVoice`: when both hands are synced, a
+ * non-sound edit on this hand also writes the other hand, so the two voices share
+ * scale/root/octaves while each keeps its own sound.
+ */
 function VoiceControls({ side }: { side: 'right' | 'left' }) {
-  const voice = useControls((s) => s[side]);
-  const setVoice = useControls((s) => s.setVoice);
+  const { state, set } = useDialsSettings();
+  const v = state.effective;
+  const syncHands = v['master.syncHands'] as boolean;
   const color = side === 'right' ? 'text-emerald-400' : 'text-blue-400';
+
+  const setField = (key: VoiceField, value: unknown) => {
+    // Reproduce setVoice's sync-hands rule (mirror the whole non-sound voice when
+    // synced, keep each hand's own sound); voiceEditWrites yields the dials writes.
+    for (const [k, val] of voiceEditWrites(side, key, value, syncHands, v)) set(k, val);
+  };
 
   return (
     <div className="space-y-2">
@@ -107,8 +128,8 @@ function VoiceControls({ side }: { side: 'right' | 'left' }) {
         Sound
         <select
           className={selectCls}
-          value={voice.sound}
-          onChange={(e) => setVoice(side, { sound: e.target.value as VoiceControl['sound'] })}
+          value={v[`${side}.sound`] as string}
+          onChange={(e) => setField('sound', e.target.value)}
         >
           {SOUND_IDS.map((id) => (
             <option key={id} value={id}>{SOUNDS[id].name}</option>
@@ -119,8 +140,8 @@ function VoiceControls({ side }: { side: 'right' | 'left' }) {
         Root
         <select
           className={selectCls}
-          value={voice.root}
-          onChange={(e) => setVoice(side, { root: Number(e.target.value) })}
+          value={v[`${side}.root`] as number}
+          onChange={(e) => setField('root', Number(e.target.value))}
         >
           {NOTES.map((n, i) => (
             <option key={n} value={i}>{n}</option>
@@ -131,8 +152,8 @@ function VoiceControls({ side }: { side: 'right' | 'left' }) {
         Scale
         <select
           className={selectCls}
-          value={voice.type}
-          onChange={(e) => setVoice(side, { type: e.target.value as ScaleTypeId })}
+          value={v[`${side}.type`] as string}
+          onChange={(e) => setField('type', e.target.value as ScaleTypeId)}
         >
           {Object.entries(SCALE_TYPES).map(([id, s]) => (
             <option key={id} value={id}>{s.name}</option>
@@ -142,15 +163,15 @@ function VoiceControls({ side }: { side: 'right' | 'left' }) {
       <label className="flex items-center justify-between gap-2 text-xs">
         Octaves
         <input
-          type="range" min={1} max={4} step={1} value={voice.octaves}
-          onChange={(e) => setVoice(side, { octaves: Number(e.target.value) })}
+          type="range" min={1} max={4} step={1} value={v[`${side}.octaves`] as number}
+          onChange={(e) => setField('octaves', Number(e.target.value))}
         />
       </label>
       <label className="flex items-center justify-between gap-2 text-xs">
         Base octave
         <input
-          type="range" min={1} max={5} step={1} value={voice.baseOctave}
-          onChange={(e) => setVoice(side, { baseOctave: Number(e.target.value) })}
+          type="range" min={1} max={5} step={1} value={v[`${side}.baseOctave`] as number}
+          onChange={(e) => setField('baseOctave', Number(e.target.value))}
         />
       </label>
     </div>
@@ -164,16 +185,16 @@ function VoiceControls({ side }: { side: 'right' | 'left' }) {
  * control per element whose {@link OVERLAY_ELEMENTS}.category matches, rendered
  * from its {@link OVERLAY_CONTROLS} descriptor. Adding an overlay element makes it
  * appear here automatically (a test enforces every element has a descriptor), so
- * this is a general framework, not a hand-maintained list.
+ * this is a general framework, not a hand-maintained list. The whole overlay object
+ * is one dial value; each edit writes a merged copy back.
  */
 function OverlayControls() {
-  const overlay = useControls((s) => s.overlay);
-  const setEl = useControls((s) => s.setOverlayElement);
-  const faceActive = useControls((s) => s.faceMapping) !== 'none';
+  const { state, set } = useDialsSettings();
+  const overlay = state.effective['overlay'] as OverlayParams;
+  const faceActive = state.effective['face.mapping'] !== 'none';
   const categoryOf = new Map(OVERLAY_ELEMENTS.map((e) => [e.name, e.category]));
-  // The React layer isn't strict-typechecked; a runtime element key loses the
-  // setOverlayElement generic narrowing, so patch with a loose cast.
-  const patch = (name: keyof OverlayParams, p: object) => setEl(name, p as never);
+  const patch = (name: keyof OverlayParams, p: object) =>
+    set('overlay', { ...overlay, [name]: { ...(overlay[name] as object), ...p } });
 
   const renderControl = (d: OverlayControlDesc) => {
     const elt = overlay[d.name] as { show: boolean } & Record<string, unknown>;
@@ -295,9 +316,10 @@ const RENDERING_LABELS: Record<RenderingId, string> = {
 
 /** Sound settings for the face chord — shown when chord mapping is active. */
 function ChordControls() {
-  const chord = useControls((s) => s.faceChord);
-  const set = useControls((s) => s.setFaceChord);
-  const tempoRelevant = isTempoRendering(chord.rendering);
+  const { state, set } = useDialsSettings();
+  const v = state.effective;
+  const rendering = v['faceChord.rendering'] as RenderingId;
+  const tempoRelevant = isTempoRendering(rendering);
 
   return (
     <div className="space-y-2 border-l-2 border-amber-300/30 pl-3">
@@ -306,8 +328,8 @@ function ChordControls() {
         Sound
         <select
           className={selectCls}
-          value={chord.sound}
-          onChange={(e) => set({ sound: e.target.value as VoiceControl['sound'] })}
+          value={v['faceChord.sound'] as string}
+          onChange={(e) => set('faceChord.sound', e.target.value)}
         >
           {SOUND_IDS.map((id) => (
             <option key={id} value={id}>{SOUNDS[id].name}</option>
@@ -317,19 +339,19 @@ function ChordControls() {
       <label className="flex items-center justify-between gap-2 text-xs">
         Volume
         <input
-          type="range" min={0} max={1} step={0.01} value={chord.volume}
-          onChange={(e) => set({ volume: Number(e.target.value) })}
+          type="range" min={0} max={1} step={0.01} value={v['faceChord.volume'] as number}
+          onChange={(e) => set('faceChord.volume', Number(e.target.value))}
         />
       </label>
       <label className="flex items-center justify-between gap-2 text-xs">
         Voicing
         <select
           className={selectCls}
-          value={chord.voicing}
-          onChange={(e) => set({ voicing: e.target.value as VoicingId })}
+          value={v['faceChord.voicing'] as string}
+          onChange={(e) => set('faceChord.voicing', e.target.value as VoicingId)}
         >
-          {VOICINGS.map((v) => (
-            <option key={v} value={v}>{VOICING_LABELS[v]}</option>
+          {VOICINGS.map((vc) => (
+            <option key={vc} value={vc}>{VOICING_LABELS[vc]}</option>
           ))}
         </select>
       </label>
@@ -337,8 +359,8 @@ function ChordControls() {
         Rendering
         <select
           className={selectCls}
-          value={chord.rendering}
-          onChange={(e) => set({ rendering: e.target.value as RenderingId })}
+          value={rendering}
+          onChange={(e) => set('faceChord.rendering', e.target.value as RenderingId)}
         >
           {RENDERINGS.map((r) => (
             <option key={r} value={r}>{RENDERING_LABELS[r]}</option>
@@ -346,10 +368,10 @@ function ChordControls() {
         </select>
       </label>
       <label className={`flex items-center justify-between gap-2 text-xs ${tempoRelevant ? '' : 'opacity-40'}`}>
-        Tempo {chord.bpm} bpm
+        Tempo {v['faceChord.bpm'] as number} bpm
         <input
-          type="range" min={40} max={200} step={1} value={chord.bpm}
-          onChange={(e) => set({ bpm: Number(e.target.value) })}
+          type="range" min={40} max={200} step={1} value={v['faceChord.bpm'] as number}
+          onChange={(e) => set('faceChord.bpm', Number(e.target.value))}
         />
       </label>
       {tempoRelevant && (
@@ -368,20 +390,29 @@ function ChordControls() {
  * feeds the readout/status there), so they show whenever a mapping is on. The
  * scale-degree dropdown + live chord MIDI are chord-specific, so they appear only
  * in chord mode (where `neutral` also gets a row — its rest chord). The (global)
- * rendering lives in ChordControls above.
+ * rendering lives in ChordControls above. The two maps are single dial values
+ * (`faceExpr.sensitivity` / `faceExpr.degrees`); each edit writes a merged copy.
  */
 function ExpressionMapping({ chordMode }: { chordMode: boolean }) {
-  const degrees = useControls((s) => s.faceExpr.degrees);
-  const sensitivity = useControls((s) => s.faceExpr.sensitivity);
-  const setDegree = useControls((s) => s.setExpressionDegree);
-  const setSens = useControls((s) => s.setExpressionSensitivity);
-  const right = useControls((s) => s.right);
-  const voicing = useControls((s) => s.faceChord.voicing);
+  const { state, set } = useDialsSettings();
+  const v = state.effective;
+  const degrees = v['faceExpr.degrees'] as Record<string, number>;
+  const sensitivity = v['faceExpr.sensitivity'] as Record<string, number>;
+  const setDegree = (label: string, degree: number) =>
+    set('faceExpr.degrees', { ...degrees, [label]: degree });
+  const setSens = (label: string, value: number) =>
+    set('faceExpr.sensitivity', { ...sensitivity, [label]: value });
+  const voicing = v['faceChord.voicing'] as VoicingId;
 
   const chordMidi = (degree: number): number[] => {
     if (degree < 0) return []; // SILENCE_DEGREE → no chord
     const triad = diatonicTriad(
-      { root: right.root, type: right.type, octaves: right.octaves, baseOctave: right.baseOctave },
+      {
+        root: v['right.root'] as number,
+        type: v['right.type'] as ScaleTypeId,
+        octaves: v['right.octaves'] as number,
+        baseOctave: v['right.baseOctave'] as number,
+      },
       degree,
     );
     return triad.length ? voiceTriad(triad, voicing, 0).slice().sort((a, b) => a - b) : [];
@@ -456,10 +487,10 @@ function ExpressionMapping({ chordMode }: { chordMode: boolean }) {
 }
 
 function FaceControls() {
-  const faceMapping = useControls((s) => s.faceMapping);
-  const setFaceMapping = useControls((s) => s.setFaceMapping);
-  const rightType = useControls((s) => s.right.type);
-  const sevenNote = isSevenNoteScale(rightType);
+  const { state, set } = useDialsSettings();
+  const v = state.effective;
+  const faceMapping = v['face.mapping'] as FaceMapping;
+  const sevenNote = isSevenNoteScale(v['right.type'] as ScaleTypeId);
 
   return (
     <div className="space-y-2">
@@ -468,7 +499,7 @@ function FaceControls() {
         <select
           className={selectCls}
           value={faceMapping}
-          onChange={(e) => setFaceMapping(e.target.value as FaceMapping)}
+          onChange={(e) => set('face.mapping', e.target.value as FaceMapping)}
         >
           {FACE_MODE_OPTIONS.map((o) => (
             <option key={o.value} value={o.value} disabled={o.value === 'chord' && !sevenNote}>
@@ -576,11 +607,10 @@ function PresetControls() {
   );
 }
 
-export default function ControlsPanel() {
-  const syncHands = useControls((s) => s.syncHands);
-  const setSync = useControls((s) => s.setSync);
-  const masterVolume = useControls((s) => s.masterVolume);
-  const setMasterVolume = useControls((s) => s.setMasterVolume);
+export default function DialsControlsPanel() {
+  const { state, set } = useDialsSettings();
+  const v = state.effective;
+  const syncHands = v['master.syncHands'] as boolean;
 
   return (
     <div className="space-y-1">
@@ -589,12 +619,12 @@ export default function ControlsPanel() {
         <label className="flex items-center justify-between gap-2 text-xs">
           Master volume
           <input
-            type="range" min={0} max={1} step={0.01} value={masterVolume}
-            onChange={(e) => setMasterVolume(Number(e.target.value))}
+            type="range" min={0} max={1} step={0.01} value={v['master.volume'] as number}
+            onChange={(e) => set('master.volume', Number(e.target.value))}
           />
         </label>
         <label className="flex items-center gap-2 text-xs">
-          <input type="checkbox" checked={syncHands} onChange={(e) => setSync(e.target.checked)} />
+          <input type="checkbox" checked={syncHands} onChange={(e) => set('master.syncHands', e.target.checked)} />
           Sync both hands
         </label>
         <VoiceControls side="right" />

--- a/src/app/dials/settingsStore.ts
+++ b/src/app/dials/settingsStore.ts
@@ -1,0 +1,106 @@
+/**
+ * The dials settings layer for the DAG app — one reactive `createSettingsStore`
+ * over {@link thoreminDials}, plus the one-way sync that keeps the synchronous hot
+ * {@link useControls} mirror (the store the DAG reads every tick) in step with it.
+ *
+ * The settings PANEL writes here (`setDial`/`resetDial`), never to `useControls`
+ * directly. On every change we re-derive the nested {@link Settings}
+ * ({@link layerToSettings}) and push it into `useControls.applySettings`, so the
+ * audio graph hears edits live (synchronously — the tick loop never awaits). The
+ * store is seeded FROM the current (persisted) hot state, so a returning player's
+ * choices are already in the panel. `recordingFormats` is a tooling pref outside the
+ * dials schema and stays on `useControls`.
+ *
+ * Framework-agnostic on purpose: the React binding lives in {@link useDialsSettings},
+ * so this module imports no React and stays unit-testable. Named "instruments"
+ * (Phase 4) are sparse dials {@link Layer}s loaded via `dialsStore.setLayer`.
+ */
+import { createSettingsStore, toSettingsForm } from '@zodal/dials-ui';
+import type { SettingFieldConfig, SettingsForm } from '@zodal/dials-ui';
+import type { SettingKey } from '@zodal/dials-core';
+import { thoreminDials, settingsToLayer, layerToSettings } from '@/settings/dials';
+import type { Settings } from '@/settings/schema';
+import { useControls, toSettings } from '../store';
+
+/** The headless form (field configs + facet groups) — value-independent, built once. */
+export const settingsForm: SettingsForm = toSettingsForm(thoreminDials);
+
+/** Field config by key, for the renderer's by-key lookups (the layout is bespoke,
+ *  so the panel pulls each field's label / bounds / enum values by key). */
+export const fieldByKey: Record<string, SettingFieldConfig> = Object.fromEntries(
+  settingsForm.fields.map((f) => [f.key, f]),
+);
+
+/** The live editing store, seeded from the current (persisted) hot control state. */
+export const dialsStore = createSettingsStore(thoreminDials, {
+  layer: settingsToLayer(toSettings(useControls.getState())),
+});
+
+/**
+ * One-way sync dials → hot store. Every dials edit re-derives the nested Settings
+ * and applies it to `useControls`. Guarded: a value the nested schema can't parse
+ * (an invalid intermediate state, e.g. an out-of-range value) is skipped rather than
+ * thrown inside a subscriber, so the hot mirror is never left half-applied and the
+ * tick loop is never interrupted — the dials `validation` surface reports such states
+ * to the UI instead.
+ *
+ * The sync-hands mirror (when synced, the left voice tracks the right except its own
+ * sound) is applied at the panel's write site, so the dials layer's `left.*` already
+ * equals `right.*`; `applySettings` then sets both hands directly, matching how
+ * loading a preset works.
+ */
+dialsStore.subscribe(() => {
+  try {
+    const settings = layerToSettings(dialsStore.getState().effective);
+    useControls.getState().applySettings(settings);
+  } catch {
+    // invalid intermediate state — keep the hot mirror on its last good value
+  }
+});
+
+/** Set one dial in the editable layer. */
+export const setDial = (key: SettingKey, value: unknown): void => dialsStore.set(key, value);
+/** Reset one dial (a lower scope — the defaults — re-wins). */
+export const resetDial = (key: SettingKey): void => dialsStore.reset(key);
+
+/**
+ * Load a full settings snapshot into the panel by re-seeding the dials layer; the
+ * one-way sync above then updates the hot store. Use this for any external load
+ * (the legacy presets today, the instruments in Phase 4) so the dials store stays
+ * the single entry point and the panel can never desync from what is playing.
+ */
+export const loadSettingsIntoDials = (settings: Settings): void =>
+  dialsStore.setLayer(settingsToLayer(settings));
+
+/** The voice fields mirrored between hands when synced. `sound` is never mirrored —
+ *  each hand keeps its own timbre. */
+const MIRRORED_VOICE_FIELDS = ['root', 'type', 'octaves', 'baseOctave'] as const;
+
+/** A field of one voice (the addressable keys under `right.` / `left.`). */
+export type VoiceField = 'root' | 'type' | 'octaves' | 'baseOctave' | 'sound';
+
+/**
+ * The dials-layer writes for one voice edit, reproducing the hot store's `setVoice`
+ * sync-hands rule exactly: the addressed field is written, and when the hands are
+ * synced the addressed hand's FULL non-sound voice is mirrored onto the other hand
+ * (which keeps its own sound). Mirroring the whole voice — not just the edited field
+ * — means a single edit re-converges the hands even if a prior un-sync/edit had left
+ * them diverged, matching `setVoice` (src/app/store.ts). Pure, so it is unit-tested
+ * directly (the panel just applies the returned writes in order).
+ */
+export function voiceEditWrites(
+  side: 'right' | 'left',
+  key: VoiceField,
+  value: unknown,
+  synced: boolean,
+  effective: Record<string, unknown>,
+): Array<[string, unknown]> {
+  const writes: Array<[string, unknown]> = [[side + '.' + key, value]];
+  if (synced) {
+    const other = side === 'right' ? 'left' : 'right';
+    for (const f of MIRRORED_VOICE_FIELDS) {
+      writes.push([other + '.' + f, f === key ? value : effective[side + '.' + f]]);
+    }
+  }
+  return writes;
+}

--- a/src/app/dials/useDialsSettings.ts
+++ b/src/app/dials/useDialsSettings.ts
@@ -1,0 +1,34 @@
+/**
+ * React binding for the dials settings store: subscribes a component to the live
+ * store and derives the per-field state. Kept apart from {@link settingsStore} so
+ * that module stays framework-agnostic (and unit-testable without React).
+ *
+ * `form` is value-independent (built once in {@link settingsStore}); `states` is the
+ * value-dependent projection (value / dirty / provenance per field), recomputed when
+ * the store state changes — the input to Phase-4 dirty indicators.
+ */
+import { useMemo, useSyncExternalStore } from 'react';
+import { toFieldStates } from '@zodal/dials-ui';
+import type { SettingFieldState, SettingsForm, SettingsState } from '@zodal/dials-ui';
+import type { SettingKey } from '@zodal/dials-core';
+import { dialsStore, settingsForm, setDial, resetDial } from './settingsStore';
+
+export interface DialsSettings {
+  /** Live store state ({@link SettingsState}): `effective` values, `dirty`, `validation`, … */
+  state: SettingsState;
+  /** The headless form (field configs + facet groups). */
+  form: SettingsForm;
+  /** Per-field value-dependent state (value / dirty / provenance). */
+  states: Record<SettingKey, SettingFieldState>;
+  /** Set one dial in the editable layer. */
+  set: (key: SettingKey, value: unknown) => void;
+  /** Reset one dial (the defaults re-win). */
+  reset: (key: SettingKey) => void;
+}
+
+/** Subscribe a React component to the live dials store. */
+export function useDialsSettings(): DialsSettings {
+  const state = useSyncExternalStore(dialsStore.subscribe, dialsStore.getState, dialsStore.getState);
+  const states = useMemo(() => toFieldStates(settingsForm.fields, state, state.dirty), [state]);
+  return { state, form: settingsForm, states, set: setDial, reset: resetDial };
+}

--- a/src/app/overlayControls.ts
+++ b/src/app/overlayControls.ts
@@ -1,6 +1,6 @@
 /**
  * UI descriptors for the overlay settings panel — the data that drives the
- * grouped, collapsible Overlay controls (see ControlsPanel `OverlayControls`).
+ * grouped, collapsible Overlay controls (see DialsControlsPanel `OverlayControls`).
  *
  * Each descriptor names an overlay element (the key into the overlay params) and
  * declares its controls: a primary `show` toggle, optional dependent sub-toggles

--- a/src/app/usePresets.ts
+++ b/src/app/usePresets.ts
@@ -1,13 +1,17 @@
 /**
  * usePresets — React glue between the async preset store (src/settings) and the
- * live zustand control store. Saving snapshots the current live state; loading
- * hydrates it. The preset store is the localStorage-backed zodal collection; the
- * live hot state stays synchronous (we never await a provider in the tick loop).
+ * settings panel. Saving snapshots the current live state (toSettings of the hot
+ * store, which the dials→hot sync keeps current); loading re-seeds the dials store
+ * (the panel's source of truth) via loadSettingsIntoDials, which then syncs into the
+ * hot store — so the panel reflects the loaded preset and a later edit can't re-derive
+ * stale values over it. The preset store is the localStorage-backed zodal collection;
+ * the live hot state stays synchronous (we never await a provider in the tick loop).
  */
 import { useCallback, useEffect, useState } from 'react';
 import { createPresetStore } from '@/settings/presets';
 import type { PresetSummary } from '@/settings/schema';
 import { useControls, toSettings } from './store';
+import { loadSettingsIntoDials } from './dials/settingsStore';
 
 // One localStorage-backed preset store for the app session.
 const presetStore = createPresetStore();
@@ -40,7 +44,7 @@ export function usePresets() {
 
   const load = useCallback(async (id: string) => {
     const p = await presetStore.load(id);
-    if (p) useControls.getState().applySettings(p.settings);
+    if (p) loadSettingsIntoDials(p.settings);
   }, []);
 
   const remove = useCallback(

--- a/test/dials_sync.test.ts
+++ b/test/dials_sync.test.ts
@@ -1,0 +1,101 @@
+/**
+ * The dials → hot-store sync (Phase 3): editing the dials store must mirror into the
+ * synchronous `useControls` store the DAG reads each tick (via `applySettings`).
+ * Covers scalar, enum, nested-voice, and structured (object) dials, plus the
+ * invalid-state guard that keeps the hot mirror on its last good value.
+ */
+import { describe, it, expect } from 'vitest';
+import { dialsStore, voiceEditWrites } from '@/app/dials/settingsStore';
+import { useControls } from '@/app/store';
+import type { OverlayParams } from '@/nodes/output/canvas_overlay';
+
+describe('dials → hot-store sync', () => {
+  it('mirrors a scalar dial (master.volume) into useControls', () => {
+    dialsStore.set('master.volume', 0.77);
+    expect(useControls.getState().masterVolume).toBeCloseTo(0.77);
+  });
+
+  it('mirrors enum / nested-voice dials (right.sound, right.type) into useControls', () => {
+    dialsStore.set('right.sound', 'bell');
+    dialsStore.set('right.type', 'major');
+    const { right } = useControls.getState();
+    expect(right.sound).toBe('bell');
+    expect(right.type).toBe('major');
+  });
+
+  it('mirrors faceChord dials into useControls', () => {
+    dialsStore.set('faceChord.bpm', 144);
+    dialsStore.set('faceChord.voicing', 'close');
+    const { faceChord } = useControls.getState();
+    expect(faceChord.bpm).toBe(144);
+    expect(faceChord.voicing).toBe('close');
+  });
+
+  it('mirrors a structured dial (overlay) into useControls', () => {
+    const overlay = dialsStore.getState().effective['overlay'] as OverlayParams;
+    dialsStore.set('overlay', { ...overlay, video: { ...overlay.video, alpha: 0.33 } });
+    expect(useControls.getState().overlay.video.alpha).toBeCloseTo(0.33);
+  });
+
+  it('mirrors the expression maps (faceExpr.degrees) into useControls', () => {
+    const degrees = dialsStore.getState().effective['faceExpr.degrees'] as Record<string, number>;
+    dialsStore.set('faceExpr.degrees', { ...degrees, happy: 4 });
+    expect(useControls.getState().faceExpr.degrees.happy).toBe(4);
+  });
+
+  it('keeps the hot mirror on its last good value when a dial goes out of range', () => {
+    dialsStore.set('master.volume', 0.5);
+    expect(useControls.getState().masterVolume).toBeCloseTo(0.5);
+    // 9 is outside the schema's 0..1 range — layerToSettings throws, the sync is
+    // skipped, and the tick loop never sees the bad state.
+    dialsStore.set('master.volume', 9);
+    expect(useControls.getState().masterVolume).toBeCloseTo(0.5);
+  });
+});
+
+describe('voiceEditWrites (the panel sync-hands mirror, reproducing setVoice)', () => {
+  // A snapshot where the two hands have DIVERGED (the reachable un-sync / edit-left
+  // / re-sync state). The mirror must re-converge them on the next edit, like setVoice.
+  const eff = {
+    'right.root': 0, 'right.type': 'major', 'right.octaves': 2, 'right.baseOctave': 3, 'right.sound': 'warmPad',
+    'left.root': 5, 'left.type': 'blues', 'left.octaves': 4, 'left.baseOctave': 2, 'left.sound': 'glass',
+  };
+
+  it('unsynced edit writes only the addressed field', () => {
+    expect(voiceEditWrites('right', 'root', 7, false, eff)).toEqual([['right.root', 7]]);
+  });
+
+  it('synced non-sound edit re-snaps the whole non-sound voice onto the other hand', () => {
+    // Editing right.octaves while synced: left re-converges to right (root/type/
+    // baseOctave) and takes the new octaves — healing the prior divergence.
+    expect(voiceEditWrites('right', 'octaves', 3, true, eff)).toEqual([
+      ['right.octaves', 3],
+      ['left.root', 0],
+      ['left.type', 'major'],
+      ['left.octaves', 3],
+      ['left.baseOctave', 3],
+    ]);
+  });
+
+  it('synced sound edit mirrors the non-sound voice but never the other hand sound', () => {
+    const writes = voiceEditWrites('right', 'sound', 'bell', true, eff);
+    expect(writes).toEqual([
+      ['right.sound', 'bell'],
+      ['left.root', 0],
+      ['left.type', 'major'],
+      ['left.octaves', 2],
+      ['left.baseOctave', 3],
+    ]);
+    expect(writes.some(([k]) => k === 'left.sound')).toBe(false);
+  });
+
+  it('mirrors left into right symmetrically', () => {
+    expect(voiceEditWrites('left', 'root', 9, true, eff)).toEqual([
+      ['left.root', 9],
+      ['right.root', 9],
+      ['right.type', 'blues'],
+      ['right.octaves', 4],
+      ['right.baseOctave', 2],
+    ]);
+  });
+});

--- a/tsconfig.dag.json
+++ b/tsconfig.dag.json
@@ -1,5 +1,5 @@
 {
-  "//": "Scoped strict typecheck for the DAG engine, node library, music helpers, the non-React DAG app glue (src/app/graph.ts; src/app/store.ts is pulled in transitively by tests), tests and scripts. The React layer (src/main.tsx, src/app/{App,ControlsPanel,useEngine}.tsx and the legacy wips app) is built and type-erased by Vite/esbuild — the project ships no @types/react — so it stays out of this config, which is Node-oriented (types: node + vitest).",
+  "//": "Scoped strict typecheck for the DAG engine, node library, music helpers, the non-React DAG app glue (src/app/graph.ts; src/app/store.ts is pulled in transitively by tests), tests and scripts. The React layer (src/main.tsx, src/app/{App,useEngine}.tsx, the React dials files src/app/dials/{DialsControlsPanel.tsx,useDialsSettings.ts} and the legacy wips app) is built and type-erased by Vite/esbuild — the project ships no @types/react — so it stays out of this config, which is Node-oriented (types: node + vitest). The framework-agnostic src/app/dials/settingsStore.ts is strict-checked transitively via test/dials_sync.test.ts.",
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "strict": true,


### PR DESCRIPTION
Renders the DAG app's settings panel from the `thoreminDials` surface instead of reading the zustand control store directly — looking and behaving identically to the old hand-wired panel.

## What
- `src/app/dials/settingsStore.ts` — a framework-agnostic `createSettingsStore` over `thoreminDials`, seeded from the persisted hot `useControls` store, with a one-way sync (every dials edit → `useControls.applySettings(layerToSettings(effective))`, guarded so an invalid intermediate value never half-applies the tick mirror). Exposes `voiceEditWrites` (a pure, unit-tested reproduction of `setVoice`'s sync-hands rule).
- `src/app/dials/useDialsSettings.ts` — the React binding (kept apart so the store stays React-free + testable).
- `src/app/dials/DialsControlsPanel.tsx` — the panel, reproducing every section/widget/conditional/style but reading & writing the dials store; bespoke widgets (expression table, overlay accordion) and non-dials sections (Recording/Keyboard) kept.
- Old `ControlsPanel.tsx` deleted; `App` renders `DialsControlsPanel`.

## Verification
typecheck · vitest (incl. new dials→hot sync + `voiceEditWrites` tests) · build · catalog (no diffs) · in-browser: pixel-identical panel driving the live DAG, sync-hands re-convergence, zero console errors. Adversarial multi-agent review run; all confirmed findings fixed.

Base for the stacked Phase 4 PR (#instruments). The legacy `?engine=legacy` app is untouched.

https://claude.ai/code/session_01JEoe7y1hA5KdEAvvpQXxxt
