### PR TITLE
Command-dispatch layer: Phase 0 foundation (#87)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@zodal/store": "^0.1.2",
         "@zodal/store-localstorage": "^0.1.0",
         "@zodal/ui": "^0.1.2",
+        "acture": "^1.3.0",
         "lucide-react": "^0.546.0",
         "motion": "^12.23.24",
         "react": "^19.0.0",
@@ -2234,6 +2235,15 @@
       },
       "peerDependencies": {
         "zod": "^3.24.0 || ^4.0.0"
+      }
+    },
+    "node_modules/acture": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/acture/-/acture-1.3.0.tgz",
+      "integrity": "sha512-eM2PoMSbF7UxJd/pBjmMWvi4EWm1nstSYdNyUpjEJTmcqJEc6Dt2VSSSgpRjiVOIY+ACoM6MYSBp/ZI3RmnHwQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "zod": "^4.0.0"
       }
     },
     "node_modules/agent-base": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@zodal/store": "^0.1.2",
     "@zodal/store-localstorage": "^0.1.0",
     "@zodal/ui": "^0.1.2",
+    "acture": "^1.3.0",
     "lucide-react": "^0.546.0",
     "motion": "^12.23.24",
     "react": "^19.0.0",

--- a/src/app/commands/dials.ts
+++ b/src/app/commands/dials.ts
@@ -1,0 +1,111 @@
+/**
+ * The generic dial-mutation commands (#87) — the param-mutation surface of thoremin
+ * as `acture` commands. Each is a named, Zod-typed operation whose handler writes
+ * through the dials settings store (`setDial`/`resetDial`), which then syncs into the
+ * hot `useControls` mirror the DAG reads each tick. This is the SINGLE write path a
+ * keyboard binding, the command palette, or the AI assistant use to parametrize the
+ * instrument — none of them re-describe a dial; they all dispatch these commands.
+ *
+ * The hard boundary (enforced by the import-firewall test): a command NEVER touches
+ * the hot store, the DAG, the nodes, or the audio layer directly. It changes sound
+ * only by writing a dial — human-frequency edits go through dispatch; the per-tick /
+ * audio path stays un-registered and real-time. `sound`/`sync`/`mode`/`volume` are
+ * all dials (`master.*`, `face.mapping`), so they are just `dial.set` with the right
+ * key; only the non-dial `muted` flag (#91) is deliberately NOT a command yet.
+ */
+import { z } from 'zod';
+import { defineCommand, ok, err } from 'acture';
+import type { SettingKey } from '@zodal/dials-core';
+import { dialsStore, setDial, resetDial } from '@/app/dials/settingsStore';
+import { thoreminDials, layerToSettings } from '@/settings/dials';
+
+/** The DECLARED dial keyspace — the SSOT for "is this a real dial". Keyed off the
+ *  dials definition, NOT the resolved `effective` map (which omits any future
+ *  UNSET/defaultless dial, so it would wrongly reject a legitimately-declared one). */
+const DIAL_KEYS = new Set<string>(thoreminDials.keys);
+/** True if `key` names a real dial (guards a bad key from the AI / palette / hotkey). */
+const isDial = (key: string): boolean => DIAL_KEYS.has(key);
+
+/**
+ * Validate a set of prospective writes against the SAME `layerToSettings` →
+ * `SettingsSchema.parse` the dials→hot sync runs — so a write's success is HONEST.
+ * The dials layer accepts any value (out-of-range values are only flagged on a
+ * separate `validation` surface, never rejected), and the hot-store sync then
+ * SILENTLY skips an unparseable state — which would leave a command reporting `ok`
+ * while the audio never changed (a panel/profile-vs-audio divergence). Refusing the
+ * write up front (errors-as-data) keeps the dials layer and the audio in agreement.
+ * Returns an error message, or null if every write is acceptable.
+ */
+function invalidWritesReason(writes: ReadonlyArray<readonly [string, unknown]>): string | null {
+  const prospective = { ...dialsStore.getState().effective };
+  for (const [k, v] of writes) prospective[k] = v;
+  try {
+    layerToSettings(prospective);
+    return null;
+  } catch (e) {
+    return e instanceof Error ? e.message : String(e);
+  }
+}
+
+/** Set one dial to a value. The value is validated against the settings schema before
+ *  it is written, so an out-of-range value is refused (errors-as-data) rather than
+ *  silently landing in the dials layer while the audio keeps the old value. */
+export const setDialCmd = defineCommand({
+  id: 'dial.set',
+  title: 'Set dial',
+  description: 'Set a single instrument parameter (dial) to a value.',
+  category: 'Dials',
+  params: z.object({
+    key: z.string().describe('The dial key, e.g. "right.baseOctave" or "face.mapping".'),
+    value: z.unknown().describe('The new value for that dial.'),
+  }),
+  execute: ({ key, value }) => {
+    if (!isDial(key)) return err('unknown_dial', `No dial named "${key}".`, { key });
+    const reason = invalidWritesReason([[key, value]]);
+    if (reason) return err('invalid_value', `Invalid value for "${key}": ${reason}`, { key, value });
+    setDial(key as SettingKey, value);
+    return ok({ key, value });
+  },
+});
+
+/** Reset one dial to its default (the lower default scope re-wins). */
+export const resetDialCmd = defineCommand({
+  id: 'dial.reset',
+  title: 'Reset dial',
+  description: 'Reset a dial to its default value.',
+  category: 'Dials',
+  params: z.object({ key: z.string().describe('The dial key to reset.') }),
+  execute: ({ key }) => {
+    if (!isDial(key)) return err('unknown_dial', `No dial named "${key}".`, { key });
+    resetDial(key as SettingKey);
+    return ok({ key });
+  },
+});
+
+/** Set several dials in one command — the atomic unit a synced-hands voice edit (a
+ *  primary write + its mirrored writes) or an instrument tweak dispatches. Truly
+ *  all-or-nothing: the whole batch is rejected up front if any key is unknown OR the
+ *  resulting state wouldn't parse, so a partial or invalid write never reaches the
+ *  dials layer. */
+export const patchDialsCmd = defineCommand({
+  id: 'dial.patch',
+  title: 'Patch dials',
+  description: 'Set several dials at once (an ordered list of [key, value] writes).',
+  category: 'Dials',
+  params: z.object({
+    writes: z
+      .array(z.tuple([z.string(), z.unknown()]))
+      .describe('Ordered [key, value] writes, applied in sequence.'),
+  }),
+  execute: ({ writes }) => {
+    const bad = writes.find(([k]) => !isDial(k));
+    if (bad) return err('unknown_dial', `No dial named "${bad[0]}".`, { key: bad[0] });
+    const reason = invalidWritesReason(writes);
+    if (reason) return err('invalid_value', `Invalid dial values: ${reason}`, { writes });
+    for (const [k, v] of writes) setDial(k as SettingKey, v);
+    return ok({ count: writes.length });
+  },
+});
+
+/** All generic dial-mutation commands, registered together. */
+export const DIAL_COMMANDS = [setDialCmd, resetDialCmd, patchDialsCmd] as const;

