### PR TITLE
Chord overlays: chord-name cue + keyboard strip (#89)

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -266,5 +266,5 @@ Mirrored video + composable overlay elements (guides, landmarks, markers, cues).
 - **roles:** overlay
 - **in:** hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], chord:number[], faceFrame:face-frame, expression:face-expression, octaveShift:number, overlayConfig:overlay-config
 - **out:** —
-- **params:** video (object={}), scaleGuide (object={}), chordGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={}), fingerLines (object={}), faceLandmarks (object={}), timbreLevels (object={}), faceExpression (object={}), fingerBars (object={})
+- **params:** video (object={}), scaleGuide (object={}), chordGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={}), fingerLines (object={}), faceLandmarks (object={}), timbreLevels (object={}), faceExpression (object={}), fingerBars (object={}), chordName (object={}), keyboardStrip (object={})
 

--- a/public/catalog.json
+++ b/public/catalog.json
@@ -105,6 +105,16 @@
         "name": "fingerBars",
         "type": "object",
         "default": {}
+      },
+      {
+        "name": "chordName",
+        "type": "object",
+        "default": {}
+      },
+      {
+        "name": "keyboardStrip",
+        "type": "object",
+        "default": {}
       }
     ]
   },

--- a/public/manual.html
+++ b/public/manual.html
@@ -311,7 +311,7 @@
         <dt>roles</dt><dd>overlay</dd>
         <dt>in</dt><dd>hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], chord:number[], faceFrame:face-frame, expression:face-expression, octaveShift:number, overlayConfig:overlay-config</dd>
         <dt>out</dt><dd>—</dd>
-        <dt>params</dt><dd>video (object={}), scaleGuide (object={}), chordGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={}), fingerLines (object={}), faceLandmarks (object={}), timbreLevels (object={}), faceExpression (object={}), fingerBars (object={})</dd>
+        <dt>params</dt><dd>video (object={}), scaleGuide (object={}), chordGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={}), fingerLines (object={}), faceLandmarks (object={}), timbreLevels (object={}), faceExpression (object={}), fingerBars (object={}), chordName (object={}), keyboardStrip (object={})</dd>
       </dl>
     </div></div></section>
 </div></body></html>

--- a/src/app/graph.ts
+++ b/src/app/graph.ts
@@ -185,8 +185,11 @@ export function defaultGraph(selection?: SlotSelection, registry?: NodeRegistry)
       { from: { node: 'exprChord', port: 'params' }, to: { node: 'merge', port: 'b' } },
       { from: { node: 'poseChord', port: 'params' }, to: { node: 'merge', port: 'c' } },
       { from: { node: 'merge', port: 'params' }, to: { node: 'synth', port: 'params' } },
-      // Also feed the hand params to the overlay so it can label each hand's note.
-      { from: { node: 'map', port: 'params' }, to: { node: 'overlay', port: 'params' } },
+      // Feed the MERGED params (hand voices + both chord instruments) to the overlay:
+      // the hand voices stay at indices 0/1 (synth-merge concatenates them first), so
+      // the per-hand note labels/markers are unchanged, while the keyboard strip's
+      // "voiced-now" cue can light the sounding CHORD voices too (#89), not just hands.
+      { from: { node: 'merge', port: 'params' }, to: { node: 'overlay', port: 'params' } },
       // And both hands' scales + octave shift, for the overlay pitch guides.
       { from: { node: 'ui', port: 'scaleRight' }, to: { node: 'overlay', port: 'scale' } },
       { from: { node: 'ui', port: 'scaleLeft' }, to: { node: 'overlay', port: 'scaleLeft' } },

--- a/src/app/overlayControls.ts
+++ b/src/app/overlayControls.ts
@@ -55,8 +55,27 @@ export const OVERLAY_CONTROLS: OverlayControlDesc[] = [
     ],
     position: true,
   },
+  {
+    name: 'chordName',
+    label: 'Chord name',
+    toggles: [
+      { key: 'roman', label: 'Function line' },
+      { key: 'nashville', label: 'Nashville (vs Roman)' },
+    ],
+    position: true,
+  },
   { name: 'timbreLevels', label: 'Timbre levels' },
   { name: 'chordGuide', label: 'Chord highlight' },
+  {
+    name: 'keyboardStrip',
+    label: 'Keyboard strip',
+    toggles: [
+      { key: 'scaleMode', label: 'Scale-only' },
+      { key: 'showChordTones', label: 'Chord tones' },
+      { key: 'showScaleRoot', label: 'Scale root' },
+      { key: 'showLabels', label: 'Note labels' },
+    ],
+  },
   { name: 'scaleGuide', label: 'Scale guide', toggles: [{ key: 'showLabels', label: 'Note labels' }] },
   { name: 'indexGuide', label: 'Index-finger guide', toggles: [{ key: 'dashed', label: 'Dashed' }] },
   { name: 'video', label: 'Video backdrop', slider: { key: 'alpha', label: 'Opacity' } },

--- a/src/music/theory.ts
+++ b/src/music/theory.ts
@@ -41,24 +41,162 @@ export function midiToName(midi: number): string {
   return `${NOTES[((r % 12) + 12) % 12]}${Math.floor(r / 12) - 1}`;
 }
 
