### PR TITLE
Feature-accurate visual cues: wrist marker, finger→effect lines/bars, face chord labels, positionable HUD

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -237,10 +237,10 @@ Steers a generative engine (Lyria RealTime) from weighted prompts + config dials
 _Audio + the captured video with overlaid guides._
 
 #### `canvas-overlay` — Canvas Overlay
-Mirrored video + composable overlay elements (guides, landmarks, markers).
+Mirrored video + composable overlay elements (guides, landmarks, markers, cues).
 
 - **roles:** overlay
 - **in:** hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], chord:number[], faceFrame:face-frame, expression:face-expression, octaveShift:number, overlayConfig:overlay-config
 - **out:** —
-- **params:** video (object={}), scaleGuide (object={}), chordGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={}), faceLandmarks (object={}), faceExpression (object={}), timbreLevels (object={})
+- **params:** video (object={}), scaleGuide (object={}), chordGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={}), fingerLines (object={}), faceLandmarks (object={}), timbreLevels (object={}), faceExpression (object={}), fingerBars (object={})
 

--- a/public/catalog.json
+++ b/public/catalog.json
@@ -2,7 +2,7 @@
   {
     "type": "canvas-overlay",
     "title": "Canvas Overlay",
-    "description": "Mirrored video + composable overlay elements (guides, landmarks, markers).",
+    "description": "Mirrored video + composable overlay elements (guides, landmarks, markers, cues).",
     "roles": [
       "overlay"
     ],
@@ -82,7 +82,17 @@
         "default": {}
       },
       {
+        "name": "fingerLines",
+        "type": "object",
+        "default": {}
+      },
+      {
         "name": "faceLandmarks",
+        "type": "object",
+        "default": {}
+      },
+      {
+        "name": "timbreLevels",
         "type": "object",
         "default": {}
       },
@@ -92,7 +102,7 @@
         "default": {}
       },
       {
-        "name": "timbreLevels",
+        "name": "fingerBars",
         "type": "object",
         "default": {}
       }

--- a/public/manual.html
+++ b/public/manual.html
@@ -276,12 +276,12 @@
 <section><h3>Output</h3><p class="blurb">Audio + the captured video with overlaid guides.</p><div class="grid">
     <div class="node">
       <h4><code>canvas-overlay</code> <span class="title">Canvas Overlay</span></h4>
-      <p>Mirrored video + composable overlay elements (guides, landmarks, markers).</p>
+      <p>Mirrored video + composable overlay elements (guides, landmarks, markers, cues).</p>
       <dl>
         <dt>roles</dt><dd>overlay</dd>
         <dt>in</dt><dd>hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], chord:number[], faceFrame:face-frame, expression:face-expression, octaveShift:number, overlayConfig:overlay-config</dd>
         <dt>out</dt><dd>—</dd>
-        <dt>params</dt><dd>video (object={}), scaleGuide (object={}), chordGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={}), faceLandmarks (object={}), faceExpression (object={}), timbreLevels (object={})</dd>
+        <dt>params</dt><dd>video (object={}), scaleGuide (object={}), chordGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={}), fingerLines (object={}), faceLandmarks (object={}), timbreLevels (object={}), faceExpression (object={}), fingerBars (object={})</dd>
       </dl>
     </div></div></section>
 </div></body></html>

--- a/src/app/dials/DialsControlsPanel.tsx
+++ b/src/app/dials/DialsControlsPanel.tsx
@@ -235,7 +235,7 @@ function OverlayControls() {
               className={selectCls}
               value={elt.position as string}
               disabled={!elt.show}
-              onChange={(e) => patch(d.name, { position: e.target.value } as never)}
+              onChange={(e) => patch(d.name, { position: e.target.value })}
             >
               <option value="left">Left</option>
               <option value="right">Right</option>

--- a/src/app/dials/DialsControlsPanel.tsx
+++ b/src/app/dials/DialsControlsPanel.tsx
@@ -228,6 +228,22 @@ function OverlayControls() {
             />
           </label>
         )}
+        {d.position && (
+          <label className={`flex items-center justify-between gap-2 pl-5 text-xs ${elt.show ? '' : 'opacity-40'}`}>
+            Position
+            <select
+              className={selectCls}
+              value={elt.position as string}
+              disabled={!elt.show}
+              onChange={(e) => patch(d.name, { position: e.target.value } as never)}
+            >
+              <option value="left">Left</option>
+              <option value="right">Right</option>
+              <option value="top">Top</option>
+              <option value="bottom">Bottom</option>
+            </select>
+          </label>
+        )}
       </div>
     );
   };

--- a/src/app/dials/instruments.ts
+++ b/src/app/dials/instruments.ts
@@ -28,6 +28,7 @@ import type { Layer } from '@zodal/dials-core';
 import { thoreminDials, settingsToLayer, layerToSettings } from '@/settings/dials';
 import type { Settings } from '@/settings/schema';
 import { DEFAULT_HAND_MAP, RECOMMENDED_FINGER_ROUTES, type HandMap, type FingerRoute, type FingerTarget } from '@/nodes/mapping/hand_map';
+import { OverlayParamsSchema } from '@/nodes/output/canvas_overlay';
 import type { FingerName } from '@/nodes/domain';
 import { dialsStore } from './settingsStore';
 
@@ -50,9 +51,10 @@ const fingerRoutes = (r: Partial<Record<FingerName, FingerRoute>>): HandMap['fin
 /** A hand map = the default (index source, no routing, classic knobs) with overrides. */
 const handMap = (over: Partial<HandMap>): HandMap => ({ ...structuredClone(DEFAULT_HAND_MAP), ...over });
 /** An overlay config = the defaults with a few element sub-objects overridden (to
- *  demo cues like the finger→effect lines / bars). */
+ *  demo cues like the finger→effect lines / bars). Parsed through the schema so a
+ *  partial sub-object override still ships a COMPLETE, valid overlay layer. */
 const overlay = (over: Record<string, unknown>): Settings['overlay'] =>
-  ({ ...DEFAULTS.overlay, ...over }) as Settings['overlay'];
+  OverlayParamsSchema.parse({ ...DEFAULTS.overlay, ...over }) as Settings['overlay'];
 
 /** Reserved profile name (a legacy autosave) — filtered out of the visible list. */
 export const LAST_MODIFIED = 'Last modified';

--- a/src/app/dials/instruments.ts
+++ b/src/app/dials/instruments.ts
@@ -49,6 +49,10 @@ const fingerRoutes = (r: Partial<Record<FingerName, FingerRoute>>): HandMap['fin
 });
 /** A hand map = the default (index source, no routing, classic knobs) with overrides. */
 const handMap = (over: Partial<HandMap>): HandMap => ({ ...structuredClone(DEFAULT_HAND_MAP), ...over });
+/** An overlay config = the defaults with a few element sub-objects overridden (to
+ *  demo cues like the finger→effect lines / bars). */
+const overlay = (over: Record<string, unknown>): Settings['overlay'] =>
+  ({ ...DEFAULTS.overlay, ...over }) as Settings['overlay'];
 
 /** Reserved profile name (a legacy autosave) — filtered out of the visible list. */
 export const LAST_MODIFIED = 'Last modified';
@@ -108,6 +112,8 @@ export const SEED_INSTRUMENTS: SeedInstrument[] = [
     right: { ...DEFAULTS.right, type: 'major', sound: 'warmPad' },
     left: { ...DEFAULTS.left, type: 'major', sound: 'warmPad' },
     handMap: handMap({ positionSource: 'wrist', fingers: { ...RECOMMENDED_FINGER_ROUTES } }),
+    // Show the finger→effect lines (fingertip→thumb, labelled value + effect).
+    overlay: overlay({ fingerLines: { show: true, showLabels: true } }),
   }),
 
   // Bend the pitch by pinching the index toward the thumb (a whole-tone bend).
@@ -181,7 +187,19 @@ export const SEED_INSTRUMENTS: SeedInstrument[] = [
     faceChord: { ...DEFAULTS.faceChord, sound: 'organ', voicing: 'close', rendering: 'pulse', bpm: 110 },
   }),
 
-  // --- Maximalist: wrist notes + all fingers routed + face timbre -----------------
+  // --- Cue demo: wrist source + all fingers routed + BOTH the lines and the bar graph.
+  seed('Finger Cues', {
+    ...DEFAULTS,
+    right: { ...DEFAULTS.right, type: 'major', sound: 'glass' },
+    left: { ...DEFAULTS.left, type: 'major', sound: 'glass' },
+    handMap: handMap({ positionSource: 'wrist', fingers: { ...RECOMMENDED_FINGER_ROUTES } }),
+    overlay: overlay({
+      fingerLines: { show: true, showLabels: true },
+      fingerBars: { show: true, position: 'left' },
+    }),
+  }),
+
+  // --- Maximalist: wrist notes + all fingers routed + face timbre + both finger cues.
   seed('Everything', {
     ...DEFAULTS,
     right: { ...DEFAULTS.right, type: 'major', sound: 'warmPad' },
@@ -196,6 +214,10 @@ export const SEED_INSTRUMENTS: SeedInstrument[] = [
         ring: route('pan'),
         pinky: route('octave', { mode: 'trigger' }),
       }),
+    }),
+    overlay: overlay({
+      fingerLines: { show: true, showLabels: true },
+      fingerBars: { show: true, position: 'right' },
     }),
   }),
 ];
@@ -213,7 +235,7 @@ export const instruments = createProfileStore(instrumentStorage());
 
 /** Bump when SEED_INSTRUMENTS changes, so a returning user gets the NEW shipped
  *  instruments added (by name) without re-seeding or clobbering their own. */