--- a/src/app/commands/index.ts
+++ b/src/app/commands/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Command-dispatch layer (#87) — the param-mutation command surface of thoremin,
+ * built on `acture`. Public entry point: the {@link registry} singleton and the
+ * command definitions. See `dials.ts` for the hard command/hot-path boundary and
+ * `test/commands_firewall.test.ts` for the import firewall that enforces it.
+ */
+export { registry, createThoreminRegistry } from './registry';
+export { DIAL_COMMANDS, setDialCmd, resetDialCmd, patchDialsCmd } from './dials';

--- a/src/app/commands/registry.ts
+++ b/src/app/commands/registry.ts
@@ -1,0 +1,23 @@
+/**
+ * The thoremin command registry (#87) — the single dispatch surface for
+ * param-mutations. Every consumer (keyboard bindings via acture-hotkeys, the
+ * command palette via acture-palette-react, the AI assistant via acture-ai-vercel /
+ * MCP) reads THIS one registry; none re-describes a dial. State is reached by the
+ * handlers' closure capture of the dials store (acture's registry never holds an
+ * adapter), so the registry stays a pure command index.
+ *
+ * `createThoreminRegistry()` builds a fresh registry (used by tests for isolation);
+ * `registry` is the app-wide singleton the consumers bind to.
+ */
+import { createRegistry, type Registry } from 'acture';
+import { DIAL_COMMANDS } from './dials';
+
+/** Build a registry with all thoremin commands registered. */
+export function createThoreminRegistry(): Registry {
+  const r = createRegistry();
+  r.registerAll(DIAL_COMMANDS);
+  return r;
+}
+
+/** The app-wide command registry singleton. */
+export const registry: Registry = createThoreminRegistry();

--- a/test/commands_dispatch.test.ts
+++ b/test/commands_dispatch.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Command dispatch (#87) — dispatching a param-mutation command writes the dials
+ * store AND syncs the hot `useControls` mirror (the same path the panel drives),
+ * and every failure is DATA (`{ ok:false, error }`), never a thrown exception across
+ * the dispatch boundary. Pure + headless: no camera, audio, or React.
+ */
+import { describe, it, expect } from 'vitest';
+import { createThoreminRegistry, registry } from '@/app/commands';
+import { dialsStore } from '@/app/dials/settingsStore';
+import { useControls } from '@/app/store';
+
+describe('command dispatch (#87)', () => {
+  it('the registry exposes the generic dial commands', () => {
+    expect(registry.has('dial.set')).toBe(true);
+    expect(registry.has('dial.reset')).toBe(true);
+    expect(registry.has('dial.patch')).toBe(true);
+  });
+
+  it('dispatch dial.set writes the dial AND syncs the hot store', async () => {
+    const r = await registry.dispatch('dial.set', { key: 'right.root', value: 5 });
+    expect(r.ok).toBe(true);
+    expect(dialsStore.getState().effective['right.root']).toBe(5);
+    expect(useControls.getState().right.root).toBe(5); // synced into the hot mirror
+  });
+
+  it('dispatch dial.reset returns a dial to its default', async () => {
+    await registry.dispatch('dial.set', { key: 'right.octaves', value: 4 });
+    expect(dialsStore.getState().effective['right.octaves']).toBe(4);
+    const r = await registry.dispatch('dial.reset', { key: 'right.octaves' });
+    expect(r.ok).toBe(true);
+    expect(dialsStore.getState().effective['right.octaves']).toBe(2); // the dial's default
+    expect(useControls.getState().right.octaves).toBe(2);
+  });
+
+  it('dispatch dial.patch sets several dials in order (a synced-voice edit)', async () => {
+    const r = await registry.dispatch('dial.patch', {
+      writes: [
+        ['right.root', 7],
+        ['left.root', 7],
+      ],
+    });
+    expect(r.ok).toBe(true);
+    expect(useControls.getState().right.root).toBe(7);
+    expect(useControls.getState().left.root).toBe(7);
+  });
+
+  it('errors are DATA: an unknown dial → err(unknown_dial), never a throw', async () => {
+    const r = await registry.dispatch('dial.set', { key: 'nope.nope', value: 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.code).toBe('unknown_dial');
+  });
+
+  it('bad params (missing key) → err(invalid_params) from the schema, no throw', async () => {
+    const r = await registry.dispatch('dial.set', { value: 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.code).toBe('invalid_params');
+  });
+
+  it('rejects an out-of-range VALUE (errors-as-data) and leaves the hot store unchanged', async () => {
+    // master.volume is bound 0..1 — the write must be refused, not silently dropped
+    // into the dials layer while the audio keeps the old value (the false-ok trap).
+    const before = useControls.getState().masterVolume;
+    const r = await registry.dispatch('dial.set', { key: 'master.volume', value: 5 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.code).toBe('invalid_value');
+    expect(useControls.getState().masterVolume).toBe(before); // audio never changed
+    expect(dialsStore.getState().effective['master.volume']).toBe(before); // dials layer clean
+  });
+
+  it('dial.patch is atomic: one invalid value rejects the WHOLE batch (no partial write)', async () => {
+    const rootBefore = dialsStore.getState().effective['right.root'];
+    const r = await registry.dispatch('dial.patch', {
+      writes: [
+        ['right.root', 6], // valid
+        ['right.octaves', 99], // valid KEY, invalid VALUE (max 4) → rejects the batch
+      ],
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.code).toBe('invalid_value');
+    // Neither write landed: the earlier (valid) write did NOT half-apply.
+    expect(dialsStore.getState().effective['right.root']).toBe(rootBefore);
+    expect(dialsStore.getState().effective['right.octaves']).not.toBe(99);
+  });
+
+  it('sync/mode are just dials: dispatching dial.set on master.syncHands works', async () => {
+    // No special "toggle sync" command — sync-hands is the `master.syncHands` dial,
+    // so the generic verb covers it (and per-dial generation will too, later).
+    const iso = createThoreminRegistry();
+    expect(iso.size()).toBe(3);
+    const r = await iso.dispatch('dial.set', { key: 'master.syncHands', value: false });
+    expect(r.ok).toBe(true);
+    expect(useControls.getState().syncHands).toBe(false);
+  });
+});

--- a/test/commands_firewall.test.ts
+++ b/test/commands_firewall.test.ts
@@ -1,0 +1,110 @@
+/**
+ * The command/hot-path import firewall (#87). thoremin lints with `tsc --noEmit`
+ * (no ESLint), so the boundary the command-dispatch design requires is enforced
+ * as a TEST instead of an ESLint `no-restricted-imports` rule:
+ *
+ *  - Nothing under `src/app/commands/` may import the hot `useControls` store, the
+ *    DAG engine, the node library, or the audio synth. A command changes sound only
+ *    by writing a DIAL (via `src/app/dials/`), so the real-time path can never
+ *    accidentally acquire dispatch overhead.
+ *  - Nothing under `src/dag/` or `src/nodes/` may import the command registry, so a
+ *    per-tick / audio event can never be routed through dispatch.
+ *
+ * Enforced over import specifiers (not raw text), so a comment mentioning a module
+ * doesn't trip it.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+/** Recursively list .ts/.tsx files under a directory. */
+function tsFiles(dir: string): string[] {
+  if (!existsSync(dir)) return [];
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...tsFiles(p));
+    else if (/\.tsx?$/.test(entry.name)) out.push(p);
+  }
+  return out;
+}
+
+/** The module specifiers a file imports (static + dynamic + re-export). */
+function importSpecifiers(src: string): string[] {
+  const specs: string[] = [];
+  const from = /(?:\bimport\b|\bexport\b)[^'"]*?\bfrom\s*['"]([^'"]+)['"]/g;
+  const dyn = /\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
+  const bare = /^\s*import\s+['"]([^'"]+)['"]/gm;
+  for (const re of [from, dyn, bare]) {
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(src))) specs.push(m[1]);
+  }
+  return specs;
+}
+
+/**
+ * The sanctioned imports a command file may make. This is an ALLOWLIST, deliberately:
+ * a denylist of "forbidden" modules is always one newly-added hot-path file behind
+ * (the host audio lives in `useEngine`/`recorder`/`useAudioEngine`, not just
+ * `src/nodes`; and a `.ts`-extension specifier can dodge a `$`-anchored name rule).
+ * With an allowlist, anything not explicitly sanctioned — the hot `useControls`
+ * store, the DAG, the nodes, the audio/host layer, any other `@/app/*` — is refused
+ * by default. Commands reach state ONLY through the dials settings layer + the pure
+ * settings-transform/schema modules.
+ */
+const COMMAND_IMPORT_ALLOWLIST: RegExp[] = [
+  /^acture(\/|$)/, // the command-dispatch library
+  /^zod(\/|$)/,
+  /^@zodal\//, // dials-core / dials-ui / store types
+  /^@\/app\/dials\//, // the dials settings layer (setDial/resetDial/dialsStore) — the write bridge
+  /^@\/settings\//, // pure settings schema + transforms (layerToSettings, thoreminDials, presets)
+  /^\.\/[^./]/, // a same-directory sibling command module (./dials, ./registry) — NOT `../` reach-out
+];
+const isAllowedFromCommands = (spec: string): boolean =>
+  COMMAND_IMPORT_ALLOWLIST.some((re) => re.test(spec));
+
+describe('command-dispatch import firewall (#87)', () => {
+  it('commands import ONLY the sanctioned surface (never the hot store / DAG / nodes / audio)', () => {
+    const files = tsFiles('src/app/commands');
+    expect(files.length).toBeGreaterThan(0); // guard: the dir exists and has files
+    for (const f of files) {
+      for (const spec of importSpecifiers(readFileSync(f, 'utf8'))) {
+        expect(
+          isAllowedFromCommands(spec),
+          `${f} imports "${spec}", which is outside the command allowlist (acture / zod / @zodal / @/app/dials / @/settings / sibling). A command must write a dial, never reach the hot store, DAG, nodes, or audio layer.`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it('the allowlist refuses hot-store / audio / DAG specifiers (incl. .ts extensions)', () => {
+    // Guard the guard: a regression for the extension-bypass + the host-audio gap.
+    for (const spec of [
+      '@/app/store',
+      '@/app/store.ts',
+      '../store',
+      '../store.ts',
+      '@/app/useEngine',
+      '@/app/recorder',
+      '@/hooks/useAudioEngine',
+      '@/nodes/output/webaudio_synth',
+      '@/dag',
+    ]) {
+      expect(isAllowedFromCommands(spec), `"${spec}" must be firewalled from commands`).toBe(false);
+    }
+    // ...while the sanctioned ones (incl. an explicit extension) stay allowed.
+    for (const spec of ['acture', 'zod', '@zodal/dials-core', '@/app/dials/settingsStore', '@/settings/dials', './registry']) {
+      expect(isAllowedFromCommands(spec), `"${spec}" is sanctioned and must be allowed`).toBe(true);
+    }
+  });
+
+  it('the DAG / node / tick layer never imports the command registry', () => {
+    for (const dir of ['src/dag', 'src/nodes']) {
+      for (const f of tsFiles(dir)) {
+        for (const spec of importSpecifiers(readFileSync(f, 'utf8'))) {
+          expect(/(^|\/)commands(\/|$)/.test(spec), `${f} imports "${spec}" — the real-time path must not route through dispatch`).toBe(false);
+        }
+      }
+    }
+  });
+});


### PR DESCRIPTION
Part of #87 (the command-dispatch linchpin). This is **Phase 0 — the registry + adapter foundation**, deliberately **behavior-neutral** (no consumer wired yet), per the phased plan in the issue's design comment.

## What lands
Param-mutation becomes the single documented write path a keyboard binding, command palette, or AI assistant will all dispatch through — **without touching the real-time tick/audio path**.

- **`acture`** added (the command-dispatch library; zod ^4 peer satisfied).
- **`src/app/commands/`** — three generic dial commands (`dial.set`, `dial.reset`, `dial.patch`) whose handlers write through the dials settings store (`setDial`/`resetDial`), which syncs into the hot `useControls` mirror the DAG reads each tick. acture's registry never holds a `StateAdapter` (state is reached by closure capture), and the keyed zodal dials store doesn't fit `acture-state-zustand`, so handlers close over the dials store's own keyed API — the "binding" in acture's actual design. `dispatch` is async; every failure is **data** (`ok`/`err`), never a throw.
- **Import firewall as a TEST** (thoremin has no ESLint; `lint` = `tsc --noEmit`): an **allowlist** — a command may import only `acture`/`zod`/`@zodal`/`@/app/dials`/`@/settings`/siblings; the hot store, DAG, nodes, and the app/host audio layer (`useEngine`/`recorder`/`useAudioEngine`) are refused by default. The inverse rule: the DAG/node layer may never import the registry, so a per-tick event can't route through dispatch.

`sync`/`mode`/`volume` are dials (`master.*`, `face.mapping`) so they're covered by `dial.set`; only the non-dial `muted` flag (#91) is deferred.

## Correctness
Writes are validated up front against the **same** `layerToSettings → SettingsSchema` the hot sync runs, so a value the hot store would silently reject is refused (errors-as-data) instead of landing in the dials layer while the audio keeps the old value; `dial.patch` is truly all-or-nothing. The keyspace guard is keyed off the **declared** dials (`thoreminDials.keys`), not the resolved effective map.

## Tests (408 pass)
Firewall (allowlist + a "guard the guard" regression for the extension-bypass and host-audio gaps) and dispatch (writes + hot-store sync, errors-as-data, out-of-range rejection, atomic patch). Verify gate: `typecheck` ✓ · `vitest` (408) ✓ · `build` ✓.

## Adversarial review
Reviewed via a multi-agent workflow (3 lenses → refutation). **All 7 confirmed findings are fixed here with regression tests:** the firewall's `.ts`-extension bypass + uncovered host-audio layer (→ allowlist inversion), a false-`ok` on out-of-range values (→ up-front validation), a non-atomic `dial.patch` (→ validate-before-write), and a resolved-vs-declared keyspace guard.

## Not in this PR (later phases)
Phase 1 (make the registry THE write path — reroute the panel) and Phases 2–4 (hotkeys, palette, AI, undo). Phase 1 has one architectural decision to make first (does the panel's live-drag path go through async dispatch or stay direct for latency) — flagged in the issue's Open Decision B.

https://claude.ai/code/session_01JEoe7y1hA5KdEAvvpQXxxt