+/** The recognized chord qualities: the basic triads plus the common sevenths. */
+export type ChordQuality =
+  | 'maj'
+  | 'min'
+  | 'dim'
+  | 'aug'
+  | 'power'
+  | 'maj7'
+  | 'dom7'
+  | 'min7'
+  | 'm7b5'
+  | 'dim7'
+  | 'minMaj7'
+  | 'augMaj7'
+  | 'unknown';
+
+/** A chord's root pitch class, classified quality, and jazz lead-sheet symbol. */
+export interface ChordInfo {
+  /** Root pitch class, 0 = C … 11 = B (the lowest tone). */
+  root: number;
+  quality: ChordQuality;
+  /** Lead-sheet symbol, e.g. `C`, `Am`, `Bdim`, `G7`, `Cmaj7`, `Bm7b5`. */
+  symbol: string;
+}
+
+/** Suffix (after the root note name) for each chord quality. */
+const QUALITY_SUFFIX: Record<ChordQuality, string> = {
+  maj: '',
+  min: 'm',
+  dim: 'dim',
+  aug: 'aug',
+  power: '5',
+  maj7: 'maj7',
+  dom7: '7',
+  min7: 'm7',
+  m7b5: 'm7b5',
+  dim7: 'dim7',
+  minMaj7: 'mMaj7',
+  augMaj7: 'augMaj7',
+  unknown: '',
+};
+
 /**
- * Name a chord from its MIDI tones (root + a basic triad quality) — e.g. "C", "Am",
- * "Bdim". Best-effort: the lowest tone is the root and the thirds classify the
- * quality; falls back to just the root note name when the shape isn't a plain triad.
+ * Classify a chord from its MIDI tones: the lowest tone is the root, and the set
+ * of intervals above it selects the quality. Sevenths are tested BEFORE the plain
+ * triads (a maj7 contains a major triad), so the most specific shape wins. Returns
+ * `null` for no tones; an unrecognized shape falls back to the bare root note name
+ * (quality `unknown`, empty suffix).
  */
