### PR TITLE
Head/face pose control: deliberate head/jaw/brow axes as a chord instrument (#76)

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -21,7 +21,7 @@ This page catalogs the engine's building blocks — every node and how they conn
 - **Discrete triggers** — `hand-features → gesture-classifier → (events)`  
   Fist/open/pinch poses emit enter/exit events to trigger scale changes, stabs, mutes.
 
-## Nodes (25)
+## Nodes (28)
 
 ### Inputs (sources)
 _Where signals enter the graph._
@@ -93,6 +93,14 @@ Face blendshapes → normalized expression controls (smile, mouthOpen, brow, bli
 - **out:** features:face-features
 - **params:** gain (number=1), smoothing (number=0)
 
+#### `face-controls` — Face Controls
+Face frame → deliberate control axes (head yaw/pitch/roll, jaw-open, smile↔frown, brow-raise, lip-pucker), each with gain/deadzone/smoothing.
+
+- **roles:** feature
+- **in:** face:face-frame
+- **out:** controls:face-controls
+- **params:** smoothing (number=0.3), headRangeDeg (number=30), headDeadzoneDeg (number=3), yawZeroDeg (number=0), pitchZeroDeg (number=0), rollZeroDeg (number=0), yawGain (number=1), pitchGain (number=1), rollGain (number=1), mouthDeadzone (number=0.08), browDeadzone (number=0.1), puckerDeadzone (number=0.12), smileDeadzone (number=0.06), mouthGain (number=1), browGain (number=1), puckerGain (number=1), smileGain (number=1)
+
 #### `face-expression` — Face Expression
 Face blendshapes → one of 7 emotions or neutral (per-class thresholds + neutral abstention, smoothing, enter/exit hysteresis, dwell).
 
@@ -153,11 +161,19 @@ Adaptive jitter smoothing for a noisy control value (smooth at rest, responsive 
 - **params:** minCutoff (number=1), beta (number=0.01), dCutoff (number=1), fallbackDt (number=0.016666666666666666)
 
 #### `synth-merge` — Synth Merge
-Union two synth-params voice streams into one (e.g. hand voices + face-chord voices).
+Union up to three synth-params voice streams into one (hand voices + emotion chord + pose chord).
 
 - **roles:** mapping
-- **in:** a:synth-params, b:synth-params
+- **in:** a:synth-params, b:synth-params, c:synth-params
 - **out:** params:synth-params
+- **params:** —
+
+#### `chord-select` — Chord Select
+Pick the first non-empty of two chord-tone streams (e.g. emotion triad vs pose chord) for the overlay.
+
+- **roles:** mapping
+- **in:** a:number[], b:number[]
+- **out:** chord:number[]
 - **params:** —
 
 ### Music logic (tonal guidance)
@@ -186,6 +202,14 @@ Facial expression → a voiced, rendered diatonic chord on the current seven-not
 - **in:** expression:face-expression, spec:scale-spec, faceMapping:face-mapping, octaveShift:number, chordConfig:chord-config, degrees:expression-degrees
 - **out:** params:synth-params, triad:number[]
 - **params:** gain (number=0.22), sound (enum(sine | triangle | square | sawtooth | warmPad | glass | bell | organ | voice | softLead | strings | flute | brass | choir)="triangle"), voicing (enum(spread | bassTriad | close | shell | power)="spread"), rendering (enum(sustained | strum | arpUp | arpDown | arpUpDown | pulse | alberti)="sustained"), bpm (number=100)
+
+#### `pose-chord` — Pose Chord
+Head/face pose axes → a voiced, rendered diatonic chord (head-yaw→degree, pitch→octave, jaw-open→gate, smile→timbre, brow→7th). Active only in face "controls" mode.
+
+- **roles:** music
+- **in:** controls:face-controls, spec:scale-spec, faceMapping:face-mapping, octaveShift:number, chordConfig:chord-config
+- **out:** params:synth-params, chord:number[]
+- **params:** gain (number=0.22), sound (enum(sine | triangle | square | sawtooth | warmPad | glass | bell | organ | voice | softLead | strings | flute | brass | choir)="warmPad"), voicing (enum(spread | bassTriad | close | shell | power)="spread"), rendering (enum(sustained | strum | arpUp | arpDown | arpUpDown | pulse | alberti)="sustained"), bpm (number=100), mouthGate (number=0.12), octaveRange (number=1), browSeventhAt (number=0.5)
 
 ### Conductor mode
 _Direct a fixed piece with gesture (tempo + dynamics)._

--- a/public/catalog.json
+++ b/public/catalog.json
@@ -152,6 +152,31 @@
     ]
   },
   {
+    "type": "chord-select",
+    "title": "Chord Select",
+    "description": "Pick the first non-empty of two chord-tone streams (e.g. emotion triad vs pose chord) for the overlay.",
+    "roles": [
+      "mapping"
+    ],
+    "inputs": [
+      {
+        "name": "a",
+        "kind": "number[]"
+      },
+      {
+        "name": "b",
+        "kind": "number[]"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "chord",
+        "kind": "number[]"
+      }
+    ],
+    "params": []
+  },
+  {
     "type": "expression-chord",
     "title": "Expression Chord",
     "description": "Facial expression → a voiced, rendered diatonic chord on the current seven-note scale (active only in face \"chord\" mode).",
@@ -221,6 +246,113 @@
         "name": "bpm",
         "type": "number",
         "default": 100
+      }
+    ]
+  },
+  {
+    "type": "face-controls",
+    "title": "Face Controls",
+    "description": "Face frame → deliberate control axes (head yaw/pitch/roll, jaw-open, smile↔frown, brow-raise, lip-pucker), each with gain/deadzone/smoothing.",
+    "roles": [
+      "feature"
+    ],
+    "inputs": [
+      {
+        "name": "face",
+        "kind": "face-frame"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "controls",
+        "kind": "face-controls"
+      }
+    ],
+    "params": [
+      {
+        "name": "smoothing",
+        "type": "number",
+        "default": 0.3
+      },
+      {
+        "name": "headRangeDeg",
+        "type": "number",
+        "default": 30
+      },
+      {
+        "name": "headDeadzoneDeg",
+        "type": "number",
+        "default": 3
+      },
+      {
+        "name": "yawZeroDeg",
+        "type": "number",
+        "default": 0
+      },
+      {
+        "name": "pitchZeroDeg",
+        "type": "number",
+        "default": 0
+      },
+      {
+        "name": "rollZeroDeg",
+        "type": "number",
+        "default": 0
+      },
+      {
+        "name": "yawGain",
+        "type": "number",
+        "default": 1
+      },
+      {
+        "name": "pitchGain",
+        "type": "number",
+        "default": 1
+      },
+      {
+        "name": "rollGain",
+        "type": "number",
+        "default": 1
+      },
+      {
+        "name": "mouthDeadzone",
+        "type": "number",
+        "default": 0.08
+      },
+      {
+        "name": "browDeadzone",
+        "type": "number",
+        "default": 0.1
+      },
+      {
+        "name": "puckerDeadzone",
+        "type": "number",
+        "default": 0.12
+      },
+      {
+        "name": "smileDeadzone",
+        "type": "number",
+        "default": 0.06
+      },
+      {
+        "name": "mouthGain",
+        "type": "number",
+        "default": 1
+      },
+      {
+        "name": "browGain",
+        "type": "number",
+        "default": 1
+      },
+      {
+        "name": "puckerGain",
+        "type": "number",
+        "default": 1
+      },
+      {
+        "name": "smileGain",
+        "type": "number",
+        "default": 1
       }
     ]
   },
@@ -705,6 +837,90 @@
     ]
   },
   {
+    "type": "pose-chord",
+    "title": "Pose Chord",
+    "description": "Head/face pose axes → a voiced, rendered diatonic chord (head-yaw→degree, pitch→octave, jaw-open→gate, smile→timbre, brow→7th). Active only in face \"controls\" mode.",
+    "roles": [
+      "music"
+    ],
+    "inputs": [
+      {
+        "name": "controls",
+        "kind": "face-controls"
+      },
+      {
+        "name": "spec",
+        "kind": "scale-spec"
+      },
+      {
+        "name": "faceMapping",
+        "kind": "face-mapping",
+        "default": "none"
+      },
+      {
+        "name": "octaveShift",
+        "kind": "number",
+        "default": 0
+      },
+      {
+        "name": "chordConfig",
+        "kind": "chord-config"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "params",
+        "kind": "synth-params"
+      },
+      {
+        "name": "chord",
+        "kind": "number[]"
+      }
+    ],
+    "params": [
+      {
+        "name": "gain",
+        "type": "number",
+        "default": 0.22
+      },
+      {
+        "name": "sound",
+        "type": "enum(sine | triangle | square | sawtooth | warmPad | glass | bell | organ | voice | softLead | strings | flute | brass | choir)",
+        "default": "warmPad"
+      },
+      {
+        "name": "voicing",
+        "type": "enum(spread | bassTriad | close | shell | power)",
+        "default": "spread"
+      },
+      {
+        "name": "rendering",
+        "type": "enum(sustained | strum | arpUp | arpDown | arpUpDown | pulse | alberti)",
+        "default": "sustained"
+      },
+      {
+        "name": "bpm",
+        "type": "number",
+        "default": 100
+      },
+      {
+        "name": "mouthGate",
+        "type": "number",
+        "default": 0.12
+      },
+      {
+        "name": "octaveRange",
+        "type": "number",
+        "default": 1
+      },
+      {
+        "name": "browSeventhAt",
+        "type": "number",
+        "default": 0.5
+      }
+    ]
+  },
+  {
     "type": "progression",
     "title": "Progression",
     "description": "Roman-numeral progression in a key + position (0..1) → current chord symbol.",
@@ -876,7 +1092,7 @@
   {
     "type": "synth-merge",
     "title": "Synth Merge",
-    "description": "Union two synth-params voice streams into one (e.g. hand voices + face-chord voices).",
+    "description": "Union up to three synth-params voice streams into one (hand voices + emotion chord + pose chord).",
     "roles": [
       "mapping"
     ],
@@ -887,6 +1103,10 @@
       },
       {
         "name": "b",
+        "kind": "synth-params"
+      },
+      {
+        "name": "c",
         "kind": "synth-params"
       }
     ],

