### PR TITLE
Configurable hand→sound mapping: wrist source, finger→effect routing, a dozen demo instruments

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -83,7 +83,7 @@ Landmarks → normalized per-hand position, openness, pinch.
 - **roles:** feature
 - **in:** hands:hands-frame
 - **out:** features:hand-features
-- **params:** mirrorX (boolean=true), mirrorHandedness (boolean=true), opennessMin (number=1.3), opennessMax (number=2.3), pinchTouch (number=0.25), pinchApart (number=1.2)
+- **params:** mirrorX (boolean=true), mirrorHandedness (boolean=true), opennessMin (number=1.3), opennessMax (number=2.3), pinchTouch (number=0.25), pinchApart (number=1.2), fingerTouch (number=0.3), fingerApart (number=1.8)
 
 #### `face-features` — Face Features
 Face blendshapes → normalized expression controls (smile, mouthOpen, brow, blink).

--- a/public/catalog.json
+++ b/public/catalog.json
@@ -382,6 +382,16 @@
         "name": "pinchApart",
         "type": "number",
         "default": 1.2
+      },
+      {
+        "name": "fingerTouch",
+        "type": "number",
+        "default": 0.3
+      },
+      {
+        "name": "fingerApart",
+        "type": "number",
+        "default": 1.8
       }
     ]
   },

--- a/public/manual.html
+++ b/public/manual.html
@@ -96,7 +96,7 @@
         <dt>roles</dt><dd>feature</dd>
         <dt>in</dt><dd>hands:hands-frame</dd>
         <dt>out</dt><dd>features:hand-features</dd>
-        <dt>params</dt><dd>mirrorX (boolean=true), mirrorHandedness (boolean=true), opennessMin (number=1.3), opennessMax (number=2.3), pinchTouch (number=0.25), pinchApart (number=1.2)</dd>
+        <dt>params</dt><dd>mirrorX (boolean=true), mirrorHandedness (boolean=true), opennessMin (number=1.3), opennessMax (number=2.3), pinchTouch (number=0.25), pinchApart (number=1.2), fingerTouch (number=0.3), fingerApart (number=1.8)</dd>
       </dl>
     </div>
     <div class="node">

--- a/src/app/dials/DialsControlsPanel.tsx
+++ b/src/app/dials/DialsControlsPanel.tsx
@@ -28,6 +28,8 @@ import { OVERLAY_CONTROLS, type OverlayControlDesc } from '../overlayControls';
 import { ExpressionHelpButton } from '../ExpressionHelpPanel';
 import { useFaceStatus } from '../faceStatus';
 import { RECORDING_FORMATS } from '../recording/formats';
+import { EFFECTS, type HandMap, type FingerTarget } from '@/nodes/mapping/hand_map';
+import { FINGER_NAMES } from '@/nodes/domain';
 import { useDialsSettings } from './useDialsSettings';
 import { voiceEditWrites, type VoiceField } from './settingsStore';
 
@@ -547,6 +549,100 @@ function RecordingControls() {
   );
 }
 
