### PR TITLE
Face-expression: retune defaults + per-device calibration wizard (make chords-by-expression hittable)

### DIFF
--- a/src/app/CalibrationWizard.tsx
+++ b/src/app/CalibrationWizard.tsx
@@ -1,0 +1,332 @@
+/**
+ * CalibrationWizard — a guided per-DEVICE calibration of the facial-expression
+ * detector. Facial production varies enormously between people (and MediaPipe
+ * under-reports several channels), so a fixed default firing bar can't be optimal for
+ * everyone. This wizard measures, for each emotion, how much the player can actually
+ * activate it, and sets that emotion's firing bar between their resting face and their
+ * achievable peak — so a subsequent production reliably fires while a resting face
+ * stays neutral.
+ *
+ * It reuses the existing machinery: the live per-emotion activations come from
+ * `useFaceStatus.scores` (bridged from the DAG's `face-expression` output), and the
+ * result is stored as `faceCalibration` (a per-emotion sensitivity override that wins
+ * over every instrument's `faceExpr.sensitivity`, so calibration is global). The pure
+ * solve is {@link calibrateSensitivity}.
+ */
+import { useEffect, useRef, useState } from 'react';
+import { EMOTIONS, calibrateSensitivity, type Emotion } from '@/music/expression';
+import { EXPRESSION_HELP } from '@/app/expressionHelp';
+import { useFaceStatus } from '@/app/faceStatus';
+import { useControls } from '@/app/store';
+
+const CAPTURE_MS = 2500;
+const BASELINE_MS = 2000;
+const SAMPLE_MS = 80;
+
+const cap = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
+const keyActionOf = (e: Emotion) => EXPRESSION_HELP.find((h) => h.name === e)?.keyAction ?? '';
+const isHard = (e: Emotion) => !!EXPRESSION_HELP.find((h) => h.name === e)?.hardToDetect;
+
+/** Step model: -2 intro · -1 neutral baseline · 0..N-1 each emotion · N summary. */
+const INTRO = -2;
+const BASELINE = -1;
+const SUMMARY = EMOTIONS.length;
+
+export function CalibrationWizard({ onClose }: { onClose: () => void }) {
+  const scores = useFaceStatus((s) => s.scores);
+  const faceStatus = useFaceStatus((s) => s.status);
+  const faceMapping = useControls((s) => s.faceMapping);
+  const setFaceMapping = useControls((s) => s.setFaceMapping);
+  const setFaceCalibration = useControls((s) => s.setFaceCalibration);
+
+  const [step, setStep] = useState(INTRO);
+  const [rest, setRest] = useState<number[]>(() => EMOTIONS.map(() => 0));
+  const [peak, setPeak] = useState<number[]>(() => EMOTIONS.map(() => 0));
+  const [capturing, setCapturing] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const captureRef = useRef<{ max: number[]; acc: number[]; n: number }>({ max: [], acc: [], n: 0 });
+
+  // The detector must be running to read activations. Turn on chord mode on entry if
+  // the face is off (calibration is for the expression→chord feature), and restore it
+  // on close only if we were the one who turned it on.
+  const enabledByUs = useRef(false);
+  useEffect(() => {
+    if (faceMapping === 'none') {
+      enabledByUs.current = true;
+      setFaceMapping('chord');
+    }
+    return () => {
+      if (enabledByUs.current) setFaceMapping('none');
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const faceLive = faceStatus.phase === 'ready' && faceStatus.faceDetected;
+  const modelLoading = faceStatus.phase === 'loading' || (faceMapping !== 'none' && faceStatus.phase !== 'ready');
+
+  // The capture loop: sample the live scores at SAMPLE_MS, tracking per-emotion peak
+  // (and, for the baseline, the running mean) until the window elapses, then commit.
+  useEffect(() => {
+    if (!capturing) return;
+    const duration = step === BASELINE ? BASELINE_MS : CAPTURE_MS;
+    const startedTick = { done: false };
+    captureRef.current = { max: EMOTIONS.map(() => 0), acc: EMOTIONS.map(() => 0), n: 0 };
+    let elapsed = 0;
+    const id = setInterval(() => {
+      const live = useFaceStatus.getState().scores;
+      const c = captureRef.current;
+      if (live) {
+        for (let i = 0; i < EMOTIONS.length; i++) {
+          const v = live[i] ?? 0;
+          if (v > c.max[i]) c.max[i] = v;
+          c.acc[i] += v;
+        }
+        c.n += 1;
+      }
+      elapsed += SAMPLE_MS;
+      setProgress(Math.min(1, elapsed / duration));
+      if (elapsed >= duration && !startedTick.done) {
+        startedTick.done = true;
+        clearInterval(id);
+        const c2 = captureRef.current;
+        if (step === BASELINE) {
+          setRest(c2.n ? c2.acc.map((a) => a / c2.n) : c2.max);
+        } else {
+          setPeak((prev) => {
+            const next = [...prev];
+            next[step] = c2.max[step];
+            return next;
+          });
+        }
+        setCapturing(false);
+        setProgress(0);
+        setStep((s) => s + 1);
+      }
+    }, SAMPLE_MS);
+    return () => clearInterval(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [capturing, step]);
+
+  const restRecord = () => Object.fromEntries(EMOTIONS.map((e, i) => [e, rest[i]])) as Record<Emotion, number>;
+  const peakRecord = () => Object.fromEntries(EMOTIONS.map((e, i) => [e, peak[i]])) as Record<Emotion, number>;
+
+  const applyAndClose = () => {
+    const cal = calibrateSensitivity(restRecord(), peakRecord());
+    const map = Object.fromEntries(EMOTIONS.map((e) => [e, cal[e].sensitivity]));
+    setFaceCalibration(map);
+    onClose();
+  };
+
+  const targetEmotion = step >= 0 && step < EMOTIONS.length ? EMOTIONS[step] : null;
+  const liveScore = targetEmotion ? (scores?.[step] ?? 0) : 0;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4" role="dialog" aria-modal="true">
+      <div className="w-full max-w-md rounded-2xl border border-white/10 bg-neutral-900 p-6 text-white shadow-2xl">
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-lg font-semibold">Calibrate expressions</h2>
+          <button className="text-white/50 hover:text-white" onClick={onClose} aria-label="Close">
+            ✕
+          </button>
+        </div>
+
+        {!faceLive && step !== SUMMARY && (
+          <p className="mb-4 rounded-lg bg-amber-400/10 px-3 py-2 text-xs text-amber-200">
+            {modelLoading ? 'Loading the face model…' : 'Position your face in the camera view to continue.'}
+          </p>
+        )}
+
+        {step === INTRO && (
+          <div className="space-y-4 text-sm text-white/80">
+            <p>
+              Facial expressions read differently on every face. This sets each expression&apos;s trigger point to what
+              <em> you </em> can actually produce, so the hard ones become reliable. It takes about a minute.
+            </p>
+            <p className="text-xs text-white/50">
+              You&apos;ll rest your face once, then make each expression when prompted. Your calibration applies to every
+              instrument and is saved on this device.
+            </p>
+            <div className="flex justify-end gap-2">
+              <button className="rounded-lg px-3 py-1.5 text-sm text-white/60 hover:text-white" onClick={onClose}>
+                Cancel
+              </button>
+              <button
+                className="rounded-lg bg-emerald-500 px-4 py-1.5 text-sm font-medium text-black hover:bg-emerald-400"
+                onClick={() => setStep(BASELINE)}
+              >
+                Start
+              </button>
+            </div>
+          </div>
+        )}
+
+        {step === BASELINE && (
+          <div className="space-y-4 text-sm text-white/80">
+            <p className="text-base font-medium text-white">Relax — neutral face</p>
+            <p>Let your face rest naturally. Don&apos;t smile or frown. I&apos;ll measure your baseline.</p>
+            <CaptureControl
+              capturing={capturing}
+              progress={progress}
+              faceLive={faceLive}
+              label="Capture baseline"
+              onCapture={() => setCapturing(true)}
+            />
+          </div>
+        )}
+
+        {targetEmotion && (
+          <div className="space-y-3 text-sm text-white/80">
+            <p className="text-xs text-white/40">
+              Expression {step + 1} of {EMOTIONS.length}
+            </p>
+            <p className="text-base font-medium text-white">
+              {cap(targetEmotion)} {isHard(targetEmotion) && <span className="text-amber-300">(harder to detect)</span>}
+            </p>
+            <p>{keyActionOf(targetEmotion)}</p>
+            <Meter value={liveScore} threshold={rest[step]} />
+            <CaptureControl
+              capturing={capturing}
+              progress={progress}
+              faceLive={faceLive}
+              label={peak[step] > 0 ? 'Recapture' : 'Hold it, then capture'}
+              onCapture={() => setCapturing(true)}
+            />
+            <div className="flex justify-between">
+              <button
+                className="rounded-lg px-2 py-1 text-xs text-white/50 hover:text-white disabled:opacity-30"
+                onClick={() => setStep((s) => s - 1)}
+                disabled={capturing}
+              >
+                ← Back
+              </button>
+              <button
+                className="rounded-lg px-2 py-1 text-xs text-white/50 hover:text-white disabled:opacity-30"
+                onClick={() => setStep((s) => s + 1)}
+                disabled={capturing}
+              >
+                Skip →
+              </button>
+            </div>
+          </div>
+        )}
+
+        {step === SUMMARY && (
+          <Summary
+            rest={restRecord()}
+            peak={peakRecord()}
+            onApply={applyAndClose}
+            onCancel={onClose}
+            onRedo={() => {
+              setPeak(EMOTIONS.map(() => 0));
+              setStep(BASELINE);
+            }}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** A capture button that shows an in-progress fill while the window runs. */
+function CaptureControl({
+  capturing,
+  progress,
+  faceLive,
+  label,
+  onCapture,
+}: {
+  capturing: boolean;
+  progress: number;
+  faceLive: boolean;
+  label: string;
+  onCapture: () => void;
+}) {
+  return (
+    <button
+      className="relative w-full overflow-hidden rounded-lg bg-emerald-500 px-4 py-2 text-sm font-medium text-black transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-40"
+      onClick={onCapture}
+      disabled={capturing || !faceLive}
+    >
+      {capturing && (
+        <span
+          className="absolute inset-y-0 left-0 bg-black/25"
+          style={{ width: `${Math.round(progress * 100)}%` }}
+          aria-hidden
+        />
+      )}
+      <span className="relative">{capturing ? 'Hold the face…' : label}</span>
+    </button>
+  );
+}
+
+/** A live activation meter with a marker at the current firing baseline. */
+function Meter({ value, threshold }: { value: number; threshold: number }) {
+  return (
+    <div className="relative h-3 w-full rounded-full bg-white/10">
+      <div
+        className="h-3 rounded-full bg-emerald-400 transition-[width] duration-75"
+        style={{ width: `${Math.round(Math.min(1, value) * 100)}%` }}
+      />
+      <div
+        className="absolute top-[-2px] h-[16px] w-[2px] bg-white/70"
+        style={{ left: `${Math.round(Math.min(1, threshold) * 100)}%` }}
+        aria-hidden
+      />
+    </div>
+  );
+}
+
+/** The end summary: which expressions calibrated cleanly (peak cleared rest). */
+function Summary({
+  rest,
+  peak,
+  onApply,
+  onCancel,
+  onRedo,
+}: {
+  rest: Record<Emotion, number>;
+  peak: Record<Emotion, number>;
+  onApply: () => void;
+  onCancel: () => void;
+  onRedo: () => void;
+}) {
+  const cal = calibrateSensitivity(rest, peak);
+  const reached = EMOTIONS.filter((e) => cal[e].reachable);
+  return (
+    <div className="space-y-3 text-sm text-white/80">
+      <p className="text-base font-medium text-white">Calibration ready</p>
+      <ul className="space-y-1">
+        {EMOTIONS.map((e) => (
+          <li key={e} className="flex items-center justify-between">
+            <span>{cap(e)}</span>
+            <span className={cal[e].reachable ? 'text-emerald-400' : 'text-white/40'}>
+              {cal[e].reachable ? `bar ${cal[e].threshold.toFixed(2)}` : 'not detected — kept default'}
+            </span>
+          </li>
+        ))}
+      </ul>
+      {reached.length < EMOTIONS.length && (
+        <p className="text-xs text-white/50">
+          {EMOTIONS.length - reached.length} expression(s) didn&apos;t register — the model may not read them on your
+          face. You can redo those or keep the defaults.
+        </p>
+      )}
+      <div className="flex justify-between gap-2">
+        <button className="rounded-lg px-3 py-1.5 text-sm text-white/60 hover:text-white" onClick={onRedo}>
+          Redo
+        </button>
+        <div className="flex gap-2">
+          <button className="rounded-lg px-3 py-1.5 text-sm text-white/60 hover:text-white" onClick={onCancel}>
+            Cancel
+          </button>
+          <button
+            className="rounded-lg bg-emerald-500 px-4 py-1.5 text-sm font-medium text-black hover:bg-emerald-400"
+            onClick={onApply}
+          >
+            Save calibration
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/CalibrationWizard.tsx
+++ b/src/app/CalibrationWizard.tsx
@@ -89,8 +89,13 @@ export function CalibrationWizard({ onClose }: { onClose: () => void }) {
         startedTick.done = true;
         clearInterval(id);
         const c2 = captureRef.current;
+        setCapturing(false);
+        setProgress(0);
+        // The face dropped for the whole window (a race after the button enabled) —
+        // don't commit a bogus zero baseline/peak or advance; let the user retry.
+        if (c2.n < 3) return;
         if (step === BASELINE) {
-          setRest(c2.n ? c2.acc.map((a) => a / c2.n) : c2.max);
+          setRest(c2.acc.map((a) => a / c2.n));
         } else {
           setPeak((prev) => {
             const next = [...prev];
@@ -98,8 +103,6 @@ export function CalibrationWizard({ onClose }: { onClose: () => void }) {
             return next;
           });
         }
-        setCapturing(false);
-        setProgress(0);
         setStep((s) => s + 1);
       }
     }, SAMPLE_MS);
@@ -112,8 +115,11 @@ export function CalibrationWizard({ onClose }: { onClose: () => void }) {
 
   const applyAndClose = () => {
     const cal = calibrateSensitivity(restRecord(), peakRecord());
-    const map = Object.fromEntries(EMOTIONS.map((e) => [e, cal[e].sensitivity]));
-    setFaceCalibration(map);
+    // Only override the emotions we could actually MEASURE — the rest fall through to
+    // the per-instrument sliders (don't pin an unreachable/skipped emotion to a
+    // build-time default and shadow the user's own slider). No reachable → clear.
+    const entries = EMOTIONS.filter((e) => cal[e].reachable).map((e) => [e, cal[e].sensitivity] as const);
+    setFaceCalibration(entries.length ? Object.fromEntries(entries) : null);
     onClose();
   };
 

--- a/src/app/dials/DialsControlsPanel.tsx
+++ b/src/app/dials/DialsControlsPanel.tsx
@@ -16,7 +16,7 @@
  * Renders just the controls *content* (no outer card); the host (App) wraps it in a
  * collapsible translucent overlay so the video stays the focus.
  */
-import { type ReactNode } from 'react';
+import { useState, type ReactNode } from 'react';
 import { NOTES, SCALE_TYPES, isSevenNoteScale, diatonicTriad, type ScaleTypeId } from '@/music/theory';
 import { SOUNDS, SOUND_IDS } from '@/music/sounds';
 import { VOICINGS, RENDERINGS, isTempoRendering, voiceTriad, type VoicingId, type RenderingId } from '@/music/voicing';
@@ -26,6 +26,7 @@ import type { FaceMapping } from '@/nodes';
 import { useControls } from '../store';
 import { OVERLAY_CONTROLS, type OverlayControlDesc } from '../overlayControls';
 import { ExpressionHelpButton } from '../ExpressionHelpPanel';
+import { CalibrationWizard } from '../CalibrationWizard';
 import { useFaceStatus } from '../faceStatus';
 import { RECORDING_FORMATS } from '../recording/formats';
 import { EFFECTS, type HandMap, type FingerTarget } from '@/nodes/mapping/hand_map';
@@ -416,6 +417,9 @@ function ExpressionMapping({ chordMode }: { chordMode: boolean }) {
   const v = state.effective;
   const degrees = v['faceExpr.degrees'] as Record<string, number>;
   const sensitivity = v['faceExpr.sensitivity'] as Record<string, number>;
+  const calibration = useControls((s) => s.faceCalibration);
+  const setCalibration = useControls((s) => s.setFaceCalibration);
+  const [wizardOpen, setWizardOpen] = useState(false);
   const setDegree = (label: string, degree: number) =>
     set('faceExpr.degrees', { ...degrees, [label]: degree });
   const setSens = (label: string, value: number) =>
@@ -442,6 +446,45 @@ function ExpressionMapping({ chordMode }: { chordMode: boolean }) {
 
   return (
     <CollapsibleSection label={chordMode ? 'Expression mapping' : 'Expression sensitivity'} defaultOpen={false}>
+      {wizardOpen && <CalibrationWizard onClose={() => setWizardOpen(false)} />}
+      {/* Per-DEVICE calibration: fits each expression's firing bar to what THIS face
+          can produce, overriding the sliders below across every instrument. */}
+      <div className="flex items-center justify-between rounded-lg bg-white/[0.04] px-2 py-1.5">
+        {calibration ? (
+          <>
+            <span className="text-[10px] text-emerald-400">✓ Calibrated to your face</span>
+            <div className="flex gap-1.5">
+              <button
+                className="rounded px-2 py-0.5 text-[10px] text-white/70 hover:bg-white/10"
+                onClick={() => setWizardOpen(true)}
+              >
+                Recalibrate
+              </button>
+              <button
+                className="rounded px-2 py-0.5 text-[10px] text-white/50 hover:bg-white/10"
+                onClick={() => setCalibration(null)}
+              >
+                Clear
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <span className="text-[10px] text-white/50">Hard to trigger? Fit it to your face.</span>
+            <button
+              className="rounded bg-emerald-500/90 px-2 py-0.5 text-[10px] font-medium text-black hover:bg-emerald-400"
+              onClick={() => setWizardOpen(true)}
+            >
+              Calibrate
+            </button>
+          </>
+        )}
+      </div>
+      {calibration && (
+        <p className="text-[10px] text-white/35">
+          Calibration is active — the sliders below are the per-instrument baseline used when you clear it.
+        </p>
+      )}
       <p className="text-[10px] leading-relaxed text-white/40">
         {chordMode ? (
           <>

--- a/src/app/faceStatus.ts
+++ b/src/app/faceStatus.ts
@@ -17,13 +17,17 @@ export interface FaceStatusState {
    *  drawn by the overlay readout directly — this store only carries the label for
    *  the text status line. */
   label: ExpressionLabel | null;
-  report(status: FaceStatus, label: ExpressionLabel | null): void;
+  /** Latest per-emotion activation scores (EMOTIONS-aligned, 0..1), or null when no
+   *  face. Used by the calibration wizard as its live meter (throttled with `label`). */
+  scores: number[] | null;
+  report(status: FaceStatus, label: ExpressionLabel | null, scores: number[] | null): void;
   reset(): void;
 }
 
 export const useFaceStatus = create<FaceStatusState>((set) => ({
   status: ABSENT_FACE_STATUS,
   label: null,
-  report: (status, label) => set({ status, label }),
-  reset: () => set({ status: ABSENT_FACE_STATUS, label: null }),
+  scores: null,
+  report: (status, label, scores) => set({ status, label, scores }),
+  reset: () => set({ status: ABSENT_FACE_STATUS, label: null, scores: null }),
 }));

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -81,6 +81,11 @@ export interface ControlState {
    * NOT part of a musical preset (it's orthogonal to the sound's sound).
    */
   recordingFormats: string[];
+  /** Per-DEVICE expression calibration: a per-emotion firing-sensitivity override
+   *  produced by the calibration wizard, applied OVER `faceExpr.sensitivity` for every
+   *  instrument (so calibration is global). Persisted to localStorage, NOT part of a
+   *  preset (like {@link recordingFormats}). Null = uncalibrated. */
+  faceCalibration: Record<string, number> | null;
   setVoice(side: 'right' | 'left', patch: Partial<VoiceControl>): void;
   setSync(v: boolean): void;
   setMasterVolume(v: number): void;
@@ -98,6 +103,8 @@ export interface ControlState {
   /** Shallow-patch the hand map (e.g. setHandMap({ positionSource: 'wrist' }), or a new
    *  `fingers` object for a route change). */
   setHandMap(patch: Partial<HandMap>): void;
+  /** Store (or clear, with null) the per-device expression calibration. */
+  setFaceCalibration(map: Record<string, number> | null): void;
   /** Replace all live controls from a settings snapshot (loading a preset). */
   applySettings(s: Settings): void;
 }
@@ -245,6 +252,7 @@ export const useControls = create<ControlState>()(
       overlay: defaultOverlay(),
       handMap: defaultHandMap(),
       recordingFormats: [...DEFAULT_RECORDING_FORMATS],
+      faceCalibration: null,
       setVoice: (side, patch) =>
         set((s) => {
           const next = { ...s[side], ...patch };
@@ -288,6 +296,7 @@ export const useControls = create<ControlState>()(
           overlay: { ...s.overlay, [key]: { ...s.overlay[key], ...patch } } as OverlayParams,
         })),
       setHandMap: (patch) => set((s) => ({ handMap: { ...s.handMap, ...patch } })),
+      setFaceCalibration: (map) => set({ faceCalibration: map ? { ...map } : null }),
       // Restore exactly the schema fields (the setters/recordingFormats are left
       // untouched). Derived from SETTINGS_KEYS, so a new preset field needs no edit.
       applySettings: (st) => set(pickSettings(st as unknown as Record<string, unknown>)),
@@ -308,6 +317,7 @@ export const useControls = create<ControlState>()(
       partialize: (s) => ({
         ...pickSettings(s as unknown as Record<string, unknown>),
         recordingFormats: s.recordingFormats,
+        faceCalibration: s.faceCalibration,
       }),
     },
   ),

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -163,6 +163,17 @@ export function migrateControls(persisted: unknown, version: number): ControlSta
     migrateInstrumentField(s.left);
     migrateInstrumentField(s.faceChord);
   }
+  if (version < 5) {
+    // The abstention retune raised the fearful/disgusted firing default 0.5 → 0.7.
+    // Deliver it to a returning player who never customized those two (persisted value
+    // still === the OLD default), while preserving any value they DID set.
+    const fe = s.faceExpr as { sensitivity?: Record<string, number> } | undefined;
+    if (fe?.sensitivity) {
+      for (const e of ['fearful', 'disgusted'] as const) {
+        if (fe.sensitivity[e] === 0.5) fe.sensitivity[e] = 0.7;
+      }
+    }
+  }
   return s as unknown as ControlState;
 }
 
@@ -303,12 +314,12 @@ export const useControls = create<ControlState>()(
     }),
     {
       name: 'thoremin-controls',
-      // Version 4: added the `handMap` (note source + finger→effect routing + the
-      // once-static voice knobs); mergeControls heals it from the default for older
-      // blobs. v3: `instrument` → `sound` rename. v2: the face-mapping chooser (#64).
-      // See migrateControls (field renames) and mergeControls (heals stale nested
-      // `overlay`/`faceChord`/`faceExpr`/`handMap` + clamps `faceMapping`).
-      version: 4,
+      // Version 5: the abstention retune — deliver the raised fearful/disgusted
+      // sensitivity default (0.5 → 0.7) to a returning player who never customized it.
+      // v4: added the `handMap`. v3: `instrument` → `sound` rename. v2: the face-mapping
+      // chooser (#64). See migrateControls (field renames/bumps) and mergeControls (heals
+      // stale nested `overlay`/`faceChord`/`faceExpr`/`handMap` + clamps `faceMapping`).
+      version: 5,
       migrate: migrateControls,
       merge: mergeControls,
       storage: createJSONStorage(controlsStorage),

--- a/src/app/useEngine.ts
+++ b/src/app/useEngine.ts
@@ -178,7 +178,7 @@ export function useThoreminEngine() {
           }
           const expr = engine.getOutput('faceExpr', 'expression') as ExpressionScores | undefined;
           const detected = fs.phase === 'ready' && fs.faceDetected && expr?.present;
-          useFaceStatus.getState().report(fs, detected ? expr!.label : null);
+          useFaceStatus.getState().report(fs, detected ? expr!.label : null, detected ? expr!.scores : null);
           lastFaceReport = now;
           lastPhase = fs.phase;
           lastDetected = fs.faceDetected;

--- a/src/music/expression.ts
+++ b/src/music/expression.ts
@@ -276,14 +276,21 @@ export function calibrateSensitivity(
     const r = clamp01(rest[e] ?? 0);
     const pk = clamp01(peak[e] ?? 0);
     const bounds = EXPRESSION_THRESHOLD_BOUNDS[e];
-    if (pk <= r + margin) {
+    const asDefault = (): CalibrationOutcome => {
       const sensitivity = DEFAULT_EXPRESSION_SENSITIVITY[e];
-      out[e] = { sensitivity, threshold: sensitivityToThreshold(sensitivity, bounds), reachable: false };
+      return { sensitivity, threshold: sensitivityToThreshold(sensitivity, bounds), reachable: false };
+    };
+    if (pk <= r + margin) {
+      out[e] = asDefault();
       continue;
     }
     const target = Math.max(r + margin, r + fraction * (pk - r));
     const sensitivity = clamp01((bounds.max - target) / (bounds.max - bounds.min));
-    out[e] = { sensitivity, threshold: sensitivityToThreshold(sensitivity, bounds), reachable: true };
+    const threshold = sensitivityToThreshold(sensitivity, bounds);
+    // A peak below the emotion's bounds.min floors the bar ABOVE the peak, so a real
+    // production could never clear it — that is NOT reachable; keep the default and
+    // flag it, so the wizard tells the user it couldn't read that face (vs a false green).
+    out[e] = pk >= threshold ? { sensitivity, threshold, reachable: true } : asDefault();
   }
   return out;
 }

--- a/src/music/expression.ts
+++ b/src/music/expression.ts
@@ -187,27 +187,41 @@ export interface ExpressionThresholdBounds {
 }
 export const EXPRESSION_THRESHOLD_BOUNDS: Record<Emotion, ExpressionThresholdBounds> = {
   happy: { min: 0.15, max: 0.6, delta: 0.06 },
+  // sad + surprised keep the higher floor: their primary channels (lower-lip drop /
+  // jaw-open) are ALSO driven by an involuntary open mouth (a yawn drives sad ≈0.33
+  // and surprised ≈0.35), so the bar must stay above that. Per-user calibration still
+  // has room down to 0.15. fearful + disgusted have NO such collision (mouth-stretch /
+  // upper-lip-raise / nose-sneer aren't a yawn or a smile), so they get a lower floor
+  // for more calibration room AND a much more sensitive default (see below) — they were
+  // the two that abstained hardest in a real recording.
   sad: { min: 0.15, max: 0.6, delta: 0.06 },
   angry: { min: 0.2, max: 0.65, delta: 0.06 },
   surprised: { min: 0.15, max: 0.6, delta: 0.06 },
-  // Lower max (→ default firing bar 0.40) — a realistic fear face barely clears it
-  // because the eyeWide/browInnerUp channels read weakly on this model.
-  fearful: { min: 0.2, max: 0.6, delta: 0.06 },
-  disgusted: { min: 0.15, max: 0.6, delta: 0.06 },
-  // Reliable channel → normal bounds.
+  fearful: { min: 0.12, max: 0.6, delta: 0.06 },
+  disgusted: { min: 0.12, max: 0.6, delta: 0.06 },
   kiss: { min: 0.15, max: 0.6, delta: 0.06 },
 };
 
 export type ExpressionSensitivity = Record<Emotion, number>;
 
-/** Default per-emotion sensitivity (angry slightly stricter — spurious-prone). */
+/**
+ * Default per-emotion sensitivity. Retuned from a real recording where the "negative
+ * cluster" mostly ABSTAINED (produced no chord) while happy + kiss fired reliably.
+ * fearful + disgusted — the two that abstained hardest and whose channels don't
+ * collide with any involuntary face — default MORE sensitive (lower firing bar) so a
+ * partial production fires. surprised + sad stay at the moderate default because a
+ * lower bar there would let a yawn (an involuntary open mouth) fire a chord. `angry`
+ * is kept STRICTER — the recording showed a strained brow-furrow firing angry and
+ * stealing the fearful/disgusted attempts, so its bar stays high to reduce that theft.
+ * Per-user calibration overrides all of these per face (the reliable fix).
+ */
 export const DEFAULT_EXPRESSION_SENSITIVITY: ExpressionSensitivity = {
   happy: 0.5,
   sad: 0.5,
   angry: 0.45,
   surprised: 0.5,
-  fearful: 0.5,
-  disgusted: 0.5,
+  fearful: 0.7,
+  disgusted: 0.7,
   kiss: 0.5,
 };
 
@@ -227,6 +241,49 @@ export function expressionThresholds(
       sensitivity[e] ?? DEFAULT_EXPRESSION_SENSITIVITY[e],
       EXPRESSION_THRESHOLD_BOUNDS[e],
     );
+  }
+  return out;
+}
+
+/** Per-emotion outcome of a calibration solve — the chosen sensitivity, the resulting
+ *  firing bar, and whether the emotion was reachably captured (peak cleared rest). */
+export interface CalibrationOutcome {
+  sensitivity: number;
+  threshold: number;
+  /** The captured peak activation cleared rest by the margin → a usable calibration. */
+  reachable: boolean;
+}
+
+/**
+ * Solve a per-user calibration from a capture: each emotion's RESTING activation and
+ * its achievable PEAK. For a reachable emotion (peak clears rest by `margin`), place
+ * the firing bar `fraction` of the way from rest to peak and invert
+ * {@link sensitivityToThreshold} to the sensitivity that yields it (clamped to the
+ * emotion's bounds) — so a production near the user's own peak fires while their rest
+ * stays below. An UNreachable emotion (never activated) keeps the default sensitivity
+ * and is flagged `reachable:false`, so calibration never silently makes an expression
+ * harder and the UI can tell the user it couldn't read that face. Pure.
+ */
+export function calibrateSensitivity(
+  rest: Partial<Record<Emotion, number>>,
+  peak: Partial<Record<Emotion, number>>,
+  opts: { fraction?: number; margin?: number } = {},
+): Record<Emotion, CalibrationOutcome> {
+  const fraction = opts.fraction ?? 0.55;
+  const margin = opts.margin ?? 0.03;
+  const out = {} as Record<Emotion, CalibrationOutcome>;
+  for (const e of EMOTIONS) {
+    const r = clamp01(rest[e] ?? 0);
+    const pk = clamp01(peak[e] ?? 0);
+    const bounds = EXPRESSION_THRESHOLD_BOUNDS[e];
+    if (pk <= r + margin) {
+      const sensitivity = DEFAULT_EXPRESSION_SENSITIVITY[e];
+      out[e] = { sensitivity, threshold: sensitivityToThreshold(sensitivity, bounds), reachable: false };
+      continue;
+    }
+    const target = Math.max(r + margin, r + fraction * (pk - r));
+    const sensitivity = clamp01((bounds.max - target) / (bounds.max - bounds.min));
+    out[e] = { sensitivity, threshold: sensitivityToThreshold(sensitivity, bounds), reachable: true };
   }
   return out;
 }

--- a/src/nodes/sources/store_controls.ts
+++ b/src/nodes/sources/store_controls.ts
@@ -39,6 +39,10 @@ export interface ControlSnapshot {
   /** Per-emotion sensitivity + per-expression degree map; the sensitivity feeds
    *  `face-expression` and the degree map feeds `expression-chord`. */
   faceExpr?: FaceExpr;
+  /** Per-DEVICE calibration: a per-emotion sensitivity override (from the calibration
+   *  wizard) that wins over the per-instrument `faceExpr.sensitivity`, so a user's
+   *  calibration applies to EVERY instrument. Null/absent = use faceExpr.sensitivity. */
+  faceCalibration?: Partial<Record<string, number>> | null;
 }
 
 const Params = z.object({});
@@ -96,7 +100,11 @@ export const storeControlsNode = defineNode<Record<string, never>>({
           };
         }
         if (c.faceExpr) {
-          out.expressionSensitivity = c.faceExpr.sensitivity;
+          // The per-device calibration overrides the per-instrument sensitivity
+          // (per-emotion), so a calibrated user keeps their bars across instruments.
+          out.expressionSensitivity = c.faceCalibration
+            ? { ...c.faceExpr.sensitivity, ...c.faceCalibration }
+            : c.faceExpr.sensitivity;
           out.expressionDegrees = c.faceExpr.degrees;
         }
         if (c.overlay) out.overlay = c.overlay;

--- a/test/app_store.test.ts
+++ b/test/app_store.test.ts
@@ -193,6 +193,25 @@ describe('persist migration (v1 → v2, returning users)', () => {
     expect(v3.right.sound).toBe('glass');
   });
 
+  it('migrateControls (v<5) delivers the fearful/disgusted retune only when unchanged', () => {
+    // A returning player who never customized: old default 0.5 → new default 0.7.
+    const unchanged = migrateControls(
+      { faceExpr: { sensitivity: { happy: 0.5, fearful: 0.5, disgusted: 0.5, angry: 0.45 } } },
+      4,
+    ) as unknown as { faceExpr: { sensitivity: Record<string, number> } };
+    expect(unchanged.faceExpr.sensitivity.fearful).toBe(0.7);
+    expect(unchanged.faceExpr.sensitivity.disgusted).toBe(0.7);
+    expect(unchanged.faceExpr.sensitivity.happy).toBe(0.5); // others untouched
+    expect(unchanged.faceExpr.sensitivity.angry).toBe(0.45);
+    // A player who DID customize those keeps their value (not bumped).
+    const customized = migrateControls(
+      { faceExpr: { sensitivity: { fearful: 0.8, disgusted: 0.3 } } },
+      4,
+    ) as unknown as { faceExpr: { sensitivity: Record<string, number> } };
+    expect(customized.faceExpr.sensitivity.fearful).toBe(0.8);
+    expect(customized.faceExpr.sensitivity.disgusted).toBe(0.3);
+  });
+
   it('mergeControls heals a stale overlay (missing later elements) so it cannot crash readers', () => {
     const initial = useControls.getInitialState();
     // A legacy overlay blob written before chordGuide / face / timbre elements existed.

--- a/test/expression_map.test.ts
+++ b/test/expression_map.test.ts
@@ -222,6 +222,15 @@ describe('calibrateSensitivity (per-user solve from rest + peak)', () => {
     expect(cal.threshold).toBeGreaterThanOrEqual(EXPRESSION_THRESHOLD_BOUNDS.angry.min - 1e-9);
     expect(cal.sensitivity).toBeLessThanOrEqual(1);
   });
+
+  it('flags a peak BELOW the emotion floor as UNreachable (the floored bar exceeds the peak)', () => {
+    // angry.min = 0.2; a peak of 0.15 floors the bar at 0.2 > 0.15 → could never fire,
+    // so it must NOT be reported reachable (that would be a false green in the wizard).
+    const cal = calibrateSensitivity(rest, { ...rest, angry: 0.15 }).angry;
+    expect(cal.reachable).toBe(false);
+    expect(cal.threshold).toBeGreaterThan(0.15); // the bar the peak can't clear
+    expect(cal.sensitivity).toBe(DEFAULT_EXPRESSION_SENSITIVITY.angry); // fell back to default
+  });
 });
 
 describe('sensitivity ↔ threshold', () => {

--- a/test/expression_map.test.ts
+++ b/test/expression_map.test.ts
@@ -13,6 +13,7 @@ import {
   decideExpression,
   sensitivityToThreshold,
   expressionThresholds,
+  calibrateSensitivity,
   EXPRESSION_PROTOTYPES,
   EXPRESSION_THRESHOLD_BOUNDS,
   DEFAULT_EXPRESSION_SENSITIVITY,
@@ -183,6 +184,43 @@ describe('reachability: sad / disgusted / fearful fire after the prototype/thres
     expect(decideExpression(expressionActivations({ jawOpen: 1, mouthLowerDownLeft: 1, mouthLowerDownRight: 1 })).label).toBe('neutral');
     // A broad smile must not leak into disgusted via any upper-lip movement.
     expect(decideExpression(expressionActivations({ mouthSmileLeft: 1, mouthSmileRight: 1 })).label).not.toBe('disgusted');
+  });
+});
+
+describe('calibrateSensitivity (per-user solve from rest + peak)', () => {
+  const rest = Object.fromEntries(EMOTIONS.map((e) => [e, 0.05])) as Record<Emotion, number>;
+
+  it('a reachable peak puts the firing bar between rest and peak, and it fires there', () => {
+    const peak = { ...rest, surprised: 0.5 };
+    const cal = calibrateSensitivity(rest, peak);
+    expect(cal.surprised.reachable).toBe(true);
+    // Bar strictly between the user's rest and peak → their production clears it.
+    expect(cal.surprised.threshold).toBeGreaterThan(rest.surprised);
+    expect(cal.surprised.threshold).toBeLessThan(peak.surprised);
+    // The solved sensitivity, fed back through the classifier, reproduces the bar.
+    expect(sensitivityToThreshold(cal.surprised.sensitivity, EXPRESSION_THRESHOLD_BOUNDS.surprised)).toBeCloseTo(
+      cal.surprised.threshold,
+    );
+  });
+
+  it('an UNreachable emotion (peak ≈ rest) keeps the default and is flagged', () => {
+    const peak = { ...rest }; // never activated above rest
+    const cal = calibrateSensitivity(rest, peak);
+    expect(cal.disgusted.reachable).toBe(false);
+    expect(cal.disgusted.sensitivity).toBe(DEFAULT_EXPRESSION_SENSITIVITY.disgusted);
+  });
+
+  it('a strong producer gets a stricter (lower-sensitivity) bar than a weak producer', () => {
+    const strong = calibrateSensitivity(rest, { ...rest, fearful: 0.8 }).fearful;
+    const weak = calibrateSensitivity(rest, { ...rest, fearful: 0.3 }).fearful;
+    expect(strong.threshold).toBeGreaterThan(weak.threshold); // strong face → higher bar
+    expect(strong.sensitivity).toBeLessThan(weak.sensitivity);
+  });
+
+  it('clamps the bar into the emotion bounds (a very weak peak can floor at min)', () => {
+    const cal = calibrateSensitivity(rest, { ...rest, angry: 0.22 }).angry;
+    expect(cal.threshold).toBeGreaterThanOrEqual(EXPRESSION_THRESHOLD_BOUNDS.angry.min - 1e-9);
+    expect(cal.sensitivity).toBeLessThanOrEqual(1);
   });
 });
 


### PR DESCRIPTION
Makes triggering chords with facial expressions reliable. A player could only hit **happy** (smile) and **kiss** (funnel); the other five abstained. Diagnosis + two fixes.

## Diagnosis (from the recordings)
The RECORD button captures **audio only** (the synth output, no webcam), so there were no faces to segment. But matching the audio against the C-major triads (librosa chroma) showed the hard five mostly produced **no chord** — *abstention* (under-activation), not confusion. Root cause: each expression's activation is a weighted mean over several blendshapes, and MediaPipe under-reports the key channels, so a partial production never clears the bar.

## 1. Retune the shared defaults
- **fearful + disgusted → sensitivity 0.7** (the two that abstained hardest, and whose channels don't collide with any involuntary face); lower calibration floor.
- **surprised + sad kept at 0.5** — a lower bar there lets a yawn (an involuntary open mouth) fire a chord. **angry kept stricter (0.45)** — a strained furrow was firing angry and stealing the other attempts.
- All false-fire guards hold (verified by arithmetic + tests: resting/faint → neutral, yawn → not sad/surprised, smile → not disgusted).
- A persist migration (v4→v5) delivers the fearful/disgusted bump to **returning** users too, only when they never customized it.

## 2. Per-person calibration (the reliable fix)
- `calibrateSensitivity()` (pure, tested): from a capture of each emotion's resting + achievable peak activation, place the firing bar between them and solve the sensitivity; a peak the user can't clear (below the emotion floor) is flagged unreachable, not a false green.
- A per-**device** `faceCalibration` override that wins over `faceExpr.sensitivity` in `store-controls`, so calibration is **global across every instrument**. Persisted (not part of a preset). Live per-emotion activations bridged to the UI for the meter.
- **CalibrationWizard**: guided neutral baseline + per-expression peak capture with a live meter and coaching, reusing `EXPRESSION_HELP`. A Calibrate button + status banner in the Face → Expression-sensitivity section. It calibrates only the emotions it could actually measure.

## Review
Adversarial multi-agent review (retune guards with arithmetic, calibration math, wizard capture loop): 9 confirmed (3 were clean guard-verifications). All actionable findings fixed — the HIGH peak-below-floor false-green, the returning-user retune migration, calibrate-reachable-only, and the zero-sample baseline guard.

## Verification
typecheck · **327** tests (calibrateSensitivity incl. unreachable-below-floor, classifier false-fire guards, migration) · build · catalog · in-browser (wizard opens + loads the face model, retuned defaults reached the sliders, zero console errors).

**Notes:** the recordings were audio-only, so no per-expression example clips were possible — a screen recording (showing the webcam) would let me extract those and tune further.

https://claude.ai/code/session_01JEoe7y1hA5KdEAvvpQXxxt