--- a/public/manual.html
+++ b/public/manual.html
@@ -23,7 +23,7 @@
   .examples code { color: #7dd3fc; } .note { color: #9aa; font-size: 13px; }
 </style></head><body><div class="wrap">
   <h1>θ Thoremin — Capabilities Manual</h1>
-  <p class="gen">Auto-generated from the node registry. 25 nodes.</p>
+  <p class="gen">Auto-generated from the node registry. 28 nodes.</p>
   <p>Thoremin turns live sensor streams (webcam hand gestures, facial expressions, computer keyboard, later MIDI) into a live audiovisual stream — musical audio plus the captured video with overlaid guides. You build sounds by wiring small, typed <b>nodes</b> into a dataflow graph (DAG): inputs → features → mapping → music-logic → synthesis/generation → output. Every edge can be recorded and replayed.</p><p>The mapping layer spans a spectrum: <b>direct</b> (a gesture *is* a note/parameter — e.g. hand position → scale-snapped pitch) through <b>indirect</b> (a gesture expresses a high-level idea — e.g. openness → musical density steering an AI model), including <b>conductor</b> mode (direct a fixed piece's tempo and dynamics).</p><p>This page catalogs the engine's building blocks — every node and how they connect. Some already run in the deployed app; wiring the full graph into the live sound is in progress.</p>
   <h3>Example pipelines</h3>
   <ul class="examples"><li><b>Theremin (direct)</b> — <code>webcam-hands → hand-features → voice-mapping → webaudio-synth ( + canvas-overlay)</code><br/><span class="note">Hand x → scale-snapped pitch, y → volume. Two hands = two voices.</span></li><li><b>Gesture → harmony</b> — <code>hand-features → pick('right.x') → progression → chord → webaudio-synth</code><br/><span class="note">Hand position walks an in-key chord progression.</span></li><li><b>Conductor</b> — <code>control → performance → transport → score → webaudio-synth</code><br/><span class="note">A control signal directs a fixed piece's tempo + dynamics (accelerando/crescendo…).</span></li><li><b>Indirect / AI (gesture or expression)</b> — <code>hand-features / face-features → indirect-map → lyria</code><br/><span class="note">Openness/smile/etc. steer weighted prompts + dials of Google Lyria RealTime.</span></li><li><b>Discrete triggers</b> — <code>hand-features → gesture-classifier → (events)</code><br/><span class="note">Fist/open/pinch poses emit enter/exit events to trigger scale changes, stabs, mutes.</span></li></ul>
@@ -110,6 +110,16 @@
       </dl>
     </div>
     <div class="node">
+      <h4><code>face-controls</code> <span class="title">Face Controls</span></h4>
+      <p>Face frame → deliberate control axes (head yaw/pitch/roll, jaw-open, smile↔frown, brow-raise, lip-pucker), each with gain/deadzone/smoothing.</p>
+      <dl>
+        <dt>roles</dt><dd>feature</dd>
+        <dt>in</dt><dd>face:face-frame</dd>
+        <dt>out</dt><dd>controls:face-controls</dd>
+        <dt>params</dt><dd>smoothing (number=0.3), headRangeDeg (number=30), headDeadzoneDeg (number=3), yawZeroDeg (number=0), pitchZeroDeg (number=0), rollZeroDeg (number=0), yawGain (number=1), pitchGain (number=1), rollGain (number=1), mouthDeadzone (number=0.08), browDeadzone (number=0.1), puckerDeadzone (number=0.12), smileDeadzone (number=0.06), mouthGain (number=1), browGain (number=1), puckerGain (number=1), smileGain (number=1)</dd>
+      </dl>
+    </div>
+    <div class="node">
       <h4><code>face-expression</code> <span class="title">Face Expression</span></h4>
       <p>Face blendshapes → one of 7 emotions or neutral (per-class thresholds + neutral abstention, smoothing, enter/exit hysteresis, dwell).</p>
       <dl>
@@ -182,11 +192,21 @@
     </div>
     <div class="node">
       <h4><code>synth-merge</code> <span class="title">Synth Merge</span></h4>
-      <p>Union two synth-params voice streams into one (e.g. hand voices + face-chord voices).</p>
+      <p>Union up to three synth-params voice streams into one (hand voices + emotion chord + pose chord).</p>
       <dl>
         <dt>roles</dt><dd>mapping</dd>
-        <dt>in</dt><dd>a:synth-params, b:synth-params</dd>
+        <dt>in</dt><dd>a:synth-params, b:synth-params, c:synth-params</dd>
         <dt>out</dt><dd>params:synth-params</dd>
+        <dt>params</dt><dd>—</dd>
+      </dl>
+    </div>
+    <div class="node">
+      <h4><code>chord-select</code> <span class="title">Chord Select</span></h4>
+      <p>Pick the first non-empty of two chord-tone streams (e.g. emotion triad vs pose chord) for the overlay.</p>
+      <dl>
+        <dt>roles</dt><dd>mapping</dd>
+        <dt>in</dt><dd>a:number[], b:number[]</dd>
+        <dt>out</dt><dd>chord:number[]</dd>
         <dt>params</dt><dd>—</dd>
       </dl>
     </div></div></section>
@@ -219,6 +239,16 @@
         <dt>in</dt><dd>expression:face-expression, spec:scale-spec, faceMapping:face-mapping, octaveShift:number, chordConfig:chord-config, degrees:expression-degrees</dd>
         <dt>out</dt><dd>params:synth-params, triad:number[]</dd>
         <dt>params</dt><dd>gain (number=0.22), sound (enum(sine | triangle | square | sawtooth | warmPad | glass | bell | organ | voice | softLead | strings | flute | brass | choir)="triangle"), voicing (enum(spread | bassTriad | close | shell | power)="spread"), rendering (enum(sustained | strum | arpUp | arpDown | arpUpDown | pulse | alberti)="sustained"), bpm (number=100)</dd>
+      </dl>
+    </div>
+    <div class="node">
+      <h4><code>pose-chord</code> <span class="title">Pose Chord</span></h4>
+      <p>Head/face pose axes → a voiced, rendered diatonic chord (head-yaw→degree, pitch→octave, jaw-open→gate, smile→timbre, brow→7th). Active only in face "controls" mode.</p>
+      <dl>
+        <dt>roles</dt><dd>music</dd>
+        <dt>in</dt><dd>controls:face-controls, spec:scale-spec, faceMapping:face-mapping, octaveShift:number, chordConfig:chord-config</dd>
+        <dt>out</dt><dd>params:synth-params, chord:number[]</dd>
+        <dt>params</dt><dd>gain (number=0.22), sound (enum(sine | triangle | square | sawtooth | warmPad | glass | bell | organ | voice | softLead | strings | flute | brass | choir)="warmPad"), voicing (enum(spread | bassTriad | close | shell | power)="spread"), rendering (enum(sustained | strum | arpUp | arpDown | arpUpDown | pulse | alberti)="sustained"), bpm (number=100), mouthGate (number=0.12), octaveRange (number=1), browSeventhAt (number=0.5)</dd>
       </dl>
     </div></div></section>
 <section><h3>Conductor mode</h3><p class="blurb">Direct a fixed piece with gesture (tempo + dynamics).</p><div class="grid">

--- a/scripts/gen_catalog.ts
+++ b/scripts/gen_catalog.ts
@@ -19,9 +19,9 @@ const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 // Layer grouping for the manual (type → category, in display order).
 const CATEGORIES: Array<{ name: string; blurb: string; types: string[] }> = [
   { name: 'Inputs (sources)', blurb: 'Where signals enter the graph.', types: ['webcam-hands', 'webcam-face', 'keyboard-source', 'store-controls', 'synthetic-hands', 'replay-source'] },
-  { name: 'Features', blurb: 'Raw sensor data → normalized control signals.', types: ['hand-features', 'face-features', 'face-expression', 'gesture-classifier'] },
-  { name: 'Mapping (direct ↔ indirect)', blurb: 'Features → engine parameters, across the expression spectrum.', types: ['voice-mapping', 'indirect-map', 'keyboard-control', 'pick', 'one-euro', 'synth-merge'] },
-  { name: 'Music logic (tonal guidance)', blurb: 'Harmony kept in-key.', types: ['chord', 'progression', 'expression-chord'] },
+  { name: 'Features', blurb: 'Raw sensor data → normalized control signals.', types: ['hand-features', 'face-features', 'face-controls', 'face-expression', 'gesture-classifier'] },
+  { name: 'Mapping (direct ↔ indirect)', blurb: 'Features → engine parameters, across the expression spectrum.', types: ['voice-mapping', 'indirect-map', 'keyboard-control', 'pick', 'one-euro', 'synth-merge', 'chord-select'] },
+  { name: 'Music logic (tonal guidance)', blurb: 'Harmony kept in-key.', types: ['chord', 'progression', 'expression-chord', 'pose-chord'] },
   { name: 'Conductor mode', blurb: 'Direct a fixed piece with gesture (tempo + dynamics).', types: ['transport', 'score', 'performance'] },
   { name: 'Synthesis & generation', blurb: 'Make sound — direct synthesis or steered AI music.', types: ['webaudio-synth', 'lyria'] },
   { name: 'Output', blurb: 'Audio + the captured video with overlaid guides.', types: ['canvas-overlay'] },

--- a/src/app/dials/DialsControlsPanel.tsx
+++ b/src/app/dials/DialsControlsPanel.tsx
@@ -26,6 +26,7 @@ import type { FaceMapping } from '@/nodes';
 import { useControls } from '../store';
 import { OVERLAY_CONTROLS, type OverlayControlDesc } from '../overlayControls';
 import { ExpressionHelpButton } from '../ExpressionHelpPanel';
+import { POSE_MOVES } from '../poseControlsHelp';
 import { CalibrationWizard } from '../CalibrationWizard';
 import { useFaceStatus } from '../faceStatus';
 import { RECORDING_FORMATS } from '../recording/formats';
@@ -268,18 +269,27 @@ const FACE_MODE_OPTIONS: { value: FaceMapping; label: string }[] = [
   { value: 'none', label: 'Off' },
   { value: 'timbre', label: 'Expression → timbre' },
   { value: 'chord', label: 'Expression → chord' },
+  { value: 'controls', label: 'Head/face pose → chord' },
 ];
 
 const FACE_MODE_HINT: Record<FaceMapping, string> = {
   none: 'No face detection. Pick a mode to map your expression to sound. Uses the same camera as hand tracking; loads a small face model on first use.',
   timbre: 'Smile → brighter tone, open mouth → vibrato — shaping the notes your hands play.',
   chord: "Your expression plays a diatonic triad on the right hand's scale (needs a 7-note scale).",
+  controls:
+    "Deliberate head/face moves play chords — turn to pick the chord, open your mouth to sound it (needs a 7-note scale). The easy, controllable alternative to emotion mode.",
 };
 
-/** Live face-model status + detected expression, driven by the engine (#65). */
-function FaceStatusReadout({ active }: { active: boolean }) {
+/** Modes whose chord needs a seven-note scale (a diatonic triad is otherwise
+ *  undefined): emotion `chord` and head-pose `controls`. */
+const needsSevenNote = (m: FaceMapping): boolean => m === 'chord' || m === 'controls';
+
+/** Live face-model status + detected expression, driven by the engine (#65). The
+ *  classified emotion `label` is shown only when it actually drives the sound — in
+ *  head-pose `controls` mode the emotion is unused, so `showLabel` is false there. */
+function FaceStatusReadout({ active, showLabel = true }: { active: boolean; showLabel?: boolean }) {
   const status = useFaceStatus((s) => s.status);
-  const label = useFaceStatus((s) => s.label);
+  const label = useFaceStatus((s) => (showLabel ? s.label : ''));
 
   let dot = 'bg-white/30';
   let text = 'Off';
@@ -563,26 +573,48 @@ function FaceControls() {
           onChange={(e) => set('face.mapping', e.target.value as FaceMapping)}
         >
           {FACE_MODE_OPTIONS.map((o) => (
-            <option key={o.value} value={o.value} disabled={o.value === 'chord' && !sevenNote}>
+            <option key={o.value} value={o.value} disabled={needsSevenNote(o.value) && !sevenNote}>
               {o.label}
-              {o.value === 'chord' && !sevenNote ? ' (needs 7-note scale)' : ''}
+              {needsSevenNote(o.value) && !sevenNote ? ' (needs 7-note scale)' : ''}
             </option>
           ))}
         </select>
       </label>
       <div className="flex items-center justify-between gap-2">
-        <FaceStatusReadout active={faceMapping !== 'none'} />
-        {faceMapping !== 'none' && <ExpressionHelpButton />}
+        <FaceStatusReadout active={faceMapping !== 'none'} showLabel={faceMapping !== 'controls'} />
+        {/* Emotion how-to help is for the expression modes; pose mode has its own moves list. */}
+        {faceMapping !== 'none' && faceMapping !== 'controls' && <ExpressionHelpButton />}
       </div>
-      {faceMapping === 'chord' && !sevenNote && (
+      {needsSevenNote(faceMapping) && !sevenNote && (
         <p className="text-[10px] leading-relaxed text-amber-300/80">
-          Chord mode needs a 7-note scale (Major / Natural Minor / Harmonic Minor) on the right hand.
+          This mode needs a 7-note scale (Major / Natural Minor / Harmonic Minor) on the right hand.
         </p>
       )}
       <p className="text-[10px] leading-relaxed text-white/40">{FACE_MODE_HINT[faceMapping]}</p>
-      {faceMapping === 'chord' && <ChordControls />}
-      {faceMapping !== 'none' && <ExpressionMapping chordMode={faceMapping === 'chord'} />}
+      {faceMapping === 'controls' && <PoseMovesHelp />}
+      {/* Both chord instruments (emotion + pose) share the same sound settings. */}
+      {(faceMapping === 'chord' || faceMapping === 'controls') && <ChordControls />}
+      {/* The per-emotion sensitivity / degree editor applies only to the emotion
+          modes, not the head-pose instrument. */}
+      {faceMapping !== 'none' && faceMapping !== 'controls' && (
+        <ExpressionMapping chordMode={faceMapping === 'chord'} />
+      )}
     </div>
+  );
+}
+
+/** The "few easy moves" help for head-pose `controls` mode (#76) — mirrors the
+ *  axis→music mapping in the `pose-chord` node so the copy can't drift from the
+ *  actual behaviour. */
+function PoseMovesHelp() {
+  return (
+    <ul className="space-y-1 pl-1 text-[10px] leading-relaxed text-white/50">
+      {POSE_MOVES.map((m) => (
+        <li key={m.move}>
+          <span className="text-white/70">{m.move}</span> — {m.effect}
+        </li>
+      ))}
+    </ul>
   );
 }
 

--- a/src/app/graph.ts
+++ b/src/app/graph.ts
@@ -120,12 +120,17 @@ export function defaultGraph(selection?: SlotSelection, registry?: NodeRegistry)
       // Chord path: classify the expression, then play its diatonic triad.
       { id: 'faceExpr', type: 'face-expression', params: {} },
       { id: 'exprChord', type: 'expression-chord', params: {} },
+      // Controls path (#76): deliberate head/face pose axes → a diatonic chord.
+      { id: 'faceCtrl', type: 'face-controls', params: {} },
+      { id: 'poseChord', type: 'pose-chord', params: {} },
       { id: 'kbd', type: 'keyboard-source' },
       { id: 'kctrl', type: 'keyboard-control', params: { magnetismStart: 0.8 } },
       { id: 'ui', type: 'store-controls' },
       { id: 'map', type: mappingType, params: { magnetism: 0.8, maxGain: 0.5 } },
       // Union the hand voices with the face-chord voices before the synth.
       { id: 'merge', type: 'synth-merge', params: {} },
+      // Pick whichever chord instrument is sounding, for the overlay pitch-guide highlight.
+      { id: 'chordSel', type: 'chord-select', params: {} },
       { id: 'synth', type: 'webaudio-synth' },
       // Overlay elements default on (video/scaleGuide/landmarks/markers); the
       // opt-in index-finger guide is off by default. See canvas_overlay.ts.
@@ -153,6 +158,16 @@ export function defaultGraph(selection?: SlotSelection, registry?: NodeRegistry)
       { from: { node: 'ui', port: 'chordConfig' }, to: { node: 'exprChord', port: 'chordConfig' } },
       // Keep the face chord in the same register as the hand melody (octave shift).
       { from: { node: 'kctrl', port: 'octaveShift' }, to: { node: 'exprChord', port: 'octaveShift' } },
+      // Controls path (#76): webcam-face → face-controls → pose-chord. The pose
+      // instrument plays a diatonic chord from head/face pose; it emits silent
+      // voices unless the mode is 'controls', so the merge is unaffected otherwise.
+      { from: { node: 'camFace', port: 'face' }, to: { node: 'faceCtrl', port: 'face' } },
+      { from: { node: 'faceCtrl', port: 'controls' }, to: { node: 'poseChord', port: 'controls' } },
+      { from: { node: 'ui', port: 'rightSpec' }, to: { node: 'poseChord', port: 'spec' } },
+      { from: { node: 'ui', port: 'faceMapping' }, to: { node: 'poseChord', port: 'faceMapping' } },
+      // Reuse the same live chord settings (sound / volume / voicing / rendering / tempo).
+      { from: { node: 'ui', port: 'chordConfig' }, to: { node: 'poseChord', port: 'chordConfig' } },
+      { from: { node: 'kctrl', port: 'octaveShift' }, to: { node: 'poseChord', port: 'octaveShift' } },
       { from: { node: 'feat', port: 'features' }, to: { node: 'map', port: 'features' } },
       { from: { node: 'feat', port: 'features' }, to: { node: 'overlay', port: 'features' } },
       { from: { node: 'kbd', port: 'pressed' }, to: { node: 'kctrl', port: 'pressed' } },
@@ -163,9 +178,12 @@ export function defaultGraph(selection?: SlotSelection, registry?: NodeRegistry)
       { from: { node: 'ui', port: 'scaleLeft' }, to: { node: 'map', port: 'scaleLeft' } },
       { from: { node: 'ui', port: 'soundRight' }, to: { node: 'map', port: 'soundRight' } },
       { from: { node: 'ui', port: 'soundLeft' }, to: { node: 'map', port: 'soundLeft' } },
-      // Merge the hand voices (map) with the face-chord voices, then to the synth.
+      // Merge the hand voices (map) with the emotion-chord AND pose-chord voices,
+      // then to the synth. Only one face chord source sounds at a time (they gate on
+      // mutually-exclusive modes), but wiring both keeps the graph mode-agnostic.
       { from: { node: 'map', port: 'params' }, to: { node: 'merge', port: 'a' } },
       { from: { node: 'exprChord', port: 'params' }, to: { node: 'merge', port: 'b' } },
+      { from: { node: 'poseChord', port: 'params' }, to: { node: 'merge', port: 'c' } },
       { from: { node: 'merge', port: 'params' }, to: { node: 'synth', port: 'params' } },
       // Also feed the hand params to the overlay so it can label each hand's note.
       { from: { node: 'map', port: 'params' }, to: { node: 'overlay', port: 'params' } },
@@ -173,8 +191,11 @@ export function defaultGraph(selection?: SlotSelection, registry?: NodeRegistry)
       { from: { node: 'ui', port: 'scaleRight' }, to: { node: 'overlay', port: 'scale' } },
       { from: { node: 'ui', port: 'scaleLeft' }, to: { node: 'overlay', port: 'scaleLeft' } },
       { from: { node: 'kctrl', port: 'octaveShift' }, to: { node: 'overlay', port: 'octaveShift' } },
-      // The face chord's tones, so the overlay can highlight them on the guide.
-      { from: { node: 'exprChord', port: 'triad' }, to: { node: 'overlay', port: 'chord' } },
+      // Whichever chord instrument is sounding (emotion triad OR pose chord), so the
+      // overlay highlights the active chord's tones on the pitch guide in both modes.
+      { from: { node: 'exprChord', port: 'triad' }, to: { node: 'chordSel', port: 'a' } },
+      { from: { node: 'poseChord', port: 'chord' }, to: { node: 'chordSel', port: 'b' } },
+      { from: { node: 'chordSel', port: 'chord' }, to: { node: 'overlay', port: 'chord' } },
       // The raw face frame (mesh) + classified expression, for the face overlays.
       { from: { node: 'camFace', port: 'face' }, to: { node: 'overlay', port: 'faceFrame' } },
       { from: { node: 'faceExpr', port: 'expression' }, to: { node: 'overlay', port: 'expression' } },

--- a/src/app/poseControlsHelp.ts
+++ b/src/app/poseControlsHelp.ts
@@ -1,0 +1,23 @@
+/**
+ * Help copy for head-pose `controls` mode (issue #76) — "the few easy moves"
+ * that replace "how to fake each emotion". Each entry names a deliberate,
+ * near-universally performable move and what it does musically. The list mirrors
+ * the axis→music mapping wired in `src/nodes/music/pose_chord.ts`, so this copy
+ * cannot drift from the actual instrument.
+ */
+export interface PoseMove {
+  /** The physical move, imperative and concrete. */
+  move: string;
+  /** What it does to the sound. */
+  effect: string;
+}
+
+/** The EASY default head-pose instrument, in the order a first-timer meets them:
+ *  pick a chord, sound it, then shade it. */
+export const POSE_MOVES: PoseMove[] = [
+  { move: 'Turn your head left/right', effect: 'picks the chord (sweeps the seven scale chords)' },
+  { move: 'Open your mouth', effect: 'sounds the chord — closed is silent, so your jaw plays and rests it' },
+  { move: 'Nod up / down', effect: 'shifts the octave (register)' },
+  { move: 'Smile / frown', effect: 'brightens / darkens the tone' },
+  { move: 'Raise both eyebrows', effect: 'adds the 7th for a richer chord' },
+];

--- a/src/music/theory.ts
+++ b/src/music/theory.ts
@@ -117,13 +117,29 @@ export function isSevenNoteScale(type: ScaleTypeId): boolean {
  * — a caller that forgets to gate it gets silence, not a wrong (wrapped) chord.
  */
 export function diatonicTriad(spec: ScaleSpec, degree: number): number[] {
-  if (degree < 0) return [];
+  return diatonicChord(spec, degree, 3);
+}
+
+/**
+ * A diatonic chord rooted on scale `degree` of a seven-note scale, built by
+ * stacking `size` scale-thirds — degrees `degree`, `degree+2`, … — within the
+ * scale's own interval set, as ascending MIDI notes. `size = 3` is the triad
+ * ({@link diatonicTriad}); `size = 4` adds the diatonic seventh (`[0,2,4,6]`),
+ * used by the head-pose instrument's brow "add-7th" modifier (#76). Degrees that
+ * step past the octave wrap up by 12 semitones, keeping the chord ascending.
+ *
+ * Returns `[]` for non-seven-note scales (see {@link isSevenNoteScale}), a
+ * negative degree (the silence sentinel), or a non-positive `size`, so callers
+ * degrade gracefully to no chord rather than indexing out of range.
+ */
+export function diatonicChord(spec: ScaleSpec, degree: number, size = 3): number[] {
+  if (degree < 0 || size < 1) return [];
   const intervals = SCALE_TYPES[spec.type].intervals;
   if (intervals.length !== 7) return [];
   const baseNote = (spec.baseOctave + 1) * 12 + spec.root;
   const d = ((degree % 7) + 7) % 7;
-  return [0, 2, 4].map((third) => {
-    const idx = d + third;
+  return Array.from({ length: size }, (_, i) => {
+    const idx = d + 2 * i;
     return baseNote + intervals[idx % 7] + 12 * Math.floor(idx / 7);
   });
 }

--- a/src/nodes/domain.ts
+++ b/src/nodes/domain.ts
@@ -118,13 +118,18 @@ export interface SynthParams {
 }
 
 /**
- * What the player's facial expression maps to (the face-mapping chooser, #64):
- *  - `none`   : no face detection or mapping (the model never loads).
- *  - `timbre` : expression continuously shapes the active voices (smile→brightness,
- *               open mouth→vibrato).
- *  - `chord`  : expression selects a diatonic triad on the current seven-note scale.
+ * What the player's face maps to (the face-mapping chooser, #64 + #76):
+ *  - `none`     : no face detection or mapping (the model never loads).
+ *  - `timbre`   : expression continuously shapes the active voices (smile→brightness,
+ *                 open mouth→vibrato).
+ *  - `chord`    : the classified *emotion* selects a diatonic triad on the current
+ *                 seven-note scale.
+ *  - `controls` : deliberate head/face *pose* axes play a chord instrument (#76) —
+ *                 head-yaw→degree, head-pitch→octave, jaw-open→gate, smile→timbre,
+ *                 brow→add-7th. The honest, controllable alternative to emotion mode.
+ * Any non-`none` mode lazy-loads the `webcam-face` model.
  */
-export const FACE_MAPPINGS = ['none', 'timbre', 'chord'] as const;
+export const FACE_MAPPINGS = ['none', 'timbre', 'chord', 'controls'] as const;
 export type FaceMapping = (typeof FACE_MAPPINGS)[number];
 
 /** Map the legacy boolean `faceEnabled` (pre-#64) onto the tri-state mapping: a
@@ -148,6 +153,78 @@ export interface FaceFrame {
   /** Normalized (0..1) face landmark points in the source frame, for drawing the
    *  face mesh overlay. Optional — the feature/expression nodes ignore it. */
   landmarks?: { x: number; y: number }[];
+  /** Head orientation (degrees) decoded from MediaPipe's facial transformation
+   *  matrix — present only when the live source enables that output (issue #76).
+   *  The offline blendshape fixture has no matrix, so this is absent there. */
+  headPose?: HeadPose;
+}
+
+// ---- Head pose (from the MediaPipe facial transformation matrix, #76) ------
+
+/**
+ * Head orientation in DEGREES, decoded from MediaPipe FaceLandmarker's facial
+ * transformation matrix. Zero on every axis = facing the camera square-on. The
+ * absolute sign of each axis depends on MediaPipe's camera convention and is
+ * deliberately not asserted here — the downstream `face-controls` node maps each
+ * to a normalized control with a per-axis gain that can be negative, so the felt
+ * direction is tunable without touching this decode.
+ */
+export interface HeadPose {
+  /** Left/right turn about the vertical axis (Y). */
+  yaw: number;
+  /** Up/down nod about the lateral axis (X). */
+  pitch: number;
+  /** Ear-to-shoulder tilt about the view axis (Z). */
+  roll: number;
+}
+
+export const ZERO_HEAD_POSE: HeadPose = { yaw: 0, pitch: 0, roll: 0 };
+
+const RAD2DEG = 180 / Math.PI;
+const clampUnit = (v: number): number => (v < -1 ? -1 : v > 1 ? 1 : v);
+
+/**
+ * Decompose a MediaPipe FaceLandmarker facial transformation matrix into head
+ * yaw/pitch/roll (degrees). `data` is the 16-element, COLUMN-MAJOR 4x4 rigid
+ * transform (canonical face → detected face) FaceLandmarker returns when
+ * `outputFacialTransformationMatrixes` is enabled; only the upper-left 3x3
+ * rotation block is read (column-major: `M[row][col] = data[col*4 + row]`).
+ *
+ * The rotation is decomposed under the intrinsic Tait–Bryan **Y-X-Z** order
+ * (yaw about Y, then pitch about X, then roll about Z — the natural order for a
+ * head) using the standard closed form (identical to three.js `Euler` order
+ * `'YXZ'`), with a gimbal-lock fold when pitch approaches ±90°.
+ *
+ * Pure and headlessly unit-testable: a matrix built from known (yaw, pitch,
+ * roll) via the matching Y-X-Z composition round-trips back to those angles.
+ * Returns {@link ZERO_HEAD_POSE} for a malformed (too-short) matrix so a caller
+ * can never index out of range.
+ */
+export function matrixToHeadPose(data: number[] | Float32Array | undefined): HeadPose {
+  if (!data || data.length < 11) return { ...ZERO_HEAD_POSE };
+  // Column-major element access: m(row, col) = data[col * 4 + row].
+  const m11 = data[0];
+  const m21 = data[1];
+  const m31 = data[2];
+  const m22 = data[5];
+  const m13 = data[8];
+  const m23 = data[9];
+  const m33 = data[10];
+  const pitch = Math.asin(-clampUnit(m23));
+  let yaw: number;
+  let roll: number;
+  if (Math.abs(m23) < 0.9999999) {
+    yaw = Math.atan2(m13, m33);
+    roll = Math.atan2(m21, m22);
+  } else {
+    // Gimbal lock (looking straight up/down): roll and yaw are degenerate; fold
+    // the free rotation into yaw and zero the roll.
+    yaw = Math.atan2(-m31, m11);
+    roll = 0;
+  }
+  // Normalize signed zero (`asin(-0)` → `-0`) so a square-on face reads a clean 0.
+  const deg = (rad: number): number => (rad === 0 ? 0 : rad * RAD2DEG);
+  return { yaw: deg(yaw), pitch: deg(pitch), roll: deg(roll) };
 }
 
 /** Normalized expression controls derived from blendshapes, all 0..1. */
@@ -172,6 +249,43 @@ export const ABSENT_FACE: FaceFeatures = {
   browRaise: 0,
   browFurrow: 0,
   eyeBlink: 0,
+};
+
+/**
+ * Orthogonal, deliberately-controllable face/head axes (issue #76) — the
+ * *control* surface that complements emotion classification for the `controls`
+ * face mode. Each is chosen to be easy to produce on purpose AND reliably
+ * detected. Head axes are bipolar (0 = neutral, facing the camera); mouth/brow/
+ * pucker are unipolar; smile↔frown is bipolar. All clamped to their range.
+ * Produced by the `face-controls` feature node from a {@link FaceFrame}.
+ */
+export interface FaceControls {
+  present: boolean;
+  /** Head turn left/right, -1..1 (from {@link HeadPose.yaw}). */
+  headYaw: number;
+  /** Head nod down/up, -1..1 (from {@link HeadPose.pitch}). */
+  headPitch: number;
+  /** Head tilt ear-to-shoulder, -1..1 (from {@link HeadPose.roll}). */
+  headRoll: number;
+  /** Jaw drop / open mouth, 0..1 (the most reliable blendshape channel). */
+  mouthOpen: number;
+  /** Smile (+) ↔ frown (-), -1..1 (bipolar mouth-corner geometry). */
+  smileFrown: number;
+  /** Both brows raised, 0..1. */
+  browRaise: number;
+  /** Lips puckered / funneled ("ooo"), 0..1 (a reliable discrete pose). */
+  lipPucker: number;
+}
+
+export const ABSENT_FACE_CONTROLS: FaceControls = {
+  present: false,
+  headYaw: 0,
+  headPitch: 0,
+  headRoll: 0,
+  mouthOpen: 0,
+  smileFrown: 0,
+  browRaise: 0,
+  lipPucker: 0,
 };
 
 /**

--- a/src/nodes/features/face_controls.ts
+++ b/src/nodes/features/face_controls.ts
@@ -1,0 +1,162 @@
+/**
+ * `face-controls` node — turns a {@link FaceFrame} into a small set of
+ * *deliberate, orthogonal* face/head control axes (issue #76): head yaw / pitch
+ * / roll (from the decoded {@link HeadPose}), jaw-open, smile↔frown, brow-raise,
+ * and a lip-pucker pose. It is the sibling of `face-features` and
+ * `face-expression`, and the *control* surface the `controls` face mode plays
+ * from — chosen because each axis is (a) easy for a player to produce on purpose
+ * and (b) reliably detected, unlike the emotion classifier's low-controllability
+ * faces read through low-SNR channels.
+ *
+ * Pure + Node-safe (no DOM/MediaPipe): the live `webcam-face` node and the
+ * offline fixture both feed it `{ present, blendshapes, headPose? }` frames, so
+ * it replays headlessly. Head axes read from `frame.headPose` (present only when
+ * the live source enables the facial transformation matrix); when it is absent
+ * (e.g. the blendshape-only fixture) the head axes rest at 0 while the
+ * blendshape-driven axes still work.
+ *
+ * Each axis is normalized with a per-axis gain (which may be NEGATIVE to flip
+ * the felt direction — the honest fix for a camera sign convention we cannot
+ * assert headlessly), a deadzone (so a resting face/head reads 0 despite the
+ * blendshapes' rest jitter and pose noise), and shared EMA smoothing so the
+ * control eases rather than jumps. Head axes additionally take a per-session
+ * neutral *zero* (degrees) — the seam a future "look at the camera" calibration
+ * fills — and a full-scale *range* (the degrees of rotation that reach ±1).
+ */
+import { z } from 'zod';
+import { defineNode } from '@/dag';
+import { ABSENT_FACE_CONTROLS, type FaceControls, type FaceFrame } from '../domain';
+
+const Params = z.object({
+  /** Shared EMA smoothing 0..1 per tick (0 = instant, higher = smoother/slower). */
+  smoothing: z.number().min(0).max(0.999).default(0.3),
+
+  // --- Head pose (degrees) → bipolar [-1,1] axes ---
+  /** Degrees of rotation (from the neutral zero) that reach full-scale ±1. */
+  headRangeDeg: z.number().min(1).default(30),
+  /** Degrees of deadzone around the neutral zero (pose noise + drift rejection). */
+  headDeadzoneDeg: z.number().min(0).default(3),
+  /** Neutral "facing the camera" zero per axis (degrees) — a calibration seam. */
+  yawZeroDeg: z.number().default(0),
+  pitchZeroDeg: z.number().default(0),
+  rollZeroDeg: z.number().default(0),
+  /** Per-axis gain (negative flips direction), applied after the deadzone. */
+  yawGain: z.number().default(1),
+  pitchGain: z.number().default(1),
+  rollGain: z.number().default(1),
+
+  // --- Blendshape → unipolar [0,1] / bipolar [-1,1] axes ---
+  /** Rest deadzone for the jaw/brow/pucker channels (they read slightly active at rest). */
+  mouthDeadzone: z.number().min(0).max(0.9).default(0.08),
+  browDeadzone: z.number().min(0).max(0.9).default(0.1),
+  puckerDeadzone: z.number().min(0).max(0.9).default(0.12),
+  /** Deadzone for the bipolar smile↔frown axis. */
+  smileDeadzone: z.number().min(0).max(0.9).default(0.06),
+  /** Per-axis gain for the blendshape channels. */
+  mouthGain: z.number().min(0).default(1),
+  browGain: z.number().min(0).default(1),
+  puckerGain: z.number().min(0).default(1),
+  smileGain: z.number().min(0).default(1),
+});
+type Params = z.infer<typeof Params>;
+
+const clamp01 = (v: number): number => (v < 0 ? 0 : v > 1 ? 1 : v);
+const clampSigned = (v: number): number => (v < -1 ? -1 : v > 1 ? 1 : v);
+
+/** Unipolar deadzone+rescale on a raw [0,1] channel: below `dz` → 0, then
+ *  `[dz, 1]` is stretched to `[0, 1]` before the gain, so the axis starts clean
+ *  at the deadzone edge and still reaches full scale. */
+function unipolar(raw: number, dz: number, gain: number): number {
+  const d = raw <= dz ? 0 : (raw - dz) / (1 - dz);
+  return clamp01(d * gain);
+}
+
+/** Bipolar deadzone+rescale on a value already in ~[-1,1]: within `±dz` → 0,
+ *  then each side is stretched so the axis starts clean at the deadzone edge. */
+function bipolar(v: number, dz: number): number {
+  const a = Math.abs(v);
+  if (a <= dz) return 0;
+  return Math.sign(v) * clampSigned((a - dz) / (1 - dz));
+}
+
+/** A degrees reading → a bipolar [-1,1] axis: recenter on `zeroDeg`, scale by the
+ *  full-scale `rangeDeg`, deadzone, then apply the (possibly negative) gain. The
+ *  deadzone ratio is capped below 1 so a (mis)configured deadzone ≥ range can never
+ *  invert the axis via `bipolar`'s `1 - dz` divisor. */
+function headAxis(deg: number, zeroDeg: number, rangeDeg: number, deadzoneDeg: number, gain: number): number {
+  const norm = (deg - zeroDeg) / rangeDeg;
+  const dz = Math.min(deadzoneDeg / rangeDeg, 0.9);
+  return clampSigned(bipolar(norm, dz) * gain);
+}
+
+/** The smoothed, mutable per-axis state (everything but `present`). */
+type AxisState = Omit<FaceControls, 'present'>;
+
+const zeroAxes = (): AxisState => ({
+  headYaw: 0,
+  headPitch: 0,
+  headRoll: 0,
+  mouthOpen: 0,
+  smileFrown: 0,
+  browRaise: 0,
+  lipPucker: 0,
+});
+
+export const faceControlsNode = defineNode<Params>({
+  type: 'face-controls',
+  roles: ['feature'],
+  title: 'Face Controls',
+  description:
+    'Face frame → deliberate control axes (head yaw/pitch/roll, jaw-open, smile↔frown, brow-raise, lip-pucker), each with gain/deadzone/smoothing.',
+  inputs: [{ name: 'face', kind: 'face-frame' }],
+  outputs: [{ name: 'controls', kind: 'face-controls' }],
+  params: Params,
+  make(p) {
+    const prev = zeroAxes();
+    const keys = Object.keys(prev) as (keyof AxisState)[];
+
+    /** EMA `prev` toward `target` (target 0 = decay toward rest). */
+    const ease = (target: AxisState) => {
+      for (const k of keys) prev[k] = prev[k] + (1 - p.smoothing) * (target[k] - prev[k]);
+    };
+
+    return {
+      process(inputs) {
+        const face = inputs.face as FaceFrame | undefined;
+        if (!face || !face.present) {
+          // Decay toward rest so a lost face relaxes the axes rather than freezing them.
+          ease(zeroAxes());
+          return { controls: { ...ABSENT_FACE_CONTROLS } };
+        }
+
+        const bs = (name: string): number => face.blendshapes[name] ?? 0;
+        const avg = (...xs: number[]): number => (xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0);
+
+        // Head axes read the decoded pose when the live source provides it; the
+        // blendshape-only fixture has none, so they rest at 0 (present stays true).
+        const pose = face.headPose;
+        const target: AxisState = {
+          headYaw: pose ? headAxis(pose.yaw, p.yawZeroDeg, p.headRangeDeg, p.headDeadzoneDeg, p.yawGain) : 0,
+          headPitch: pose ? headAxis(pose.pitch, p.pitchZeroDeg, p.headRangeDeg, p.headDeadzoneDeg, p.pitchGain) : 0,
+          headRoll: pose ? headAxis(pose.roll, p.rollZeroDeg, p.headRangeDeg, p.headDeadzoneDeg, p.rollGain) : 0,
+          mouthOpen: unipolar(bs('jawOpen'), p.mouthDeadzone, p.mouthGain),
+          smileFrown: clampSigned(
+            bipolar(
+              avg(bs('mouthSmileLeft'), bs('mouthSmileRight')) - avg(bs('mouthFrownLeft'), bs('mouthFrownRight')),
+              p.smileDeadzone,
+            ) * p.smileGain,
+          ),
+          browRaise: unipolar(
+            avg(bs('browInnerUp'), bs('browOuterUpLeft'), bs('browOuterUpRight')),
+            p.browDeadzone,
+            p.browGain,
+          ),
+          lipPucker: unipolar(avg(bs('mouthPucker'), bs('mouthFunnel')), p.puckerDeadzone, p.puckerGain),
+        };
+
+        ease(target);
+        return { controls: { present: true, ...prev } as FaceControls };
+      },
+    };
+  },
+});

--- a/src/nodes/index.ts
+++ b/src/nodes/index.ts
@@ -12,17 +12,20 @@ import { syntheticHandsNode } from './sources/synthetic_hands';
 import { replaySourceNode } from './sources/replay';
 import { handFeaturesNode } from './features/hand_features';
 import { faceFeaturesNode } from './features/face_features';
+import { faceControlsNode } from './features/face_controls';
 import { faceExpressionNode } from './features/face_expression';
 import { gestureClassifierNode } from './features/gesture_classifier';
 import { voiceMappingNode } from './mapping/voice_mapping';
 import { keyboardControlNode } from './mapping/keyboard_control';
 import { indirectMapNode } from './mapping/indirect_map';
 import { synthMergeNode } from './mapping/synth_merge';
+import { chordSelectNode } from './mapping/chord_select';
 import { pickNode } from './mapping/pick';
 import { oneEuroNode } from './mapping/one_euro';
 import { lyriaNode } from './output/lyria';
 import { chordNode } from './music/chord';
 import { expressionChordNode } from './music/expression_chord';
+import { poseChordNode } from './music/pose_chord';
 import { progressionNode } from './music/progression';
 import { transportNode } from './music/transport';
 import { scoreNode } from './music/score';
@@ -32,6 +35,7 @@ export { syntheticHandsNode } from './sources/synthetic_hands';
 export { replaySourceNode } from './sources/replay';
 export { handFeaturesNode } from './features/hand_features';
 export { faceFeaturesNode } from './features/face_features';
+export { faceControlsNode } from './features/face_controls';
 export { faceExpressionNode } from './features/face_expression';
 export { gestureClassifierNode } from './features/gesture_classifier';
 export type { Pose, GestureEvent } from './features/gesture_classifier';
@@ -39,11 +43,13 @@ export { voiceMappingNode } from './mapping/voice_mapping';
 export { keyboardControlNode } from './mapping/keyboard_control';
 export { indirectMapNode } from './mapping/indirect_map';
 export { synthMergeNode } from './mapping/synth_merge';
+export { chordSelectNode } from './mapping/chord_select';
 export { pickNode } from './mapping/pick';
 export { oneEuroNode } from './mapping/one_euro';
 export { lyriaNode } from './output/lyria';
 export { chordNode, voiceChord } from './music/chord';
 export { expressionChordNode, CHORD_VOICE_ID_BASE, MAX_CHORD_VOICES } from './music/expression_chord';
+export { poseChordNode, POSE_VOICE_ID_BASE, MAX_POSE_VOICES, yawToDegree } from './music/pose_chord';
 export { progressionNode } from './music/progression';
 export { transportNode } from './music/transport';
 export { scoreNode } from './music/score';
@@ -57,17 +63,20 @@ export const CORE_NODES = [
   replaySourceNode,
   handFeaturesNode,
   faceFeaturesNode,
+  faceControlsNode,
   faceExpressionNode,
   gestureClassifierNode,
   voiceMappingNode,
   keyboardControlNode,
   indirectMapNode,
   synthMergeNode,
+  chordSelectNode,
   pickNode,
   oneEuroNode,
   lyriaNode,
   chordNode,
   expressionChordNode,
+  poseChordNode,
   progressionNode,
   transportNode,
   scoreNode,

--- a/src/nodes/mapping/chord_select.ts
+++ b/src/nodes/mapping/chord_select.ts
@@ -1,0 +1,31 @@
+/**
+ * `chord-select` node — picks the first non-empty of two chord-tone streams into
+ * one, so a single overlay `chord` input can show whichever chord instrument is
+ * currently sounding. The engine forbids fan-IN to one input port, so the
+ * emotion `expression-chord` (`triad`) and the head-pose `pose-chord` (`chord`)
+ * cannot both wire into `overlay.chord`; this node is the join.
+ *
+ * The two sources are mutually exclusive by face mode (emotion `chord` vs pose
+ * `controls`), and each emits `[]` while idle, so "first non-empty" cleanly
+ * yields the active chord's un-voiced tones (and `[]` when neither sounds).
+ * Pure + deterministic.
+ */
+import { defineNode } from '@/dag';
+
+const asTones = (v: unknown): number[] => (Array.isArray(v) ? (v as number[]) : []);
+
+export const chordSelectNode = defineNode({
+  type: 'chord-select',
+  roles: ['mapping'],
+  title: 'Chord Select',
+  description: 'Pick the first non-empty of two chord-tone streams (e.g. emotion triad vs pose chord) for the overlay.',
+  inputs: [
+    { name: 'a', kind: 'number[]' },
+    { name: 'b', kind: 'number[]' },
+  ],
+  outputs: [{ name: 'chord', kind: 'number[]' }],
+  process(inputs) {
+    const a = asTones(inputs.a);
+    return { chord: a.length ? a : asTones(inputs.b) };
+  },
+});

--- a/src/nodes/mapping/synth_merge.ts
+++ b/src/nodes/mapping/synth_merge.ts
@@ -1,15 +1,17 @@
 /**
- * `synth-merge` node — unions two {@link SynthParams} voice streams into one.
+ * `synth-merge` node — unions up to three {@link SynthParams} voice streams into one.
  *
- * The engine forbids fan-IN to a single input port, so two producers of synth
- * params (e.g. the hand `voice-mapping` and the face `expression-chord`) cannot
- * both wire into the synth's one `params` input. This node is the merge point:
- * it takes them on distinct ports and concatenates their voices, so the player's
- * hand melody and face-driven chord sound together. Voices keep their own ids
- * (hands use 0/1, chords use ids ≥ 2), so the synth voices them independently.
+ * The engine forbids fan-IN to a single input port, so several producers of synth
+ * params (the hand `voice-mapping`, the emotion `expression-chord`, and the head-
+ * pose `pose-chord`) cannot each wire into the synth's one `params` input. This
+ * node is the merge point: it takes them on distinct ports and concatenates their
+ * voices, so hand melody + face-driven chords sound together. Voices keep their
+ * own ids (hands 0/1, emotion chord 2..5, pose chord ≥ 6), so the synth voices
+ * them independently.
  *
- * Pure + deterministic. An absent/empty input contributes no voices, so when the
- * face chord is idle the merge passes the hand voices through unchanged.
+ * Pure + deterministic. An absent/empty input contributes no voices, so the third
+ * port `c` is fully back-compatible (graphs wiring only `a`/`b` are unchanged) and
+ * an idle chord source simply passes the other streams through unchanged.
  */
 import { defineNode } from '@/dag';
 import type { SynthParams } from '../domain';
@@ -25,15 +27,18 @@ export const synthMergeNode = defineNode({
   type: 'synth-merge',
   roles: ['mapping'],
   title: 'Synth Merge',
-  description: 'Union two synth-params voice streams into one (e.g. hand voices + face-chord voices).',
+  description: 'Union up to three synth-params voice streams into one (hand voices + emotion chord + pose chord).',
   inputs: [
     { name: 'a', kind: 'synth-params' },
     { name: 'b', kind: 'synth-params' },
+    // Optional third stream (e.g. the head-pose chord); absent → contributes nothing.
+    { name: 'c', kind: 'synth-params' },
   ],
   outputs: [{ name: 'params', kind: 'synth-params' }],
   process(inputs) {
     const a = asParams(inputs.a);
     const b = asParams(inputs.b);
-    return { params: { voices: [...a.voices, ...b.voices] } };
+    const c = asParams(inputs.c);
+    return { params: { voices: [...a.voices, ...b.voices, ...c.voices] } };
   },
 });

--- a/src/nodes/music/pose_chord.ts
+++ b/src/nodes/music/pose_chord.ts
@@ -1,0 +1,202 @@
+/**
+ * `pose-chord` node — the head/face *pose* instrument (issue #76), the `controls`
+ * counterpart of the emotion-driven `expression-chord`. It turns the deliberate
+ * control axes from `face-controls` into a voiced, rendered diatonic chord, using
+ * the EASY default mapping the issue recommends as the first-run instrument:
+ *
+ *  - **head yaw → scale degree** — sweep the seven diatonic chords left→right, a
+ *    horizontal "keyboard of chords";
+ *  - **head pitch → octave register** — nod up/down to shift the chord's octave;
+ *  - **jaw-open → gate** — the chord sounds only while the mouth is open (jaw
+ *    closed = rest), the most reliable channel as the play/rest control;
+ *  - **smile ↔ frown → brightness** — smiling opens the timbre, frowning darkens it;
+ *  - **brow-raise → add the diatonic 7th** — a richer chord while both brows are up.
+ *
+ * It reuses the same voicing / rendering / beat-clock machinery as
+ * `expression-chord` (via {@link voiceTriad} / {@link renderGains}) and the same
+ * live `chordConfig` settings (sound / volume / voicing / rendering / tempo), so
+ * the two chord instruments sound consistent. Voices sit on ids ≥
+ * {@link POSE_VOICE_ID_BASE} — above the hand voices (0, 1) AND the
+ * expression-chord voices (2..5) — so all three can be unioned into the synth
+ * without id collisions. It ALWAYS emits {@link MAX_POSE_VOICES} voices on stable
+ * ids (silent when idle), so a vanishing voice never leaves a chord stuck.
+ *
+ * Active ONLY when `faceMapping === 'controls'`, the controls are present, and the
+ * scale is seven-note (a diatonic chord is otherwise undefined) — else silent.
+ * Stateful (a beat clock + strum re-trigger) but deterministic given the tick
+ * timing, so it replays exactly.
+ */
+import { z } from 'zod';
+import { defineNode } from '@/dag';
+import type { NodeContext } from '@/dag';
+import { diatonicChord, midiToFreq, type ScaleSpec } from '@/music/theory';
+import { SoundSchema } from '@/music/sounds';
+import { VOICINGS, RENDERINGS, voiceTriad, renderGains, type VoicingId, type RenderingId } from '@/music/voicing';
+import type { FaceControls, VoiceParams } from '../domain';
+
+/** Pose-chord voices start here — above the hand voices (0, 1) and the
+ *  expression-chord voices (2..5), so hand melody + emotion chord + pose chord
+ *  can all be merged into the synth without id collisions. */
+export const POSE_VOICE_ID_BASE = 6;
+
+/** The largest chord is a voiced triad (up to 4 voices) plus the brow 7th. */
+export const MAX_POSE_VOICES = 5;
+
+/** The seven diatonic degrees the head-yaw sweep spans. */
+const DEGREE_COUNT = 7;
+
+const Params = z.object({
+  /** Volume of the chord (0..1) — gentle by default so it supports a melody. */
+  gain: z.number().min(0).max(1).default(0.22),
+  /** Instrument timbre for the chord voices. */
+  sound: SoundSchema.default('warmPad'),
+  /** How the triad is arranged (low bass + upper structure). */
+  voicing: z.enum(VOICINGS).default('spread'),
+  /** How the voiced chord is played over time. */
+  rendering: z.enum(RENDERINGS).default('sustained'),
+  /** Tempo (BPM) for the tempo-based renderings. */
+  bpm: z.number().min(40).max(200).default(100),
+  /** Jaw-open gate: the chord sounds only when `mouthOpen` reaches this (0..1). */
+  mouthGate: z.number().min(0).max(1).default(0.12),
+  /** Head-pitch octave span: `round(headPitch * octaveRange)` octaves of shift. */
+  octaveRange: z.number().int().min(0).max(3).default(1),
+  /** Brow-raise threshold to add the diatonic 7th (0..1). */
+  browSeventhAt: z.number().min(0).max(1).default(0.5),
+});
+type Params = z.infer<typeof Params>;
+
+/** Live chord settings from the UI store (override the static params each tick) —
+ *  the SAME shape `expression-chord` consumes, so both chord instruments share the
+ *  faceChord settings. */
+interface ChordConfig {
+  sound?: VoiceParams['sound'];
+  gain?: number;
+  voicing?: VoicingId;
+  rendering?: RenderingId;
+  bpm?: number;
+}
+
+const clamp01 = (v: number): number => (v < 0 ? 0 : v > 1 ? 1 : v);
+const clampSigned = (v: number): number => (v < -1 ? -1 : v > 1 ? 1 : v);
+
+/** Head-yaw [-1,1] → a scale degree 0..(DEGREE_COUNT-1): a left→right sweep of the
+ *  seven diatonic chords, with each degree occupying an equal slice of the range. */
+export function yawToDegree(headYaw: number): number {
+  const t = (clampSigned(headYaw) + 1) / 2; // [-1,1] → [0,1]
+  const d = Math.floor(t * DEGREE_COUNT);
+  return d < 0 ? 0 : d >= DEGREE_COUNT ? DEGREE_COUNT - 1 : d;
+}
+
+export const poseChordNode = defineNode<Params>({
+  type: 'pose-chord',
+  roles: ['music'],
+  title: 'Pose Chord',
+  description:
+    'Head/face pose axes → a voiced, rendered diatonic chord (head-yaw→degree, pitch→octave, jaw-open→gate, smile→timbre, brow→7th). Active only in face "controls" mode.',
+  inputs: [
+    { name: 'controls', kind: 'face-controls' },
+    { name: 'spec', kind: 'scale-spec' },
+    { name: 'faceMapping', kind: 'face-mapping', default: 'none' },
+    // Live keyboard octave shift, so the chord tracks the melody's register.
+    { name: 'octaveShift', kind: 'number', default: 0 },
+    // Live chord settings (sound / volume / voicing / rendering / tempo).
+    { name: 'chordConfig', kind: 'chord-config' },
+  ],
+  outputs: [
+    { name: 'params', kind: 'synth-params' },
+    // The un-voiced chord tones (pitch classes), for an overlay highlight — [] when idle.
+    { name: 'chord', kind: 'number[]' },
+  ],
+  params: Params,
+  make(p) {
+    let beat = 0;
+    let timeSinceChange = 0;
+    let lastKey = '';
+
+    const silent = (sound: VoiceParams['sound']): VoiceParams[] =>
+      Array.from({ length: MAX_POSE_VOICES }, (_, i) => ({
+        id: POSE_VOICE_ID_BASE + i,
+        present: false,
+        freq: midiToFreq(60),
+        gain: 0,
+        sound,
+      }));
+
+    return {
+      process(inputs, ctx: NodeContext) {
+        const cfg = (inputs.chordConfig as ChordConfig | undefined) ?? {};
+        const sound = cfg.sound ?? p.sound;
+        const gain = cfg.gain ?? p.gain;
+        const voicing = cfg.voicing ?? p.voicing;
+        const rendering = cfg.rendering ?? p.rendering;
+        const bpm = cfg.bpm ?? p.bpm;
+
+        const controls = inputs.controls as FaceControls | undefined;
+        const spec = inputs.spec as ScaleSpec | undefined;
+        const baseShift = typeof inputs.octaveShift === 'number' ? inputs.octaveShift : 0;
+        const active = inputs.faceMapping === 'controls' && !!controls && controls.present && !!spec;
+
+        // The jaw gates play/rest: no sound until the mouth opens past the gate.
+        const sounding = active && (controls as FaceControls).mouthOpen >= p.mouthGate;
+
+        const dt = typeof ctx?.dt === 'number' && Number.isFinite(ctx.dt) ? ctx.dt : 0;
+        beat += (bpm / 60) * dt;
+
+        if (!sounding) {
+          // Keep the clock running (so re-articulation stays phase-consistent) but
+          // reset the chord key so the next onset strums fresh.
+          lastKey = '';
+          timeSinceChange = 0;
+          return { params: { voices: silent(sound) }, chord: [] };
+        }
+
+        const c = controls as FaceControls;
+        const degree = yawToDegree(c.headYaw);
+        // Head pitch sweeps the octave; brow raises add the diatonic 7th.
+        const octaveShift = baseShift + Math.round(clampSigned(c.headPitch) * p.octaveRange);
+        const withSeventh = c.browRaise >= p.browSeventhAt;
+        // Smile↔frown opens/darkens the timbre: -1 → 0 (dark), 0 → 0.5, +1 → 1 (bright).
+        const brightness = clamp01(0.5 + 0.5 * c.smileFrown);
+
+        const tones = diatonicChord(spec!, degree, withSeventh ? 4 : 3);
+        const triad = tones.slice(0, 3);
+        let voiced = triad.length >= 3 ? voiceTriad(triad, voicing, octaveShift) : [];
+        if (withSeventh && tones.length >= 4) {
+          // Add the diatonic 7th one register up with the chord (kept in the voiced
+          // structure's octave via the same shift), then re-sort ascending so an
+          // arpeggio still traverses low→high by actual pitch.
+          voiced = [...voiced, tones[3] + 12 * octaveShift];
+        }
+        voiced = voiced.sort((a, b) => a - b);
+
+        if (voiced.length === 0) return { params: { voices: silent(sound) }, chord: [] };
+
+        // Restart the strum on any genuine chord change (the sounding pitches).
+        const key = voiced.join(',');
+        if (key !== lastKey) {
+          timeSinceChange = 0;
+          lastKey = key;
+        } else {
+          timeSinceChange += dt;
+        }
+
+        const gains = renderGains(voiced.length, rendering, beat, timeSinceChange);
+        const voices: VoiceParams[] = [];
+        for (let i = 0; i < MAX_POSE_VOICES; i++) {
+          const midi = voiced[i];
+          const raw = gains[i];
+          const g = midi !== undefined && Number.isFinite(raw) ? gain * raw : 0;
+          voices.push({
+            id: POSE_VOICE_ID_BASE + i,
+            present: g > 0,
+            freq: midiToFreq(midi ?? 60),
+            gain: g,
+            sound,
+            brightness,
+          });
+        }
+        return { params: { voices }, chord: tones };
+      },
+    };
+  },
+});

--- a/src/nodes/sources/webcam_face.ts
+++ b/src/nodes/sources/webcam_face.ts
@@ -25,7 +25,7 @@
 import { z } from 'zod';
 import { defineNode } from '@/dag';
 import type { NodeContext } from '@/dag';
-import type { FaceFrame, FaceMapping, FaceStatus } from '../domain';
+import { matrixToHeadPose, type FaceFrame, type FaceMapping, type FaceStatus } from '../domain';
 
 // MediaPipe FaceLandmarker assets, loaded from a CDN on demand (mirrors how
 // `webcam-hands` resolves its MediaPipe solution from jsDelivr). The wasm
@@ -52,13 +52,18 @@ export interface FaceLandmarkerResultLike {
   faceBlendshapes?: Array<{ categories: Array<{ categoryName: string; score: number }> }>;
   /** Normalized (0..1) landmark points per detected face, for the face-mesh overlay. */
   faceLandmarks?: Array<Array<{ x: number; y: number }>>;
+  /** Per-face 4x4 rigid transform (canonical → detected face), COLUMN-MAJOR in
+   *  `data`. Present only when `outputFacialTransformationMatrixes` is enabled
+   *  (issue #76); the rotation block yields head yaw/pitch/roll. */
+  facialTransformationMatrixes?: Array<{ data: number[] | Float32Array }>;
 }
 
 /**
  * Pure converter: a MediaPipe FaceLandmarker result → a {@link FaceFrame} (the 52
- * blendshapes plus the normalized landmark points, when present). Exported so it
- * can be unit-tested headlessly (the live inference itself is browser-only).
- * Returns the absent frame when no face was detected.
+ * blendshapes, the normalized landmark points, and — when the transformation
+ * matrix is present — the decoded head pose). Exported so it can be unit-tested
+ * headlessly (the live inference itself is browser-only). Returns the absent
+ * frame when no face was detected.
  */
 export function blendshapesToFaceFrame(result: FaceLandmarkerResultLike): FaceFrame {
   const categories = result.faceBlendshapes?.[0]?.categories;
@@ -68,6 +73,8 @@ export function blendshapesToFaceFrame(result: FaceLandmarkerResultLike): FaceFr
   const frame: FaceFrame = { present: true, blendshapes };
   const pts = result.faceLandmarks?.[0];
   if (pts && pts.length) frame.landmarks = pts.map((p) => ({ x: p.x, y: p.y }));
+  const matrix = result.facialTransformationMatrixes?.[0]?.data;
+  if (matrix && matrix.length >= 11) frame.headPose = matrixToHeadPose(matrix);
   return frame;
 }
 
@@ -84,6 +91,7 @@ interface TasksVisionModule {
       opts: {
         baseOptions: { modelAssetPath: string; delegate?: 'GPU' | 'CPU' };
         outputFaceBlendshapes?: boolean;
+        outputFacialTransformationMatrixes?: boolean;
         numFaces?: number;
         runningMode?: 'IMAGE' | 'VIDEO';
       },
@@ -176,6 +184,9 @@ export const webcamFaceNode = defineNode<Params>({
     const optionsFor = (delegate: 'GPU' | 'CPU') => ({
       baseOptions: { modelAssetPath: MODEL_URL, delegate },
       outputFaceBlendshapes: true,
+      // Head-pose control axes (#76): the rigid face→camera transform, decoded to
+      // yaw/pitch/roll by `blendshapesToFaceFrame` → `matrixToHeadPose`.
+      outputFacialTransformationMatrixes: true,
       numFaces: 1,
       runningMode: 'VIDEO' as const,
     });

--- a/src/settings/dials.ts
+++ b/src/settings/dials.ts
@@ -82,9 +82,13 @@ export const thoreminDials = defineDials(
     constraints: {
       assertions: [
         {
-          message: 'Chord face-mapping needs a 7-note scale (Major / Natural Minor / Harmonic Minor) on the right hand.',
+          message:
+            'Chord and head-pose face-mappings need a 7-note scale (Major / Natural Minor / Harmonic Minor) on the right hand.',
           keys: ['face.mapping', 'right.type'],
-          check: (v) => v['face.mapping'] !== 'chord' || isSevenNoteScale(v['right.type'] as ScaleTypeId),
+          check: (v) => {
+            const m = v['face.mapping'];
+            return (m !== 'chord' && m !== 'controls') || isSevenNoteScale(v['right.type'] as ScaleTypeId);
+          },
         },
       ],
     },

--- a/test/app_graph.test.ts
+++ b/test/app_graph.test.ts
@@ -28,15 +28,27 @@ describe('production app graph', () => {
     expect(order.indexOf('camFace')).toBeLessThan(order.indexOf('faceExpr'));
     expect(order.indexOf('faceExpr')).toBeLessThan(order.indexOf('exprChord'));
     expect(order.indexOf('exprChord')).toBeLessThan(order.indexOf('merge'));
-    expect(order).toHaveLength(13);
+    // head-pose controls branch: webcam-face → face-controls → pose-chord → merge (#76)
+    expect(order.indexOf('camFace')).toBeLessThan(order.indexOf('faceCtrl'));
+    expect(order.indexOf('faceCtrl')).toBeLessThan(order.indexOf('poseChord'));
+    expect(order.indexOf('poseChord')).toBeLessThan(order.indexOf('merge'));
+    // both chord instruments feed the overlay highlight via the chord-select join
+    expect(order.indexOf('exprChord')).toBeLessThan(order.indexOf('chordSel'));
+    expect(order.indexOf('poseChord')).toBeLessThan(order.indexOf('chordSel'));
+    expect(order.indexOf('chordSel')).toBeLessThan(order.indexOf('overlay'));
+    expect(order).toHaveLength(16);
   });
 
-  it('wires the face overlays (mesh + expression readout)', () => {
+  it('wires the face overlays (mesh + expression readout + both chord highlights)', () => {
     const edges = defaultGraph().edges;
     const has = (fn: string, fp: string, tn: string, tp: string) =>
       edges.some((e) => e.from.node === fn && e.from.port === fp && e.to.node === tn && e.to.port === tp);
     expect(has('camFace', 'face', 'overlay', 'faceFrame')).toBe(true); // face mesh data
     expect(has('faceExpr', 'expression', 'overlay', 'expression')).toBe(true); // expression readout
+    // The overlay chord highlight is fed by whichever chord instrument sounds (#76).
+    expect(has('exprChord', 'triad', 'chordSel', 'a')).toBe(true);
+    expect(has('poseChord', 'chord', 'chordSel', 'b')).toBe(true);
+    expect(has('chordSel', 'chord', 'overlay', 'chord')).toBe(true);
   });
 
   it('ticks cleanly with no host resources (everything no-ops or idles)', () => {
@@ -57,11 +69,12 @@ describe('production app graph', () => {
     expect(params[0].voices).toHaveLength(2);
 
     // The synth's actual input is the merge of hand voices (0,1) + the 4 stable
-    // chord voices (2..5) — distinct ids, all silent while the face chord is idle.
+    // emotion-chord voices (2..5) + the 5 stable pose-chord voices (6..10) — all
+    // distinct ids, all silent while both face chord sources are idle (#76).
     const merged = recorder.values('merge.params') as SynthParams[];
     const ids = merged[0].voices.map((v) => v.id);
-    expect(ids).toEqual([0, 1, 2, 3, 4, 5]);
-    expect(new Set(ids).size).toBe(6); // no id collision between hands and chord
+    expect(ids).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    expect(new Set(ids).size).toBe(11); // no id collision across hands + both chords
     expect(merged[0].voices.every((v) => !v.present)).toBe(true);
   });
 });

--- a/test/face_chord_nodes.test.ts
+++ b/test/face_chord_nodes.test.ts
@@ -8,7 +8,7 @@
 import { describe, it, expect } from 'vitest';
 import { replayNode } from '@/dag';
 import type { NodeContext } from '@/dag';
-import { faceExpressionNode, expressionChordNode, synthMergeNode, voiceMappingNode } from '@/nodes';
+import { faceExpressionNode, expressionChordNode, synthMergeNode, chordSelectNode, voiceMappingNode } from '@/nodes';
 import { MAX_CHORD_VOICES, ABSENT_HAND, ABSENT_FACE } from '@/nodes';
 import type { ExpressionScores } from '@/music/expression';
 import { DEFAULT_EXPRESSION_TO_DEGREE, DEFAULT_EXPRESSION_SENSITIVITY } from '@/music/expression';
@@ -369,5 +369,35 @@ describe('synth-merge node', () => {
     const a: SynthParams = { voices: [{ id: 0, present: true, freq: 440, gain: 0.5, sound: 'sine' }] };
     const out = await replayNode(node, { a: [a] });
     expect((out[0].params as SynthParams).voices).toHaveLength(1);
+  });
+
+  it('unions the optional third stream (hand + emotion chord + pose chord) (#76)', async () => {
+    const node = synthMergeNode.make(synthMergeNode.params.parse({}));
+    const a: SynthParams = { voices: [{ id: 0, present: true, freq: 440, gain: 0.5, sound: 'sine' }] };
+    const b: SynthParams = { voices: [{ id: 2, present: true, freq: 550, gain: 0.2, sound: 'triangle' }] };
+    const c: SynthParams = { voices: [{ id: 6, present: true, freq: 660, gain: 0.2, sound: 'warmPad' }] };
+    const out = await replayNode(node, { a: [a], b: [b], c: [c] });
+    expect((out[0].params as SynthParams).voices.map((v) => v.id)).toEqual([0, 2, 6]);
+    // Back-compat: a and b alone still merge, with c contributing nothing.
+    const out2 = await replayNode(node, { a: [a], b: [b] });
+    expect((out2[0].params as SynthParams).voices.map((v) => v.id)).toEqual([0, 2]);
+  });
+});
+
+describe('chord-select node (#76)', () => {
+  it('picks the first non-empty chord-tone stream (the sounding instrument)', async () => {
+    const node = chordSelectNode.make(chordSelectNode.params.parse({}));
+    // Emotion chord sounding, pose idle → emotion tones.
+    const out = await replayNode(node, { a: [[60, 64, 67]], b: [[]] });
+    expect(out[0].chord).toEqual([60, 64, 67]);
+    // Pose chord sounding, emotion idle → pose tones.
+    const out2 = await replayNode(node, { a: [[]], b: [[62, 65, 69]] });
+    expect(out2[0].chord).toEqual([62, 65, 69]);
+    // Neither sounding → empty (no highlight).
+    const out3 = await replayNode(node, { a: [[]], b: [[]] });
+    expect(out3[0].chord).toEqual([]);
+    // Missing inputs are treated as empty.
+    const out4 = await replayNode(node, { a: [undefined as unknown as number[]] });
+    expect(out4[0].chord).toEqual([]);
   });
 });

--- a/test/face_controls.test.ts
+++ b/test/face_controls.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests the `face-controls` node (issue #76): a face frame → deliberate control
+ * axes (head yaw/pitch/roll, jaw-open, smile↔frown, brow-raise, lip-pucker).
+ * Unit cases run with `smoothing: 0` so a single tick reflects the raw mapping;
+ * a separate case exercises the EMA easing.
+ */
+import { describe, it, expect } from 'vitest';
+import { replayNode } from '@/dag';
+import { faceControlsNode } from '@/nodes';
+import { ABSENT_FACE_CONTROLS, type FaceControls, type FaceFrame, type HeadPose } from '@/nodes/domain';
+
+const frame = (blendshapes: Record<string, number>, headPose?: HeadPose): FaceFrame => ({
+  present: true,
+  blendshapes,
+  ...(headPose ? { headPose } : {}),
+});
+
+async function run(input: FaceFrame, params: Record<string, unknown> = {}): Promise<FaceControls> {
+  const p = faceControlsNode.params.parse({ smoothing: 0, ...params });
+  const [out] = await replayNode(faceControlsNode.make(p), { face: [input] });
+  return out.controls as FaceControls;
+}
+
+describe('face-controls node (unit)', () => {
+  it('returns absent controls when no face is present', async () => {
+    const c = await run({ present: false, blendshapes: {} });
+    expect(c).toEqual(ABSENT_FACE_CONTROLS);
+  });
+
+  it('maps jaw-open through the deadzone + rescale', async () => {
+    const c = await run(frame({ jawOpen: 0.5 })); // default mouthDeadzone 0.08
+    expect(c.present).toBe(true);
+    expect(c.mouthOpen).toBeCloseTo((0.5 - 0.08) / (1 - 0.08), 5);
+  });
+
+  it('rejects rest jitter below the deadzone', async () => {
+    const c = await run(frame({ jawOpen: 0.05 }));
+    expect(c.mouthOpen).toBe(0);
+  });
+
+  it('maps smile as the positive side of the bipolar smile↔frown axis', async () => {
+    const c = await run(frame({ mouthSmileLeft: 0.8, mouthSmileRight: 0.6 }));
+    // avg 0.7, smileDeadzone 0.06 → (0.7-0.06)/(1-0.06)
+    expect(c.smileFrown).toBeCloseTo((0.7 - 0.06) / (1 - 0.06), 5);
+  });
+
+  it('maps frown as the negative side', async () => {
+    const c = await run(frame({ mouthFrownLeft: 0.5, mouthFrownRight: 0.5 }));
+    expect(c.smileFrown).toBeCloseTo(-((0.5 - 0.06) / (1 - 0.06)), 5);
+  });
+
+  it('averages both brows for brow-raise', async () => {
+    const c = await run(frame({ browInnerUp: 0.6, browOuterUpLeft: 0.6, browOuterUpRight: 0.6 }));
+    expect(c.browRaise).toBeCloseTo((0.6 - 0.1) / (1 - 0.1), 5); // browDeadzone 0.1
+  });
+
+  it('reads lip-pucker from pucker + funnel', async () => {
+    const c = await run(frame({ mouthPucker: 0.7, mouthFunnel: 0.5 })); // avg 0.6
+    expect(c.lipPucker).toBeCloseTo((0.6 - 0.12) / (1 - 0.12), 5); // puckerDeadzone 0.12
+  });
+
+  it('maps head yaw to a bipolar axis at full scale', async () => {
+    const c = await run(frame({}, { yaw: 30, pitch: 0, roll: 0 })); // headRangeDeg 30
+    expect(c.headYaw).toBeCloseTo(1, 5);
+    expect(c.headPitch).toBe(0);
+    expect(c.headRoll).toBe(0);
+  });
+
+  it('maps a partial head yaw through the deadzone', async () => {
+    const c = await run(frame({}, { yaw: 15, pitch: 0, roll: 0 }));
+    // norm 0.5, deadzone 3/30 = 0.1 → (0.5-0.1)/(1-0.1)
+    expect(c.headYaw).toBeCloseTo((0.5 - 0.1) / (1 - 0.1), 5);
+  });
+
+  it('clamps extreme head angles to ±1', async () => {
+    const c = await run(frame({}, { yaw: 90, pitch: -90, roll: 0 }));
+    expect(c.headYaw).toBe(1);
+    expect(c.headPitch).toBe(-1);
+  });
+
+  it('honors a negative per-axis gain to flip direction', async () => {
+    const c = await run(frame({}, { yaw: 30, pitch: 0, roll: 0 }), { yawGain: -1 });
+    expect(c.headYaw).toBeCloseTo(-1, 5);
+  });
+
+  it('applies the neutral zero (recenter) before scaling', async () => {
+    // With the zero at 20°, a 20° yaw reads as neutral (0).
+    const c = await run(frame({}, { yaw: 20, pitch: 0, roll: 0 }), { yawZeroDeg: 20 });
+    expect(c.headYaw).toBe(0);
+  });
+
+  it('keeps blendshape axes working when the head pose is absent (present stays true)', async () => {
+    const c = await run(frame({ jawOpen: 0.5 })); // no headPose
+    expect(c.present).toBe(true);
+    expect(c.headYaw).toBe(0);
+    expect(c.headPitch).toBe(0);
+    expect(c.mouthOpen).toBeGreaterThan(0);
+  });
+
+  it('eases toward the target under smoothing (does not jump)', async () => {
+    const p = faceControlsNode.params.parse({ smoothing: 0.5 });
+    const node = faceControlsNode.make(p);
+    const f = frame({ jawOpen: 1 }); // target mouthOpen = (1-0.08)/(1-0.08) = 1
+    const outs = await replayNode(node, { face: [f, f, f] });
+    // Ticks ease 0 → 0.5 → 0.75 → 0.875: monotonic, never overshooting the target.
+    const seq = outs.map((o) => (o.controls as FaceControls).mouthOpen);
+    expect(seq[0]).toBeCloseTo(0.5, 5);
+    expect(seq[2]).toBeGreaterThan(seq[0]);
+    expect(seq[2]).toBeLessThan(1);
+  });
+});

--- a/test/head_pose.test.ts
+++ b/test/head_pose.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests `matrixToHeadPose` (issue #76): decoding MediaPipe's facial
+ * transformation matrix into head yaw/pitch/roll degrees. We build a
+ * column-major rotation matrix from KNOWN angles using the matching intrinsic
+ * Y-X-Z composition and assert the decode round-trips them — so the decode is
+ * verified against its own convention without a live camera. Sign/feel live
+ * tuning is the `face-controls` node's job (per-axis gain), not this decode's.
+ */
+import { describe, it, expect } from 'vitest';
+import { matrixToHeadPose, ZERO_HEAD_POSE } from '@/nodes/domain';
+
+const DEG = Math.PI / 180;
+
+/**
+ * A 16-element COLUMN-MAJOR 4x4 rotation matrix from (pitch, yaw, roll) degrees
+ * under the intrinsic Y-X-Z order — the exact composition `matrixToHeadPose`
+ * inverts (three.js `makeRotationFromEuler` order 'YXZ'). Column-major layout:
+ * element (row, col) sits at index `col*4 + row`.
+ */
+function yxzColumnMajor(pitchDeg: number, yawDeg: number, rollDeg: number): number[] {
+  const c1 = Math.cos(pitchDeg * DEG); // x
+  const s1 = Math.sin(pitchDeg * DEG);
+  const c2 = Math.cos(yawDeg * DEG); // y
+  const s2 = Math.sin(yawDeg * DEG);
+  const c3 = Math.cos(rollDeg * DEG); // z
+  const s3 = Math.sin(rollDeg * DEG);
+  const te = new Array(16).fill(0);
+  te[0] = c2 * c3 + s1 * s2 * s3; // m11
+  te[4] = s1 * s2 * c3 - c2 * s3; // m12
+  te[8] = c1 * s2; // m13
+  te[1] = c1 * s3; // m21
+  te[5] = c1 * c3; // m22
+  te[9] = -s1; // m23
+  te[2] = c2 * s1 * s3 - s2 * c3; // m31
+  te[6] = s2 * s3 + c2 * s1 * c3; // m32
+  te[10] = c1 * c2; // m33
+  te[15] = 1;
+  return te;
+}
+
+describe('matrixToHeadPose', () => {
+  it('decodes the identity as facing the camera (all zero)', () => {
+    expect(matrixToHeadPose(yxzColumnMajor(0, 0, 0))).toEqual({ yaw: 0, pitch: 0, roll: 0 });
+  });
+
+  it('round-trips a pure yaw', () => {
+    const p = matrixToHeadPose(yxzColumnMajor(0, 20, 0));
+    expect(p.yaw).toBeCloseTo(20, 4);
+    expect(p.pitch).toBeCloseTo(0, 4);
+    expect(p.roll).toBeCloseTo(0, 4);
+  });
+
+  it('round-trips a pure pitch', () => {
+    const p = matrixToHeadPose(yxzColumnMajor(15, 0, 0));
+    expect(p.pitch).toBeCloseTo(15, 4);
+    expect(p.yaw).toBeCloseTo(0, 4);
+    expect(p.roll).toBeCloseTo(0, 4);
+  });
+
+  it('round-trips a pure roll', () => {
+    const p = matrixToHeadPose(yxzColumnMajor(0, 0, 10));
+    expect(p.roll).toBeCloseTo(10, 4);
+    expect(p.yaw).toBeCloseTo(0, 4);
+    expect(p.pitch).toBeCloseTo(0, 4);
+  });
+
+  it('round-trips a combined rotation', () => {
+    const p = matrixToHeadPose(yxzColumnMajor(15, 20, 10));
+    expect(p.pitch).toBeCloseTo(15, 4);
+    expect(p.yaw).toBeCloseTo(20, 4);
+    expect(p.roll).toBeCloseTo(10, 4);
+  });
+
+  it('round-trips negative angles', () => {
+    const p = matrixToHeadPose(yxzColumnMajor(-12, -25, -8));
+    expect(p.pitch).toBeCloseTo(-12, 4);
+    expect(p.yaw).toBeCloseTo(-25, 4);
+    expect(p.roll).toBeCloseTo(-8, 4);
+  });
+
+  it('degrades gracefully at the gimbal (pitch ≈ 90°): no NaN, roll folded to 0', () => {
+    const p = matrixToHeadPose(yxzColumnMajor(90, 30, 20));
+    expect(Number.isNaN(p.yaw)).toBe(false);
+    expect(Number.isNaN(p.pitch)).toBe(false);
+    expect(p.pitch).toBeCloseTo(90, 2);
+    expect(p.roll).toBe(0);
+  });
+
+  it('accepts a Float32Array (the live MediaPipe payload type)', () => {
+    const p = matrixToHeadPose(Float32Array.from(yxzColumnMajor(0, 18, 0)));
+    expect(p.yaw).toBeCloseTo(18, 4);
+  });
+
+  it('returns the zero pose for a malformed / too-short matrix', () => {
+    expect(matrixToHeadPose(undefined)).toEqual(ZERO_HEAD_POSE);
+    expect(matrixToHeadPose([])).toEqual(ZERO_HEAD_POSE);
+    expect(matrixToHeadPose([1, 0, 0, 0])).toEqual(ZERO_HEAD_POSE);
+    // A fresh object each call (not a shared mutable constant).
+    expect(matrixToHeadPose(undefined)).not.toBe(ZERO_HEAD_POSE);
+  });
+});

--- a/test/pose_chord.test.ts
+++ b/test/pose_chord.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Tests the `pose-chord` node and its helpers (issue #76): head/face pose axes →
+ * a voiced, rendered diatonic chord in the `controls` face mode. Pure + headless
+ * via replayNode; the default `sustained` rendering makes every voiced note
+ * sound each tick, so a single tick reflects the mapping.
+ */
+import { describe, it, expect } from 'vitest';
+import { replayNode } from '@/dag';
+import { poseChordNode, yawToDegree, POSE_VOICE_ID_BASE, MAX_POSE_VOICES } from '@/nodes';
+import { ABSENT_FACE_CONTROLS, type FaceControls, type VoiceParams } from '@/nodes/domain';
+import { diatonicChord, diatonicTriad, midiToFreq, type ScaleSpec } from '@/music/theory';
+import { voiceTriad } from '@/music/voicing';
+
+const cMajor: ScaleSpec = { root: 0, type: 'major', octaves: 2, baseOctave: 3 };
+const pentatonic: ScaleSpec = { root: 0, type: 'pentatonic', octaves: 2, baseOctave: 3 };
+
+const ctrl = (patch: Partial<FaceControls>): FaceControls => ({
+  ...ABSENT_FACE_CONTROLS,
+  present: true,
+  ...patch,
+});
+
+/** yaw that lands on a given degree (each degree is a 1/7 slice of [-1,1]). */
+const yawForDegree = (d: number): number => -1 + ((d + 0.5) / 7) * 2;
+
+async function play(
+  controls: FaceControls,
+  {
+    spec = cMajor,
+    faceMapping = 'controls',
+    octaveShift = 0,
+    chordConfig,
+    params = {},
+  }: {
+    spec?: ScaleSpec;
+    faceMapping?: string;
+    octaveShift?: number;
+    chordConfig?: Record<string, unknown>;
+    params?: Record<string, unknown>;
+  } = {},
+): Promise<{ voices: VoiceParams[]; chord: number[] }> {
+  const node = poseChordNode.make(poseChordNode.params.parse(params));
+  const inputs: Record<string, unknown[]> = {
+    controls: [controls],
+    spec: [spec],
+    faceMapping: [faceMapping],
+    octaveShift: [octaveShift],
+  };
+  if (chordConfig) inputs.chordConfig = [chordConfig];
+  const [out] = await replayNode(node, inputs);
+  return { voices: (out.params as { voices: VoiceParams[] }).voices, chord: out.chord as number[] };
+}
+
+const sounding = (voices: VoiceParams[]): VoiceParams[] => voices.filter((v) => v.present && v.gain > 0);
+
+describe('yawToDegree', () => {
+  it('sweeps [-1,1] across the seven diatonic degrees', () => {
+    expect(yawToDegree(-1)).toBe(0);
+    expect(yawToDegree(1)).toBe(6);
+    expect(yawToDegree(0)).toBe(3);
+    expect(yawToDegree(-2)).toBe(0); // clamped
+    expect(yawToDegree(2)).toBe(6); // clamped
+  });
+});
+
+describe('diatonicChord', () => {
+  it('extends the triad with the diatonic 7th at size 4', () => {
+    const triad = diatonicChord(cMajor, 0, 3);
+    const seventh = diatonicChord(cMajor, 0, 4);
+    expect(seventh.slice(0, 3)).toEqual(triad);
+    expect(seventh).toHaveLength(4);
+    // C major I7: C E G B → the 7th is 11 semitones above the root.
+    expect(seventh[3] - seventh[0]).toBe(11);
+  });
+
+  it('matches diatonicTriad for size 3', () => {
+    expect(diatonicChord(cMajor, 4, 3)).toEqual(diatonicTriad(cMajor, 4));
+  });
+
+  it('returns [] for a non-seven-note scale or negative degree', () => {
+    expect(diatonicChord(pentatonic, 0, 3)).toEqual([]);
+    expect(diatonicChord(cMajor, -1, 3)).toEqual([]);
+  });
+});
+
+describe('pose-chord node', () => {
+  it('is silent in every non-controls mode', async () => {
+    for (const mode of ['none', 'timbre', 'chord']) {
+      const { voices, chord } = await play(ctrl({ headYaw: 0, mouthOpen: 1 }), { faceMapping: mode });
+      expect(sounding(voices)).toHaveLength(0);
+      expect(chord).toEqual([]);
+    }
+  });
+
+  it('always emits MAX_POSE_VOICES on stable ids above the other voice sources', async () => {
+    const { voices } = await play(ctrl({ mouthOpen: 0 })); // idle (mouth closed)
+    expect(voices).toHaveLength(MAX_POSE_VOICES);
+    expect(voices.map((v) => v.id)).toEqual([6, 7, 8, 9, 10]);
+    expect(voices.every((v) => v.id >= POSE_VOICE_ID_BASE)).toBe(true);
+  });
+
+  it('gates on the jaw: silent when the mouth is closed, sounding when open', async () => {
+    const closed = await play(ctrl({ headYaw: yawForDegree(0), mouthOpen: 0.05 })); // < gate 0.12
+    expect(sounding(closed.voices)).toHaveLength(0);
+    expect(closed.chord).toEqual([]);
+
+    const open = await play(ctrl({ headYaw: yawForDegree(0), mouthOpen: 0.5 }));
+    expect(sounding(open.voices).length).toBeGreaterThan(0);
+    expect(open.chord).toEqual(diatonicChord(cMajor, 0, 3));
+  });
+
+  it('maps head yaw to the chord degree', async () => {
+    for (const d of [0, 2, 4, 6]) {
+      const { chord } = await play(ctrl({ headYaw: yawForDegree(d), mouthOpen: 0.5 }));
+      expect(chord).toEqual(diatonicChord(cMajor, d, 3));
+    }
+  });
+
+  it('voices the triad exactly as the voicing helper does', async () => {
+    const { voices } = await play(ctrl({ headYaw: yawForDegree(0), mouthOpen: 0.5 }));
+    const expected = voiceTriad(diatonicTriad(cMajor, 0), 'spread', 0)
+      .slice()
+      .sort((a, b) => a - b)
+      .map((m) => midiToFreq(m));
+    const freqs = sounding(voices)
+      .map((v) => v.freq)
+      .sort((a, b) => a - b);
+    expect(freqs).toEqual(expected);
+  });
+
+  it('adds the diatonic 7th when both brows are raised', async () => {
+    const plain = await play(ctrl({ headYaw: yawForDegree(0), mouthOpen: 0.5, browRaise: 0.2 }));
+    expect(plain.chord).toHaveLength(3);
+
+    const seventh = await play(ctrl({ headYaw: yawForDegree(0), mouthOpen: 0.5, browRaise: 0.8 }));
+    expect(seventh.chord).toEqual(diatonicChord(cMajor, 0, 4));
+    // The 7th is an extra sounding voice on top.
+    expect(sounding(seventh.voices).length).toBeGreaterThan(sounding(plain.voices).length);
+  });
+
+  it('shifts the octave with head pitch (nod up = higher)', async () => {
+    const flat = await play(ctrl({ headYaw: yawForDegree(0), mouthOpen: 0.5, headPitch: 0 }));
+    const up = await play(ctrl({ headYaw: yawForDegree(0), mouthOpen: 0.5, headPitch: 1 })); // octaveRange 1 → +1
+    const lo = (vs: VoiceParams[]) => Math.min(...sounding(vs).map((v) => v.freq));
+    expect(lo(up.voices) / lo(flat.voices)).toBeCloseTo(2, 5); // one octave up
+  });
+
+  it('opens/darkens the timbre with smile↔frown (brightness)', async () => {
+    const bright = await play(ctrl({ headYaw: yawForDegree(0), mouthOpen: 0.5, smileFrown: 1 }));
+    const dark = await play(ctrl({ headYaw: yawForDegree(0), mouthOpen: 0.5, smileFrown: -1 }));
+    const neutral = await play(ctrl({ headYaw: yawForDegree(0), mouthOpen: 0.5, smileFrown: 0 }));
+    expect(sounding(bright.voices)[0].brightness).toBeCloseTo(1, 5);
+    expect(sounding(dark.voices)[0].brightness).toBeCloseTo(0, 5);
+    expect(sounding(neutral.voices)[0].brightness).toBeCloseTo(0.5, 5);
+  });
+
+  it('needs a seven-note scale (a pentatonic scale stays silent)', async () => {
+    const { voices, chord } = await play(ctrl({ headYaw: yawForDegree(0), mouthOpen: 1 }), { spec: pentatonic });
+    expect(sounding(voices)).toHaveLength(0);
+    expect(chord).toEqual([]);
+  });
+
+  it('honors a live chordConfig (volume + voicing) over the static params', async () => {
+    const { voices } = await play(ctrl({ headYaw: yawForDegree(0), mouthOpen: 0.5 }), {
+      chordConfig: { gain: 0.5, voicing: 'power' },
+    });
+    const expected = voiceTriad(diatonicTriad(cMajor, 0), 'power', 0)
+      .slice()
+      .sort((a, b) => a - b)
+      .map((m) => midiToFreq(m));
+    const freqs = sounding(voices)
+      .map((v) => v.freq)
+      .sort((a, b) => a - b);
+    expect(freqs).toEqual(expected);
+    // gain 0.5 * sustained (1.0) = 0.5 per voice.
+    expect(sounding(voices)[0].gain).toBeCloseTo(0.5, 5);
+  });
+});

--- a/test/webcam_face.test.ts
+++ b/test/webcam_face.test.ts
@@ -120,6 +120,20 @@ describe('blendshapesToFaceFrame', () => {
     // No landmarks in the result → the field is omitted (not an empty array).
     expect(blendshapesToFaceFrame({ faceBlendshapes: [{ categories: [{ categoryName: 'jawOpen', score: 0.3 }] }] }).landmarks).toBeUndefined();
   });
+
+  it('decodes the head pose from the facial transformation matrix when present (#76)', () => {
+    // Identity rotation (column-major) → facing the camera, zero on every axis.
+    const identity = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+    const frame = blendshapesToFaceFrame({
+      faceBlendshapes: [{ categories: [{ categoryName: 'jawOpen', score: 0.3 }] }],
+      facialTransformationMatrixes: [{ data: identity }],
+    });
+    expect(frame.headPose).toEqual({ yaw: 0, pitch: 0, roll: 0 });
+    // No matrix → the field is omitted (the offline blendshape fixture case).
+    expect(
+      blendshapesToFaceFrame({ faceBlendshapes: [{ categories: [{ categoryName: 'jawOpen', score: 0.3 }] }] }).headPose,
+    ).toBeUndefined();
+  });
 });
 
 describe('webcam-face node gating', () => {


### PR DESCRIPTION
Implements issue #76 — moves the face→music surface **beyond emotion classification** toward a small set of orthogonal, deliberately-controllable **head/face pose axes** (the honest fix for "emotions are arbitrary and hard to control volitionally"). Ships as a new `controls` face mapping that **coexists** with the emotion modes (the classifier is not removed).

## What you get
Select **Head/face pose → chord** in the Face panel, then play:
- **Turn your head** → picks the chord (sweeps the seven diatonic chords)
- **Open your mouth** → sounds the chord (closed = silent — your jaw plays and rests it)
- **Nod up/down** → shifts the octave
- **Smile / frown** → brightens / darkens the tone
- **Raise both brows** → adds the 7th

## How it's built (issue's 5-phase plan, Phases 0–3)
- **Phase 0 — plumbing:** enable MediaPipe `outputFacialTransformationMatrixes`; a pure `matrixToHeadPose()` (Y-X-Z / three.js `'YXZ'` Euler decode, gimbal-safe, signed-zero-clean); `FaceFrame.headPose`.
- **Phase 1 — `face-controls` node:** a `FaceFrame` → 7 axes (head yaw/pitch/roll, jaw-open, smile↔frown, brow-raise, lip-pucker), each with per-axis gain/deadzone/smoothing and a calibration-ready neutral zero. Head axes rest at 0 when the transform matrix is absent (offline fixture), so blendshape axes still work.
- **Phase 2 — `pose-chord` node + `controls` mode:** the EASY default instrument; reuses the existing voicing/rendering machinery; unioned into the synth via a back-compatible **3rd `synth-merge` port** (voice ids 6–10, no collision with hand 0/1 or emotion-chord 2–5).
- **Phase 3 — surface:** `controls` in the Face dropdown (the 7-note-scale constraint now covers it), the chord **sound settings reused**, the emotion sensitivity editor gated out of pose mode, a "few easy moves" help list, and an overlay pitch-guide highlight for **both** chord instruments via a small `chord-select` join.

`diatonicTriad` now delegates to a generalized `diatonicChord(spec, degree, size)` (triad or seventh; identical for size 3).

## Review & verification
Adversarially reviewed via a 4-dimension verify workflow (head-pose math, pose-chord music, wiring/persistence, regressions/UX). **No blockers/highs**; all confirmed low/nit findings fixed in this PR (overlay highlight parity, emotion-label hidden in pose mode, deadzone clamp, catalog categories).

Verify gate green: `typecheck` · **367** vitest (incl. new head-pose round-trip, axis, and pose-chord tests) · `build` · `catalog` (28 nodes).

### One honest limitation
The head-pose axis **signs** (does turning right sweep chords rightward?) can't be verified against MediaPipe's live camera convention headlessly. Defaults are `+1`; any axis that feels reversed is a one-constant per-axis gain flip — I'll confirm on the first live test after deploy.

### Follow-ups (not in this PR)
Per-axis **live tuning UI** + per-user **head-pose calibration** ("look at the camera" zero), and demoting emotion mode to opt-in (issue's Phase 4). RECORD still captures audio only.

https://claude.ai/code/session_01JEoe7y1hA5KdEAvvpQXxxt