### PR TITLE
Fix mute: silence the chords too + a "muted" HUD cue (#91)

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -161,10 +161,10 @@ Adaptive jitter smoothing for a noisy control value (smooth at rest, responsive 
 - **params:** minCutoff (number=1), beta (number=0.01), dCutoff (number=1), fallbackDt (number=0.016666666666666666)
 
 #### `synth-merge` — Synth Merge
-Union up to three synth-params voice streams into one (hand voices + emotion chord + pose chord).
+Union up to three synth-params voice streams into one (hand voices + emotion chord + pose chord); master mute.
 
 - **roles:** mapping
-- **in:** a:synth-params, b:synth-params, c:synth-params
+- **in:** a:synth-params, b:synth-params, c:synth-params, mute:boolean
 - **out:** params:synth-params
 - **params:** —
 

--- a/public/catalog.json
+++ b/public/catalog.json
@@ -1092,7 +1092,7 @@
   {
     "type": "synth-merge",
     "title": "Synth Merge",
-    "description": "Union up to three synth-params voice streams into one (hand voices + emotion chord + pose chord).",
+    "description": "Union up to three synth-params voice streams into one (hand voices + emotion chord + pose chord); master mute.",
     "roles": [
       "mapping"
     ],
@@ -1108,6 +1108,11 @@
       {
         "name": "c",
         "kind": "synth-params"
+      },
+      {
+        "name": "mute",
+        "kind": "boolean",
+        "default": false
       }
     ],
     "outputs": [

--- a/public/manual.html
+++ b/public/manual.html
@@ -192,10 +192,10 @@
     </div>
     <div class="node">
       <h4><code>synth-merge</code> <span class="title">Synth Merge</span></h4>
-      <p>Union up to three synth-params voice streams into one (hand voices + emotion chord + pose chord).</p>
+      <p>Union up to three synth-params voice streams into one (hand voices + emotion chord + pose chord); master mute.</p>
       <dl>
         <dt>roles</dt><dd>mapping</dd>
-        <dt>in</dt><dd>a:synth-params, b:synth-params, c:synth-params</dd>
+        <dt>in</dt><dd>a:synth-params, b:synth-params, c:synth-params, mute:boolean</dd>
         <dt>out</dt><dd>params:synth-params</dd>
         <dt>params</dt><dd>—</dd>
       </dl>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -9,7 +9,7 @@
  * All signal processing happens in the DAG engine via {@link useThoreminEngine};
  * this component is purely presentational + lifecycle.
  */
-import { Play, BookOpen, Circle, Square } from 'lucide-react';
+import { Play, BookOpen, Circle, Square, VolumeX } from 'lucide-react';
 import { useThoreminEngine } from './useEngine';
 import { useControls } from './store';
 import { useFaceStatus } from './faceStatus';
@@ -49,6 +49,20 @@ function FaceChip() {
   );
 }
 
+/** A persistent, unmissable cue shown whenever the instrument is muted (#91).
+ * Non-interactive (the `m` key is the toggle SSOT via the graph); it tells the
+ * player how to unmute so a muted instrument is never mistaken for a broken one. */
+function MutedBadge() {
+  const muted = useControls((s) => s.muted);
+  if (!muted) return null;
+  return (
+    <div className="pointer-events-none absolute left-1/2 top-3 z-30 flex -translate-x-1/2 items-center gap-2 rounded-full bg-red-500/90 px-4 py-1.5 text-[11px] font-bold uppercase tracking-widest text-white shadow-lg backdrop-blur">
+      <VolumeX className="h-3.5 w-3.5" />
+      Muted — press M to unmute
+    </div>
+  );
+}
+
 export default function App() {
   const { videoRef, canvasRef, status, error, audioOn, isRecording, isSaving, startAudio, toggleRecording } =
     useThoreminEngine();
@@ -77,6 +91,9 @@ export default function App() {
         </div>
       </div>
       <FaceChip />
+
+      {/* Top-center: unmissable "muted" cue (audio silenced by the m key). */}
+      <MutedBadge />
 
       {/* Bottom-left: link to the generated capabilities manual. */}
       <a

--- a/src/app/graph.ts
+++ b/src/app/graph.ts
@@ -4,7 +4,7 @@
  *
  *   webcam ─┬─▶ hand-features ─┬─▶ voice-mapping ─▶ synth-merge ─▶ webaudio-synth
  *           │                  │        ▲ ▲ ▲ ▲          ▲
- *           └────────▶ overlay ◀┘        │ │ │ │         │ (+ face chord)
+ *           └────────▶ overlay ◀┘        │ │ │ │         │ (+ face chord; master mute)
  *                       (video+guides)   │ │ │ └── store-controls (scale/instrument)
  *                                        │ │ └──── keyboard-control (magnetism/octave/mute)
  *                                        │ └────── keyboard-source ─▶ keyboard-control
@@ -184,6 +184,11 @@ export function defaultGraph(selection?: SlotSelection, registry?: NodeRegistry)
       { from: { node: 'map', port: 'params' }, to: { node: 'merge', port: 'a' } },
       { from: { node: 'exprChord', port: 'params' }, to: { node: 'merge', port: 'b' } },
       { from: { node: 'poseChord', port: 'params' }, to: { node: 'merge', port: 'c' } },
+      // Master mute reaches the merge — the single convergence point of ALL sound
+      // producers — so muting silences the hands AND both face-chord instruments
+      // (#91). The `kctrl.mute → map.mute` edge above still silences the hand voices
+      // at the mapping stage; this is the catch-all that also covers the chords.
+      { from: { node: 'kctrl', port: 'mute' }, to: { node: 'merge', port: 'mute' } },
       { from: { node: 'merge', port: 'params' }, to: { node: 'synth', port: 'params' } },
       // Also feed the hand params to the overlay so it can label each hand's note.
       { from: { node: 'map', port: 'params' }, to: { node: 'overlay', port: 'params' } },

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -56,6 +56,15 @@ export interface ControlState {
   syncHands: boolean;
   masterVolume: number; // 0..1
   /**
+   * Master mute. When true the whole instrument is silent (hands AND both face-
+   * chord instruments) — read by `useEngine` to zero the host master gain, and
+   * mirrored from the graph's `keyboard-control` mute so the HUD cue reflects the
+   * `m` key. Deliberately NOT persisted (not a musical preset, not in
+   * {@link SETTINGS_KEYS} nor `partialize`), so a fresh reload always starts
+   * un-muted — the least-surprising behaviour, and it needs no persist migration.
+   */
+  muted: boolean;
+  /**
    * What the player's facial expression maps to: `none` (off, default), `timbre`
    * (smile→brightness, open mouth→vibrato), or `chord` (expression selects a
    * diatonic triad). Any non-`none` mode lazy-loads the `webcam-face` model. Read
@@ -89,6 +98,10 @@ export interface ControlState {
   setVoice(side: 'right' | 'left', patch: Partial<VoiceControl>): void;
   setSync(v: boolean): void;
   setMasterVolume(v: number): void;
+  /** Set the master mute directly. */
+  setMuted(v: boolean): void;
+  /** Toggle the master mute (the `m` key path mirrors here). */
+  toggleMuted(): void;
   setFaceMapping(v: FaceMapping): void;
   /** Patch the face-chord settings (e.g. setFaceChord({ voicing: 'spread' })). */
   setFaceChord(patch: Partial<FaceChord>): void;
@@ -254,6 +267,7 @@ export const useControls = create<ControlState>()(
       left: defaultVoice(DEFAULT_SOUND_LEFT),
       syncHands: true,
       masterVolume: 0.4,
+      muted: false,
       faceMapping: 'none',
       faceChord: { ...DEFAULT_FACE_CHORD },
       faceExpr: {
@@ -281,6 +295,8 @@ export const useControls = create<ControlState>()(
         }),
       setSync: (v) => set({ syncHands: v }),
       setMasterVolume: (v) => set({ masterVolume: v }),
+      setMuted: (v) => set({ muted: v }),
+      toggleMuted: () => set((s) => ({ muted: !s.muted })),
       setFaceMapping: (v) => set({ faceMapping: v }),
       setFaceChord: (patch) => set((s) => ({ faceChord: { ...s.faceChord, ...patch } })),
       setExpressionSensitivity: (emotion, value) =>

--- a/src/app/useEngine.ts
+++ b/src/app/useEngine.ts
@@ -87,6 +87,7 @@ export function useThoreminEngine() {
   const [isSaving, setIsSaving] = useState(false);
 
   const masterVolume = useControls((s) => s.masterVolume);
+  const muted = useControls((s) => s.muted);
 
   useEffect(() => {
     let disposed = false;
@@ -157,6 +158,11 @@ export function useThoreminEngine() {
         let lastFaceReport = 0;
         let lastPhase: FaceStatus['phase'] | null = null;
         let lastDetected = false;
+        // Mirror the graph's mute (toggled by the `m` key in `keyboard-control`)
+        // into the store so the HUD "muted" cue + the host master mute follow the
+        // keyboard. Seeded from the store so a mid-session engine rebuild doesn't
+        // spuriously re-announce the current state.
+        let lastMute = useControls.getState().muted;
         const reportFace = (now: number) => {
           const fs = engine.getOutput('camFace', 'status') as FaceStatus | undefined;
           if (!fs) return;
@@ -192,6 +198,13 @@ export function useThoreminEngine() {
             const t = performance.now();
             engine.tick(t / 1000);
             reportFace(t);
+            // Reflect a keyboard mute toggle into the store (only on change, so
+            // this is not a per-frame setState). Drives the master gain + HUD cue.
+            const m = engine.getOutput('kctrl', 'mute') === true;
+            if (m !== lastMute) {
+              lastMute = m;
+              useControls.getState().setMuted(m);
+            }
           } catch (err) {
             console.error('[thoremin] engine tick error (frame dropped)', err);
           }
@@ -227,13 +240,17 @@ export function useThoreminEngine() {
     };
   }, []);
 
-  // Keep master gain synced to the UI volume.
+  // Keep master gain synced to the UI volume, and drop it to zero while muted.
+  // This is the host-level catch-all mute (belt-and-suspenders with the in-graph
+  // `synth-merge` mute), so ANY audio reaching the master bus — including a
+  // non-graph producer like the Lyria plugin — goes silent too. The 50ms target
+  // ramp makes both muting and unmuting click-free.
   useEffect(() => {
     const ac = resourcesRef.current.audioContext as AudioContext | undefined;
     if (masterGainRef.current && ac) {
-      masterGainRef.current.gain.setTargetAtTime(masterVolume, ac.currentTime, 0.05);
+      masterGainRef.current.gain.setTargetAtTime(muted ? 0 : masterVolume, ac.currentTime, 0.05);
     }
-  }, [masterVolume]);
+  }, [masterVolume, muted]);
 
   const startAudio = useCallback(async () => {
     const resources = resourcesRef.current;
@@ -242,7 +259,8 @@ export function useThoreminEngine() {
       const Ctor = window.AudioContext || (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext;
       ac = new Ctor({ latencyHint: 'interactive' });
       const master = ac.createGain();
-      master.gain.setValueAtTime(useControls.getState().masterVolume, ac.currentTime);
+      const { masterVolume: v0, muted: muted0 } = useControls.getState();
+      master.gain.setValueAtTime(muted0 ? 0 : v0, ac.currentTime);
       master.connect(ac.destination);
       resources.audioContext = ac;
       resources.masterGain = master;

--- a/src/nodes/mapping/synth_merge.ts
+++ b/src/nodes/mapping/synth_merge.ts
@@ -9,9 +9,17 @@
  * own ids (hands 0/1, emotion chord 2..5, pose chord ≥ 6), so the synth voices
  * them independently.
  *
+ * Because it is the single convergence point downstream of EVERY sound producer,
+ * it also carries the master `mute`: when the `mute` input is true every merged
+ * voice is silenced (gain 0, present false), so muting covers the hands AND both
+ * face-chord instruments AND any future producer that merges here — fixing the
+ * bug (#91) where the chords bypassed the hand-voice mute. The synth ramps a
+ * gain-0 voice down over its per-voice release, so the mute is click-free.
+ *
  * Pure + deterministic. An absent/empty input contributes no voices, so the third
  * port `c` is fully back-compatible (graphs wiring only `a`/`b` are unchanged) and
- * an idle chord source simply passes the other streams through unchanged.
+ * an idle chord source simply passes the other streams through unchanged; an
+ * absent `mute` is treated as false (passthrough), so pre-mute graphs are unchanged.
  */
 import { defineNode } from '@/dag';
 import type { SynthParams } from '../domain';
@@ -27,18 +35,28 @@ export const synthMergeNode = defineNode({
   type: 'synth-merge',
   roles: ['mapping'],
   title: 'Synth Merge',
-  description: 'Union up to three synth-params voice streams into one (hand voices + emotion chord + pose chord).',
+  description: 'Union up to three synth-params voice streams into one (hand voices + emotion chord + pose chord); master mute.',
   inputs: [
     { name: 'a', kind: 'synth-params' },
     { name: 'b', kind: 'synth-params' },
     // Optional third stream (e.g. the head-pose chord); absent → contributes nothing.
     { name: 'c', kind: 'synth-params' },
+    // Master mute: true → silence every merged voice at this single convergence
+    // point (all producers pass through here). Absent → false (passthrough).
+    { name: 'mute', kind: 'boolean', default: false },
   ],
   outputs: [{ name: 'params', kind: 'synth-params' }],
   process(inputs) {
     const a = asParams(inputs.a);
     const b = asParams(inputs.b);
     const c = asParams(inputs.c);
-    return { params: { voices: [...a.voices, ...b.voices, ...c.voices] } };
+    const voices = [...a.voices, ...b.voices, ...c.voices];
+    // Master mute: zero every voice (and mark it absent) so hands + both chord
+    // instruments go quiet together. The synth's per-voice release ramp makes
+    // this a smooth, click-free fade rather than an abrupt cut.
+    if (inputs.mute === true) {
+      return { params: { voices: voices.map((v) => ({ ...v, gain: 0, present: false })) } };
+    }
+    return { params: { voices } };
   },
 });

--- a/test/app_graph.test.ts
+++ b/test/app_graph.test.ts
@@ -51,6 +51,18 @@ describe('production app graph', () => {
     expect(has('chordSel', 'chord', 'overlay', 'chord')).toBe(true);
   });
 
+  it('routes the mute to the merge so it silences the chords too (#91)', () => {
+    const edges = defaultGraph().edges;
+    const has = (fn: string, fp: string, tn: string, tp: string) =>
+      edges.some((e) => e.from.node === fn && e.from.port === fp && e.to.node === tn && e.to.port === tp);
+    // The master mute reaches the single convergence point (synth-merge), so the
+    // face-chord instruments (which merge in after voice-mapping) are muted along
+    // with the hand voices — the fix for #91.
+    expect(has('kctrl', 'mute', 'merge', 'mute')).toBe(true);
+    // The original hand-stage mute edge is still present (belt-and-suspenders).
+    expect(has('kctrl', 'mute', 'map', 'mute')).toBe(true);
+  });
+
   it('ticks cleanly with no host resources (everything no-ops or idles)', () => {
     const recorder = new StreamRecorder();
     // No resources: webcam has no video (emits empty frame), synth has no

--- a/test/app_store.test.ts
+++ b/test/app_store.test.ts
@@ -8,7 +8,7 @@
  */
 import { describe, it, expect, beforeEach } from 'vitest';
 import { useControls, toSettings, migrateControls, mergeControls } from '@/app/store';
-import { DEFAULT_FACE_CHORD } from '@/settings/schema';
+import { DEFAULT_FACE_CHORD, SettingsSchema } from '@/settings/schema';
 import { storeControlsNode } from '@/nodes/browser';
 import { generateScale } from '@/music/theory';
 import { DEFAULT_SOUND_RIGHT, DEFAULT_SOUND_LEFT } from '@/music/sounds';
@@ -112,6 +112,27 @@ describe('control store', () => {
   it('setMasterVolume updates the master volume', () => {
     useControls.getState().setMasterVolume(0.75);
     expect(useControls.getState().masterVolume).toBeCloseTo(0.75, 6);
+  });
+
+  it('muted defaults false; setMuted / toggleMuted flip it (#91)', () => {
+    expect(useControls.getState().muted).toBe(false);
+    useControls.getState().setMuted(true);
+    expect(useControls.getState().muted).toBe(true);
+    useControls.getState().toggleMuted();
+    expect(useControls.getState().muted).toBe(false);
+    useControls.getState().toggleMuted();
+    expect(useControls.getState().muted).toBe(true);
+  });
+
+  it('muted is not a persisted preset field, so a reload always starts un-muted', () => {
+    // muted is deliberately excluded from the persisted blob (not in the settings
+    // schema, not in partialize), so a rehydrate over the initial state always
+    // yields the initializer's `false` — a fresh load never opens muted, and no
+    // persist-version bump was needed to add the field.
+    expect('muted' in SettingsSchema.shape).toBe(false);
+    const initial = useControls.getInitialState();
+    // A real persisted blob never carries `muted`; it rehydrates to false.
+    expect(mergeControls({ masterVolume: 0.5 }, initial).muted).toBe(false);
   });
 
   it('has overlay element defaults (index-finger guide opt-in/off)', () => {

--- a/test/synth_merge.test.ts
+++ b/test/synth_merge.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests the `synth-merge` node — the single convergence point that unions the
+ * hand voices + both face-chord instruments into one stream, and carries the
+ * master mute (#91). Pure + headless via replayNode: no camera, audio, or DOM.
+ */
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import { replayNode, Engine, createRegistry, defineNode } from '@/dag';
+import { synthMergeNode, keyboardControlNode } from '@/nodes';
+import type { SynthParams, VoiceParams } from '@/nodes/domain';
+
+const voice = (id: number, patch: Partial<VoiceParams> = {}): VoiceParams => ({
+  id,
+  present: true,
+  freq: 440,
+  gain: 0.5,
+  sound: 'sine',
+  brightness: 1,
+  vibrato: 0,
+  pan: 0,
+  ...patch,
+});
+
+const params = (voices: VoiceParams[]): SynthParams => ({ voices });
+
+describe('synth-merge', () => {
+  it('unions the three streams in order, preserving voice ids + gains', async () => {
+    const hands = params([voice(0), voice(1)]); // voice-mapping
+    const emo = params([voice(2), voice(3)]); // expression-chord
+    const pose = params([voice(6, { gain: 0.3 })]); // pose-chord
+    const [out] = await replayNode(synthMergeNode.make({}), {
+      a: [hands],
+      b: [emo],
+      c: [pose],
+    });
+    const merged = (out.params as SynthParams).voices;
+    expect(merged.map((v) => v.id)).toEqual([0, 1, 2, 3, 6]);
+    expect(merged.every((v) => v.present)).toBe(true);
+    expect(merged.find((v) => v.id === 6)!.gain).toBeCloseTo(0.3);
+  });
+
+  it('an absent stream contributes nothing (back-compatible a-only graphs)', async () => {
+    const hands = params([voice(0)]);
+    const [out] = await replayNode(synthMergeNode.make({}), { a: [hands] });
+    // b, c, mute all absent → just the hand voice, unchanged.
+    expect((out.params as SynthParams).voices.map((v) => v.id)).toEqual([0]);
+  });
+
+  it('master mute silences EVERY voice — hands AND both chord instruments (#91)', async () => {
+    // The regression guard for #91: the chord voices (b/c) used to bypass the
+    // hand-voice mute entirely and kept sounding. At the merge they all go quiet.
+    const hands = params([voice(0), voice(1)]);
+    const emo = params([voice(2, { gain: 0.4 }), voice(3, { gain: 0.4 })]);
+    const pose = params([voice(6, { gain: 0.4 })]);
+    const [out] = await replayNode(synthMergeNode.make({}), {
+      a: [hands],
+      b: [emo],
+      c: [pose],
+      mute: [true],
+    });
+    const merged = (out.params as SynthParams).voices;
+    expect(merged).toHaveLength(5);
+    // Every voice — including the chord voices (ids 2,3,6) — is now silent.
+    expect(merged.every((v) => v.gain === 0)).toBe(true);
+    expect(merged.every((v) => !v.present)).toBe(true);
+    // Ids are preserved, so the synth still tracks + ramps each voice down by id.
+    expect(merged.map((v) => v.id)).toEqual([0, 1, 2, 3, 6]);
+  });
+
+  it('mute=false passes every stream through unchanged', async () => {
+    const hands = params([voice(0, { gain: 0.5 })]);
+    const emo = params([voice(2, { gain: 0.4 })]);
+    const [out] = await replayNode(synthMergeNode.make({}), {
+      a: [hands],
+      b: [emo],
+      mute: [false],
+    });
+    const merged = (out.params as SynthParams).voices;
+    expect(merged.every((v) => v.present)).toBe(true);
+    expect(merged.find((v) => v.id === 0)!.gain).toBeCloseTo(0.5);
+    expect(merged.find((v) => v.id === 2)!.gain).toBeCloseTo(0.4);
+  });
+});
+
+// A test-only source that scripts the `pressed` keys per tick, so the REAL
+// keyboard-control node can be driven through the engine without a browser window.
+const pressedSource = defineNode<{ frames: string[][] }>({
+  type: 'pressed-source',
+  inputs: [],
+  outputs: [{ name: 'pressed', kind: 'string[]' }],
+  params: z.object({ frames: z.array(z.array(z.string())).default([]) }),
+  make({ frames }) {
+    let i = 0;
+    return {
+      process() {
+        const pressed = frames[i] ?? [];
+        i += 1;
+        return { pressed };
+      },
+    };
+  },
+});
+
+// A test-only source of always-present synth voices, standing in for a chord
+// instrument (expression-chord / pose-chord) that merges in on b / c — the very
+// voices that used to bypass the mute (#91).
+const chordSource = defineNode<{ base: number }>({
+  type: 'chord-source',
+  inputs: [],
+  outputs: [{ name: 'params', kind: 'synth-params' }],
+  params: z.object({ base: z.number().default(2) }),
+  make({ base }) {
+    return {
+      process() {
+        return { params: { voices: [voice(base, { gain: 0.4 }), voice(base + 1, { gain: 0.4 })] } };
+      },
+    };
+  },
+});
+
+describe('mute composes through the engine end-to-end (m key → chords silent, #91)', () => {
+  it('the real keyboard-control → synth-merge wiring silences the chord voices when muted', () => {
+    // Closes the gap between the isolated-node test (mute:[true] silences voices)
+    // and the edge-existence test (kctrl.mute → merge.mute is wired): here the REAL
+    // keyboard-control + synth-merge nodes run through the engine over the exact
+    // production edge, with two always-sounding chord streams on b/c. An `m`
+    // keypress must silence them — proving the pieces actually compose, so a future
+    // port rename or mis-wire can't leave both half-guards green while mute is dead.
+    const engine = new Engine(
+      {
+        nodes: [
+          // Press `m` on tick 1 (mute on) and again on tick 3 (mute off).
+          { id: 'keys', type: 'pressed-source', params: { frames: [[], ['m'], [], ['m']] } },
+          { id: 'kctrl', type: 'keyboard-control', params: {} },
+          { id: 'emo', type: 'chord-source', params: { base: 2 } }, // emotion chord → merge.b
+          { id: 'pose', type: 'chord-source', params: { base: 6 } }, // pose chord → merge.c
+          { id: 'merge', type: 'synth-merge', params: {} },
+        ],
+        edges: [
+          { from: { node: 'keys', port: 'pressed' }, to: { node: 'kctrl', port: 'pressed' } },
+          { from: { node: 'kctrl', port: 'mute' }, to: { node: 'merge', port: 'mute' } },
+          { from: { node: 'emo', port: 'params' }, to: { node: 'merge', port: 'b' } },
+          { from: { node: 'pose', port: 'params' }, to: { node: 'merge', port: 'c' } },
+        ],
+      },
+      createRegistry([pressedSource, chordSource, keyboardControlNode, synthMergeNode]),
+    );
+
+    const frames: SynthParams[] = [];
+    for (let i = 0; i < 4; i++) {
+      engine.tick();
+      frames.push(engine.getOutput('merge', 'params') as SynthParams);
+    }
+
+    // tick 0: unmuted → both chord streams sound (ids 2,3 emotion + 6,7 pose).
+    expect(frames[0].voices.map((v) => v.id)).toEqual([2, 3, 6, 7]);
+    expect(frames[0].voices.every((v) => v.present && v.gain > 0)).toBe(true);
+    // tick 1: `m` pressed → mute on → EVERY chord voice is silenced (the #91 fix).
+    expect(frames[1].voices.every((v) => !v.present && v.gain === 0)).toBe(true);
+    // tick 2: no key → mute latches → chords stay silent.
+    expect(frames[2].voices.every((v) => !v.present && v.gain === 0)).toBe(true);
+    // tick 3: `m` pressed again → unmute → the chords sound again.
+    expect(frames[3].voices.every((v) => v.present && v.gain > 0)).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #91.

## The bug
Mute (the `m` key) only silenced the **hand** voices via `voice-mapping`. The
`expression-chord` and `pose-chord` instruments are separate producers merged in
downstream at `synth-merge`, so they **bypassed the mute and kept sounding** while
the instrument was "muted". There was also no on-screen indication of mute at all.

## The fix
- **`synth-merge`** gains a `mute` input. Because it is the single convergence
  point of *every* sound producer (hands `a`, emotion-chord `b`, pose-chord `c`),
  muting there silences everything — hands **and** both chord instruments — and is
  future-proof for any producer that merges in later. It's click-free: the synth
  ramps a `gain:0` voice down over its per-voice release.
- **`graph`** wires `kctrl.mute → merge.mute` (the original hand-stage
  `kctrl.mute → map.mute` edge stays, belt-and-suspenders).
- **`store`** adds a **non-persisted** `muted` flag + `setMuted`/`toggleMuted`.
  It's deliberately not in the settings schema or `partialize`, so a fresh reload
  always starts un-muted and **no persist-version bump** was needed.
- **`useEngine`** zeroes the host master gain while muted (a catch-all for any
  non-graph audio path, e.g. the Lyria plugin) and mirrors the graph's mute into
  the store so the HUD cue + master gain follow the `m` key.
- **`App`** shows an unmissable, non-interactive **"Muted — press M to unmute"**
  badge (top-center) whenever muted.

## Acceptance (from #91)
- ✅ Toggling mute silences **all** audio (hand voices **and** chords).
- ✅ A clear on-screen "muted — press m to unmute" cue is visible whenever muted.

## Tests (375 pass)
- `synth-merge` mute — isolated (`mute:true` silences all voices incl. chord ids)
  **and** a real-engine **composition test** that drives `keyboard-control →
  synth-merge` with an actual `m` keypress and asserts the chord voices go silent
  end-to-end (then unmute and sound again).
- Store `muted` reducers + the not-persisted / resets-on-reload guarantee.
- The `kctrl.mute → merge.mute` graph edge.

Verify gate: `typecheck` ✓ · `vitest` (375) ✓ · `build` ✓ · `catalog` ✓.

Adversarially reviewed via a multi-agent workflow (4 lenses → per-finding
refutation). Of 7 candidate findings, 6 were refuted (notably: muting a recording
is the *intended* true-master-mute semantics per the issue; the store↔graph
"desync" concern is speculative future work with no UI wired to it today). The one
confirmed gap — no end-to-end composition test — is closed by the composition test
above.

https://claude.ai/code/session_01JEoe7y1hA5KdEAvvpQXxxt