-export function chordName(tones: number[]): string {
-  if (!tones.length) return '';
+export function classifyChord(tones: number[]): ChordInfo | null {
+  if (!tones.length) return null;
   const sorted = [...tones].sort((a, b) => a - b);
   const root = (((sorted[0] % 12) + 12) % 12);
-  const intervals = new Set(sorted.map((m) => ((((m - sorted[0]) % 12) + 12) % 12)));
-  const has = (i: number) => intervals.has(i);
-  let quality = '';
-  if (has(4) && has(7)) quality = '';
-  else if (has(3) && has(7)) quality = 'm';
+  const iv = new Set(sorted.map((m) => ((((m - sorted[0]) % 12) + 12) % 12)));
+  const has = (i: number) => iv.has(i);
+  let quality: ChordQuality = 'unknown';
+  if (has(4) && has(7) && has(11)) quality = 'maj7';
+  else if (has(4) && has(7) && has(10)) quality = 'dom7';
+  else if (has(3) && has(7) && has(10)) quality = 'min7';
+  else if (has(3) && has(6) && has(10)) quality = 'm7b5';
+  else if (has(3) && has(6) && has(9)) quality = 'dim7';
+  else if (has(3) && has(7) && has(11)) quality = 'minMaj7';
+  else if (has(4) && has(8) && has(11)) quality = 'augMaj7'; // e.g. harmonic-minor III + brow 7th
+  else if (has(4) && has(7)) quality = 'maj';
+  else if (has(3) && has(7)) quality = 'min';
   else if (has(3) && has(6)) quality = 'dim';
   else if (has(4) && has(8)) quality = 'aug';
-  else if (has(7) && !has(3) && !has(4)) quality = '5';
-  return NOTES[root] + quality;
+  else if (has(7) && !has(3) && !has(4)) quality = 'power';
+  return { root, quality, symbol: NOTES[root] + QUALITY_SUFFIX[quality] };
+}
+
+/**
+ * Name a chord from its MIDI tones (root + quality) — e.g. "C", "Am", "Bdim",
+ * "G7", "Cmaj7". Best-effort: the lowest tone is the root and the intervals
+ * classify the quality (see {@link classifyChord}); falls back to just the root
+ * note name when the shape isn't a recognized triad/seventh, and "" for no tones.
+ */
+export function chordName(tones: number[]): string {
+  return classifyChord(tones)?.symbol ?? '';
+}
+
+const ROMAN_NUMERALS = ['I', 'II', 'III', 'IV', 'V', 'VI', 'VII'] as const;
+/** Qualities that render lowercase (minor-ish) in Roman analysis. */
+const MINORISH_QUALITIES: ReadonlySet<ChordQuality> = new Set([
+  'min',
+  'dim',
+  'min7',
+  'm7b5',
+  'dim7',
+  'minMaj7',
+]);
+/**
+ * The function-label suffix (after the Roman numeral / Nashville number) per
+ * quality — the mark that encodes the chord's colour. The major/minor distinction
+ * is carried separately (Roman = case, Nashville = a leading `m`); these marks add
+ * only what case can't: the diminished/augmented/half-diminished symbol and the
+ * seventh. `ø` already denotes a half-diminished *seventh*, so it stands alone.
+ */
+const FUNCTION_MARK: Record<ChordQuality, string> = {
+  maj: '',
+  min: '',
+  dim: '°',
+  aug: '+',
+  power: '5',
+  maj7: 'maj7',
+  dom7: '7',
+  min7: '7',
+  m7b5: 'ø',
+  dim7: '°7',
+  minMaj7: 'maj7',
+  augMaj7: '+maj7',
+  unknown: '',
+};
+
+/**
+ * The scale degree (0 = tonic … 6) whose pitch class equals `pitchClass`, or -1
+ * if it is not in the scale. A scale's distinct pitch classes, in ascending order
+ * within its first octave, ARE its degrees — so this maps a chord root back to the
+ * degree it was built on (exact for diatonic chords, which is all thoremin plays
+ * in chord mode). Feeds the Roman/Nashville function label without a new port.
+ */
+export function scaleDegreeOf(pitchClass: number, scale: number[]): number {
+  const target = (((pitchClass % 12) + 12) % 12);
+  const pcs: number[] = [];
+  for (const m of scale) {
+    const pc = (((m % 12) + 12) % 12);
+    if (!pcs.includes(pc)) pcs.push(pc);
+  }
+  return pcs.indexOf(target);
+}
+
+/**
+ * The Roman-numeral function of a chord on scale `degree` (0..6) with the given
+ * `quality`: case encodes major/minor (upper/lower) and {@link FUNCTION_MARK} adds
+ * the colour (e.g. `I`, `ii`, `V7`, `vii°`, `iiø`, `Imaj7`). Returns "" for an
+ * out-of-range degree.
+ */
+export function romanNumeral(degree: number, quality: ChordQuality): string {
+  if (degree < 0 || degree > 6) return '';
+  const r = MINORISH_QUALITIES.has(quality)
+    ? ROMAN_NUMERALS[degree].toLowerCase()
+    : (ROMAN_NUMERALS[degree] as string);
+  return r + FUNCTION_MARK[quality];
+}
+
+/**
+ * The Nashville-number function of a chord: the degree as 1..7, a trailing `m`
+ * for plain minor qualities, and {@link FUNCTION_MARK} for the colour (e.g. `1`,
+ * `2m`, `57`, `7°`, `7ø`, `1maj7`). The number-first shorthand many non-classical
+ * players prefer. Returns "" for an out-of-range degree.
+ */
+export function nashvilleNumber(degree: number, quality: ChordQuality): string {
+  if (degree < 0 || degree > 6) return '';
+  // A plain minor triad/seventh gets an `m`; dim/aug/half-dim carry their own mark.
+  const m = quality === 'min' || quality === 'min7' || quality === 'minMaj7' ? 'm' : '';
+  return String(degree + 1) + m + FUNCTION_MARK[quality];
 }
 
 export interface ScaleSpec {

--- a/src/nodes/output/canvas_overlay.ts
+++ b/src/nodes/output/canvas_overlay.ts
@@ -25,7 +25,17 @@
 import { z } from 'zod';
 import { defineNode } from '@/dag';
 import type { NodeContext } from '@/dag';
-import { chordName, freqToMidi, midiToName, scaleGuide } from '@/music/theory';
+import {
+  chordName,
+  classifyChord,
+  freqToMidi,
+  midiToName,
+  nashvilleNumber,
+  NOTES,
+  romanNumeral,
+  scaleDegreeOf,
+  scaleGuide,
+} from '@/music/theory';
 import { EMOTIONS, type ExpressionScores } from '@/music/expression';
 import { EFFECT_SHORT, type HandMap } from '../mapping/hand_map';
 import {
@@ -87,6 +97,41 @@ const Params = z.object({
   /** Finger→effect bar graph (HUD cue): a bar per routed finger, effect-labelled. Opt-in. */
   fingerBars: z
     .object({ show: z.boolean().default(false), position: CuePositionEnum.default('left') })
+    .prefault({}),
+  /**
+   * Chord-name HUD cue: the sounding chord's jazz symbol (e.g. `Am7`) plus an
+   * optional function line — the Roman numeral (`vi7`) or, with `nashville`, the
+   * Nashville number (`6m7`) of the chord within the current scale. Only shows
+   * while a chord actually sounds (face chord / pose modes).
+   */
+  chordName: z
+    .object({
+      show: z.boolean().default(true),
+      position: CuePositionEnum.default('top'),
+      /** Show the secondary function line (Roman / Nashville) under the symbol. */
+      roman: z.boolean().default(true),
+      /** Use Nashville numbers instead of Roman numerals for the function line. */
+      nashville: z.boolean().default(false),
+    })
+    .prefault({}),
+  /**
+   * Keyboard strip (bottom-edge): a thin piano/scale ribbon showing, with a
+   * shape+brightness hierarchy, the chord root (gold diamond) ▸ voiced-now (glow)
+   * ▸ chord-tone set (faint gold) ▸ scale root (blue ring) over the in-scale keys.
+   * `scaleMode` swaps the standard chromatic piano for a decluttered scale-only
+   * ribbon. Opt-in (it's a large element).
+   */
+  keyboardStrip: z
+    .object({
+      show: z.boolean().default(false),
+      /** false = standard chromatic piano; true = scale-only equal cells. */
+      scaleMode: z.boolean().default(false),
+      /** Strip height as a fraction of the canvas height. */
+      height: z.number().min(0.05).max(0.2).default(0.1),
+      showLabels: z.boolean().default(false),
+      showChordTones: z.boolean().default(true),
+      showScaleRoot: z.boolean().default(true),
+    })
     .prefault({}),
 });
 type Params = z.infer<typeof Params>;
@@ -680,6 +725,236 @@ function routedFingers(view: OverlayView): {
   return { side, items };
 }
 
+// ---- Chord overlays (#89): a chord-name cue + a keyboard strip ------------------
+
+const NAME_PRIMARY_PX = 40;
+const NAME_SECONDARY_PX = 20;
+/** Monospace glyph advance ≈ this × font px (used to size the cue box headlessly). */
+const NAME_CHAR_W = 0.62;
+
+/** Pitch class of a MIDI note (0..11). */
+const pcOf = (m: number) => (((m % 12) + 12) % 12);
+
+/** The actually-sounding MIDI notes (rounded), read from the synth voices — the
+ *  "what is rendering right now" layer for the keyboard strip. */
+function voicedNotes(view: OverlayView): number[] {
+  const voices = view.inputs.params?.voices;
+  if (!voices) return [];
+  return voices.filter((v) => v.present && v.freq > 0).map((v) => Math.round(freqToMidi(v.freq)));
+}
+
+/** The Roman/Nashville function line for the current chord within the current
+ *  scale, or '' when off / unavailable / non-diatonic. */
+function chordFunctionLabel(view: OverlayView): string {
+  const p = view.params.chordName;
+  if (!p.roman) return '';
+  const chord = view.inputs.chord;
+  const scale = view.inputs.scale;
+  if (!Array.isArray(chord) || !chord.length || !Array.isArray(scale) || scale.length < 2) return '';
+  const info = classifyChord(chord);
+  if (!info) return '';
+  const degree = scaleDegreeOf(info.root, scale);
+  if (degree < 0) return '';
+  return p.nashville ? nashvilleNumber(degree, info.quality) : romanNumeral(degree, info.quality);
+}
+
+/** The chord-name cue's rendered text + box size, or null when nothing to show.
+ *  Shared by `measure` (layout) and `draw`, so the two never disagree. */
+function chordNameBox(view: OverlayView): { symbol: string; secondary: string; w: number; h: number } | null {
+  const p = view.params.chordName;
+  if (!p.show) return null;
+  const chord = view.inputs.chord;
+  if (!Array.isArray(chord) || chord.length === 0) return null;
+  const info = classifyChord(chord);
+  if (!info) return null;
+  const secondary = chordFunctionLabel(view);
+  const primaryW = info.symbol.length * NAME_PRIMARY_PX * NAME_CHAR_W;
+  const secondaryW = secondary ? secondary.length * NAME_SECONDARY_PX * NAME_CHAR_W : 0;
+  const w = Math.max(primaryW, secondaryW) + PAD * 2;
+  const h = NAME_PRIMARY_PX + (secondary ? NAME_SECONDARY_PX + 4 : 0) + PAD * 2;
+  return { symbol: info.symbol, secondary, w, h };
+}
+
+const chordNameCue: OverlayElement = {
+  name: 'chordName',
+  category: 'output',
+  cue: true,
+  positionOf: (view) => view.params.chordName.position,
+  measure(view) {
+    const box = chordNameBox(view);
+    return box ? { w: box.w, h: box.h } : null;
+  },
+  draw(g, view) {
+    const origin = view.layout['chordName'];
+    const box = chordNameBox(view);
+    if (!origin || !box) return;
+    g.save();
+    // Dark backing plate so gold/white glyphs read over any (dimmed) video.
+    g.globalAlpha = 0.4;
+    g.fillStyle = '#000000';
+    g.fillRect(origin.x, origin.y, box.w, box.h);
+    const cx = origin.x + box.w / 2;
+    g.textAlign = 'center';
+    // Primary: the jazz chord symbol, large + gold.
+    g.globalAlpha = 1;
+    g.fillStyle = CHORD_COLOR;
+    g.font = `bold ${NAME_PRIMARY_PX}px monospace`;
+    g.fillText(box.symbol, cx, origin.y + PAD + NAME_PRIMARY_PX * 0.78);
+    // Secondary: the function line (Roman / Nashville), smaller + dimmer.
+    if (box.secondary) {
+      g.globalAlpha = 0.8;
+      g.fillStyle = '#ffffff';
+      g.font = `${NAME_SECONDARY_PX}px monospace`;
+      g.fillText(box.secondary, cx, origin.y + PAD + NAME_PRIMARY_PX + NAME_SECONDARY_PX * 0.9);
+    }
+    g.textAlign = 'left';
+    g.restore();
+  },
+};
+
+/** The natural (white-key) pitch classes; the rest are the black keys. */
+const NATURAL_PCS = new Set([0, 2, 4, 5, 7, 9, 11]);
+const STRIP_MARGIN = 8;
+
+/** One drawable key of the keyboard strip. */
+interface StripKey {
+  midi: number;
+  x: number;
+  w: number;
+  h: number;
+  isWhite: boolean;
+}
+
+/** Standard chromatic piano keys spanning the scale's MIDI range: equal-width
+ *  whites first (full height), then the narrower/shorter blacks on top. The range
+ *  is snapped OUT to natural keys (down at the bottom, up at the top) so a black
+ *  key never leads the row — otherwise a sharp root (C#/D#/F#/G#/A#) would place
+ *  the first black key at a negative x, off the left edge. */
+function standardStripKeys(scale: number[], W: number, stripH: number): StripKey[] {
+  let lo = scale[0];
+  while (!NATURAL_PCS.has(pcOf(lo))) lo -= 1; // snap down to a white key
+  let hi = scale[scale.length - 1];
+  while (!NATURAL_PCS.has(pcOf(hi))) hi += 1; // snap up to a white key
+  const whites: number[] = [];
+  const blacks: { midi: number; afterWhite: number }[] = [];
+  for (let m = lo; m <= hi; m++) {
+    if (NATURAL_PCS.has(pcOf(m))) whites.push(m);
+    else blacks.push({ midi: m, afterWhite: whites.length }); // boundary = whites drawn so far
+  }
+  if (!whites.length) return [];
+  const whiteW = (W - 2 * STRIP_MARGIN) / whites.length;
+  const blackW = whiteW * 0.62;
+  const blackH = stripH * 0.6;
+  const keys: StripKey[] = whites.map((midi, i) => ({
+    midi,
+    x: STRIP_MARGIN + i * whiteW,
+    w: whiteW,
+    h: stripH,
+    isWhite: true,
+  }));
+  for (const b of blacks) {
+    keys.push({ midi: b.midi, x: STRIP_MARGIN + b.afterWhite * whiteW - blackW / 2, w: blackW, h: blackH, isWhite: false });
+  }
+  return keys;
+}
+
+/** Scale-only keys: one equal-width cell per scale note (a decluttered ribbon). */
+function scaleStripKeys(scale: number[], W: number, stripH: number): StripKey[] {
+  const cellW = (W - 2 * STRIP_MARGIN) / scale.length;
+  return scale.map((midi, i) => ({ midi, x: STRIP_MARGIN + i * cellW, w: cellW, h: stripH, isWhite: true }));
+}
+
+/**
+ * The keyboard strip (#89): a thin bottom-edge piano/scale ribbon that shows what
+ * is playing, with a shape+brightness cue hierarchy (never hue alone) so it reads
+ * over the dimmed video and survives colour-blindness:
+ *   chord ROOT (gold filled diamond) ▸ VOICED-now (bright gold base band) ▸
+ *   CHORD-tone set (faint gold tint) ▸ SCALE root (hollow blue ring) ▸
+ *   in-scale (light tint) ▸ out-of-scale (greyed).
+ * Not a HUD cue — it owns a fixed bottom rectangle and draws in list order.
+ */
+const keyboardStripElement: OverlayElement = {
+  name: 'keyboardStrip',
+  category: 'guide',
+  draw(g, view) {
+    const p = view.params.keyboardStrip;
+    if (!p.show) return;
+    const scale = view.inputs.scale;
+    if (!Array.isArray(scale) || scale.length < 2) return;
+    const { W, H } = view;
+    const stripH = Math.round(H * p.height);
+    const y0 = H - stripH;
+
+    const scalePcs = new Set(scale.map(pcOf));
+    const scaleRoot = pcOf(scale[0]); // generateScale starts on the root, so scale[0] IS the tonic
+    const chord = Array.isArray(view.inputs.chord) ? view.inputs.chord : [];
+    const chordPcs = new Set(chord.map(pcOf));
+    const chordRootPc = chord.length ? pcOf(Math.min(...chord)) : -1;
+    const voicedPcs = new Set(voicedNotes(view).map(pcOf)); // what's actually sounding now
+    const keys = p.scaleMode ? scaleStripKeys(scale, W, stripH) : standardStripKeys(scale, W, stripH);
+
+    g.save();
+    // Dark backing plate: a stable substrate so keys read over any video frame.
+    g.globalAlpha = 0.4;
+    g.fillStyle = '#000000';
+    g.fillRect(0, y0, W, stripH);
+
+    for (const k of keys) {
+      const pc = pcOf(k.midi);
+      const inScale = scalePcs.has(pc);
+      // Base fill: in-scale keys tinted, out-of-scale greyed; whites light, blacks dark.
+      g.globalAlpha = k.isWhite ? (inScale ? 0.16 : 0.06) : inScale ? 0.4 : 0.55;
+      g.fillStyle = k.isWhite ? '#ffffff' : '#000000';
+      g.fillRect(k.x, y0, k.w, k.h);
+      // Chord-tone set: the chord's footprint, recessive (matches chordGuide alpha).
+      if (p.showChordTones && chordPcs.has(pc)) {
+        g.globalAlpha = 0.28;
+        g.fillStyle = CHORD_COLOR;
+        g.fillRect(k.x, y0, k.w, k.h);
+      }
+      // Voiced-now: a bright gold band at the key base — the strongest cue.
+      if (voicedPcs.has(pc)) {
+        g.globalAlpha = 0.9;
+        g.fillStyle = CHORD_COLOR;
+        g.fillRect(k.x, y0 + k.h * 0.55, k.w, k.h * 0.45);
+      }
+      // Scale root: a hollow cool-blue ring (different shape + temperature than the
+      // warm filled chord-root diamond, so the two roots never blur together).
+      if (p.showScaleRoot && pc === scaleRoot) {
+        g.globalAlpha = 0.9;
+        g.strokeStyle = LEFT_COLOR;
+        g.lineWidth = 2;
+        g.beginPath();
+        g.arc(k.x + k.w / 2, y0 + k.h * 0.72, Math.min(k.w * 0.3, 6), 0, Math.PI * 2);
+        g.stroke();
+      }
+      // Chord root: a filled gold diamond marker at the key top — highest salience.
+      if (pc === chordRootPc) {
+        g.globalAlpha = 1;
+        g.fillStyle = CHORD_COLOR;
+        const dx = k.x + k.w / 2;
+        const dy = y0 + k.h * 0.26;
+        const r = Math.min(k.w * 0.32, 7);
+        g.beginPath();
+        g.moveTo(dx, dy - r);
+        g.lineTo(dx + r, dy);
+        g.lineTo(dx, dy + r);
+        g.lineTo(dx - r, dy);
+        g.fill();
+      }
+      if (p.showLabels) {
+        g.globalAlpha = 0.85;
+        g.fillStyle = k.isWhite ? '#111111' : '#ffffff';
+        g.font = '9px monospace';
+        g.textAlign = 'center';
+        g.fillText(NOTES[pc], k.x + k.w / 2, y0 + k.h - 3);
+      }
+    }
+    g.textAlign = 'left';
+    g.restore();
+  },
+};
+
 /**
  * The overlay elements, in draw (z) order. In-scene first, HUD cues last (on top).
  * Each has a `category` and a `<name>` sub-object in `Params`. Append here to add one.
@@ -688,12 +963,18 @@ export const OVERLAY_ELEMENTS: readonly OverlayElement[] = [
   videoBackdrop,
   scaleGuideElement,
   chordGuideElement,
+  // The keyboard strip is an in-scene bottom-edge element: above the video/guides,
+  // below the landmarks/markers (so hands read over it) and the HUD cues.
+  keyboardStripElement,
   indexFingerGuide,
   faceMesh,
   landmarkDots,
   controlMarkers,
   fingerLinesElement,
   timbreLevels,
+  // HUD cues last (on top). chordName sits before the others so `fingerBars`
+  // stays the topmost cue; cues on different edges don't overlap regardless.
+  chordNameCue,
   faceExpressionCue,
   fingerBarsCue,
 ];
@@ -717,6 +998,12 @@ function layoutCues(view: OverlayView): Record<string, { x: number; y: number }>
       size: { w: number; h: number };
     }[];
     let off = edge === 'left' || edge === 'right' ? CUE_TOP_INSET : CUE_MARGIN;
+    // Center a horizontal (top/bottom) group of cues so a lone cue reads centered
+    // and away from the top-left brand / top-right panel.
+    if (edge === 'top' || edge === 'bottom') {
+      const totalW = cues.reduce((s, c) => s + c.size.w, 0) + Math.max(0, cues.length - 1) * CUE_GAP;
+      off = Math.max(CUE_MARGIN, (view.W - totalW) / 2);
+    }
     for (const { e, size } of cues) {
       let x = CUE_MARGIN;
       let y = CUE_MARGIN;

--- a/test/app_graph.test.ts
+++ b/test/app_graph.test.ts
@@ -49,6 +49,11 @@ describe('production app graph', () => {
     expect(has('exprChord', 'triad', 'chordSel', 'a')).toBe(true);
     expect(has('poseChord', 'chord', 'chordSel', 'b')).toBe(true);
     expect(has('chordSel', 'chord', 'overlay', 'chord')).toBe(true);
+    // The overlay reads the MERGED params (hands + both chord instruments) so the
+    // keyboard strip's voiced-now cue lights the sounding chord voices, not only the
+    // hands (#89). The hand voices stay at indices 0/1, so per-hand labels are intact.
+    expect(has('merge', 'params', 'overlay', 'params')).toBe(true);
+    expect(has('map', 'params', 'overlay', 'params')).toBe(false);
   });
 
   it('ticks cleanly with no host resources (everything no-ops or idles)', () => {

--- a/test/app_store.test.ts
+++ b/test/app_store.test.ts
@@ -119,6 +119,11 @@ describe('control store', () => {
     expect(o.video.show).toBe(true);
     expect(o.scaleGuide.show).toBe(true);
     expect(o.indexGuide.show).toBe(false);
+    // #89 chord overlays: the chord name reads by default; the keyboard strip is
+    // opt-in (it's a large element).
+    expect(o.chordName.show).toBe(true);
+    expect(o.chordName.position).toBe('top');
+    expect(o.keyboardStrip.show).toBe(false);
   });
 
   it('setOverlayElement patches one element without touching the others', () => {

--- a/test/music_theory.test.ts
+++ b/test/music_theory.test.ts
@@ -8,6 +8,10 @@ import {
   rangeMap,
   midiToName,
   chordName,
+  classifyChord,
+  scaleDegreeOf,
+  romanNumeral,
+  nashvilleNumber,
   scaleGuide,
   DEFAULT_SCALE,
 } from '@/music/theory';
@@ -27,6 +31,62 @@ describe('chordName', () => {
   it('falls back gracefully (empty / power / non-triad)', () => {
     expect(chordName([])).toBe('');
     expect(chordName([60, 67])).toBe('C5'); // root + fifth, no third
+  });
+  it('names the diatonic sevenths (the pose/brow add-7th chords)', () => {
+    expect(chordName([60, 64, 67, 71])).toBe('Cmaj7'); // C E G B  → major 7th
+    expect(chordName([67, 71, 74, 77])).toBe('G7'); // G B D F  → dominant 7th
+    expect(chordName([62, 65, 69, 72])).toBe('Dm7'); // D F A C  → minor 7th
+    expect(chordName([71, 74, 77, 81])).toBe('Bm7b5'); // B D F A  → half-diminished
+    expect(chordName([71, 74, 77, 80])).toBe('Bdim7'); // B D F Ab → diminished 7th
+    // Harmonic-minor III with the pose brow-7th: an augmented triad + major 7th.
+    // Must NOT collapse to a plain augmented triad (dropping the sounding 7th).
+    expect(chordName([63, 67, 71, 74])).toBe('D#augMaj7'); // D# G B D → aug(maj7)
+    expect(chordName([60, 64, 68])).toBe('Caug'); // plain augmented triad still 'aug'
+  });
+});
+
+describe('classifyChord', () => {
+  it('returns root pitch class + quality + symbol; null for no tones', () => {
+    expect(classifyChord([])).toBeNull();
+    expect(classifyChord([60, 64, 67])).toEqual({ root: 0, quality: 'maj', symbol: 'C' });
+    expect(classifyChord([57, 60, 64])).toMatchObject({ root: 9, quality: 'min' });
+    expect(classifyChord([67, 71, 74, 77])).toMatchObject({ root: 7, quality: 'dom7', symbol: 'G7' });
+  });
+});
+
+describe('scaleDegreeOf', () => {
+  const cMajor = generateScale({ root: 0, type: 'major', octaves: 2, baseOctave: 3 });
+  it('maps a pitch class to its scale degree (0=tonic), -1 when out of scale', () => {
+    expect(scaleDegreeOf(0, cMajor)).toBe(0); // C = tonic
+    expect(scaleDegreeOf(7, cMajor)).toBe(4); // G = V
+    expect(scaleDegreeOf(11, cMajor)).toBe(6); // B = vii
+    expect(scaleDegreeOf(1, cMajor)).toBe(-1); // C# not in C major
+  });
+  it('is octave-agnostic (a high chord root still resolves to its degree)', () => {
+    expect(scaleDegreeOf(67 % 12, cMajor)).toBe(4); // G in any octave → V
+  });
+});
+
+describe('romanNumeral / nashvilleNumber', () => {
+  it('encodes degree + quality (case, °/ø/+, sevenths)', () => {
+    expect(romanNumeral(0, 'maj')).toBe('I');
+    expect(romanNumeral(1, 'min')).toBe('ii');
+    expect(romanNumeral(4, 'dom7')).toBe('V7');
+    expect(romanNumeral(6, 'dim')).toBe('vii°');
+    expect(romanNumeral(6, 'm7b5')).toBe('viiø');
+    expect(romanNumeral(0, 'maj7')).toBe('Imaj7');
+    expect(romanNumeral(2, 'aug')).toBe('III+');
+    expect(romanNumeral(2, 'augMaj7')).toBe('III+maj7'); // uppercase (major-ish) + aug-maj7 mark
+    expect(romanNumeral(-1, 'maj')).toBe(''); // silence sentinel → no label
+  });
+  it('nashville: number-first with m / marks', () => {
+    expect(nashvilleNumber(0, 'maj')).toBe('1');
+    expect(nashvilleNumber(1, 'min')).toBe('2m');
+    expect(nashvilleNumber(4, 'dom7')).toBe('57');
+    expect(nashvilleNumber(6, 'dim')).toBe('7°');
+    expect(nashvilleNumber(6, 'm7b5')).toBe('7ø');
+    expect(nashvilleNumber(0, 'maj7')).toBe('1maj7');
+    expect(nashvilleNumber(-1, 'maj')).toBe('');
   });
 });
 

--- a/test/overlay_elements.test.ts
+++ b/test/overlay_elements.test.ts
@@ -55,6 +55,7 @@ function makeRecordingCanvas(width = 1280, height = 720) {
   for (const m of [
     'clearRect', 'save', 'restore', 'beginPath', 'arc', 'fill', 'stroke',
     'moveTo', 'lineTo', 'drawImage', 'fillText', 'setLineDash', 'scale', 'translate', 'rotate',
+    'fillRect', // chord-name plate + keyboard-strip keys (#89)
   ]) {
     ctx[m] = rec(m);
   }
@@ -431,5 +432,134 @@ describe('canvas-overlay composable elements', () => {
       engine.tick();
     }).not.toThrow();
     expect(rc.count('clearRect')).toBe(2); // overlay ran both ticks
+  });
+});
+
+// A C-major scale spanning an octave (7 distinct pitch classes), so the
+// degree-derivation for the Roman/Nashville function line is well-defined.
+const C_MAJOR = [48, 50, 52, 53, 55, 57, 59, 60];
+const textsOf = (rc: ReturnType<typeof makeRecordingCanvas>) =>
+  rc.calls.filter((c) => c.m === 'fillText').map((c) => c.args[0]);
+
+describe('chordName cue (#89)', () => {
+  it('shows the sounding chord as a jazz symbol (primary line)', () => {
+    const rc = drawWith(onlyElement('chordName'), { chord: [60, 64, 67], scale: C_MAJOR }); // C major
+    expect(textsOf(rc)).toContain('C');
+  });
+
+  it('adds the Roman-numeral function of the chord within the scale', () => {
+    // G major triad in C major is the V chord.
+    const rc = drawWith(onlyElement('chordName'), { chord: [67, 71, 74], scale: C_MAJOR });
+    const texts = textsOf(rc);
+    expect(texts).toContain('G'); // symbol
+    expect(texts).toContain('V'); // function
+  });
+
+  it('the nashville toggle swaps the function line to a number', () => {
+    const rc = drawWith(
+      { ...onlyElement('chordName'), chordName: { show: true, nashville: true } },
+      { chord: [67, 71, 74], scale: C_MAJOR },
+    );
+    expect(textsOf(rc)).toContain('5'); // V → Nashville "5"
+  });
+
+  it('roman off → symbol only, no function line', () => {
+    const rc = drawWith(
+      { ...onlyElement('chordName'), chordName: { show: true, roman: false } },
+      { chord: [67, 71, 74], scale: C_MAJOR },
+    );
+    const texts = textsOf(rc);
+    expect(texts).toContain('G');
+    expect(texts).not.toContain('V');
+  });
+
+  it('draws nothing when no chord sounds (idle)', () => {
+    const rc = drawWith(onlyElement('chordName'), { chord: undefined, scale: C_MAJOR });
+    expect(rc.count('fillRect')).toBe(0); // no plate
+    expect(rc.count('fillText')).toBe(0);
+  });
+});
+
+describe('keyboardStrip (#89)', () => {
+  const noVoices = { params: { voices: [] } };
+
+  it('is opt-in (off by default) — draws no strip rectangles', () => {
+    // scaleGuide on, everything else (incl. strip + chordName) off.
+    expect(drawWith(onlyElement('scaleGuide'), noVoices).count('fillRect')).toBe(0);
+  });
+
+  it('standard mode: a dark plate + a rect per white/black key over the scale range', () => {
+    const rc = drawWith(onlyElement('keyboardStrip'), { ...noVoices, scale: C_MAJOR });
+    // 1 plate + 8 whites (C..C) + 5 blacks (C#,D#,F#,G#,A#) = 14.
+    expect(rc.count('fillRect')).toBe(14);
+  });
+
+  it('scale mode: one equal cell per scale note (+ the plate)', () => {
+    const rc = drawWith(
+      { ...onlyElement('keyboardStrip'), keyboardStrip: { show: true, scaleMode: true } },
+      { ...noVoices, scale: C_MAJOR },
+    );
+    expect(rc.count('fillRect')).toBe(1 + C_MAJOR.length);
+  });
+
+  it('marks the scale root with a hollow ring (arc + stroke, not a fill)', () => {
+    const rc = drawWith(onlyElement('keyboardStrip'), { ...noVoices, scale: C_MAJOR });
+    expect(rc.count('arc')).toBeGreaterThan(0);
+    expect(rc.count('stroke')).toBeGreaterThan(0);
+  });
+
+  it('a sounding chord adds tone tints + a filled chord-root diamond', () => {
+    const base = drawWith(onlyElement('keyboardStrip'), { ...noVoices, scale: C_MAJOR }).count('fillRect');
+    const withChord = drawWith(onlyElement('keyboardStrip'), { ...noVoices, scale: C_MAJOR, chord: [55, 59, 62] }); // G B D
+    expect(withChord.count('fillRect')).toBeGreaterThan(base); // chord-tone tints
+    expect(withChord.count('fill')).toBeGreaterThan(0); // the diamond path fill
+  });
+
+  it('lights the voiced-now notes — reads the actual synth voices', () => {
+    const base = drawWith(onlyElement('keyboardStrip'), { ...noVoices, scale: C_MAJOR }).count('fillRect');
+    // A present voice at 440Hz (A4) → the A key gets a bright voiced band.
+    const voiced = drawWith(onlyElement('keyboardStrip'), {
+      scale: C_MAJOR,
+      params: { voices: [{ id: 0, present: true, freq: 440, gain: 0.5, sound: 'sine' }] },
+    });
+    expect(voiced.count('fillRect')).toBeGreaterThan(base);
+  });
+
+  it('a sharp root (C#) keeps the leading black key on-canvas (no negative x)', () => {
+    // C# major starts on a black key; the piano range must snap down to a natural
+    // so the first C# never draws at a negative x off the left edge.
+    const cSharp = [49, 51, 53, 54, 56, 58, 60, 61]; // starts on C# (a black key)
+    const rc = drawWith(onlyElement('keyboardStrip'), { ...noVoices, scale: cSharp });
+    const xs = rc.calls.filter((c) => c.m === 'fillRect').map((c) => c.args[0] as number);
+    expect(xs.length).toBeGreaterThan(0);
+    expect(Math.min(...xs)).toBeGreaterThanOrEqual(0);
+  });
+
+  it('showScaleRoot off removes the scale-root ring', () => {
+    const on = drawWith(onlyElement('keyboardStrip'), { ...noVoices, scale: C_MAJOR });
+    const off = drawWith(
+      { ...onlyElement('keyboardStrip'), keyboardStrip: { show: true, showScaleRoot: false } },
+      { ...noVoices, scale: C_MAJOR },
+    );
+    expect(on.count('arc')).toBeGreaterThan(0); // ring on by default
+    expect(off.count('arc')).toBe(0); // ...gone when toggled off
+  });
+
+  it('showChordTones off removes the chord-tone tint', () => {
+    const withTint = drawWith(onlyElement('keyboardStrip'), { ...noVoices, scale: C_MAJOR, chord: [55, 59, 62] });
+    const noTint = drawWith(
+      { ...onlyElement('keyboardStrip'), keyboardStrip: { show: true, showChordTones: false } },
+      { ...noVoices, scale: C_MAJOR, chord: [55, 59, 62] },
+    );
+    expect(noTint.count('fillRect')).toBeLessThan(withTint.count('fillRect'));
+  });
+
+  it('showLabels draws note names on the keys (off by default)', () => {
+    expect(drawWith(onlyElement('keyboardStrip'), { ...noVoices, scale: C_MAJOR }).count('fillText')).toBe(0);
+    const labeled = drawWith(
+      { ...onlyElement('keyboardStrip'), keyboardStrip: { show: true, showLabels: true } },
+      { ...noVoices, scale: C_MAJOR },
+    );
+    expect(labeled.count('fillText')).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
Closes #89.

Two composable, independently-toggleable overlay elements that show, at a glance, **what chord is playing**.

## `chordName` — a HUD cue
The sounding chord's **jazz symbol** (e.g. `Am7`) as the primary line, plus an optional **function line**: the Roman numeral (`vi7`) or, with the Nashville toggle, the Nashville number (`6m7`) of the chord *within the current scale*. Dark backing plate for contrast over the dimmed video. Defaults to top-center.

## `keyboardStrip` — a bottom-edge ribbon (opt-in)
A thin piano/scale strip with a **shape + brightness cue hierarchy** (never hue alone — for colour-blindness and video contrast):

> chord **ROOT** (gold diamond) ▸ **VOICED-now** (bright gold band) ▸ **CHORD-tone** set (faint gold) ▸ **SCALE root** (blue ring) ▸ in-scale (light tint) ▸ out-of-scale (grey)

Two modes: standard chromatic piano and a decluttered scale-only ribbon.

## Design: no new producer logic
The chord **degree** for the function line is **derived** (`scaleDegreeOf(chordRootPc, scale)` — exact for the diatonic chords chord-mode produces) and the scale root is `scale[0]`'s pitch class, so neither element needs new producer/port logic. The overlay's `params` input is rewired from the **merged** stream so the strip's voiced-now cue lights the sounding **chord** voices too, not just the hands (hand voices stay at indices 0/1, so per-hand labels/markers are unchanged).

## theory
`chordName()` refactored via a new `classifyChord()` that now recognizes sevenths (`maj7`/`7`/`m7`/`m7b5`/`dim7` + the `min-maj7`/`aug-maj7` exotics); new `scaleDegreeOf` / `romanNumeral` / `nashvilleNumber`. Existing triad outputs (`C`, `Am`, `Bdim`, `Caug`, `C5`) are preserved.

## Tests (388 pass)
Theory unit tests (triads preserved, sevenths, degree/roman/nashville), overlay draw-tests for both elements (symbol + function line, Nashville swap, the cue hierarchy primitives, opt-in behaviour), the merged-params graph edge, and the new store defaults.

Verify gate: `typecheck` ✓ · `vitest` (388) ✓ · `build` ✓ · `catalog` ✓.

## Adversarial review
Reviewed via a multi-agent workflow (5 lenses → per-finding refutation). Of 9 candidate findings, **5 were confirmed and are fixed here with regression tests**; 4 were refuted:
- **aug-maj7 mislabel** (harmonic-minor III + brow-7th) collapsed to a plain augmented triad, dropping the 7th → added an `augMaj7` branch (most-specific-first).
- **voiced-now band never lit the chord** — the overlay read `map.params` (hand voices only); rewired to `merge.params`.
- **sharp-root black keys drew off-screen** — the standard-piano range now snaps out to natural keys so no leading black key lands at a negative x.
- **missing OFF-path tests** for the `showScaleRoot` / `showChordTones` toggles → added.

## Note on verification
The overlays render only with a live chord/scale and the app gates on camera access, so headless browser verification isn't feasible (consistent with the repo's recording-canvas overlay tests). **A quick manual visual check is recommended** (enable chord/pose face mode; toggle the keyboard strip on).

https://claude.ai/code/session_01JEoe7y1hA5KdEAvvpQXxxt