+const EFFECT_LABELS: Record<FingerTarget, string> = {
+  none: 'Off',
+  brightness: 'Brightness',
+  vibrato: 'Vibrato',
+  pan: 'Pan',
+  pitchBend: 'Pitch bend',
+  octave: 'Octave',
+  gate: 'Gate',
+};
+
+/**
+ * Hand→sound mapping: the note SOURCE (index fingertip or the steadier wrist), the
+ * whole-hand knobs (fist-mute, open-brightness, pinch-vibrato, scale snap), and the
+ * per-finger→effect routing (pinch a finger toward the thumb to drive its effect,
+ * continuous or as a discrete trigger). Grounded in the hand-control research (#80).
+ */
+function HandControls() {
+  const { state, set } = useDialsSettings();
+  const hm = state.effective['handMap'] as HandMap;
+  const patch = (p: Partial<HandMap>) => set('handMap', { ...hm, ...p });
+  const patchFinger = (name: (typeof FINGER_NAMES)[number], r: Partial<HandMap['fingers'][string]>) =>
+    set('handMap', { ...hm, fingers: { ...hm.fingers, [name]: { ...hm.fingers[name], ...r } } });
+
+  return (
+    <div className="space-y-2">
+      <label className="flex items-center justify-between gap-2 text-xs">
+        Note source
+        <select
+          className={selectCls}
+          value={hm.positionSource}
+          onChange={(e) => patch({ positionSource: e.target.value as HandMap['positionSource'] })}
+        >
+          <option value="index">Index finger</option>
+          <option value="wrist">Wrist</option>
+        </select>
+      </label>
+      <Toggle label="Closed fist mutes" checked={hm.opennessGatesGain} onChange={(v) => patch({ opennessGatesGain: v })} />
+      <Toggle label="Open hand → brighter" checked={hm.opennessControlsBrightness} onChange={(v) => patch({ opennessControlsBrightness: v })} />
+      <Toggle label="Pinch → vibrato" checked={hm.pinchControlsVibrato} onChange={(v) => patch({ pinchControlsVibrato: v })} />
+      <label className="flex items-center justify-between gap-2 text-xs">
+        Scale snap
+        <input
+          type="range" min={0} max={1} step={0.01} value={hm.magnetism}
+          onChange={(e) => patch({ magnetism: Number(e.target.value) })}
+        />
+      </label>
+
+      <CollapsibleSection label="Finger effects" defaultOpen={false}>
+        <p className="text-[10px] leading-relaxed text-white/40">
+          Each finger's distance to the thumb controls an effect — pinch a finger toward the thumb to drive it.
+          The index finger is the most controllable; the ring the least.
+        </p>
+        {FINGER_NAMES.map((name) => {
+          const r = hm.fingers[name];
+          return (
+            <div key={name} className="space-y-1">
+              <div className="flex items-center gap-2 text-xs">
+                <span className="w-12 shrink-0 capitalize">{name}</span>
+                <select
+                  className={`${selectCls} flex-1`}
+                  value={r.target}
+                  onChange={(e) => patchFinger(name, { target: e.target.value as FingerTarget })}
+                >
+                  {(['none', ...EFFECTS] as FingerTarget[]).map((t) => (
+                    <option key={t} value={t}>{EFFECT_LABELS[t]}</option>
+                  ))}
+                </select>
+                <button
+                  type="button"
+                  className={`rounded px-1.5 py-1 text-[9px] uppercase tracking-widest transition ${r.target === 'none' ? 'opacity-30' : 'bg-white/10 text-white/70 hover:bg-white/20'}`}
+                  title={r.mode === 'trigger' ? 'Discrete trigger (pinch to fire)' : 'Continuous'}
+                  disabled={r.target === 'none'}
+                  onClick={() => patchFinger(name, { mode: r.mode === 'continuous' ? 'trigger' : 'continuous' })}
+                >
+                  {r.mode === 'trigger' ? 'trig' : 'cont'}
+                </button>
+              </div>
+              {r.target !== 'none' && (
+                <label className="flex items-center justify-between gap-2 pl-12 text-[10px] text-white/60">
+                  sensitivity
+                  <input
+                    type="range" min={0} max={2} step={0.05} value={r.sensitivity}
+                    onChange={(e) => patchFinger(name, { sensitivity: Number(e.target.value) })}
+                  />
+                </label>
+              )}
+            </div>
+          );
+        })}
+      </CollapsibleSection>
+    </div>
+  );
+}
+
 export default function DialsControlsPanel() {
   const { state, set } = useDialsSettings();
   const v = state.effective;
@@ -569,6 +665,10 @@ export default function DialsControlsPanel() {
         </label>
         <VoiceControls side="right" />
         {!syncHands && <VoiceControls side="left" />}
+      </TopSection>
+
+      <TopSection label="Hand">
+        <HandControls />
       </TopSection>
 
       <TopSection label="Face">

--- a/src/app/dials/DialsControlsPanel.tsx
+++ b/src/app/dials/DialsControlsPanel.tsx
@@ -588,11 +588,19 @@ function HandControls() {
       <Toggle label="Closed fist mutes" checked={hm.opennessGatesGain} onChange={(v) => patch({ opennessGatesGain: v })} />
       <Toggle label="Open hand → brighter" checked={hm.opennessControlsBrightness} onChange={(v) => patch({ opennessControlsBrightness: v })} />
       <Toggle label="Pinch → vibrato" checked={hm.pinchControlsVibrato} onChange={(v) => patch({ pinchControlsVibrato: v })} />
-      <label className="flex items-center justify-between gap-2 text-xs">
-        Scale snap
+      <Toggle label="Position → stereo pan" checked={hm.panByPosition} onChange={(v) => patch({ panByPosition: v })} />
+      <label className={`flex items-center justify-between gap-2 text-xs ${hm.panByPosition ? '' : 'opacity-40'}`}>
+        Pan spread
         <input
-          type="range" min={0} max={1} step={0.01} value={hm.magnetism}
-          onChange={(e) => patch({ magnetism: Number(e.target.value) })}
+          type="range" min={0} max={1} step={0.01} value={hm.panSpread}
+          onChange={(e) => patch({ panSpread: Number(e.target.value) })}
+        />
+      </label>
+      <label className="flex items-center justify-between gap-2 text-xs">
+        Max volume
+        <input
+          type="range" min={0} max={1} step={0.01} value={hm.maxGain}
+          onChange={(e) => patch({ maxGain: Number(e.target.value) })}
         />
       </label>
 
@@ -624,6 +632,17 @@ function HandControls() {
                   onClick={() => patchFinger(name, { mode: r.mode === 'continuous' ? 'trigger' : 'continuous' })}
                 >
                   {r.mode === 'trigger' ? 'trig' : 'cont'}
+                </button>
+                <button
+                  type="button"
+                  className={`rounded px-1.5 py-1 text-[9px] uppercase tracking-widest transition ${
+                    r.target === 'none' ? 'opacity-30' : r.invert ? 'bg-amber-300/20 text-amber-200' : 'bg-white/10 text-white/50 hover:bg-white/20'
+                  }`}
+                  title={r.invert ? 'Inverted: far from the thumb drives it' : 'Normal: close to the thumb drives it'}
+                  disabled={r.target === 'none'}
+                  onClick={() => patchFinger(name, { invert: !r.invert })}
+                >
+                  inv
                 </button>
               </div>
               {r.target !== 'none' && (

--- a/src/app/dials/InstrumentsPanel.tsx
+++ b/src/app/dials/InstrumentsPanel.tsx
@@ -13,7 +13,7 @@
  * overwritten on an explicit, confirmed Save. Re-selecting an instrument reverts.
  */
 import { useState } from 'react';
-import { Music2, Settings, X, ArrowLeft } from 'lucide-react';
+import { Music2, Settings, X, ArrowLeft, Star, Search } from 'lucide-react';
 import DialsControlsPanel from './DialsControlsPanel';
 import { useInstruments } from './useInstruments';
 import { useDialsSettings } from './useDialsSettings';
@@ -26,7 +26,9 @@ export default function InstrumentsPanel() {
   const [view, setView] = useState<'list' | 'editor'>('list');
   const [confirming, setConfirming] = useState(false);
   const [newName, setNewName] = useState('');
-  const { list, selected, ready, select, save, create } = useInstruments();
+  const [query, setQuery] = useState('');
+  const { list, selected, ready, select, save, create, defaultName, setDefault } = useInstruments();
+  const shown = list.filter((p) => p.name.toLowerCase().includes(query.trim().toLowerCase()));
   const { state } = useDialsSettings();
   const dirty = state.dirty.length > 0;
 
@@ -86,45 +88,72 @@ export default function InstrumentsPanel() {
             {!ready ? (
               <p className="px-2 py-3 text-[11px] text-white/40">Loading instruments…</p>
             ) : (
-              <ul className="space-y-0.5">
-                {list.map((p) => {
-                  const isSel = p.name === selected;
-                  return (
-                    <li
-                      key={p.name}
-                      className={`flex items-center gap-1 rounded-lg ${isSel ? 'bg-white/10' : 'hover:bg-white/5'}`}
-                    >
-                      <button
-                        className={`flex flex-1 items-center gap-2 truncate px-2 py-2 text-left text-xs transition ${
-                          isSel ? 'text-emerald-300' : 'text-white/80 hover:text-white'
-                        }`}
-                        title="Select & play"
-                        onClick={() => select(p.name)}
+              <>
+                {list.length > 6 && (
+                  <div className="mb-1 flex items-center gap-1.5 rounded-lg bg-white/5 px-2">
+                    <Search className="h-3 w-3 shrink-0 text-white/30" aria-hidden />
+                    <input
+                      className="w-full bg-transparent py-1.5 text-xs text-white/80 outline-none placeholder:text-white/30"
+                      placeholder="Search instruments…"
+                      value={query}
+                      onChange={(e) => setQuery(e.target.value)}
+                      aria-label="Search instruments"
+                    />
+                  </div>
+                )}
+                <ul className="space-y-0.5">
+                  {shown.map((p) => {
+                    const isSel = p.name === selected;
+                    const isDefault = p.name === defaultName;
+                    return (
+                      <li
+                        key={p.name}
+                        className={`flex items-center gap-1 rounded-lg ${isSel ? 'bg-white/10' : 'hover:bg-white/5'}`}
                       >
-                        <span
-                          className={`inline-block h-1.5 w-1.5 shrink-0 rounded-full ${isSel ? 'bg-emerald-400' : 'bg-white/20'}`}
-                          aria-hidden
-                        />
-                        <span className="truncate">{p.name}</span>
-                        {isSel && dirty && (
-                          <span className="ml-1 shrink-0 text-[9px] uppercase tracking-widest text-amber-300/80">edited</span>
-                        )}
-                      </button>
-                      <button
-                        className="rounded p-2 text-white/40 transition hover:bg-white/10 hover:text-white"
-                        title={`Edit ${p.name}`}
-                        aria-label={`Edit ${p.name}`}
-                        onClick={() => openEditor(p.name)}
-                      >
-                        <Settings className="h-3.5 w-3.5" />
-                      </button>
-                    </li>
-                  );
-                })}
-              </ul>
+                        <button
+                          className={`flex flex-1 items-center gap-2 truncate px-2 py-2 text-left text-xs transition ${
+                            isSel ? 'text-emerald-300' : 'text-white/80 hover:text-white'
+                          }`}
+                          title="Select & play"
+                          onClick={() => select(p.name)}
+                        >
+                          <span
+                            className={`inline-block h-1.5 w-1.5 shrink-0 rounded-full ${isSel ? 'bg-emerald-400' : 'bg-white/20'}`}
+                            aria-hidden
+                          />
+                          <span className="truncate">{p.name}</span>
+                          {isSel && dirty && (
+                            <span className="ml-1 shrink-0 text-[9px] uppercase tracking-widest text-amber-300/80">edited</span>
+                          )}
+                        </button>
+                        <button
+                          className={`rounded p-1.5 transition hover:bg-white/10 ${isDefault ? 'text-amber-300' : 'text-white/25 hover:text-white/70'}`}
+                          title={isDefault ? 'Default instrument (click to clear)' : 'Set as default'}
+                          aria-label={isDefault ? `${p.name} is the default instrument` : `Set ${p.name} as default`}
+                          onClick={() => setDefault(p.name)}
+                        >
+                          <Star className={`h-3.5 w-3.5 ${isDefault ? 'fill-current' : ''}`} />
+                        </button>
+                        <button
+                          className="rounded p-2 text-white/40 transition hover:bg-white/10 hover:text-white"
+                          title={`Edit ${p.name}`}
+                          aria-label={`Edit ${p.name}`}
+                          onClick={() => openEditor(p.name)}
+                        >
+                          <Settings className="h-3.5 w-3.5" />
+                        </button>
+                      </li>
+                    );
+                  })}
+                  {shown.length === 0 && (
+                    <li className="px-2 py-3 text-[11px] text-white/40">No instruments match “{query}”.</li>
+                  )}
+                </ul>
+              </>
             )}
             <p className="px-2 pb-2 pt-3 text-[10px] leading-relaxed text-white/40">
-              Click a name to play it. The gear edits an instrument; your tweaks are kept until you Save.
+              Click a name to play it. ★ sets your default (loaded next time); the gear edits an
+              instrument (tweaks kept until you Save).
             </p>
             <div className="mt-1 flex gap-1 border-t border-white/10 px-2 pt-2">
               <input

--- a/src/app/dials/instruments.ts
+++ b/src/app/dials/instruments.ts
@@ -27,7 +27,28 @@ import type { ProfileStorage } from '@zodal/dials-ui';
 import type { Layer } from '@zodal/dials-core';
 import { thoreminDials, settingsToLayer, layerToSettings } from '@/settings/dials';
 import type { Settings } from '@/settings/schema';
+import { DEFAULT_HAND_MAP, RECOMMENDED_FINGER_ROUTES, type HandMap, type FingerRoute, type FingerTarget } from '@/nodes/mapping/hand_map';
+import type { FingerName } from '@/nodes/domain';
 import { dialsStore } from './settingsStore';
+
+// --- Hand-map builders for the feature-demo seeds ---------------------------------
+const route = (target: FingerTarget, over: Partial<FingerRoute> = {}): FingerRoute => ({
+  target,
+  sensitivity: 1,
+  mode: 'continuous',
+  invert: false,
+  ...over,
+});
+/** A finger route set with the named fingers overridden, the rest off. */
+const fingerRoutes = (r: Partial<Record<FingerName, FingerRoute>>): HandMap['fingers'] => ({
+  index: route('none'),
+  middle: route('none'),
+  ring: route('none'),
+  pinky: route('none'),
+  ...r,
+});
+/** A hand map = the default (index source, no routing, classic knobs) with overrides. */
+const handMap = (over: Partial<HandMap>): HandMap => ({ ...structuredClone(DEFAULT_HAND_MAP), ...over });
 
 /** Reserved profile name (a legacy autosave) — filtered out of the visible list. */
 export const LAST_MODIFIED = 'Last modified';
@@ -49,43 +70,99 @@ function seed(name: string, s: Settings): SeedInstrument {
 }
 
 /**
- * The shipped instruments. A spread of variety to exercise the stack: a forgiving
- * pentatonic default, two face-chord configs (sustained pad vs strummed), a punchy
- * organ lead, and a shimmery arpeggiated ambient patch. Face-chord instruments use a
- * 7-note scale (today's requirement; see issue #75 for relaxing it).
+ * The shipped instruments — a dozen, each demoing a feature of the stack:
+ *  - the gentle default;
+ *  - WRIST note-tracking + open/closed-hand effects (fist-mute, open-brightness);
+ *  - FINGER→effect routing (per-finger closeness → brightness / vibrato / pan / bend /
+ *    octave / gate), continuous and discrete-trigger;
+ *  - different sound in the left vs right hand;
+ *  - face-chord arpeggio and pulse renderings.
+ * Face-chord instruments use a 7-note scale (today's requirement; see issue #75).
+ * See discussion #80 for the research behind the finger→effect defaults.
  */
 export const SEED_INSTRUMENTS: SeedInstrument[] = [
-  // Forgiving + consonant out of the box — the gentle default (≈ the dials defaults).
+  // --- The gentle default (index note source, no finger routing) ------------------
   seed('Pentatonic', { ...DEFAULTS }),
 
-  // The face-chord showcase: a major scale, expression plays a sustained triad.
-  seed('Major + face chords', {
+  // --- Wrist tracking + open/closed hand (6) --------------------------------------
+  // Play with your whole hand (steadier than the fingertip); a closed fist silences.
+  seed('Wrist Theremin', {
     ...DEFAULTS,
-    right: { ...DEFAULTS.right, type: 'major' },
-    left: { ...DEFAULTS.left, type: 'major' },
-    faceMapping: 'chord',
+    right: { ...DEFAULTS.right, sound: 'warmPad' },
+    left: { ...DEFAULTS.left, sound: 'warmPad' },
+    handMap: handMap({ positionSource: 'wrist', opennessGatesGain: true }),
   }),
 
-  // Bossa-ish: major pads, gently strummed chords from the face. (strum is staggered
-  // by a fixed onset, not BPM — see isTempoRendering in music/voicing.ts — so no bpm.)
-  seed('Bossa Pads', {
+  // Wrist notes; opening the hand opens the tone (open = brighter).
+  seed('Open Air Pad', {
+    ...DEFAULTS,
+    right: { ...DEFAULTS.right, sound: 'glass' },
+    left: { ...DEFAULTS.left, sound: 'glass' },
+    handMap: handMap({ positionSource: 'wrist', opennessControlsBrightness: true }),
+  }),
+
+  // The finger-routing showcase: index→brightness, middle→vibrato, ring→pan,
+  // pinky→pitch-bend (the research-grounded default; discussion #80).
+  seed('Finger FX', {
     ...DEFAULTS,
     right: { ...DEFAULTS.right, type: 'major', sound: 'warmPad' },
-    left: { ...DEFAULTS.left, type: 'major', sound: 'strings' },
-    faceMapping: 'chord',
-    faceChord: { ...DEFAULTS.faceChord, sound: 'strings', voicing: 'spread', rendering: 'strum' },
+    left: { ...DEFAULTS.left, type: 'major', sound: 'warmPad' },
+    handMap: handMap({ positionSource: 'wrist', fingers: { ...RECOMMENDED_FINGER_ROUTES } }),
   }),
 
-  // A punchy blues lead on organ, no face mapping — immediate and hands-only.
-  seed('Blues Organ', {
+  // Bend the pitch by pinching the index toward the thumb (a whole-tone bend).
+  seed('Pitch Bender', {
     ...DEFAULTS,
-    right: { ...DEFAULTS.right, type: 'blues', sound: 'organ' },
-    left: { ...DEFAULTS.left, type: 'blues', sound: 'organ' },
-    masterVolume: 0.45,
+    right: { ...DEFAULTS.right, sound: 'softLead' },
+    left: { ...DEFAULTS.left, sound: 'softLead' },
+    handMap: handMap({
+      positionSource: 'wrist',
+      fingers: fingerRoutes({ index: route('pitchBend', { sensitivity: 1.5 }) }),
+    }),
   }),
 
-  // Shimmery ambient: higher register, glass/bell, expression arpeggiates a chord
-  // (arpUp IS a tempo rendering, so bpm 90 is audible — paired with a crisp bell).
+  // The index finger gates the voice on/off (touch the thumb to sound); middle brightens.
+  seed('Finger Gate', {
+    ...DEFAULTS,
+    right: { ...DEFAULTS.right, sound: 'glass' },
+    left: { ...DEFAULTS.left, sound: 'glass' },
+    handMap: handMap({
+      positionSource: 'wrist',
+      fingers: fingerRoutes({ index: route('gate'), middle: route('brightness') }),
+    }),
+  }),
+
+  // Discrete triggers: pinch the index for +1 octave, the middle to sustain (gate).
+  seed('Trigger Octaves', {
+    ...DEFAULTS,
+    right: { ...DEFAULTS.right, sound: 'bell' },
+    left: { ...DEFAULTS.left, sound: 'bell' },
+    handMap: handMap({
+      positionSource: 'wrist',
+      fingers: fingerRoutes({
+        index: route('octave', { mode: 'trigger' }),
+        middle: route('gate', { mode: 'trigger' }),
+      }),
+    }),
+  }),
+
+  // --- Different sound in each hand (2) -------------------------------------------
+  seed('Split Voices', {
+    ...DEFAULTS,
+    syncHands: false,
+    right: { ...DEFAULTS.right, type: 'major', sound: 'organ' },
+    left: { ...DEFAULTS.left, type: 'minor', sound: 'glass' },
+  }),
+
+  seed('Bell & Strings', {
+    ...DEFAULTS,
+    syncHands: false,
+    right: { ...DEFAULTS.right, type: 'major', sound: 'bell' },
+    left: { ...DEFAULTS.left, type: 'major', sound: 'strings' },
+  }),
+
+  // --- Face-chord renderings (2) --------------------------------------------------
+  // Shimmery ambient: expression arpeggiates a chord (arpUp is tempo-driven → bpm 90).
   seed('Glass Bells', {
     ...DEFAULTS,
     right: { ...DEFAULTS.right, type: 'major', sound: 'glass', baseOctave: 4 },
@@ -93,6 +170,33 @@ export const SEED_INSTRUMENTS: SeedInstrument[] = [
     faceMapping: 'chord',
     faceChord: { ...DEFAULTS.faceChord, sound: 'bell', voicing: 'spread', rendering: 'arpUp', bpm: 90 },
     masterVolume: 0.35,
+  }),
+
+  // Rhythmic re-articulated chords from the face (pulse, tempo-driven).
+  seed('Pulse Organ', {
+    ...DEFAULTS,
+    right: { ...DEFAULTS.right, type: 'major', sound: 'organ' },
+    left: { ...DEFAULTS.left, type: 'major', sound: 'organ' },
+    faceMapping: 'chord',
+    faceChord: { ...DEFAULTS.faceChord, sound: 'organ', voicing: 'close', rendering: 'pulse', bpm: 110 },
+  }),
+
+  // --- Maximalist: wrist notes + all fingers routed + face timbre -----------------
+  seed('Everything', {
+    ...DEFAULTS,
+    right: { ...DEFAULTS.right, type: 'major', sound: 'warmPad' },
+    left: { ...DEFAULTS.left, type: 'major', sound: 'warmPad' },
+    faceMapping: 'timbre',
+    handMap: handMap({
+      positionSource: 'wrist',
+      opennessControlsBrightness: true,
+      fingers: fingerRoutes({
+        index: route('brightness'),
+        middle: route('vibrato'),
+        ring: route('pan'),
+        pinky: route('octave', { mode: 'trigger' }),
+      }),
+    }),
   }),
 ];
 

--- a/src/app/dials/instruments.ts
+++ b/src/app/dials/instruments.ts
@@ -211,13 +211,40 @@ function instrumentStorage(): ProfileStorage {
 /** The instruments profile store (named layers persisted to localStorage). */
 export const instruments = createProfileStore(instrumentStorage());
 
-/** Seed the shipped instruments on first run (when no named instrument exists yet).
- *  Idempotent: a no-op once any named instrument is present. */
+/** Bump when SEED_INSTRUMENTS changes, so a returning user gets the NEW shipped
+ *  instruments added (by name) without re-seeding or clobbering their own. */
+const SEED_VERSION = 2;
+const SEED_VERSION_KEY = 'thoremin.instruments.seedVersion';
+
+const readSeedVersion = (): number => {
+  try {
+    return Number(localStorage.getItem(SEED_VERSION_KEY)) || 0;
+  } catch {
+    return 0;
+  }
+};
+const writeSeedVersion = (): void => {
+  try {
+    localStorage.setItem(SEED_VERSION_KEY, String(SEED_VERSION));
+  } catch {
+    /* non-browser / disabled storage */
+  }
+};
+
+/**
+ * Ensure the shipped instruments are present. First run seeds them all; a later run
+ * whose stored SEED_VERSION is behind ADDS any shipped instrument whose name isn't
+ * already saved (so an existing user gains the new demos without losing their own or
+ * having edits/deletions of same-named ones clobbered). Idempotent once up to date.
+ */
 export async function ensureSeeded(): Promise<void> {
   const list = await instruments.list();
-  const named = list.filter((p) => p.name !== LAST_MODIFIED);
-  if (named.length > 0) return;
-  for (const s of SEED_INSTRUMENTS) await instruments.save(s.name, s.layer);
+  const named = new Set(list.filter((p) => p.name !== LAST_MODIFIED).map((p) => p.name));
+  if (named.size > 0 && readSeedVersion() >= SEED_VERSION) return;
+  for (const s of SEED_INSTRUMENTS) {
+    if (!named.has(s.name)) await instruments.save(s.name, s.layer);
+  }
+  writeSeedVersion();
 }
 
 const SELECTED_KEY = 'thoremin.instruments.selected';
@@ -263,6 +290,17 @@ export function setDefaultName(name: string): void {
   }
 }
 
+/** True on a genuinely fresh browser — no persisted working state yet. The hot store
+ *  (zustand persist, key 'thoremin-controls') writes only on the first edit/selection,
+ *  so its absence marks a first-ever visit (when the default instrument should open). */
+function isFreshBrowser(): boolean {
+  try {
+    return !localStorage.getItem('thoremin-controls');
+  } catch {
+    return false;
+  }
+}
+
 // --- Orchestration over the dials store (framework-agnostic, unit-tested) ---------
 
 /**
@@ -300,10 +338,14 @@ export async function restoreSession(): Promise<string | null> {
     sel = null;
     setSelectedName(''); // the selected instrument was deleted — clear the stale name
   }
-  // No selection yet (a fresh session) → load the user's default instrument fully.
-  if (!selLayer) {
+  // Open on the user's default instrument ONLY on a genuinely fresh browser (no
+  // persisted working state). On later runs we resume the working layer instead, so
+  // unsaved edits are never discarded by the default. StrictMode-safe: the first
+  // restore writes the hot-store key, so a re-mount takes the resume path.
+  if (!selLayer && isFreshBrowser()) {
     const def = getDefaultName();
     const defLayer = def ? (await instruments.load(def)) ?? null : null;
+    if (def && !defLayer) setDefaultName(''); // the default instrument was deleted — clear it
     if (defLayer) {
       setSelectedName(def!);
       dialsStore.setLayer(defLayer);

--- a/src/app/dials/instruments.ts
+++ b/src/app/dials/instruments.ts
@@ -241,6 +241,28 @@ export function setSelectedName(name: string): void {
   }
 }
 
+const DEFAULT_KEY = 'thoremin.instruments.default';
+
+/** The user's default instrument (loaded on a fresh session), or null. Per-browser
+ *  (thoremin is single-tenant), so "each user" = each browser. */
+export function getDefaultName(): string | null {
+  try {
+    return localStorage.getItem(DEFAULT_KEY) || null;
+  } catch {
+    return null;
+  }
+}
+
+/** Set (or clear, with an empty string) the default instrument name. */
+export function setDefaultName(name: string): void {
+  try {
+    if (name) localStorage.setItem(DEFAULT_KEY, name);
+    else localStorage.removeItem(DEFAULT_KEY);
+  } catch {
+    /* non-browser / disabled storage */
+  }
+}
+
 // --- Orchestration over the dials store (framework-agnostic, unit-tested) ---------
 
 /**
@@ -277,6 +299,17 @@ export async function restoreSession(): Promise<string | null> {
   if (sel && !selLayer) {
     sel = null;
     setSelectedName(''); // the selected instrument was deleted — clear the stale name
+  }
+  // No selection yet (a fresh session) → load the user's default instrument fully.
+  if (!selLayer) {
+    const def = getDefaultName();
+    const defLayer = def ? (await instruments.load(def)) ?? null : null;
+    if (defLayer) {
+      setSelectedName(def!);
+      dialsStore.setLayer(defLayer);
+      dialsStore.markSaved();
+      return def;
+    }
   }
   if (selLayer) {
     dialsStore.setLayer(selLayer);

--- a/src/app/dials/useInstruments.ts
+++ b/src/app/dials/useInstruments.ts
@@ -21,6 +21,8 @@ import {
   selectInstrument,
   commitToInstrument,
   restoreSession,
+  getDefaultName,
+  setDefaultName,
 } from './instruments';
 
 export interface InstrumentsApi {
@@ -36,6 +38,10 @@ export interface InstrumentsApi {
   save: (name: string) => Promise<void>;
   /** Save the current working layer as a NEW named instrument and select it. */
   create: (name: string) => Promise<void>;
+  /** The default instrument (loaded on a fresh session), or null. */
+  defaultName: string | null;
+  /** Toggle an instrument as the per-browser default (clicking the current one clears it). */
+  setDefault: (name: string) => void;
   /** Re-read the named-instrument list. */
   refresh: () => void;
 }
@@ -44,6 +50,7 @@ export function useInstruments(): InstrumentsApi {
   const [list, setList] = useState<ProfileMeta[]>([]);
   const [selected, setSelected] = useState<string | null>(null);
   const [ready, setReady] = useState(false);
+  const [defaultName, setDefaultState] = useState<string | null>(null);
 
   // Track the current selection without making `select` depend on it (so the click
   // handlers stay stable), for reverting an optimistic pick that fails to load.
@@ -60,6 +67,7 @@ export function useInstruments(): InstrumentsApi {
       const sel = await restoreSession();
       if (cancelled) return;
       setSelected(sel);
+      setDefaultState(getDefaultName());
       refresh();
       setReady(true);
     })();
@@ -104,5 +112,11 @@ export function useInstruments(): InstrumentsApi {
     [refresh],
   );
 
-  return { list, selected, ready, select, save, create, refresh };
+  const setDefault = useCallback((name: string) => {
+    const next = getDefaultName() === name ? '' : name; // clicking the current default clears it
+    setDefaultName(next);
+    setDefaultState(next || null);
+  }, []);
+
+  return { list, selected, ready, select, save, create, defaultName, setDefault, refresh };
 }

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -24,12 +24,18 @@ import {
   DEFAULT_FACE_EXPR,
   FaceChordSchema,
   FaceExprSchema,
+  HandMapSchema,
   SettingsSchema,
   type Settings,
   type FaceChord,
   type FaceExpr,
 } from '@/settings/schema';
+import { DEFAULT_HAND_MAP, type HandMap } from '@/nodes/mapping/hand_map';
 import { DEFAULT_RECORDING_FORMATS } from './recording/formats';
+
+/** A fresh deep copy of the default hand map (nested fingers/routes), so the store's
+ *  initializer and healers never share mutable sub-objects with the constant. */
+const defaultHandMap = (): HandMap => structuredClone(DEFAULT_HAND_MAP);
 
 /** The preset keys (derived from the schema — the SSOT). Add a field to
  *  SettingsSchema (+ the store) and it is snapshotted, persisted, and restored
@@ -65,6 +71,10 @@ export interface ControlState {
   faceExpr: FaceExpr;
   /** Composable overlay element config (see canvas_overlay.ts). Live-controlled. */
   overlay: OverlayParams;
+  /** The hand→sound mapping: note source (index/wrist), finger→effect routing, and
+   *  the once-static voice knobs. Read live by `voice-mapping` via
+   *  `ctx.resources.controls`. See src/nodes/mapping/hand_map.ts. */
+  handMap: HandMap;
   /**
    * Output formats a recording is saved in (ids from the recording format
    * registry; always ≥1). A tooling preference — persisted to localStorage but
@@ -85,6 +95,9 @@ export interface ControlState {
   setRecordingFormat(id: string, on: boolean): void;
   /** Patch one overlay element's options (e.g. setOverlayElement('indexGuide', { show: true })). */
   setOverlayElement<K extends keyof OverlayParams>(key: K, patch: Partial<OverlayParams[K]>): void;
+  /** Shallow-patch the hand map (e.g. setHandMap({ positionSource: 'wrist' }), or a new
+   *  `fingers` object for a route change). */
+  setHandMap(patch: Partial<HandMap>): void;
   /** Replace all live controls from a settings snapshot (loading a preset). */
   applySettings(s: Settings): void;
 }
@@ -192,7 +205,18 @@ export function mergeControls(persisted: unknown, current: ControlState): Contro
   const faceMapping = (FACE_MAPPINGS as readonly string[]).includes(p.faceMapping as string)
     ? (p.faceMapping as FaceMapping)
     : legacyFaceToMapping(p.faceEnabled);
-  return { ...current, ...p, overlay, faceMapping, faceChord, faceExpr };
+  // Heal the hand map: re-parse through the schema (older blobs lack it entirely →
+  // fall back to the default index-source, no-routing map), so a returning user can
+  // never leave a finger route or knob unbound.
+  let handMap = current.handMap;
+  if (p.handMap) {
+    try {
+      handMap = HandMapSchema.parse(p.handMap);
+    } catch {
+      handMap = current.handMap;
+    }
+  }
+  return { ...current, ...p, overlay, faceMapping, faceChord, faceExpr, handMap };
 }
 
 // localStorage in the browser; a no-op elsewhere (Node test runtime) so the
@@ -219,6 +243,7 @@ export const useControls = create<ControlState>()(
         degrees: { ...DEFAULT_FACE_EXPR.degrees },
       },
       overlay: defaultOverlay(),
+      handMap: defaultHandMap(),
       recordingFormats: [...DEFAULT_RECORDING_FORMATS],
       setVoice: (side, patch) =>
         set((s) => {
@@ -262,18 +287,19 @@ export const useControls = create<ControlState>()(
         set((s) => ({
           overlay: { ...s.overlay, [key]: { ...s.overlay[key], ...patch } } as OverlayParams,
         })),
+      setHandMap: (patch) => set((s) => ({ handMap: { ...s.handMap, ...patch } })),
       // Restore exactly the schema fields (the setters/recordingFormats are left
       // untouched). Derived from SETTINGS_KEYS, so a new preset field needs no edit.
       applySettings: (st) => set(pickSettings(st as unknown as Record<string, unknown>)),
     }),
     {
       name: 'thoremin-controls',
-      // Version 3: the per-hand / chord timbre field was renamed `instrument` →
-      // `sound` (the word "instrument" is now reserved for a saved config). v2 added
-      // the face-mapping chooser (#64: `faceEnabled` → `faceMapping`). See
-      // migrateControls (both field renames) and mergeControls (heals a stale
-      // `overlay`/`faceChord`/`faceExpr` + clamps `faceMapping`).
-      version: 3,
+      // Version 4: added the `handMap` (note source + finger→effect routing + the
+      // once-static voice knobs); mergeControls heals it from the default for older
+      // blobs. v3: `instrument` → `sound` rename. v2: the face-mapping chooser (#64).
+      // See migrateControls (field renames) and mergeControls (heals stale nested
+      // `overlay`/`faceChord`/`faceExpr`/`handMap` + clamps `faceMapping`).
+      version: 4,
       migrate: migrateControls,
       merge: mergeControls,
       storage: createJSONStorage(controlsStorage),

--- a/src/nodes/domain.ts
+++ b/src/nodes/domain.ts
@@ -22,6 +22,13 @@ export interface Hand {
   handedness: Handedness;
   /** 21 keypoints in pixel coordinates of the source frame. */
   keypoints: Keypoint[];
+  /**
+   * 21 keypoints in MediaPipe *world* coordinates (metres, origin at the hand's
+   * geometric centre). Roughly camera-pose-invariant, so distances between them are
+   * scale- AND rotation-robust — the basis for the invariant finger→thumb features.
+   * Optional: absent for the synthetic source / older detectors (2D fallback then).
+   */
+  worldKeypoints?: Keypoint[];
   score?: number;
 }
 
@@ -32,6 +39,14 @@ export interface HandsFrame {
   hands: Hand[];
 }
 
+/** The four non-thumb fingers, in radial order. */
+export const FINGER_NAMES = ['index', 'middle', 'ring', 'pinky'] as const;
+export type FingerName = (typeof FINGER_NAMES)[number];
+
+/** Per-finger thumb closeness, 0 = far from thumb, 1 = touching the thumb.
+ *  Rotation/scale-invariant (palm-span-normalized world-landmark distances). */
+export type FingerCloseness = Record<FingerName, number>;
+
 /** Per-hand features derived from landmarks, all normalized to [0, 1]. */
 export interface SingleHandFeatures {
   present: boolean;
@@ -39,10 +54,18 @@ export interface SingleHandFeatures {
   x: number;
   /** Index-fingertip vertical position, 0 = top, 1 = bottom. */
   y: number;
+  /** Wrist horizontal position, 0 = left, 1 = right (the wrist-tracking source). */
+  wristX: number;
+  /** Wrist vertical position, 0 = top, 1 = bottom. */
+  wristY: number;
   /** Hand openness: 0 = closed fist, 1 = fully spread. */
   openness: number;
-  /** Thumb-to-index pinch: 0 = wide apart, 1 = touching. */
+  /** Thumb-to-index pinch: 0 = wide apart, 1 = touching. (== fingers.index; kept for
+   *  back-compat with the legacy pinch→vibrato knob.) */
   pinch: number;
+  /** Per-finger thumb closeness (rotation/scale-invariant), the basis of the
+   *  configurable finger→effect routing. */
+  fingers: FingerCloseness;
 }
 
 export interface HandFeatures {
@@ -54,8 +77,11 @@ export const ABSENT_HAND: SingleHandFeatures = {
   present: false,
   x: 0,
   y: 0,
+  wristX: 0,
+  wristY: 0,
   openness: 0,
   pinch: 0,
+  fingers: { index: 0, middle: 0, ring: 0, pinky: 0 },
 };
 
 /** Synthesis parameters for one voice. */
@@ -212,6 +238,12 @@ export function kp(hand: Hand, index: number): Keypoint | undefined {
 
 export function dist2d(a: Keypoint, b: Keypoint): number {
   return Math.hypot(a.x - b.x, a.y - b.y);
+}
+
+/** Euclidean distance including z when present (else 2D). Meaningful on *world*
+ *  (metric) keypoints, where z is a real depth and the distance is view-invariant. */
+export function dist3d(a: Keypoint, b: Keypoint): number {
+  return Math.hypot(a.x - b.x, a.y - b.y, (a.z ?? 0) - (b.z ?? 0));
 }
 
 // ---- Synthetic hand geometry ---------------------------------------------

--- a/src/nodes/domain.ts
+++ b/src/nodes/domain.ts
@@ -60,8 +60,9 @@ export interface SingleHandFeatures {
   wristY: number;
   /** Hand openness: 0 = closed fist, 1 = fully spread. */
   openness: number;
-  /** Thumb-to-index pinch: 0 = wide apart, 1 = touching. (== fingers.index; kept for
-   *  back-compat with the legacy pinch→vibrato knob.) */
+  /** Thumb-to-index pinch: 0 = wide apart, 1 = touching. A similar but separately
+   *  normalized measure to `fingers.index` (2D, hand-scale reference, its own
+   *  thresholds); kept distinct for back-compat with the legacy pinch→vibrato knob. */
   pinch: number;
   /** Per-finger thumb closeness (rotation/scale-invariant), the basis of the
    *  configurable finger→effect routing. */

--- a/src/nodes/features/hand_features.ts
+++ b/src/nodes/features/hand_features.ts
@@ -13,11 +13,16 @@ import { defineNode } from '@/dag';
 import {
   ABSENT_HAND,
   dist2d,
+  dist3d,
+  FINGER_NAMES,
   kp,
   LM,
+  type FingerCloseness,
+  type FingerName,
   type Hand,
   type HandFeatures,
   type HandsFrame,
+  type Keypoint,
   type SingleHandFeatures,
 } from '../domain';
 
@@ -37,6 +42,15 @@ const Params = z.object({
   pinchTouch: z.number().default(0.25),
   /** pinchDist/handScale at/above which pinch=0 (apart). */
   pinchApart: z.number().default(1.2),
+  /**
+   * Finger→thumb closeness range, as a distance RATIO (thumb-tip→fingertip divided
+   * by the rigid palm span index-MCP→pinky-MCP). Rotation/scale-invariant: computed
+   * on world landmarks when present. `fingerTouch` (small ratio) → closeness 1;
+   * `fingerApart` (large ratio) → closeness 0. Defaults are sane starting points; a
+   * per-user open/closed calibration is the intended refinement (see discussion #80).
+   */
+  fingerTouch: z.number().default(0.3),
+  fingerApart: z.number().default(1.8),
 })
   // Fail fast on degenerate ranges (the openness/pinch maps divide by these).
   .refine((p) => p.opennessMax > p.opennessMin, {
@@ -46,6 +60,10 @@ const Params = z.object({
   .refine((p) => p.pinchApart > p.pinchTouch, {
     message: 'pinchApart must be greater than pinchTouch',
     path: ['pinchApart'],
+  })
+  .refine((p) => p.fingerApart > p.fingerTouch, {
+    message: 'fingerApart must be greater than fingerTouch',
+    path: ['fingerApart'],
   });
 type Params = z.infer<typeof Params>;
 
@@ -72,6 +90,43 @@ function handScaleOf(hand: Hand): number {
   return s > 1e-6 ? s : 1;
 }
 
+const FINGER_TIP_LM: Record<FingerName, number> = {
+  index: LM.index_tip,
+  middle: LM.middle_tip,
+  ring: LM.ring_tip,
+  pinky: LM.pinky_tip,
+};
+const ZERO_FINGERS: FingerCloseness = { index: 0, middle: 0, ring: 0, pinky: 0 };
+
+/**
+ * Per-finger thumb closeness (0 = far, 1 = touching the thumb), invariant to hand
+ * orientation and camera distance: uses MediaPipe *world* landmarks when present
+ * (metric 3D → rotation-robust), normalizing the thumb-tip→fingertip distance by the
+ * RIGID palm span (index-MCP → pinky-MCP), then mapping the ratio through
+ * [fingerApart, fingerTouch]. Falls back to 2D image landmarks (scale-invariant only)
+ * when world landmarks are absent (the synthetic source). See discussion #80.
+ */
+function fingerClosenessOf(hand: Hand, p: Params): FingerCloseness {
+  const world = hand.worldKeypoints;
+  const useWorld = !!(world && world.length >= 21);
+  const d = useWorld ? dist3d : dist2d;
+  const get = (i: number): Keypoint | undefined => (useWorld ? world![i] : kp(hand, i));
+  const thumbTip = get(LM.thumb_tip);
+  const indexMcp = get(LM.index_mcp);
+  const pinkyMcp = get(LM.pinky_mcp);
+  if (!thumbTip || !indexMcp || !pinkyMcp) return { ...ZERO_FINGERS };
+  const palmSpan = d(indexMcp, pinkyMcp);
+  if (palmSpan < 1e-6) return { ...ZERO_FINGERS };
+  const out: FingerCloseness = { ...ZERO_FINGERS };
+  for (const name of FINGER_NAMES) {
+    const tip = get(FINGER_TIP_LM[name]);
+    if (!tip) continue;
+    // Inverted range: a small ratio (finger near thumb) → 1, a large ratio → 0.
+    out[name] = normRange(d(thumbTip, tip) / palmSpan, p.fingerApart, p.fingerTouch);
+  }
+  return out;
+}
+
 function extractOne(hand: Hand, frame: HandsFrame, p: Params): SingleHandFeatures {
   const indexTip = kp(hand, LM.index_tip);
   const wrist = kp(hand, LM.wrist);
@@ -80,6 +135,12 @@ function extractOne(hand: Hand, frame: HandsFrame, p: Params): SingleHandFeature
   const xRaw = indexTip.x / frame.width;
   const x = clamp01(p.mirrorX ? 1 - xRaw : xRaw);
   const y = clamp01(indexTip.y / frame.height);
+
+  // Wrist position (the alternative, steadier note source — the whole hand rather
+  // than the index fingertip). Mirrored like x for the selfie view.
+  const wristXRaw = wrist.x / frame.width;
+  const wristX = clamp01(p.mirrorX ? 1 - wristXRaw : wristXRaw);
+  const wristY = clamp01(wrist.y / frame.height);
 
   const handScale = handScaleOf(hand);
 
@@ -103,7 +164,9 @@ function extractOne(hand: Hand, frame: HandsFrame, p: Params): SingleHandFeature
     pinch = normRange(pinchDist, p.pinchApart, p.pinchTouch);
   }
 
-  return { present: true, x, y, openness, pinch };
+  const fingers = fingerClosenessOf(hand, p);
+
+  return { present: true, x, y, wristX, wristY, openness, pinch, fingers };
 }
 
 export const handFeaturesNode = defineNode<Params>({

--- a/src/nodes/mapping/hand_map.ts
+++ b/src/nodes/mapping/hand_map.ts
@@ -1,0 +1,125 @@
+/**
+ * The hand→sound mapping model — how wrist position and the per-finger→thumb
+ * distances are routed to aspects of the sound. This is the configurable heart of an
+ * "instrument" beyond scale/sound: the note SOURCE (index fingertip or the steadier
+ * wrist), and a routing of each finger to a sound EFFECT from a small palette, each
+ * with a sensitivity and a continuous/trigger mode.
+ *
+ * The design is grounded in the hand-control research (discussion #80): the most
+ * controllable fingers (index) should drive the most perceptually salient sound
+ * aspects (brightness), and coupled/coarse fingers (ring, pinky) the peripheral ones
+ * (pan, pitch-bend) — so finger enslaving falls along congruent sonic dimensions.
+ *
+ * Pure + framework-agnostic (imports only domain types), so {@link fingerEffects} is
+ * unit-tested directly; the {@link voiceMappingNode} applies its output, and the
+ * settings layer builds a Zod schema over {@link EFFECTS} / {@link HandMap}.
+ */
+import { FINGER_NAMES, type FingerCloseness, type FingerName } from '../domain';
+
+/** The sound aspects a finger can be routed to control. All are applied in the voice
+ *  mapping (no synth changes): additive to brightness/vibrato/pan, folded into the
+ *  pitch for pitchBend/octave, and a gain gate for `gate`. */
+export const EFFECTS = ['brightness', 'vibrato', 'pan', 'pitchBend', 'octave', 'gate'] as const;
+export type EffectId = (typeof EFFECTS)[number];
+
+/** A finger route target: an effect, or `none` (the finger does nothing). */
+export type FingerTarget = EffectId | 'none';
+
+/** How a finger's closeness drives its target. `continuous` = proportional;
+ *  `trigger` = a discrete on/off past a threshold (a pinch gesture). */
+export const FINGER_MODES = ['continuous', 'trigger'] as const;
+export type FingerMode = (typeof FINGER_MODES)[number];
+
+export interface FingerRoute {
+  target: FingerTarget;
+  /** Gain on the finger closeness before it drives the effect (0..2). */
+  sensitivity: number;
+  mode: FingerMode;
+  /** Flip the sense (closeness→0 drives the effect instead of closeness→1). */
+  invert: boolean;
+}
+
+/** Where the note pitch/volume comes from: the index fingertip (classic) or the
+ *  wrist (steadier, whole-hand — frees the fingers for effects). */
+export const POSITION_SOURCES = ['index', 'wrist'] as const;
+export type PositionSource = (typeof POSITION_SOURCES)[number];
+
+/** The full hand→sound mapping config (per instrument). Beyond the finger routing it
+ *  also exposes the voice-mapping knobs that used to be static graph params, so an
+ *  instrument can vary them (fist→mute, open→brighter, pinch→vibrato, pan, magnetism). */
+export interface HandMap {
+  positionSource: PositionSource;
+  fingers: Record<FingerName, FingerRoute>;
+  /** 0 = free glide, 1 = hard snap to scale notes. */
+  magnetism: number;
+  /** Max output volume (0..1) at the top of the frame. */
+  maxGain: number;
+  /** A closed fist mutes the voice (openness gates gain). */
+  opennessGatesGain: boolean;
+  /** Hand openness shapes tone brightness (open = brighter). */
+  opennessControlsBrightness: boolean;
+  /** Thumb-index pinch adds vibrato. */
+  pinchControlsVibrato: boolean;
+  /** Hand x position pans the voice in stereo. */
+  panByPosition: boolean;
+  /** Max stereo spread (0..1) at the frame edges when panByPosition is on. */
+  panSpread: number;
+}
+
+const OFF: FingerRoute = { target: 'none', sensitivity: 1, mode: 'continuous', invert: false };
+const route = (target: FingerTarget): FingerRoute => ({ ...OFF, target });
+
+/** No finger routing, index note source — byte-identical to the classic behavior.
+ *  The base app and any instrument that doesn't configure a hand map use this. */
+export const DEFAULT_HAND_MAP: HandMap = {
+  positionSource: 'index',
+  fingers: { index: { ...OFF }, middle: { ...OFF }, ring: { ...OFF }, pinky: { ...OFF } },
+  magnetism: 0.8,
+  maxGain: 0.5,
+  opennessGatesGain: false,
+  opennessControlsBrightness: true,
+  pinchControlsVibrato: true,
+  panByPosition: true,
+  panSpread: 0.5,
+};
+
+/** The research-grounded starting routing (discussion #80): finest finger → most
+ *  salient aspect (index→brightness), then vibrato, then the peripheral pan / pitch
+ *  on the coarser, more-coupled fingers. */
+export const RECOMMENDED_FINGER_ROUTES: Record<FingerName, FingerRoute> = {
+  index: route('brightness'),
+  middle: route('vibrato'),
+  ring: route('pan'),
+  pinky: route('pitchBend'),
+};
+
+/** Closeness above which a `trigger`-mode finger fires (with a little hysteresis room). */
+export const TRIGGER_THRESHOLD = 0.6;
+/** Max upward pitch bend a finger→pitchBend applies, in semitones. */
+export const BEND_SEMITONES = 2;
+
+/**
+ * Combine the finger routes into a per-effect amount. Each routed finger contributes
+ * its (mode/invert/sensitivity-shaped) closeness to its target; fingers sharing a
+ * target are AVERAGED — so routing several fingers to one effect gives the "combined
+ * spread" the user described. Additive effects default to 0; `gate` (multiplicative)
+ * defaults to 1 (pass-through) when no finger drives it. Pure.
+ */
+export function fingerEffects(fingers: FingerCloseness, routes: Record<FingerName, FingerRoute>): Record<EffectId, number> {
+  const bucket: Partial<Record<EffectId, number[]>> = {};
+  for (const name of FINGER_NAMES) {
+    const r = routes[name];
+    if (!r || r.target === 'none') continue;
+    let c = fingers[name];
+    if (r.mode === 'trigger') c = c > TRIGGER_THRESHOLD ? 1 : 0;
+    if (r.invert) c = 1 - c;
+    const amount = Math.max(0, Math.min(1, c * r.sensitivity));
+    (bucket[r.target] ??= []).push(amount);
+  }
+  const out = {} as Record<EffectId, number>;
+  for (const e of EFFECTS) {
+    const a = bucket[e];
+    out[e] = a && a.length ? a.reduce((s, x) => s + x, 0) / a.length : e === 'gate' ? 1 : 0;
+  }
+  return out;
+}

--- a/src/nodes/mapping/voice_mapping.ts
+++ b/src/nodes/mapping/voice_mapping.ts
@@ -23,6 +23,7 @@ import {
 import { SoundSchema, SOUND_IDS } from '@/music/sounds';
 import { ABSENT_HAND, type FaceFeatures, type HandFeatures, type SynthParams, type VoiceParams } from '../domain';
 import { MAPPING_SLOT_INPUTS, MAPPING_SLOT_OUTPUT } from './mapping_contract';
+import { BEND_SEMITONES, DEFAULT_HAND_MAP, fingerEffects, type HandMap } from './hand_map';
 
 /** How much a full smile / open mouth add to brightness / vibrato (0..1). */
 const FACE_SMILE_BRIGHTNESS = 0.5;
@@ -81,32 +82,71 @@ interface Control {
   mute: boolean;
 }
 
+const clampPan = (v: number): number => Math.max(-1, Math.min(1, v));
+
+/**
+ * A live hand map (from the control store) wins; otherwise one is built from the
+ * static node params (finger routing off, index note source) — byte-identical to the
+ * classic behavior, so headless graphs/tests are unchanged.
+ */
+function resolveHandMap(live: HandMap | undefined, p: Params): HandMap {
+  if (live) return live;
+  return {
+    ...DEFAULT_HAND_MAP,
+    magnetism: p.magnetism,
+    maxGain: p.maxGain,
+    opennessGatesGain: p.opennessGatesGain,
+    opennessControlsBrightness: p.opennessControlsBrightness,
+    pinchControlsVibrato: p.pinchControlsVibrato,
+    panByPosition: p.panByPosition,
+    panSpread: p.panSpread,
+  };
+}
+
 function voiceFor(
   id: number,
   feat: typeof ABSENT_HAND,
   scaleMidis: number[],
   sound: VoiceParams['sound'],
-  p: Params,
+  hm: HandMap,
   ctrl: Control,
   faceMod: FaceMod,
 ): VoiceParams {
   if (!feat.present || ctrl.mute) {
     return { id, present: false, freq: midiToFreq(scaleMidis[0] ?? 60), gain: 0, sound, brightness: 1, vibrato: 0, pan: 0 };
   }
-  const midi = magneticPitch(feat.x, scaleMidis, ctrl.magnetism) + ctrl.octaveShift * 12;
+  // Note source: the index fingertip (classic) or the steadier wrist. The chosen
+  // position drives pitch (x) and volume (y); the fingers are then free for effects.
+  const px = hm.positionSource === 'wrist' ? feat.wristX : feat.x;
+  const py = hm.positionSource === 'wrist' ? feat.wristY : feat.y;
+
+  // Finger→effect routing (averaged per shared target — the "combined spread").
+  const fx = fingerEffects(feat.fingers, hm.fingers);
+
+  // Pitch: scale-snapped position, plus keyboard octave shift, plus finger octave
+  // and pitch-bend contributions folded into the note.
+  const midi =
+    magneticPitch(px, scaleMidis, ctrl.magnetism) +
+    ctrl.octaveShift * 12 +
+    fx.octave * 12 +
+    fx.pitchBend * BEND_SEMITONES;
   const freq = midiToFreq(midi);
-  let gain = (1 - feat.y) * p.maxGain;
-  if (p.opennessGatesGain) gain *= feat.openness;
+
+  let gain = (1 - py) * hm.maxGain;
+  if (hm.opennessGatesGain) gain *= feat.openness;
+  gain *= fx.gate; // finger gate (1 when no finger routes to gate)
+
   // Openness shapes brightness: closed hand stays mellow (0.3) but never fully
-  // muffled; open hand is fully present (1.0). Off → neutral (fully open). A
-  // smile (face) brightens further.
-  const baseBright = p.opennessControlsBrightness ? 0.3 + 0.7 * feat.openness : 1;
-  const brightness = clamp01(baseBright + faceMod.brightness);
-  // Pinch adds vibrato (0 = none .. 1 = full wobble); an open mouth adds more.
-  const baseVib = p.pinchControlsVibrato ? clamp01(feat.pinch) : 0;
-  const vibrato = clamp01(baseVib + faceMod.vibrato);
-  // Hand x places the voice in stereo: centre at x=0.5, spreading to ±panSpread.
-  const pan = p.panByPosition ? Math.max(-1, Math.min(1, (feat.x - 0.5) * 2 * p.panSpread)) : 0;
+  // muffled; open hand is fully present (1.0). Off → neutral (fully open). A smile
+  // (face) and any finger→brightness routing brighten further.
+  const baseBright = hm.opennessControlsBrightness ? 0.3 + 0.7 * feat.openness : 1;
+  const brightness = clamp01(baseBright + faceMod.brightness + fx.brightness);
+  // Pinch adds vibrato (0 = none .. 1 = full wobble); an open mouth / finger add more.
+  const baseVib = hm.pinchControlsVibrato ? clamp01(feat.pinch) : 0;
+  const vibrato = clamp01(baseVib + faceMod.vibrato + fx.vibrato);
+  // Hand x places the voice in stereo; a finger→pan routing pushes it further.
+  const basePan = hm.panByPosition ? clampPan((px - 0.5) * 2 * hm.panSpread) : 0;
+  const pan = clampPan(basePan + fx.pan);
   return { id, present: true, freq, gain, sound, brightness, vibrato, pan };
 }
 
@@ -126,8 +166,14 @@ export const voiceMappingNode = defineNode<Params>({
       left: { ...ABSENT_HAND },
       right: { ...ABSENT_HAND },
     };
+    // Live control store: the face mode (to suppress timbre in chord mode) and the
+    // hand map (note source + finger→effect routing + the once-static knobs).
+    const controls = (
+      ctx?.resources?.controls as (() => { faceMapping?: string; handMap?: HandMap }) | undefined
+    )?.();
+    const hm = resolveHandMap(controls?.handMap, p);
     const ctrl: Control = {
-      magnetism: typeof inputs.magnetism === 'number' ? inputs.magnetism : p.magnetism,
+      magnetism: typeof inputs.magnetism === 'number' ? inputs.magnetism : hm.magnetism,
       octaveShift: typeof inputs.octaveShift === 'number' ? inputs.octaveShift : 0,
       mute: inputs.mute === true,
     };
@@ -152,8 +198,7 @@ export const voiceMappingNode = defineNode<Params>({
     // The mode is read live from the control store; when it is absent (pure
     // headless tests, or a host that predates the chooser) timbre applies as
     // before — preserving the original face→brightness behaviour.
-    const faceMapping = (ctx?.resources?.controls as (() => { faceMapping?: string }) | undefined)?.()
-      ?.faceMapping;
+    const faceMapping = controls?.faceMapping;
     const timbreMode = faceMapping === undefined || faceMapping === 'timbre';
     const face = inputs.face as FaceFeatures | undefined;
     const faceMod: FaceMod =
@@ -165,8 +210,8 @@ export const voiceMappingNode = defineNode<Params>({
         : NO_FACE_MOD;
 
     const voices: VoiceParams[] = [
-      voiceFor(0, f.right, rightScale, instR, p, ctrl, faceMod),
-      voiceFor(1, f.left, leftScale, instL, p, ctrl, faceMod),
+      voiceFor(0, f.right, rightScale, instR, hm, ctrl, faceMod),
+      voiceFor(1, f.left, leftScale, instL, hm, ctrl, faceMod),
     ];
     const out: SynthParams = { voices };
     return { params: out };

--- a/src/nodes/sources/webcam_hands.ts
+++ b/src/nodes/sources/webcam_hands.ts
@@ -50,6 +50,9 @@ interface CategoryLike {
 /** The minimal slice of a `HandLandmarkerResult` this node reads. */
 export interface HandLandmarkerResultLike {
   landmarks: NormalizedLandmarkLike[][];
+  /** Metric 3D landmarks (metres), roughly camera-pose-invariant — used for the
+   *  rotation/scale-invariant finger features. Optional (older results omit it). */
+  worldLandmarks?: NormalizedLandmarkLike[][];
   handedness: CategoryLike[][];
 }
 
@@ -65,6 +68,9 @@ export function resultToHandsFrame(res: HandLandmarkerResultLike, w: number, h: 
   const hands: Hand[] = (res.landmarks ?? []).map((lms, i) => ({
     handedness: (res.handedness?.[i]?.[0]?.categoryName as Handedness) ?? 'Right',
     keypoints: lms.map((l): Keypoint => ({ x: l.x * w, y: l.y * h, z: l.z })),
+    // World landmarks stay in metres (not scaled to pixels) so 3D distances between
+    // them are metric + view-invariant. Absent → downstream falls back to 2D.
+    worldKeypoints: res.worldLandmarks?.[i]?.map((l): Keypoint => ({ x: l.x, y: l.y, z: l.z })),
   }));
   return { width: w, height: h, hands };
 }

--- a/src/settings/dials.ts
+++ b/src/settings/dials.ts
@@ -20,7 +20,8 @@ import { VOICINGS, RENDERINGS, type VoicingId, type RenderingId } from '@/music/
 import { FACE_MAPPINGS, type FaceMapping } from '@/nodes/domain';
 import { DEFAULT_EXPRESSION_SENSITIVITY, DEFAULT_EXPRESSION_TO_DEGREE } from '@/music/expression';
 import { OverlayParamsSchema } from '@/nodes/output/canvas_overlay';
-import { SettingsSchema, DEFAULT_FACE_CHORD, type Settings } from './schema';
+import { DEFAULT_HAND_MAP } from '@/nodes/mapping/hand_map';
+import { SettingsSchema, HandMapSchema, DEFAULT_FACE_CHORD, type Settings } from './schema';
 
 const ScaleEnum = z.enum(Object.keys(SCALE_TYPES) as [ScaleTypeId, ...ScaleTypeId[]]);
 const SoundEnum = z.enum(SOUND_IDS as [SoundId, ...SoundId[]]);
@@ -73,6 +74,9 @@ export const thoreminDials = defineDials(
       .default({ ...DEFAULT_EXPRESSION_TO_DEGREE })
       .meta({ facets: ['Face', 'advanced'], title: 'Expression chord map' }),
     overlay: OverlayParamsSchema.default(OverlayParamsSchema.parse({})).meta({ facets: ['Overlay'], title: 'Overlay' }),
+    // The hand→sound mapping (note source + finger routing + knobs) — a whole-object
+    // dial rendered by the bespoke Hand widget, like `overlay` / the expression maps.
+    handMap: HandMapSchema.default(DEFAULT_HAND_MAP).meta({ facets: ['Hand'], title: 'Hand mapping' }),
   }),
   {
     constraints: {
@@ -111,6 +115,7 @@ export function settingsToLayer(s: Settings): Layer {
     'faceExpr.sensitivity': s.faceExpr.sensitivity,
     'faceExpr.degrees': s.faceExpr.degrees,
     overlay: s.overlay,
+    handMap: s.handMap,
   };
 }
 
@@ -131,5 +136,6 @@ export function layerToSettings(v: Record<string, unknown>): Settings {
     },
     faceExpr: { sensitivity: v['faceExpr.sensitivity'], degrees: v['faceExpr.degrees'] },
     overlay: v.overlay,
+    handMap: v.handMap,
   });
 }

--- a/src/settings/schema.ts
+++ b/src/settings/schema.ts
@@ -56,7 +56,9 @@ export const HandMapSchema = z
     panByPosition: z.boolean(),
     panSpread: z.number().min(0).max(1),
   })
-  .default(DEFAULT_HAND_MAP);
+  // A fresh deep clone per parse — `.default(obj)` only shallow-copies, so nested
+  // finger-route objects would otherwise be shared across every parse AND the constant.
+  .default(() => structuredClone(DEFAULT_HAND_MAP));
 export type HandMapSettings = z.infer<typeof HandMapSchema>;
 
 /** What the player's facial expression controls (none / timbre / chord). */

--- a/src/settings/schema.ts
+++ b/src/settings/schema.ts
@@ -16,9 +16,48 @@ import { VOICINGS, RENDERINGS, type VoicingId, type RenderingId } from '@/music/
 import { FACE_MAPPINGS, legacyFaceToMapping, type FaceMapping } from '@/nodes/domain';
 import { OverlayParamsSchema } from '@/nodes/output/canvas_overlay';
 import { DEFAULT_EXPRESSION_SENSITIVITY, DEFAULT_EXPRESSION_TO_DEGREE } from '@/music/expression';
+import {
+  EFFECTS,
+  POSITION_SOURCES,
+  FINGER_MODES,
+  DEFAULT_HAND_MAP,
+  type FingerTarget,
+  type PositionSource,
+  type FingerMode,
+} from '@/nodes/mapping/hand_map';
 
 const ScaleTypeEnum = z.enum(Object.keys(SCALE_TYPES) as [ScaleTypeId, ...ScaleTypeId[]]);
 const InstrumentEnum = z.enum(SOUND_IDS as [SoundId, ...SoundId[]]);
+
+// ---- Hand map (note source + finger→effect routing + once-static voice knobs) ----
+const FingerTargetEnum = z.enum(['none', ...EFFECTS] as unknown as [FingerTarget, ...FingerTarget[]]);
+const FingerRouteSchema = z.object({
+  target: FingerTargetEnum,
+  sensitivity: z.number().min(0).max(2),
+  mode: z.enum(FINGER_MODES as unknown as [FingerMode, ...FingerMode[]]),
+  invert: z.boolean(),
+});
+/** A saved hand→sound mapping. `.default(...)` keeps presets/instruments saved before
+ *  the hand map existed valid (they get the classic index-note-source, no-routing map). */
+export const HandMapSchema = z
+  .object({
+    positionSource: z.enum(POSITION_SOURCES as unknown as [PositionSource, ...PositionSource[]]),
+    fingers: z.object({
+      index: FingerRouteSchema,
+      middle: FingerRouteSchema,
+      ring: FingerRouteSchema,
+      pinky: FingerRouteSchema,
+    }),
+    magnetism: z.number().min(0).max(1),
+    maxGain: z.number().min(0).max(1),
+    opennessGatesGain: z.boolean(),
+    opennessControlsBrightness: z.boolean(),
+    pinchControlsVibrato: z.boolean(),
+    panByPosition: z.boolean(),
+    panSpread: z.number().min(0).max(1),
+  })
+  .default(DEFAULT_HAND_MAP);
+export type HandMapSettings = z.infer<typeof HandMapSchema>;
 
 /** What the player's facial expression controls (none / timbre / chord). */
 export const FaceMappingSchema = z.enum(
@@ -100,6 +139,8 @@ export const SettingsSchema = z.object({
   // presets saved before the expression-mapping editor valid.
   faceExpr: FaceExprSchema,
   overlay: OverlayParamsSchema,
+  // Note source + finger→effect routing + the once-static voice-mapping knobs.
+  handMap: HandMapSchema,
 });
 export type Settings = z.infer<typeof SettingsSchema>;
 

--- a/test/dials.test.ts
+++ b/test/dials.test.ts
@@ -51,6 +51,28 @@ describe('thoreminDials', () => {
     }
   });
 
+  it('round-trips a fully custom handMap (not just the default)', () => {
+    const custom = sample({
+      handMap: {
+        positionSource: 'wrist',
+        fingers: {
+          index: { target: 'brightness', sensitivity: 1.5, mode: 'continuous', invert: false },
+          middle: { target: 'vibrato', sensitivity: 0.8, mode: 'trigger', invert: true },
+          ring: { target: 'pan', sensitivity: 1, mode: 'continuous', invert: false },
+          pinky: { target: 'octave', sensitivity: 2, mode: 'trigger', invert: false },
+        },
+        magnetism: 0.3,
+        maxGain: 0.7,
+        opennessGatesGain: true,
+        opennessControlsBrightness: false,
+        pinchControlsVibrato: false,
+        panByPosition: false,
+        panSpread: 0.9,
+      },
+    });
+    expect(layerToSettings(settingsToLayer(custom)).handMap).toEqual(custom.handMap);
+  });
+
   it('enforces the chord-needs-a-7-note-scale constraint', () => {
     const base = thoreminDials.defaults as Record<string, unknown>;
     expect(thoreminDials.validate({ ...base, 'face.mapping': 'chord', 'right.type': 'pentatonic' }).ok).toBe(false);

--- a/test/hand_map.test.ts
+++ b/test/hand_map.test.ts
@@ -1,0 +1,75 @@
+/**
+ * The finger→effect routing math (hand_map.ts). fingerEffects combines the per-finger
+ * closeness into a per-effect amount: additive effects default to 0, the gain `gate`
+ * defaults to 1 (pass-through), fingers sharing a target are averaged ("combined
+ * spread"), and the mode/invert/sensitivity shaping is applied. Pure — the voice
+ * mapping just applies this output.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  fingerEffects,
+  DEFAULT_HAND_MAP,
+  RECOMMENDED_FINGER_ROUTES,
+  EFFECTS,
+  TRIGGER_THRESHOLD,
+  type FingerRoute,
+} from '@/nodes/mapping/hand_map';
+import type { FingerCloseness } from '@/nodes/domain';
+
+const closeness = (o: Partial<FingerCloseness> = {}): FingerCloseness => ({ index: 0, middle: 0, ring: 0, pinky: 0, ...o });
+const route = (over: Partial<FingerRoute>): FingerRoute => ({ target: 'none', sensitivity: 1, mode: 'continuous', invert: false, ...over });
+const noRoutes = () => ({ index: route({}), middle: route({}), ring: route({}), pinky: route({}) });
+
+describe('fingerEffects', () => {
+  it('no routing → every additive effect 0, gate 1 (pass-through)', () => {
+    const fx = fingerEffects(closeness({ index: 0.8 }), noRoutes());
+    for (const e of EFFECTS) expect(fx[e]).toBe(e === 'gate' ? 1 : 0);
+  });
+
+  it('a continuous route passes closeness*sensitivity to its target', () => {
+    const routes = { ...noRoutes(), index: route({ target: 'brightness', sensitivity: 1 }) };
+    expect(fingerEffects(closeness({ index: 0.7 }), routes).brightness).toBeCloseTo(0.7);
+    const routes2 = { ...noRoutes(), index: route({ target: 'brightness', sensitivity: 2 }) };
+    expect(fingerEffects(closeness({ index: 0.7 }), routes2).brightness).toBe(1); // clamped
+  });
+
+  it('two fingers on the same target are averaged (combined spread)', () => {
+    const routes = {
+      ...noRoutes(),
+      index: route({ target: 'brightness' }),
+      middle: route({ target: 'brightness' }),
+    };
+    expect(fingerEffects(closeness({ index: 1, middle: 0 }), routes).brightness).toBeCloseTo(0.5);
+  });
+
+  it('trigger mode is binary at the threshold', () => {
+    const routes = { ...noRoutes(), pinky: route({ target: 'octave', mode: 'trigger' }) };
+    expect(fingerEffects(closeness({ pinky: TRIGGER_THRESHOLD + 0.05 }), routes).octave).toBe(1);
+    expect(fingerEffects(closeness({ pinky: TRIGGER_THRESHOLD - 0.05 }), routes).octave).toBe(0);
+  });
+
+  it('invert flips the sense', () => {
+    const routes = { ...noRoutes(), index: route({ target: 'vibrato', invert: true }) };
+    expect(fingerEffects(closeness({ index: 0.25 }), routes).vibrato).toBeCloseTo(0.75);
+  });
+
+  it('gate averages when driven, else passes through at 1', () => {
+    const routes = { ...noRoutes(), ring: route({ target: 'gate' }) };
+    expect(fingerEffects(closeness({ ring: 0.4 }), routes).gate).toBeCloseTo(0.4);
+    expect(fingerEffects(closeness({ ring: 0 }), routes).gate).toBe(0); // driven → 0 (muted)
+    expect(fingerEffects(closeness({}), noRoutes()).gate).toBe(1); // undriven → pass-through
+  });
+
+  it('the default hand map does no finger routing (backward compatible)', () => {
+    const fx = fingerEffects(closeness({ index: 1, middle: 1, ring: 1, pinky: 1 }), DEFAULT_HAND_MAP.fingers);
+    for (const e of EFFECTS) expect(fx[e]).toBe(e === 'gate' ? 1 : 0);
+  });
+
+  it('the recommended routes drive brightness/vibrato/pan/pitchBend', () => {
+    const fx = fingerEffects(closeness({ index: 0.9, middle: 0.5, ring: 0.3, pinky: 0.2 }), RECOMMENDED_FINGER_ROUTES);
+    expect(fx.brightness).toBeCloseTo(0.9);
+    expect(fx.vibrato).toBeCloseTo(0.5);
+    expect(fx.pan).toBeCloseTo(0.3);
+    expect(fx.pitchBend).toBeCloseTo(0.2);
+  });
+});

--- a/test/hand_pipeline.test.ts
+++ b/test/hand_pipeline.test.ts
@@ -72,6 +72,24 @@ describe('hand-features node', () => {
     expect((pinched.features as HandFeatures).right.pinch).toBeGreaterThan(0.5);
   });
 
+  it('finger→thumb closeness: index rises as the thumb pinches toward it; wrist position reported', async () => {
+    const run = (spread: number, pinch: number) =>
+      replayNode(handFeaturesNode.make(FEAT_PARSED), { hands: [rightHandFrame(spread, pinch)] });
+    const [pinched] = await run(0.5, 1);
+    const [unpinched] = await run(0.5, 0);
+    const rp = (pinched.features as HandFeatures).right;
+    const ru = (unpinched.features as HandFeatures).right;
+    // The synthetic thumb swings toward the index tip on pinch → fingers.index rises.
+    expect(rp.fingers.index).toBeGreaterThan(ru.fingers.index);
+    expect(rp.fingers.index).toBeGreaterThan(0.9);
+    expect(Number.isFinite(rp.fingers.middle)).toBe(true);
+    // Wrist position is reported in [0, 1] (the alternative note source).
+    for (const v of [rp.wristX, rp.wristY]) {
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThanOrEqual(1);
+    }
+  });
+
   it('reports both hands absent when no hands present', async () => {
     const [out] = await replayNode(handFeaturesNode.make(FEAT_PARSED), {
       hands: [{ width: 640, height: 480, hands: [] } as HandsFrame],

--- a/test/instruments.test.ts
+++ b/test/instruments.test.ts
@@ -53,22 +53,22 @@ describe('seed instruments', () => {
 describe('instruments orchestration over the dials store', () => {
   it('selectInstrument loads the layer as a clean baseline (dirty empty)', async () => {
     await ensureSeeded();
-    const layer = await selectInstrument('Blues Organ');
+    const layer = await selectInstrument('Split Voices');
     expect(layer).not.toBeNull();
     const s = dialsStore.getState();
-    expect(s.effective['right.type']).toBe('blues');
+    expect(s.effective['right.type']).toBe('major');
     expect(s.effective['right.sound']).toBe('organ');
     expect(s.dirty.length).toBe(0);
   });
 
   it('editing after select dirties the store; commit clears it and persists', async () => {
     await ensureSeeded();
-    await selectInstrument('Blues Organ');
+    await selectInstrument('Split Voices');
     dialsStore.set('master.volume', 0.9);
     expect(dialsStore.getState().dirty.length).toBeGreaterThan(0);
-    await commitToInstrument('Blues Organ');
+    await commitToInstrument('Split Voices');
     expect(dialsStore.getState().dirty.length).toBe(0);
-    const reloaded = await instruments.load('Blues Organ');
+    const reloaded = await instruments.load('Split Voices');
     expect(reloaded?.['master.volume']).toBe(0.9);
   });
 
@@ -94,12 +94,12 @@ describe('instruments orchestration over the dials store', () => {
     try {
       await ensureSeeded();
       await selectInstrument('Pentatonic'); // working layer = Pentatonic, clean
-      setSelectedName('Blues Organ'); // pretend Blues Organ is the selected instrument
+      setSelectedName('Split Voices'); // pretend Split Voices is the selected instrument
       dialsStore.set('master.volume', 0.123); // an unsaved working tweak
       const sel = await restoreSession();
-      expect(sel).toBe('Blues Organ');
+      expect(sel).toBe('Split Voices');
       expect(dialsStore.getState().effective['master.volume']).toBeCloseTo(0.123); // working preserved
-      expect(dialsStore.getState().dirty.length).toBeGreaterThan(0); // dirty vs Blues Organ baseline
+      expect(dialsStore.getState().dirty.length).toBeGreaterThan(0); // dirty vs Split Voices baseline
     } finally {
       (globalThis as { localStorage?: unknown }).localStorage = orig;
     }

--- a/test/overlay_elements.test.ts
+++ b/test/overlay_elements.test.ts
@@ -84,8 +84,8 @@ function fullInputs() {
     ],
   };
   const features: HandFeatures = {
-    right: { present: true, x: 0.7, y: 0.4, openness: 0.6, pinch: 0.2 },
-    left: { present: true, x: 0.3, y: 0.6, openness: 0.3, pinch: 0.8 },
+    right: { present: true, x: 0.7, y: 0.4, wristX: 0.7, wristY: 0.5, openness: 0.6, pinch: 0.2, fingers: { index: 0.2, middle: 0.1, ring: 0.1, pinky: 0.1 } },
+    left: { present: true, x: 0.3, y: 0.6, wristX: 0.3, wristY: 0.6, openness: 0.3, pinch: 0.8, fingers: { index: 0.8, middle: 0.3, ring: 0.2, pinky: 0.1 } },
   };
   const params: SynthParams = {
     voices: [

--- a/test/webcam_hands.test.ts
+++ b/test/webcam_hands.test.ts
@@ -34,4 +34,24 @@ describe('resultToHandsFrame', () => {
     const frame = resultToHandsFrame({ landmarks: [], handedness: [] }, 640, 480);
     expect(frame.hands).toEqual([]);
   });
+
+  it('carries metric world landmarks unscaled (for the invariant finger features)', () => {
+    const landmarks = Array.from({ length: 21 }, () => ({ x: 0.5, y: 0.5, z: 0 }));
+    const world = Array.from({ length: 21 }, (_, i) => ({ x: i * 0.01, y: 0, z: -0.02 }));
+    const res: HandLandmarkerResultLike = {
+      landmarks: [landmarks],
+      worldLandmarks: [world],
+      handedness: [[{ categoryName: 'Right' }]],
+    };
+    const frame = resultToHandsFrame(res, 640, 480);
+    expect(frame.hands[0].worldKeypoints).toHaveLength(21);
+    // World coords stay in metres — NOT multiplied by width/height.
+    expect(frame.hands[0].worldKeypoints![20]).toMatchObject({ x: 0.2, y: 0, z: -0.02 });
+  });
+
+  it('omits worldKeypoints when the result has no world landmarks', () => {
+    const one = Array.from({ length: 21 }, () => ({ x: 0.5, y: 0.5, z: 0 }));
+    const frame = resultToHandsFrame({ landmarks: [one], handedness: [[{ categoryName: 'Right' }]] }, 100, 100);
+    expect(frame.hands[0].worldKeypoints).toBeUndefined();
+  });
 });


### PR DESCRIPTION
Adds a configurable **hand-to-sound mapping** so instruments demo far more than scale + sound — grounded in research posted to **discussion #80** ("On hand control").

## What
- **Invariant hand features** (`domain.ts`, `hand_features.ts`, `webcam_hands.ts`): a wrist note source (steadier than the fingertip) and per-finger→thumb **closeness** (index/middle/ring/pinky), made rotation- & scale-invariant by normalizing on the rigid palm span (index-MCP↔pinky-MCP) over MediaPipe **world landmarks** (2D fallback).
- **`hand_map.ts`**: the model — a note source, a per-finger route to a sound **effect** (`brightness/vibrato/pan/pitchBend/octave/gate`) with sensitivity + continuous/trigger + invert; plus the once-static voice knobs. `fingerEffects()` averages fingers that share a target (the "combined spread"). Pure + unit-tested. **Research-grounded default** (finest finger → most salient aspect: index→brightness, middle→vibrato, ring→pan, pinky→pitchBend).
- **voice-mapping** reads the live hand map via `ctx.resources.controls`; the static-param path is **byte-identical** (headless graphs/tests unchanged).
- **Settings wiring**: `handMap` in the Settings schema + control store (persist **v4**, healed) + the dials schema + the bijection.
- **A dozen demo instruments**: Wrist Theremin (fist-mute), Open Air Pad, Finger FX, Pitch Bender, Finger Gate, Trigger Octaves, Split Voices, Bell & Strings, arp/pulse face chords, "Everything", + Pentatonic. `ensureSeeded` reconciles by seed-version so **existing users gain the new demos** (kept alongside their own).
- **UI**: a "Hand" settings section (note source, whole-hand knobs, per-finger routing editor) + a per-browser **default instrument** (★, opens on a fresh browser) + a **search** box.

## Research → discussion #80 (reusable in the manual + by dev agents)
Four cited studies (tables/mermaid/Vancouver refs): DMI mapping strategies (convergent > one-to-one); finger motor finesse (index highest, ring lowest / most enslaved); rotation/scale-invariant distance recipe; sound-parameter salience (pitch>loudness>brightness). Design principle: map the finest fingers to the most salient sound aspects, letting finger-enslaving fall along congruent sonic dimensions. Composable-instruments "configuration calculus" designed in **#82**.

## Verification
typecheck · **313** tests (finger closeness + wrist, world-landmark mapping, fingerEffects, custom-handMap round-trip) · build · catalog · in-browser (12 seeds, hand map flows through, Hand editor, default/search, migration to 15 for an existing user, zero console errors). Adversarial multi-agent review run; all 8 confirmed findings fixed (default-restore edit-preservation, inert magnetism slider removed, Zod default aliasing, pinch doc, test coverage). Backward compatible; the legacy `?engine=legacy` app is untouched.

**Deferred fast-follows:** the pulse-strength knob (expose `voicing.ts`'s `pulseGate`), per-user finger calibration, tremolo/reverb effects (need synth work).

https://claude.ai/code/session_01JEoe7y1hA5KdEAvvpQXxxt