-const SEED_VERSION = 2;
+const SEED_VERSION = 3;
 const SEED_VERSION_KEY = 'thoremin.instruments.seedVersion';
 
 const readSeedVersion = (): number => {

--- a/src/app/overlayControls.ts
+++ b/src/app/overlayControls.ts
@@ -24,6 +24,8 @@ export interface OverlayControlDesc {
   toggles?: { key: string; label: string }[];
   /** A 0..1 slider param (disabled when the element's `show` is off). */
   slider?: { key: string; label: string };
+  /** A cue-position select (`.position` = left/right/top/bottom), for HUD cues. */
+  position?: boolean;
   /** Only meaningful with an active face mapping (the model must be loaded). */
   needsFace?: boolean;
 }
@@ -33,7 +35,26 @@ export const OVERLAY_CONTROLS: OverlayControlDesc[] = [
   { name: 'landmarks', label: 'Hand landmarks' },
   { name: 'faceLandmarks', label: 'Face mesh', needsFace: true },
   { name: 'markers', label: 'Control markers', toggles: [{ key: 'showNotes', label: 'Note names' }] },
-  { name: 'faceExpression', label: 'Face expression' },
+  {
+    name: 'fingerLines',
+    label: 'Finger effect lines',
+    toggles: [{ key: 'showLabels', label: 'Value + effect labels' }],
+  },
+  {
+    name: 'fingerBars',
+    label: 'Finger bar graph',
+    position: true,
+  },
+  {
+    name: 'faceExpression',
+    label: 'Face expression',
+    toggles: [
+      { key: 'topLabel', label: 'Big label on top' },
+      { key: 'exprLabels', label: 'Expression names (x-axis)' },
+      { key: 'chordLabels', label: 'Chord names (x-axis)' },
+    ],
+    position: true,
+  },
   { name: 'timbreLevels', label: 'Timbre levels' },
   { name: 'chordGuide', label: 'Chord highlight' },
   { name: 'scaleGuide', label: 'Scale guide', toggles: [{ key: 'showLabels', label: 'Note labels' }] },

--- a/src/music/theory.ts
+++ b/src/music/theory.ts
@@ -41,6 +41,26 @@ export function midiToName(midi: number): string {
   return `${NOTES[((r % 12) + 12) % 12]}${Math.floor(r / 12) - 1}`;
 }
 
+/**
+ * Name a chord from its MIDI tones (root + a basic triad quality) — e.g. "C", "Am",
+ * "Bdim". Best-effort: the lowest tone is the root and the thirds classify the
+ * quality; falls back to just the root note name when the shape isn't a plain triad.
+ */
+export function chordName(tones: number[]): string {
+  if (!tones.length) return '';
+  const sorted = [...tones].sort((a, b) => a - b);
+  const root = (((sorted[0] % 12) + 12) % 12);
+  const intervals = new Set(sorted.map((m) => ((((m - sorted[0]) % 12) + 12) % 12)));
+  const has = (i: number) => intervals.has(i);
+  let quality = '';
+  if (has(4) && has(7)) quality = '';
+  else if (has(3) && has(7)) quality = 'm';
+  else if (has(3) && has(6)) quality = 'dim';
+  else if (has(4) && has(8)) quality = 'aug';
+  else if (has(7) && !has(3) && !has(4)) quality = '5';
+  return NOTES[root] + quality;
+}
+
 export interface ScaleSpec {
   /** Pitch class of the root, 0 = C ... 11 = B. */
   root: number;

--- a/src/nodes/mapping/hand_map.ts
+++ b/src/nodes/mapping/hand_map.ts
@@ -22,6 +22,16 @@ import { FINGER_NAMES, type FingerCloseness, type FingerName } from '../domain';
 export const EFFECTS = ['brightness', 'vibrato', 'pan', 'pitchBend', 'octave', 'gate'] as const;
 export type EffectId = (typeof EFFECTS)[number];
 
+/** Very short effect names for on-canvas cue labels. */
+export const EFFECT_SHORT: Record<EffectId, string> = {
+  brightness: 'brt',
+  vibrato: 'vib',
+  pan: 'pan',
+  pitchBend: 'bnd',
+  octave: 'oct',
+  gate: 'gate',
+};
+
 /** A finger route target: an effect, or `none` (the finger does nothing). */
 export type FingerTarget = EffectId | 'none';
 

--- a/src/nodes/output/canvas_overlay.ts
+++ b/src/nodes/output/canvas_overlay.ts
@@ -1,30 +1,38 @@
 /**
- * `canvas-overlay` node (browser-only) — the visual output + guides.
+ * `canvas-overlay` node (browser-only) — the visual output + guides + cues.
  *
  * The overlay is composed of an ordered list of independent **overlay elements**
  * (see `OVERLAY_ELEMENTS`): the mirrored webcam backdrop, a per-scale-note pitch
- * guide ("fretboard"), an index-finger guide (a dashed line from the fingertip to
- * the frame edge), hand landmark dots, and a per-hand control marker (openness =
- * ring size, pinch = fill) with the sounding note name.
+ * guide, finger guides, hand/face landmark dots, per-hand control markers, the
+ * finger→thumb effect lines, and HUD "cue" readouts (the face-expression bar graph
+ * and the finger bar graph).
  *
- * Each element is drawn in list order (= z-order), reads only the inputs/params
- * it needs, and is toggled/parameterized by its own sub-object in `Params`. This
- * is the worked example of the project's "sub-components are toggled functions
- * inside one node, never separate DAG nodes" rule (the engine forbids fan-in to
- * the single canvas, and the elements share the 2D context, mirror transform, and
- * z-order). See `docs/design/component-model.md`.
+ * Two kinds of element:
+ *  - **in-scene** elements draw at a feature's location (markers on the hand, lines
+ *    from fingertip to thumb, guides across the frame);
+ *  - **cue** elements are HUD boxes (bar graphs) placed on a screen EDGE and
+ *    auto-stacked when several share one — a cue declares `cue:true` + `measure()`
+ *    + `positionOf()`, and reads its computed origin from `view.layout[name]`.
  *
- * Canvas + video are injected via `ctx.resources`. Pure drawing; produces no
- * port output.
+ * Each element is drawn in list order (= z-order), reads only what it needs, and is
+ * toggled/parameterized by its own sub-object in `Params`. This is the worked
+ * example of the "sub-components are toggled functions inside one node" rule. To
+ * reflect the actual mapping, elements read the live **hand map** (note source +
+ * finger routing) and the expression→degree map via `ctx.resources.controls`.
+ *
+ * Canvas + video are injected via `ctx.resources`. Pure drawing; no port output.
  */
 import { z } from 'zod';
 import { defineNode } from '@/dag';
 import type { NodeContext } from '@/dag';
-import { freqToMidi, midiToName, scaleGuide } from '@/music/theory';
+import { chordName, freqToMidi, midiToName, scaleGuide } from '@/music/theory';
 import { EMOTIONS, type ExpressionScores } from '@/music/expression';
+import { EFFECT_SHORT, type HandMap } from '../mapping/hand_map';
 import {
+  FINGER_NAMES,
   kp,
   LM,
+  type FingerName,
   type FaceFrame,
   type HandFeatures,
   type HandsFrame,
@@ -32,91 +40,70 @@ import {
   type SynthParams,
 } from '../domain';
 
+/** Which screen edge a HUD cue is placed on. */
+const CuePositionEnum = z.enum(['left', 'right', 'top', 'bottom']);
+export type CuePosition = z.infer<typeof CuePositionEnum>;
+
 /**
  * Per-element configuration. Each element has its own sub-object so it can be
- * toggled and parameterized independently — and so a settings panel can be
- * generated one collapsible section per element.
+ * toggled and parameterized independently.
  */
 const Params = z.object({
   /** Mirrored webcam backdrop. `alpha` is the "grey-out" amount (0 = hidden). */
-  video: z
-    .object({
-      show: z.boolean().default(true),
-      alpha: z.number().min(0).max(1).default(0.35),
-    })
-    .prefault({}),
+  video: z.object({ show: z.boolean().default(true), alpha: z.number().min(0).max(1).default(0.35) }).prefault({}),
   /** Faint vertical guide at each scale note (a "fretboard"), with note labels. */
-  scaleGuide: z
-    .object({
-      show: z.boolean().default(true),
-      /** Draw the note-name labels (split from the lines so each toggles alone). */
-      showLabels: z.boolean().default(true),
-    })
-    .prefault({}),
+  scaleGuide: z.object({ show: z.boolean().default(true), showLabels: z.boolean().default(true) }).prefault({}),
   /** Highlight the face-driven chord's tones on the pitch guide (face chord mode). */
-  chordGuide: z
-    .object({
-      show: z.boolean().default(true),
-    })
-    .prefault({}),
+  chordGuide: z.object({ show: z.boolean().default(true) }).prefault({}),
   /** Dashed vertical line from each index fingertip to the frame edge. Opt-in. */
-  indexGuide: z
-    .object({
-      show: z.boolean().default(false),
-      dashed: z.boolean().default(true),
-    })
-    .prefault({}),
-  /** Hand landmark dots + a ring around each index fingertip. */
-  landmarks: z
-    .object({
-      show: z.boolean().default(true),
-    })
-    .prefault({}),
-  /** Per-hand control marker (openness = ring size, pinch = fill). */
-  markers: z
-    .object({
-      show: z.boolean().default(true),
-      /** Show the note name each hand is sounding, above its marker. */
-      showNotes: z.boolean().default(true),
-    })
-    .prefault({}),
+  indexGuide: z.object({ show: z.boolean().default(false), dashed: z.boolean().default(true) }).prefault({}),
+  /** Hand landmark dots + a ring around each hand's active note source. */
+  landmarks: z.object({ show: z.boolean().default(true) }).prefault({}),
+  /** Per-hand control marker at the note source (openness = ring size, pinch = fill). */
+  markers: z.object({ show: z.boolean().default(true), showNotes: z.boolean().default(true) }).prefault({}),
+  /** Lines from each ROUTED fingertip to the thumb, labelled value + effect. Opt-in. */
+  fingerLines: z.object({ show: z.boolean().default(false), showLabels: z.boolean().default(true) }).prefault({}),
   /** The detected face mesh (input feature) — available when a face mapping is on. */
-  faceLandmarks: z
-    .object({
-      show: z.boolean().default(true),
-    })
-    .prefault({}),
-  /** Live readout of the classified facial expression (output feature). */
+  faceLandmarks: z.object({ show: z.boolean().default(true) }).prefault({}),
+  /** Per-hand brightness/vibrato level bars (output feature). Opt-in. */
+  timbreLevels: z.object({ show: z.boolean().default(false) }).prefault({}),
+  /**
+   * Face-expression bar graph (HUD cue): a bar + firing tick per emotion; the winner
+   * is highlighted. Optional vertical x-axis labels (the expression name and/or the
+   * chord each maps to) replace the old top label.
+   */
   faceExpression: z
     .object({
       show: z.boolean().default(true),
+      position: CuePositionEnum.default('left'),
+      /** The big winning-label text above the bars (superseded by the highlight). */
+      topLabel: z.boolean().default(false),
+      /** x-axis: the expression name under each bar (vertical). */
+      exprLabels: z.boolean().default(true),
+      /** x-axis: the chord each expression maps to, under each bar (vertical). */
+      chordLabels: z.boolean().default(true),
     })
     .prefault({}),
-  /** Per-hand brightness/vibrato level bars (output feature). Opt-in. */
-  timbreLevels: z
-    .object({
-      show: z.boolean().default(false),
-    })
+  /** Finger→effect bar graph (HUD cue): a bar per routed finger, effect-labelled. Opt-in. */
+  fingerBars: z
+    .object({ show: z.boolean().default(false), position: CuePositionEnum.default('left') })
     .prefault({}),
 });
 type Params = z.infer<typeof Params>;
 
 /**
- * The overlay's per-element params schema, exported so it is the single source
- * of truth for the overlay portion of saved settings (see src/settings/schema.ts)
- * and for the overlay settings panel. Reuse this rather than redeclaring shapes.
+ * The overlay's per-element params schema, exported so it is the single source of
+ * truth for the overlay portion of saved settings and for the overlay settings panel.
  */
 export const OverlayParamsSchema = Params;
 export type OverlayParams = Params;
 
 const RIGHT_COLOR = '#10b981';
 const LEFT_COLOR = '#3b82f6';
+const FACE_COLOR = '#22d3ee'; // cyan — distinct from hands (emerald/blue) + chord (gold)
+const CHORD_COLOR = '#f5d142'; // warm gold
 
-/**
- * Everything an overlay element needs to draw a frame. `inputs` mirrors the
- * node's input ports; `video` is the optional backdrop resource. All x are drawn
- * mirrored to match the flipped webcam (helpers below).
- */
+/** Everything an overlay element needs to draw a frame. */
 export interface OverlayView {
   W: number;
   H: number;
@@ -128,28 +115,21 @@ export interface OverlayView {
     scale?: number[];
     scaleLeft?: number[];
     octaveShift: number;
-    /** The face-driven chord's tones (MIDI), to highlight on the pitch guide. */
     chord?: number[];
-    /** The raw face frame (blendshapes + landmark geometry), for the face mesh. */
     faceFrame?: FaceFrame;
-    /** The classified facial expression, for the live expression readout. */
     expression?: ExpressionScores;
+    /** Live hand map (note source + finger routing), for feature-accurate cues. */
+    handMap?: HandMap;
+    /** Live expression→scale-degree map, to name each expression's chord. */
+    faceDegrees?: Record<string, number>;
   };
   params: Params;
+  /** Computed top-left origin per cue element name (set by the layout pass). */
+  layout: Record<string, { x: number; y: number }>;
 }
 
-/**
- * The category an overlay element belongs to — the "target space" framing the
- * settings panel groups by (extensible; add more as the mapping space grows):
- *  - `input`    : raw features the camera detected (hand/face landmarks).
- *  - `output`   : what those inputs are mapped to (sounding note, chord, expression,
- *                 timbre levels).
- *  - `guide`    : reference overlays (the pitch fretboard, finger guides).
- *  - `backdrop` : the video itself.
- */
 export type OverlayCategory = 'input' | 'output' | 'guide' | 'backdrop';
 
-/** Category display order + labels for the settings panel (the grouping UI). */
 export const OVERLAY_CATEGORIES: { id: OverlayCategory; label: string; blurb: string }[] = [
   { id: 'input', label: 'Input features', blurb: 'What the camera detected.' },
   { id: 'output', label: 'Output features', blurb: 'What your gestures are mapped to.' },
@@ -158,26 +138,27 @@ export const OVERLAY_CATEGORIES: { id: OverlayCategory; label: string; blurb: st
 ];
 
 /**
- * One composable piece of the overlay. `draw` is responsible for honoring its
- * own `view.params.<name>.show` toggle. `category` groups it in the settings
- * panel (see {@link OVERLAY_CATEGORIES}). Elements are plain functions held inside
- * this node — deliberately NOT DAG nodes (see the module docstring).
+ * One composable piece of the overlay. In-scene elements implement `draw`. A HUD
+ * `cue` also sets `cue:true`, `measure()` (its box size, or null when idle) and
+ * `positionOf()` (its edge); the layout pass computes `view.layout[name]` and `draw`
+ * reads that origin.
  */
 export interface OverlayElement {
   name: string;
   category: OverlayCategory;
+  cue?: boolean;
+  measure?(view: OverlayView): { w: number; h: number } | null;
+  positionOf?(view: OverlayView): CuePosition;
   draw(g: CanvasRenderingContext2D, view: OverlayView): void;
 }
 
-/** Mirror a source-frame x (pixels) into mirrored canvas x. */
 function mirrorX(xPx: number, frameW: number, W: number): number {
   return W - (xPx / frameW) * W;
 }
-
-/** The displayed-right hand is the detected 'Left' (the video is mirrored). */
 function isDisplayedRight(handedness: string): boolean {
   return handedness === 'Left';
 }
+const clamp01 = (x: number) => (x < 0 ? 0 : x > 1 ? 1 : x);
 
 const videoBackdrop: OverlayElement = {
   name: 'video',
@@ -194,8 +175,7 @@ const videoBackdrop: OverlayElement = {
   },
 };
 
-const arrEq = (a?: number[], b?: number[]) =>
-  !!a && !!b && a.length === b.length && a.every((v, i) => v === b[i]);
+const arrEq = (a?: number[], b?: number[]) => !!a && !!b && a.length === b.length && a.every((v, i) => v === b[i]);
 
 const scaleGuideElement: OverlayElement = {
   name: 'scaleGuide',
@@ -234,16 +214,6 @@ const scaleGuideElement: OverlayElement = {
   },
 };
 
-/**
- * Highlights the face-driven chord (issue #64): when the player is in face "chord"
- * mode, the chord's tones light up on the existing pitch guide so the player sees
- * which notes their expression is playing. The highlight reflects the chord's
- * PITCH CLASSES (with octave repetition) — for a C chord {C, E, G}, every visible
- * C, E and G guide line lights up — NOT the specific rendered voicing (which may
- * add a bass octave, doublings, etc.). It is a subtle tint over the guide lines.
- * Idle (no chord) → draws nothing.
- */
-const CHORD_COLOR = '#f5d142'; // warm gold, distinct from the white/blue scale guides
 const chordGuideElement: OverlayElement = {
   name: 'chordGuide',
   category: 'output',
@@ -256,7 +226,7 @@ const chordGuideElement: OverlayElement = {
     const pitchClass = (m: number) => (((m % 12) + 12) % 12);
     const chordPcs = new Set(chord.map(pitchClass));
     g.save();
-    g.globalAlpha = 0.28; // subtle: a visible tint, not a hard band
+    g.globalAlpha = 0.28;
     g.strokeStyle = CHORD_COLOR;
     g.lineWidth = 2;
     for (const { midi, x } of scaleGuide(scale)) {
@@ -271,13 +241,6 @@ const chordGuideElement: OverlayElement = {
   },
 };
 
-/**
- * The "old" overlay the player remembers: a dashed vertical line from each index
- * fingertip up to the top edge (displayed-right hand) or down to the bottom edge
- * (displayed-left hand), in the hand's colour. Reconstructed from the legacy
- * `src/components/Theremin.tsx` (which used `keypoint.name`; here we use the
- * MediaPipe index `LM.index_tip` via `kp()`). Opt-in alongside the marker/guide.
- */
 const indexFingerGuide: OverlayElement = {
   name: 'indexGuide',
   category: 'guide',
@@ -305,13 +268,19 @@ const indexFingerGuide: OverlayElement = {
   },
 };
 
+/** The landmark used as the "note source" ring, per the hand map. */
+const sourceLm = (view: OverlayView): number =>
+  view.inputs.handMap?.positionSource === 'wrist' ? LM.wrist : LM.index_tip;
+
 const landmarkDots: OverlayElement = {
   name: 'landmarks',
   category: 'input',
-  draw(g, { W, H, inputs, params }) {
+  draw(g, view) {
+    const { W, H, inputs, params } = view;
     if (!params.landmarks.show) return;
     const frame = inputs.hands;
     if (!frame) return;
+    const srcLm = sourceLm(view);
     for (const hand of frame.hands) {
       const color = hand.handedness === 'Left' ? RIGHT_COLOR : LEFT_COLOR; // mirrored
       g.fillStyle = color;
@@ -322,10 +291,11 @@ const landmarkDots: OverlayElement = {
         g.arc(sx, sy, 3, 0, Math.PI * 2);
         g.fill();
       }
-      const tip = hand.keypoints[LM.index_tip];
-      if (tip) {
-        const sx = mirrorX(tip.x, frame.width, W);
-        const sy = (tip.y / frame.height) * H;
+      // Ring the ACTIVE note source (wrist or index), matching what plays the note.
+      const src = hand.keypoints[srcLm];
+      if (src) {
+        const sx = mirrorX(src.x, frame.width, W);
+        const sy = (src.y / frame.height) * H;
         g.beginPath();
         g.arc(sx, sy, 10, 0, Math.PI * 2);
         g.strokeStyle = '#fff';
@@ -339,11 +309,13 @@ const landmarkDots: OverlayElement = {
 const controlMarkers: OverlayElement = {
   name: 'markers',
   category: 'output',
-  draw(g, { W, H, inputs, params }) {
+  draw(g, view) {
+    const { W, H, inputs, params } = view;
     if (!params.markers.show) return;
     const feats = inputs.features;
     if (!feats) return;
     const sp = inputs.params;
+    const wrist = inputs.handMap?.positionSource === 'wrist';
     const noteFor = (voiceId: number): string | null => {
       const v = sp?.voices?.[voiceId];
       if (!v || !v.present || v.freq <= 0) return null;
@@ -351,8 +323,9 @@ const controlMarkers: OverlayElement = {
     };
     const drawMarker = (f: SingleHandFeatures, color: string, note: string | null) => {
       if (!f.present) return;
-      const sx = f.x * W;
-      const sy = f.y * H;
+      // The marker sits at the ACTIVE note source (wrist or index fingertip).
+      const sx = (wrist ? f.wristX : f.x) * W;
+      const sy = (wrist ? f.wristY : f.y) * H;
       const ring = 14 + f.openness * 26;
       g.beginPath();
       g.arc(sx, sy, ring, 0, Math.PI * 2);
@@ -378,13 +351,66 @@ const controlMarkers: OverlayElement = {
   },
 };
 
-const FACE_COLOR = '#22d3ee'; // cyan — distinct from hands (emerald/blue) + chord (gold)
-
 /**
- * The detected face mesh (input feature) — the raw face landmarks, drawn as dots,
- * so the player can SEE that face detection is working. Only present when a face
- * mapping is active (the model is loaded); otherwise the face frame is absent.
+ * Finger→thumb effect lines (in-scene): for each ROUTED finger, a line from the
+ * fingertip to the thumb tip, labelled with the normalized closeness value and a very
+ * short effect name (brt/vib/pan/bnd/oct/gate). Shows exactly which distances drive
+ * which sound aspect. Opt-in; nothing without a hand map that routes fingers.
  */
+const fingerLinesElement: OverlayElement = {
+  name: 'fingerLines',
+  category: 'output',
+  draw(g, view) {
+    const { W, H, inputs, params } = view;
+    if (!params.fingerLines.show) return;
+    const frame = inputs.hands;
+    const feats = inputs.features;
+    const routes = inputs.handMap?.fingers;
+    if (!frame || !feats || !routes) return;
+    const TIP: Record<FingerName, number> = {
+      index: LM.index_tip,
+      middle: LM.middle_tip,
+      ring: LM.ring_tip,
+      pinky: LM.pinky_tip,
+    };
+    g.save();
+    g.font = 'bold 11px monospace';
+    g.textAlign = 'center';
+    for (const hand of frame.hands) {
+      const right = isDisplayedRight(hand.handedness);
+      const f = right ? feats.right : feats.left;
+      if (!f.present) continue;
+      const color = right ? RIGHT_COLOR : LEFT_COLOR;
+      const thumb = kp(hand, LM.thumb_tip);
+      if (!thumb) continue;
+      const tx = mirrorX(thumb.x, frame.width, W);
+      const ty = (thumb.y / frame.height) * H;
+      for (const name of FINGER_NAMES) {
+        const r = routes[name];
+        if (!r || r.target === 'none') continue;
+        const tip = kp(hand, TIP[name]);
+        if (!tip) continue;
+        const fx = mirrorX(tip.x, frame.width, W);
+        const fy = (tip.y / frame.height) * H;
+        const value = f.fingers[name];
+        g.globalAlpha = 0.35 + 0.55 * value;
+        g.strokeStyle = color;
+        g.lineWidth = 1.5;
+        g.beginPath();
+        g.moveTo(fx, fy);
+        g.lineTo(tx, ty);
+        g.stroke();
+        if (params.fingerLines.showLabels) {
+          g.globalAlpha = 0.9;
+          g.fillStyle = color;
+          g.fillText(`${EFFECT_SHORT[r.target]} ${value.toFixed(2)}`, (fx + tx) / 2, (fy + ty) / 2 - 3);
+        }
+      }
+    }
+    g.restore();
+  },
+};
+
 const faceMesh: OverlayElement = {
   name: 'faceLandmarks',
   category: 'input',
@@ -395,12 +421,9 @@ const faceMesh: OverlayElement = {
     g.save();
     g.globalAlpha = 0.45;
     g.fillStyle = FACE_COLOR;
-    // One path for all ~478 dots, filled once (moveTo separates the sub-paths so
-    // they don't connect) — far cheaper than a fill per landmark each frame.
     const r = 1.1;
     g.beginPath();
     for (const lm of face.landmarks) {
-      // Landmarks are normalized (0..1) in the source frame; mirror x like the video.
       const sx = (1 - lm.x) * W;
       const sy = lm.y * H;
       g.moveTo(sx + r, sy);
@@ -411,64 +434,6 @@ const faceMesh: OverlayElement = {
   },
 };
 
-/**
- * Live readout of the classified facial expression (output feature) — the decided
- * label plus, per emotion, an activation bar with a white tick at its firing
- * threshold, so the player SEES each emotion's level against its (user-tunable)
- * sensitivity. A fired emotion is opaque; the winning one (driving the chord)
- * glows gold; `neutral` shows no winner (nothing cleared its bar). Top-centre;
- * absent when no face is detected.
- */
-const faceExpressionReadout: OverlayElement = {
-  name: 'faceExpression',
-  category: 'output',
-  draw(g, { W, H, inputs, params }) {
-    if (!params.faceExpression.show) return;
-    const expr = inputs.expression;
-    if (!expr?.present || !expr.scores?.length) return;
-    const clamp01 = (x: number) => (x < 0 ? 0 : x > 1 ? 1 : x);
-    g.save();
-    g.textAlign = 'center';
-    g.font = 'bold 15px monospace';
-    g.fillStyle = FACE_COLOR;
-    g.fillText(expr.label, W * 0.5, H * 0.05);
-    const n = expr.scores.length; // = EMOTIONS.length
-    const barW = 14;
-    const gap = 5;
-    const maxH = 30;
-    const baseY = H * 0.05 + 30;
-    const startX = W * 0.5 - (n * (barW + gap) - gap) / 2 + barW / 2;
-    for (let i = 0; i < n; i++) {
-      const cx = startX + i * (barW + gap);
-      const fired = expr.fired?.[i] ?? false;
-      const isWinner = EMOTIONS[i] === expr.label;
-      // The activation bar — opaque if it fired, dim otherwise; gold if it won.
-      g.globalAlpha = fired ? 0.9 : 0.4;
-      g.strokeStyle = isWinner ? CHORD_COLOR : FACE_COLOR;
-      g.lineWidth = barW;
-      g.beginPath();
-      g.moveTo(cx, baseY);
-      g.lineTo(cx, baseY - (2 + clamp01(expr.scores[i]) * maxH));
-      g.stroke();
-      // The firing-threshold tick (lower tick = more sensitive).
-      const ty = baseY - (2 + clamp01(expr.thresholds?.[i] ?? 0) * maxH);
-      g.globalAlpha = 0.85;
-      g.strokeStyle = '#ffffff';
-      g.lineWidth = 2;
-      g.beginPath();
-      g.moveTo(cx - barW / 2, ty);
-      g.lineTo(cx + barW / 2, ty);
-      g.stroke();
-    }
-    g.restore();
-  },
-};
-
-/**
- * Per-hand brightness/vibrato level bars (output feature) — the timbre values the
- * hand (and, in timbre mode, the face) maps to. NOT the index x/y, which the
- * marker already cues. Opt-in. Drawn as two thin bars beside each hand's marker.
- */
 const timbreLevels: OverlayElement = {
   name: 'timbreLevels',
   category: 'output',
@@ -483,8 +448,6 @@ const timbreLevels: OverlayElement = {
       if (!v) return;
       const sx = f.x * W;
       const sy = f.y * H;
-      // Place the bars toward screen-centre so a hand near the right edge doesn't
-      // push them off-canvas.
       const side = f.x > 0.5 ? -1 : 1;
       const bar = (offset: number, value: number, c: string) => {
         const bx = sx + side * (32 + offset);
@@ -493,11 +456,11 @@ const timbreLevels: OverlayElement = {
         g.lineWidth = 5;
         g.beginPath();
         g.moveTo(bx, sy + 18);
-        g.lineTo(bx, sy + 18 - (3 + Math.max(0, Math.min(1, value)) * 32));
+        g.lineTo(bx, sy + 18 - (3 + clamp01(value) * 32));
         g.stroke();
       };
-      bar(0, v.brightness ?? 1, color); // brightness (from openness / smile)
-      bar(9, v.vibrato ?? 0, CHORD_COLOR); // vibrato (from pinch / open mouth)
+      bar(0, v.brightness ?? 1, color);
+      bar(9, v.vibrato ?? 0, CHORD_COLOR);
     };
     g.save();
     drawLevels(feats.right, 0, RIGHT_COLOR);
@@ -506,10 +469,195 @@ const timbreLevels: OverlayElement = {
   },
 };
 
+// ---- Bar-graph HUD cue helper ----------------------------------------------------
+
+interface BarSpec {
+  value: number; // 0..1
+  threshold?: number; // 0..1, drawn as a white tick
+  color: string;
+  highlight?: boolean; // winner → gold
+  /** Bright (fired) vs dim; defaults to value-cleared-its-threshold. */
+  fired?: boolean;
+  /** Up-to-two vertical x-axis labels (drawn rotated), e.g. expression / chord. */
+  labels?: string[];
+}
+interface BarGraphOpts {
+  title?: string; // optional top label
+  barW?: number;
+  gap?: number;
+  maxH?: number;
+  labelColor?: string;
+}
+const BAR_W = 14;
+const BAR_GAP = 6;
+const BAR_MAXH = 34;
+const PAD = 8;
+const LABEL_LINE_H = 44; // vertical label column height per label line
+
+/** Box size of a bar graph (only the bar count + label lines matter for sizing). */
+function measureBarGraph(bars: { labels?: string[] }[], opts: BarGraphOpts): { w: number; h: number } {
+  const barW = opts.barW ?? BAR_W;
+  const gap = opts.gap ?? BAR_GAP;
+  const maxH = opts.maxH ?? BAR_MAXH;
+  const n = bars.length;
+  const w = n * (barW + gap) - gap + PAD * 2;
+  const labelLines = Math.max(0, ...bars.map((b) => b.labels?.filter(Boolean).length ?? 0));
+  const h = (opts.title ? 18 : 0) + maxH + 6 + labelLines * LABEL_LINE_H + PAD;
+  return { w, h };
+}
+
+/** Draw a bar graph with its top-left at (x0, y0). */
+function drawBarGraph(g: CanvasRenderingContext2D, x0: number, y0: number, bars: BarSpec[], opts: BarGraphOpts): void {
+  const barW = opts.barW ?? BAR_W;
+  const gap = opts.gap ?? BAR_GAP;
+  const maxH = opts.maxH ?? BAR_MAXH;
+  const labelColor = opts.labelColor ?? FACE_COLOR;
+  g.save();
+  let topY = y0 + PAD;
+  if (opts.title) {
+    g.globalAlpha = 1;
+    g.fillStyle = labelColor;
+    g.font = 'bold 14px monospace';
+    g.textAlign = 'left';
+    g.fillText(opts.title, x0 + PAD, topY + 12);
+    topY += 18;
+  }
+  const baseY = topY + maxH;
+  bars.forEach((b, i) => {
+    const cx = x0 + PAD + i * (barW + gap) + barW / 2;
+    const bright = b.fired ?? b.value >= (b.threshold ?? 0.001);
+    g.globalAlpha = bright ? 0.9 : 0.4;
+    g.strokeStyle = b.highlight ? CHORD_COLOR : b.color;
+    g.lineWidth = barW;
+    g.beginPath();
+    g.moveTo(cx, baseY);
+    g.lineTo(cx, baseY - (2 + clamp01(b.value) * maxH));
+    g.stroke();
+    if (b.threshold !== undefined) {
+      const ty = baseY - (2 + clamp01(b.threshold) * maxH);
+      g.globalAlpha = 0.85;
+      g.strokeStyle = '#ffffff';
+      g.lineWidth = 2;
+      g.beginPath();
+      g.moveTo(cx - barW / 2, ty);
+      g.lineTo(cx + barW / 2, ty);
+      g.stroke();
+    }
+    // Vertical x-axis labels (rotated 90°), one line per label.
+    const labels = b.labels?.filter(Boolean) ?? [];
+    labels.forEach((text, li) => {
+      g.save();
+      g.globalAlpha = b.highlight ? 1 : 0.75;
+      g.fillStyle = b.highlight ? CHORD_COLOR : labelColor;
+      g.font = '10px monospace';
+      g.textAlign = 'left';
+      g.translate(cx + 3, baseY + 6 + li * LABEL_LINE_H);
+      g.rotate(Math.PI / 2);
+      g.fillText(text, 0, 0);
+      g.restore();
+    });
+  });
+  g.restore();
+}
+
+/** Diatonic triad tones for a scale degree, from the scale's ascending MIDI notes. */
+function triadForDegree(scale: number[] | undefined, degree: number): number[] {
+  if (!Array.isArray(scale) || degree < 0) return [];
+  const a = scale[degree];
+  const b = scale[degree + 2];
+  const c = scale[degree + 4];
+  return [a, b, c].filter((n): n is number => typeof n === 'number');
+}
+
+const faceExpressionCue: OverlayElement = {
+  name: 'faceExpression',
+  category: 'output',
+  cue: true,
+  positionOf: (view) => view.params.faceExpression.position,
+  measure(view) {
+    const expr = view.inputs.expression;
+    if (!view.params.faceExpression.show || !expr?.present || !expr.scores?.length) return null;
+    const p = view.params.faceExpression;
+    const labelLines = (p.exprLabels ? 1 : 0) + (p.chordLabels ? 1 : 0);
+    return measureBarGraph(
+      expr.scores.map(() => ({ value: 0, labels: new Array(labelLines).fill('x') })),
+      { title: p.topLabel ? expr.label : undefined },
+    );
+  },
+  draw(g, view) {
+    const expr = view.inputs.expression;
+    const origin = view.layout['faceExpression'];
+    if (!expr?.present || !expr.scores?.length || !origin) return;
+    const p = view.params.faceExpression;
+    const bars: BarSpec[] = expr.scores.map((score, i) => {
+      const name = EMOTIONS[i];
+      const isWinner = name === expr.label;
+      const labels: string[] = [];
+      if (p.exprLabels) labels.push(name ?? '');
+      if (p.chordLabels) {
+        const deg = view.inputs.faceDegrees?.[name] ?? -1;
+        labels.push(deg >= 0 ? chordName(triadForDegree(view.inputs.scale, deg)) : '—');
+      }
+      return {
+        value: clamp01(score),
+        threshold: clamp01(expr.thresholds?.[i] ?? 0),
+        color: FACE_COLOR,
+        highlight: isWinner,
+        fired: expr.fired?.[i] ?? false,
+        labels,
+      };
+    });
+    drawBarGraph(g, origin.x, origin.y, bars, { title: p.topLabel ? expr.label : undefined, labelColor: FACE_COLOR });
+  },
+};
+
+const fingerBarsCue: OverlayElement = {
+  name: 'fingerBars',
+  category: 'output',
+  cue: true,
+  positionOf: (view) => view.params.fingerBars.position,
+  measure(view) {
+    if (!view.params.fingerBars.show) return null;
+    const routed = routedFingers(view);
+    if (!routed.length) return null;
+    return measureBarGraph(
+      routed.map(() => ({ value: 0, labels: ['x'] })),
+      { title: 'fingers' },
+    );
+  },
+  draw(g, view) {
+    const origin = view.layout['fingerBars'];
+    if (!origin) return;
+    const routed = routedFingers(view);
+    if (!routed.length) return;
+    const bars: BarSpec[] = routed.map(({ name, target, value }) => ({
+      value: clamp01(value),
+      color: RIGHT_COLOR,
+      labels: [`${name[0]}·${EFFECT_SHORT[target]}`],
+    }));
+    drawBarGraph(g, origin.x, origin.y, bars, { title: 'fingers', labelColor: RIGHT_COLOR });
+  },
+};
+
+/** The routed fingers + the closeness of the present hand (right preferred). */
+function routedFingers(view: OverlayView): { name: FingerName; target: keyof typeof EFFECT_SHORT; value: number }[] {
+  const routes = view.inputs.handMap?.fingers;
+  const feats = view.inputs.features;
+  if (!routes || !feats) return [];
+  const hand = feats.right.present ? feats.right : feats.left.present ? feats.left : null;
+  if (!hand) return [];
+  const out: { name: FingerName; target: keyof typeof EFFECT_SHORT; value: number }[] = [];
+  for (const name of FINGER_NAMES) {
+    const r = routes[name];
+    if (!r || r.target === 'none') continue;
+    out.push({ name, target: r.target, value: hand.fingers[name] });
+  }
+  return out;
+}
+
 /**
- * The overlay elements, in draw (z) order (backdrop first, readouts on top). Each
- * has a `category` (the settings panel groups by it) and a `<name>` sub-object in
- * `Params` with at least a `show` toggle. Append here to add an element.
+ * The overlay elements, in draw (z) order. In-scene first, HUD cues last (on top).
+ * Each has a `category` and a `<name>` sub-object in `Params`. Append here to add one.
  */
 export const OVERLAY_ELEMENTS: readonly OverlayElement[] = [
   videoBackdrop,
@@ -519,35 +667,72 @@ export const OVERLAY_ELEMENTS: readonly OverlayElement[] = [
   faceMesh,
   landmarkDots,
   controlMarkers,
+  fingerLinesElement,
   timbreLevels,
-  faceExpressionReadout,
+  faceExpressionCue,
+  fingerBarsCue,
 ];
+
+// ---- Cue layout: stack the active cues along their chosen edges ------------------
+const CUE_MARGIN = 12;
+const CUE_GAP = 10;
+const CUE_TOP_INSET = 68; // leave room for the top-left brand / top-right panel
+
+/** Compute each active cue's top-left origin, auto-stacking cues that share an edge. */
+function layoutCues(view: OverlayView): Record<string, { x: number; y: number }> {
+  const layout: Record<string, { x: number; y: number }> = {};
+  const active = OVERLAY_ELEMENTS.filter((e) => e.cue).map((e) => ({
+    e,
+    pos: e.positionOf!(view),
+    size: e.measure!(view),
+  }));
+  for (const edge of ['left', 'right', 'top', 'bottom'] as CuePosition[]) {
+    const cues = active.filter((c) => c.size && c.pos === edge) as {
+      e: OverlayElement;
+      size: { w: number; h: number };
+    }[];
+    let off = edge === 'left' || edge === 'right' ? CUE_TOP_INSET : CUE_MARGIN;
+    for (const { e, size } of cues) {
+      let x = CUE_MARGIN;
+      let y = CUE_MARGIN;
+      if (edge === 'left') {
+        x = CUE_MARGIN;
+        y = off;
+        off += size.h + CUE_GAP;
+      } else if (edge === 'right') {
+        x = view.W - size.w - CUE_MARGIN;
+        y = off;
+        off += size.h + CUE_GAP;
+      } else if (edge === 'top') {
+        x = off;
+        y = CUE_MARGIN;
+        off += size.w + CUE_GAP;
+      } else {
+        x = off;
+        y = view.H - size.h - CUE_MARGIN;
+        off += size.w + CUE_GAP;
+      }
+      layout[e.name] = { x, y };
+    }
+  }
+  return layout;
+}
 
 export const canvasOverlayNode = defineNode<Params>({
   type: 'canvas-overlay',
   roles: ['overlay'],
   title: 'Canvas Overlay',
-  description: 'Mirrored video + composable overlay elements (guides, landmarks, markers).',
+  description: 'Mirrored video + composable overlay elements (guides, landmarks, markers, cues).',
   inputs: [
     { name: 'hands', kind: 'hands-frame' },
     { name: 'features', kind: 'hand-features' },
-    // Optional: the synth params (voice 0 = right, 1 = left) so the overlay can
-    // label each hand with the note it is sounding. Unconnected → no labels.
     { name: 'params', kind: 'synth-params' },
-    // Optional: the right hand's scale (MIDI notes) to draw a pitch guide.
     { name: 'scale', kind: 'number[]' },
-    // Optional: the left hand's scale, drawn as a second guide when it differs.
     { name: 'scaleLeft', kind: 'number[]' },
-    // Optional: the face-driven chord's tones (MIDI), highlighted on the guide.
     { name: 'chord', kind: 'number[]' },
-    // Optional: the raw face frame (blendshapes + landmarks), for the face mesh.
     { name: 'faceFrame', kind: 'face-frame' },
-    // Optional: the classified expression, for the live expression readout.
     { name: 'expression', kind: 'face-expression' },
-    // Optional: the live octave shift, so guide labels match the sounding pitch.
     { name: 'octaveShift', kind: 'number', default: 0 },
-    // Optional: a live overlay element config (from the UI store) that overrides
-    // the static `params`, so toggling elements never rebuilds the graph.
     { name: 'overlayConfig', kind: 'overlay-config' },
   ],
   outputs: [],
@@ -565,14 +750,22 @@ export const canvasOverlayNode = defineNode<Params>({
         const H = canvas.height;
         g.clearRect(0, 0, W, H);
 
-        // A live config on the overlayConfig input overrides the static params,
-        // so UI toggles take effect each tick without rebuilding the graph.
+        // Live control store: the hand map (note source + finger routing) and the
+        // expression→degree map, so cues reflect the ACTUAL mapping. Read like
+        // voice-mapping (ctx.resources.controls); absent in headless tests.
+        const controls = (
+          ctx.resources.controls as
+            | (() => { handMap?: HandMap; faceExpr?: { degrees?: Record<string, number> } })
+            | undefined
+        )?.();
+
         const liveConfig = inputs.overlayConfig as OverlayParams | undefined;
         const view: OverlayView = {
           W,
           H,
           video,
           params: liveConfig ?? p,
+          layout: {},
           inputs: {
             hands: inputs.hands as HandsFrame | undefined,
             features: inputs.features as HandFeatures | undefined,
@@ -583,9 +776,12 @@ export const canvasOverlayNode = defineNode<Params>({
             chord: inputs.chord as number[] | undefined,
             faceFrame: inputs.faceFrame as FaceFrame | undefined,
             expression: inputs.expression as ExpressionScores | undefined,
+            handMap: controls?.handMap,
+            faceDegrees: controls?.faceExpr?.degrees,
           },
         };
 
+        view.layout = layoutCues(view);
         for (const element of OVERLAY_ELEMENTS) element.draw(g, view);
 
         return {};

--- a/src/nodes/output/canvas_overlay.ts
+++ b/src/nodes/output/canvas_overlay.ts
@@ -122,6 +122,8 @@ export interface OverlayView {
     handMap?: HandMap;
     /** Live expression→scale-degree map, to name each expression's chord. */
     faceDegrees?: Record<string, number>;
+    /** Live face mapping mode ('chord'/'timbre'/…); chord labels show only in 'chord'. */
+    faceMapping?: string;
   };
   params: Params;
   /** Computed top-left origin per cue element name (set by the layout pass). */
@@ -500,7 +502,11 @@ function measureBarGraph(bars: { labels?: string[] }[], opts: BarGraphOpts): { w
   const gap = opts.gap ?? BAR_GAP;
   const maxH = opts.maxH ?? BAR_MAXH;
   const n = bars.length;
-  const w = n * (barW + gap) - gap + PAD * 2;
+  const barsW = n * (barW + gap) - gap + PAD * 2;
+  // A short title (bold 14px monospace ≈ 8.4px/char) can be wider than a 1-bar box;
+  // take the max so horizontally-stacked (top/bottom) cues don't overlap.
+  const titleW = opts.title ? opts.title.length * 8.4 + PAD * 2 : 0;
+  const w = Math.max(barsW, titleW);
   const labelLines = Math.max(0, ...bars.map((b) => b.labels?.filter(Boolean).length ?? 0));
   const h = (opts.title ? 18 : 0) + maxH + 6 + labelLines * LABEL_LINE_H + PAD;
   return { w, h };
@@ -560,13 +566,21 @@ function drawBarGraph(g: CanvasRenderingContext2D, x0: number, y0: number, bars:
   g.restore();
 }
 
-/** Diatonic triad tones for a scale degree, from the scale's ascending MIDI notes. */
+/**
+ * Diatonic triad tones for a scale degree, by stacking thirds WITHIN the scale's own
+ * octave and wrapping high degrees up an octave (so `vi`/`vii` don't run off a
+ * single-octave array). `per` = notes per octave, detected from the scale. Only used
+ * for chord-mode labels, where the app enforces a seven-note scale — the same shape
+ * `diatonicTriad` plays, so the label agrees with the audio.
+ */
 function triadForDegree(scale: number[] | undefined, degree: number): number[] {
-  if (!Array.isArray(scale) || degree < 0) return [];
-  const a = scale[degree];
-  const b = scale[degree + 2];
-  const c = scale[degree + 4];
-  return [a, b, c].filter((n): n is number => typeof n === 'number');
+  if (!Array.isArray(scale) || scale.length < 3 || degree < 0) return [];
+  const per = scale.filter((m) => m < scale[0] + 12).length || scale.length;
+  const at = (d: number): number | undefined => {
+    const base = scale[((d % per) + per) % per];
+    return typeof base === 'number' ? base + Math.floor(d / per) * 12 : undefined;
+  };
+  return [at(degree), at(degree + 2), at(degree + 4)].filter((n): n is number => typeof n === 'number');
 }
 
 const faceExpressionCue: OverlayElement = {
@@ -578,7 +592,10 @@ const faceExpressionCue: OverlayElement = {
     const expr = view.inputs.expression;
     if (!view.params.faceExpression.show || !expr?.present || !expr.scores?.length) return null;
     const p = view.params.faceExpression;
-    const labelLines = (p.exprLabels ? 1 : 0) + (p.chordLabels ? 1 : 0);
+    // Chord labels are only meaningful (and correct) in chord mode — that's where a
+    // chord actually plays and the app enforces a seven-note scale.
+    const chordMode = view.inputs.faceMapping === 'chord';
+    const labelLines = (p.exprLabels ? 1 : 0) + (p.chordLabels && chordMode ? 1 : 0);
     return measureBarGraph(
       expr.scores.map(() => ({ value: 0, labels: new Array(labelLines).fill('x') })),
       { title: p.topLabel ? expr.label : undefined },
@@ -589,12 +606,13 @@ const faceExpressionCue: OverlayElement = {
     const origin = view.layout['faceExpression'];
     if (!expr?.present || !expr.scores?.length || !origin) return;
     const p = view.params.faceExpression;
+    const chordMode = view.inputs.faceMapping === 'chord';
     const bars: BarSpec[] = expr.scores.map((score, i) => {
       const name = EMOTIONS[i];
       const isWinner = name === expr.label;
       const labels: string[] = [];
       if (p.exprLabels) labels.push(name ?? '');
-      if (p.chordLabels) {
+      if (p.chordLabels && chordMode) {
         const deg = view.inputs.faceDegrees?.[name] ?? -1;
         labels.push(deg >= 0 ? chordName(triadForDegree(view.inputs.scale, deg)) : '—');
       }
@@ -618,41 +636,48 @@ const fingerBarsCue: OverlayElement = {
   positionOf: (view) => view.params.fingerBars.position,
   measure(view) {
     if (!view.params.fingerBars.show) return null;
-    const routed = routedFingers(view);
-    if (!routed.length) return null;
+    const { items } = routedFingers(view);
+    if (!items.length) return null;
     return measureBarGraph(
-      routed.map(() => ({ value: 0, labels: ['x'] })),
+      items.map(() => ({ value: 0, labels: ['x'] })),
       { title: 'fingers' },
     );
   },
   draw(g, view) {
     const origin = view.layout['fingerBars'];
     if (!origin) return;
-    const routed = routedFingers(view);
-    if (!routed.length) return;
-    const bars: BarSpec[] = routed.map(({ name, target, value }) => ({
+    const { side, items } = routedFingers(view);
+    if (!items.length) return;
+    // Colour by the hand actually being read (right preferred), not always emerald.
+    const color = side === 'left' ? LEFT_COLOR : RIGHT_COLOR;
+    const bars: BarSpec[] = items.map(({ name, target, value }) => ({
       value: clamp01(value),
-      color: RIGHT_COLOR,
+      color,
       labels: [`${name[0]}·${EFFECT_SHORT[target]}`],
     }));
-    drawBarGraph(g, origin.x, origin.y, bars, { title: 'fingers', labelColor: RIGHT_COLOR });
+    drawBarGraph(g, origin.x, origin.y, bars, { title: 'fingers', labelColor: color });
   },
 };
 
-/** The routed fingers + the closeness of the present hand (right preferred). */
-function routedFingers(view: OverlayView): { name: FingerName; target: keyof typeof EFFECT_SHORT; value: number }[] {
+/** The routed fingers + the closeness of the present hand (right preferred), plus which
+ *  hand was read (so the bar graph can colour-match it). */
+function routedFingers(view: OverlayView): {
+  side: 'right' | 'left' | null;
+  items: { name: FingerName; target: keyof typeof EFFECT_SHORT; value: number }[];
+} {
   const routes = view.inputs.handMap?.fingers;
   const feats = view.inputs.features;
-  if (!routes || !feats) return [];
-  const hand = feats.right.present ? feats.right : feats.left.present ? feats.left : null;
-  if (!hand) return [];
-  const out: { name: FingerName; target: keyof typeof EFFECT_SHORT; value: number }[] = [];
+  if (!routes || !feats) return { side: null, items: [] };
+  const side: 'right' | 'left' | null = feats.right.present ? 'right' : feats.left.present ? 'left' : null;
+  const hand = side === 'right' ? feats.right : side === 'left' ? feats.left : null;
+  if (!hand) return { side: null, items: [] };
+  const items: { name: FingerName; target: keyof typeof EFFECT_SHORT; value: number }[] = [];
   for (const name of FINGER_NAMES) {
     const r = routes[name];
     if (!r || r.target === 'none') continue;
-    out.push({ name, target: r.target, value: hand.fingers[name] });
+    items.push({ name, target: r.target, value: hand.fingers[name] });
   }
-  return out;
+  return { side, items };
 }
 
 /**
@@ -755,7 +780,11 @@ export const canvasOverlayNode = defineNode<Params>({
         // voice-mapping (ctx.resources.controls); absent in headless tests.
         const controls = (
           ctx.resources.controls as
-            | (() => { handMap?: HandMap; faceExpr?: { degrees?: Record<string, number> } })
+            | (() => {
+                handMap?: HandMap;
+                faceExpr?: { degrees?: Record<string, number> };
+                faceMapping?: string;
+              })
             | undefined
         )?.();
 
@@ -778,6 +807,7 @@ export const canvasOverlayNode = defineNode<Params>({
             expression: inputs.expression as ExpressionScores | undefined,
             handMap: controls?.handMap,
             faceDegrees: controls?.faceExpr?.degrees,
+            faceMapping: controls?.faceMapping,
           },
         };
 

--- a/test/dials_sync.test.ts
+++ b/test/dials_sync.test.ts
@@ -37,6 +37,20 @@ describe('dials → hot-store sync', () => {
     expect(useControls.getState().overlay.video.alpha).toBeCloseTo(0.33);
   });
 
+  it('heals a PARTIAL overlay layer on load — the effective overlay is complete (instrument-load path)', () => {
+    // An old instrument saved before the cue fields existed: only a partial overlay
+    // (faceExpression with just `show`, and no fingerLines/fingerBars). The dials
+    // deep-merge must back-fill every field, or the panel would read `.show` on
+    // undefined and crash on select. Pins the strategy the panel depends on.
+    dialsStore.setLayer({ overlay: { faceExpression: { show: true } } } as never);
+    const eff = dialsStore.getState().effective['overlay'] as OverlayParams;
+    expect(eff.fingerBars?.show).toBe(false); // new element back-filled
+    expect(eff.fingerLines?.show).toBe(false); // new element back-filled
+    expect(eff.faceExpression.position).toBe('left'); // new field back-filled
+    expect(eff.faceExpression.chordLabels).toBe(true);
+    expect(eff.faceExpression.show).toBe(true); // the partial value preserved
+  });
+
   it('mirrors the expression maps (faceExpr.degrees) into useControls', () => {
     const degrees = dialsStore.getState().effective['faceExpr.degrees'] as Record<string, number>;
     dialsStore.set('faceExpr.degrees', { ...degrees, happy: 4 });

--- a/test/music_theory.test.ts
+++ b/test/music_theory.test.ts
@@ -7,9 +7,28 @@ import {
   nearestScaleNote,
   rangeMap,
   midiToName,
+  chordName,
   scaleGuide,
   DEFAULT_SCALE,
 } from '@/music/theory';
+
+describe('chordName', () => {
+  it('classifies triad quality from the tones (root = lowest)', () => {
+    expect(chordName([60, 64, 67])).toBe('C'); // C E G  → major
+    expect(chordName([57, 60, 64])).toBe('Am'); // A C E  → minor
+    expect(chordName([59, 62, 65])).toBe('Bdim'); // B D F  → diminished
+    expect(chordName([60, 64, 68])).toBe('Caug'); // C E G# → augmented
+    expect(chordName([62, 66, 69])).toBe('D'); // D F# A → major, different root
+  });
+  it('is octave-agnostic and unsorted-input safe', () => {
+    expect(chordName([67, 60, 64])).toBe('C'); // reordered C major
+    expect(chordName([48, 52, 55])).toBe('C'); // low octave
+  });
+  it('falls back gracefully (empty / power / non-triad)', () => {
+    expect(chordName([])).toBe('');
+    expect(chordName([60, 67])).toBe('C5'); // root + fifth, no third
+  });
+});
 
 describe('scaleGuide', () => {
   it('places notes at ascending normalized x matching the magneticPitch mapping', () => {

--- a/test/overlay_elements.test.ts
+++ b/test/overlay_elements.test.ts
@@ -14,6 +14,7 @@ import { createAppRegistry } from '@/nodes/browser';
 import { defaultGraph } from '@/app/graph';
 import { canvasOverlayNode, OVERLAY_ELEMENTS, OVERLAY_CATEGORIES } from '@/nodes/output/canvas_overlay';
 import { OVERLAY_CONTROLS } from '@/app/overlayControls';
+import { DEFAULT_HAND_MAP } from '@/nodes/mapping/hand_map';
 import {
   makeHandKeypoints,
   type HandFeatures,
@@ -53,7 +54,7 @@ function makeRecordingCanvas(width = 1280, height = 720) {
     };
   for (const m of [
     'clearRect', 'save', 'restore', 'beginPath', 'arc', 'fill', 'stroke',
-    'moveTo', 'lineTo', 'drawImage', 'fillText', 'setLineDash', 'scale', 'translate',
+    'moveTo', 'lineTo', 'drawImage', 'fillText', 'setLineDash', 'scale', 'translate', 'rotate',
   ]) {
     ctx[m] = rec(m);
   }
@@ -141,7 +142,7 @@ describe('canvas-overlay composable elements', () => {
       expect(categories.has(el.category)).toBe(true); // grouped under a known category
     }
     expect(names[0]).toBe('video'); // backdrop drawn first (bottom)
-    expect(names[names.length - 1]).toBe('faceExpression'); // readout on top
+    expect(names[names.length - 1]).toBe('fingerBars'); // HUD cue on top
   });
 
   it('every overlay element has a UI control descriptor (the panel is data-driven, no silent drop)', () => {
@@ -280,7 +281,9 @@ describe('canvas-overlay composable elements', () => {
       fired: [true, false, false, false, false, false, false],
     };
     const rc = drawWith(onlyElement('faceExpression'), { expression });
-    expect(rc.count('fillText')).toBe(1); // the label
+    // Default x-axis labels: an expression name + a chord name under each bar (top
+    // label off) → 7 emotions × 2 labels.
+    expect(rc.count('fillText')).toBe(14);
     const strokes = rc.calls.filter((c) => c.m === 'stroke');
     expect(strokes).toHaveLength(14); // 7 emotions × (activation bar + threshold tick)
     expect(strokes[0].stroke).toBe('#f5d142'); // happy bar — the winner glows gold
@@ -299,7 +302,7 @@ describe('canvas-overlay composable elements', () => {
       fired: [false, false, false, false, false, false, false],
     };
     const rc = drawWith(onlyElement('faceExpression'), { expression });
-    expect(rc.count('fillText')).toBe(1); // 'neutral' label still renders
+    expect(rc.count('fillText')).toBe(14); // x-axis labels still render; no winner highlighted
     const strokes = rc.calls.filter((c) => c.m === 'stroke');
     expect(strokes).toHaveLength(14);
     // No activation bar (even indices) uses the gold winner colour.
@@ -329,6 +332,40 @@ describe('canvas-overlay composable elements', () => {
     expect(drawWith({ ...onlyElement('timbreLevels'), timbreLevels: { show: false } }).count('stroke')).toBe(0);
     // Default is off (opt-in).
     expect((canvasOverlayNode.params.parse({}) as { timbreLevels: { show: boolean } }).timbreLevels.show).toBe(false);
+  });
+
+  const handMapWith = (over: Record<string, unknown>) => ({ ...structuredClone(DEFAULT_HAND_MAP), ...over });
+  const withControls = (handMap: unknown) => ({ controls: () => ({ handMap }) });
+  const routeIndex = { ...DEFAULT_HAND_MAP.fingers, index: { target: 'brightness', sensitivity: 1, mode: 'continuous', invert: false } };
+
+  it('fingerLines (Output): a labelled line per ROUTED finger, per present hand', () => {
+    const handMap = handMapWith({ fingers: routeIndex });
+    const rc = draw(onlyElement('fingerLines'), withControls(handMap));
+    expect(rc.count('lineTo')).toBe(2); // 2 hands × 1 routed finger (index)
+    expect(rc.count('fillText')).toBe(2); // value + effect label per line
+    // No routes → nothing; no hand map (no controls) → nothing.
+    expect(draw(onlyElement('fingerLines'), withControls(handMapWith({}))).count('lineTo')).toBe(0);
+    expect(draw(onlyElement('fingerLines')).count('lineTo')).toBe(0);
+    // Labels toggle independently.
+    expect(draw({ ...onlyElement('fingerLines'), fingerLines: { show: true, showLabels: false } }, withControls(handMap)).count('fillText')).toBe(0);
+  });
+
+  it('fingerBars (Output HUD cue): a bar per routed finger; opt-in; positionable', () => {
+    const handMap = handMapWith({
+      fingers: { ...routeIndex, middle: { target: 'vibrato', sensitivity: 1, mode: 'continuous', invert: false } },
+    });
+    const rc = draw({ ...onlyElement('fingerBars'), fingerBars: { show: true, position: 'left' } }, withControls(handMap));
+    expect(rc.count('stroke')).toBe(2); // 2 routed fingers → 2 bars (no thresholds)
+    // Default off; nothing without a routing hand map.
+    expect((canvasOverlayNode.params.parse({}) as { fingerBars: { show: boolean } }).fingerBars.show).toBe(false);
+    expect(draw({ ...onlyElement('fingerBars'), fingerBars: { show: true, position: 'left' } }, withControls(handMapWith({}))).count('stroke')).toBe(0);
+  });
+
+  it('markers + landmark ring draw without error using the wrist source', () => {
+    const handMap = handMapWith({ positionSource: 'wrist' });
+    expect(() => draw({ ...onlyElement('markers'), scaleGuide: { show: false } }, withControls(handMap))).not.toThrow();
+    const rc = draw({ ...onlyElement('markers'), scaleGuide: { show: false } }, withControls(handMap));
+    expect(rc.count('arc')).toBeGreaterThan(0); // markers still drawn at the wrist source
   });
 
   it('a live overlayConfig input overrides the static params', () => {

--- a/test/overlay_elements.test.ts
+++ b/test/overlay_elements.test.ts
@@ -281,9 +281,9 @@ describe('canvas-overlay composable elements', () => {
       fired: [true, false, false, false, false, false, false],
     };
     const rc = drawWith(onlyElement('faceExpression'), { expression });
-    // Default x-axis labels: an expression name + a chord name under each bar (top
-    // label off) → 7 emotions × 2 labels.
-    expect(rc.count('fillText')).toBe(14);
+    // Default x-axis labels: an expression name per bar (chord names are gated to
+    // chord mode, which the headless test isn't in) → 7 expression labels.
+    expect(rc.count('fillText')).toBe(7);
     const strokes = rc.calls.filter((c) => c.m === 'stroke');
     expect(strokes).toHaveLength(14); // 7 emotions × (activation bar + threshold tick)
     expect(strokes[0].stroke).toBe('#f5d142'); // happy bar — the winner glows gold
@@ -302,11 +302,39 @@ describe('canvas-overlay composable elements', () => {
       fired: [false, false, false, false, false, false, false],
     };
     const rc = drawWith(onlyElement('faceExpression'), { expression });
-    expect(rc.count('fillText')).toBe(14); // x-axis labels still render; no winner highlighted
+    expect(rc.count('fillText')).toBe(7); // expression x-axis labels still render; no winner highlighted
     const strokes = rc.calls.filter((c) => c.m === 'stroke');
     expect(strokes).toHaveLength(14);
     // No activation bar (even indices) uses the gold winner colour.
     expect(strokes.filter((_, i) => i % 2 === 0).every((s) => s.stroke !== '#f5d142')).toBe(true);
+  });
+
+  it('faceExpression: chord names appear ONLY in chord mode, computed from the scale+degree', () => {
+    const expression = {
+      present: true,
+      label: 'happy',
+      scores: [0.7, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1],
+      thresholds: [0.4, 0.4, 0.45, 0.4, 0.4, 0.4, 0.375],
+      fired: [true, false, false, false, false, false, false],
+    };
+    // A seven-note C-major scale (two octaves) + happy→degree 0 (I = C major).
+    const draw = (faceMapping: string | undefined) => {
+      const rc = makeRecordingCanvas();
+      const handlers = canvasOverlayNode.make(canvasOverlayNode.params.parse(onlyElement('faceExpression')));
+      const controls = () => ({ faceMapping, faceExpr: { degrees: { happy: 0 } } });
+      const ctx: NodeContext = { tick: 0, time: 0, dt: 0, resources: { canvas: rc.canvas, video: rc.video, controls } };
+      handlers.process(
+        { ...fullInputs(), expression, scale: [48, 50, 52, 53, 55, 57, 59, 60, 62, 64] },
+        ctx,
+      );
+      return rc;
+    };
+    // Timbre mode: chord labels suppressed → 7 (expression names only).
+    expect(draw('timbre').count('fillText')).toBe(7);
+    // Chord mode: expression + chord labels → 14, and the happy→I chord names as "C".
+    const rc = draw('chord');
+    expect(rc.count('fillText')).toBe(14);
+    expect(rc.calls.some((c) => c.m === 'fillText' && c.args[0] === 'C')).toBe(true);
   });
 
   it('faceExpression: nothing when the expression is absent or toggled off', () => {


### PR DESCRIPTION
The overlay now reflects the **actual** mapping instead of always cueing the index, adds finger-distance visualization, upgrades the face bar graph, and makes HUD cues positionable — addressing the report that "the hand overlay does not correspond to the actual features."

## What
- **Note-source-accurate marker**: the control marker + note label + landmark ring follow `handMap.positionSource` (wrist vs index) — fixes wrist instruments still highlighting the index.
- **Finger→thumb effect lines** (new, opt-in): a line from each ROUTED fingertip to the thumb, labelled with the normalized closeness + a short effect name (`brt/vib/pan/bnd/oct/gate`).
- **Finger bar graph** (new HUD cue): a bar per routed finger, effect-labelled, coloured by the hand being read.
- **Face-expression upgrades**: vertical x-axis labels (the expression name **and** the chord each maps to), the winner highlighted, the old top label made optional. Chord names are gated to **chord mode** (where a 7-note scale is enforced) and computed to agree with the played `diatonicTriad`.
- **Cue layout system**: HUD cues get a `position` (left/right/top/bottom, default left) and **auto-stack** when several share an edge.
- The overlay reads the live hand map + expression→degree map + face-mapping mode via `ctx.resources.controls` (like voice-mapping); the classic/headless/static path is **byte-identical** (backward compatible).
- **Settings**: every new drawable has a descriptor (test-enforced) + a cue-position select.
- **Demos**: Finger FX shows the lines; a new **"Finger Cues"** shows lines + bars; Everything shows both. `SEED_VERSION` 3 so returning users gain "Finger Cues".

## Review
Adversarial multi-agent review (backward-compat / correctness / persistence-UI): 12 confirmed (3 were clean no-regression verifications). All actionable findings fixed — the **HIGH** chord-name bug (positional-index triad wrong for non-7-note scales / disagreed with the audio), title-width under-measure, left-hand cue colour, `as never` cast, partial-overlay seed helper, and an instrument-load overlay-heal regression test.

## Verification
typecheck · **321** tests (finger lines/bars, wrist marker, face x-labels, chordName classification, chord-mode gating, partial-overlay heal) · build · catalog · in-browser (config flows, all new settings controls render, zero console errors). The cues render live when hands/face are in frame — their drawing is covered by the unit tests.

**"Facial pose instead of expressions"** you recalled = issue #76 (head yaw/pitch/roll) — researched, separate feature; this overlay could later visualize it.

https://claude.ai/code/session_01JEoe7y1hA5KdEAvvpQXxxt
