### PR TITLE
feat(source): camera-free pre-recorded video source (?source=video) — M-A

### DIFF
--- a/docs/design/stream-applier.md
+++ b/docs/design/stream-applier.md
@@ -187,7 +187,9 @@ boundaries allow.
   `currentTime !== lastVideoTime` gate freezes on a non-advancing clip),
   `await loadedmetadata`, StrictMode `disposed` guards, `onended` → `exhausted`,
   loop-boundary MediaPipe tracking-reset. Medium, not 15 lines. The hand model
-  still loads (not free).
+  still loads (not free). Known limitation: the instrument mirrors the video
+  (selfie assumption), so a non-mirror-image clip renders flipped with Left/Right
+  swapped — a per-source `mirror` flag is deferred to the M-C Source contract.
 - **M-B — Clock + speed multiplier (R5 control-rate core).** `src/dag/clock.ts`;
   refit `useEngine` rAF → `RealtimeClock(1)`, `runHeadless` loop →
   `BatchClock(ticks)` (preserve the no-arg `tick()` call). Seed first `dt=0` in

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -11,6 +11,7 @@
  */
 import { Play, BookOpen, Circle, Square, VolumeX } from 'lucide-react';
 import { useThoreminEngine } from './useEngine';
+import { DEFAULT_SOURCE, type SourceSpec } from './sourceSpec';
 import { useControls } from './store';
 import { useFaceStatus } from './faceStatus';
 import InstrumentsPanel from './dials/InstrumentsPanel';
@@ -64,9 +65,9 @@ function MutedBadge() {
   );
 }
 
-export default function App() {
+export default function App({ source = DEFAULT_SOURCE }: { source?: SourceSpec }) {
   const { videoRef, canvasRef, status, error, audioOn, isRecording, isSaving, startAudio, toggleRecording } =
-    useThoreminEngine();
+    useThoreminEngine(source);
 
   return (
     <div className="relative h-dvh w-screen overflow-hidden bg-black font-mono text-white">
@@ -146,7 +147,9 @@ export default function App() {
           <div className="text-center">
             <div className="mx-auto mb-3 h-12 w-12 animate-spin rounded-full border-4 border-emerald-500/30 border-t-emerald-500" />
             <p className="text-xs uppercase tracking-widest text-emerald-500">Loading neural engine</p>
-            <p className="mt-1 text-[10px] uppercase tracking-widest text-white/40">allow camera access</p>
+            <p className="mt-1 text-[10px] uppercase tracking-widest text-white/40">
+              {source.kind === 'video' ? 'loading video…' : 'allow camera access'}
+            </p>
           </div>
         </div>
       )}

--- a/src/app/sourceSpec.ts
+++ b/src/app/sourceSpec.ts
@@ -1,0 +1,49 @@
+/**
+ * Startup source selection (Stream Applier, milestone M-A).
+ *
+ * Decides which primary source feeds the instrument at launch: the live camera
+ * (default) or a pre-recorded video file (camera-free), so the overlays and the
+ * command palette can run without a webcam. This is the minimal URL seam; the
+ * async-iterator `Source` contract + `source` slot (M-C) will generalize it.
+ * See docs/design/stream-applier.md.
+ */
+
+/** The selected primary source. Origin-tagged; the host (useEngine) branches on
+ *  `kind` to acquire the underlying `<video>` (camera stream vs file). */
+export type SourceSpec =
+  | { kind: 'camera' }
+  | { kind: 'video'; url: string };
+
+/** Default when nothing is requested: the live webcam. */
+export const DEFAULT_SOURCE: SourceSpec = { kind: 'camera' };
+
+/**
+ * Parse a URL query string into a {@link SourceSpec}.
+ *
+ * `?source=video&video=<url>` (alias `clip=<url>`) plays a pre-recorded file as
+ * the primary source. Anything else — including `source=video` with a missing or
+ * blank url — falls back to the live camera (a missing url warns, since
+ * camera-free was the likely intent).
+ *
+ * Notes for the `<url>`:
+ *  - Prefer a **same-origin** clip (e.g. dropped in `public/`, referenced as
+ *    `/clip.mp4`). A remote clip must be **CORS-enabled** — the frames are read
+ *    into a canvas + MediaPipe, which taints (and blocks) a non-CORS source.
+ *  - **Percent-encode** the value if it contains `&` or its own `?query`, or
+ *    `URLSearchParams` will truncate it at the first delimiter.
+ *  - The instrument **mirrors** the video (selfie assumption): a clip that is
+ *    not already a mirror image renders horizontally flipped with Left/Right
+ *    handedness swapped. Use a mirror-friendly clip, or expect the flip. A
+ *    per-source `mirror` flag is a Source-contract concern (M-C), not M-A.
+ *
+ * @param search a `location.search` string (leading `?` optional).
+ */
+export function parseSourceSpec(search: string): SourceSpec {
+  const params = new URLSearchParams(search);
+  if (params.get('source') === 'video') {
+    const url = (params.get('video') ?? params.get('clip'))?.trim();
+    if (url) return { kind: 'video', url };
+    console.warn('[thoremin] ?source=video needs a non-empty &video=<url>; falling back to the camera');
+  }
+  return DEFAULT_SOURCE;
+}

--- a/src/app/useEngine.ts
+++ b/src/app/useEngine.ts
@@ -9,6 +9,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { Engine } from '@/dag';
 import { createAppRegistry } from '@/nodes/browser';
 import { defaultGraph } from './graph';
+import { DEFAULT_SOURCE, type SourceSpec } from './sourceSpec';
 import { useControls } from './store';
 import { PerformanceRecorder, recordingFilename, extForMime } from './recorder';
 import { recordingFormat } from './recording/formats';
@@ -22,6 +23,15 @@ export type EngineStatus = 'idle' | 'loading' | 'ready' | 'error';
 
 /** Min interval (ms) between face-status reports to React (throttle the readout). */
 const FACE_REPORT_MS = 100;
+
+/**
+ * Max wait (ms) for a file source to deliver metadata before we give up. A URL
+ * that returns 200 but never delivers a playable stream (hung CDN, truncated
+ * moov atom) fires neither `loadedmetadata` nor `error`, so without this the
+ * view would wedge on "loading" forever. Applied to the file path only — the
+ * camera keeps its original settle behavior.
+ */
+const VIDEO_LOAD_TIMEOUT_MS = 15000;
 
 /**
  * Convert the native (WebM/Opus) recording into each selected output format and
@@ -70,7 +80,7 @@ async function saveRecording(
   }
 }
 
-export function useThoreminEngine() {
+export function useThoreminEngine(source: SourceSpec = DEFAULT_SOURCE) {
   const videoRef = useRef<HTMLVideoElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const engineRef = useRef<Engine | null>(null);
@@ -101,31 +111,76 @@ export function useThoreminEngine() {
       try {
         setStatus('loading');
         const video = videoRef.current!;
-        // Ask for HD 16:9 so the fullscreen video is crisp, and the front
-        // (user-facing) camera so the mirrored view shows your own hands on
-        // mobile. All are `ideal` soft constraints: the camera returns the
-        // closest mode it supports and never fails.
-        stream = await navigator.mediaDevices.getUserMedia({
-          video: {
-            width: { ideal: 1280 },
-            height: { ideal: 720 },
-            facingMode: { ideal: 'user' },
-          },
-          audio: false,
-        });
-        if (disposed) {
-          // Cleanup already ran (it saw stream === null), so stop it here.
-          stream.getTracks().forEach((t) => t.stop());
-          return;
+        if (source.kind === 'video') {
+          // Camera-free (Stream Applier M-A): play a pre-recorded clip into the
+          // same <video> the webcam would fill, so the overlays + palette run
+          // with no camera. The webcam-hands/face nodes read ctx.resources.video
+          // origin-blind and time their inference off performance.now(), so the
+          // file path needs no node changes.
+          //   loop  — REQUIRED: those nodes only run inference while
+          //           video.currentTime advances, so a stopped clip freezes the
+          //           overlay; looping keeps it live (the wrap costs one cosmetic
+          //           position jump, not a MediaPipe error).
+          //   muted — keeps autoplay allowed and frees the audio path for the
+          //           synth (we never want the clip's own audio).
+          //   crossOrigin — lets a CORS-enabled remote clip be read into the
+          //           canvas/MediaPipe; a same-origin clip (public/) needs nothing.
+          video.srcObject = null;
+          video.crossOrigin = 'anonymous';
+          video.loop = true;
+          video.muted = true;
+          video.src = source.url;
+        } else {
+          // Ask for HD 16:9 so the fullscreen video is crisp, and the front
+          // (user-facing) camera so the mirrored view shows your own hands on
+          // mobile. All are `ideal` soft constraints: the camera returns the
+          // closest mode it supports and never fails.
+          stream = await navigator.mediaDevices.getUserMedia({
+            video: {
+              width: { ideal: 1280 },
+              height: { ideal: 720 },
+              facingMode: { ideal: 'user' },
+            },
+            audio: false,
+          });
+          if (disposed) {
+            // Cleanup already ran (it saw stream === null), so stop it here.
+            stream.getTracks().forEach((t) => t.stop());
+            return;
+          }
+          video.srcObject = stream;
         }
-        video.srcObject = stream;
-        await new Promise<void>((resolve) => {
+        await new Promise<void>((resolve, reject) => {
+          // File path only: a stalling clip fires neither event, so bound the
+          // wait and surface a timeout. The camera path (timer === null) keeps
+          // its original "settle only on metadata" behavior.
+          const timer =
+            source.kind === 'video'
+              ? setTimeout(
+                  () => reject(new Error(`Timed out loading video source: ${source.url}`)),
+                  VIDEO_LOAD_TIMEOUT_MS,
+                )
+              : null;
           video.onloadedmetadata = () => {
+            if (timer) clearTimeout(timer);
             void video.play();
             resolve();
           };
+          // A bad clip URL (decode/CORS failure) surfaces as an error instead of
+          // hanging; onerror covers *errors*, the timer above covers *stalls*.
+          // The camera path effectively never fires either.
+          video.onerror = () => {
+            if (timer) clearTimeout(timer);
+            reject(
+              new Error(
+                source.kind === 'video'
+                  ? `Could not load video source: ${source.url}`
+                  : 'Camera video element error',
+              ),
+            );
+          };
         });
-        if (disposed) return; // cleanup stops the now-assigned stream
+        if (disposed) return; // cleanup stops the stream / releases the clip
 
         // Size the canvas drawing buffer to the camera's native resolution so
         // the overlay renders at full sharpness (CSS object-cover then scales it
@@ -231,6 +286,16 @@ export function useThoreminEngine() {
       recorderRef.current?.dispose();
       recorderRef.current = null;
       stream?.getTracks().forEach((t) => t.stop());
+      // Symmetric to stopping camera tracks: pause a file clip so an aborted
+      // (StrictMode) or unmounted run stops decoding instead of playing on, and
+      // drop its handlers so a stale rejecter can't fire if the source is ever
+      // re-acquired (the effect deps allow it).
+      const fileVideo = source.kind === 'video' ? videoRef.current : null;
+      if (fileVideo) {
+        fileVideo.pause();
+        fileVideo.onloadedmetadata = null;
+        fileVideo.onerror = null;
+      }
       // Close the AudioContext so its nodes (master, recorder tap, voices) are
       // released instead of leaking one un-closed context per unmount.
       const ac = resourcesRef.current.audioContext as AudioContext | undefined;
@@ -238,7 +303,9 @@ export function useThoreminEngine() {
       resourcesRef.current.audioContext = undefined;
       masterGainRef.current = null;
     };
-  }, []);
+    // Primitive deps (not the SourceSpec object) so a stable selection doesn't
+    // re-run the effect; a genuine source change tears down and re-acquires.
+  }, [source.kind, source.kind === 'video' ? source.url : null]);
 
   // Keep master gain synced to the UI volume, and drop it to zero while muted.
   // This is the host-level catch-all mute (belt-and-suspenders with the in-graph

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,14 +8,19 @@
  * is still honored and equals the default, so existing links keep working.
  * Only the non-default (legacy) view is code-split, so it never weighs on the
  * default path.
+ *
+ * `?source=video&video=<url>` runs the DAG view camera-free from a pre-recorded
+ * clip (Stream Applier M-A); see {@link parseSourceSpec}.
  */
 import {StrictMode, Suspense, lazy} from 'react';
 import {createRoot} from 'react-dom/client';
 import DagApp from './app/App.tsx';
+import {parseSourceSpec} from './app/sourceSpec';
 import './index.css';
 
 const engineParam = new URLSearchParams(window.location.search).get('engine');
 const useLegacyEngine = engineParam === 'legacy' || engineParam === 'classic';
+const source = parseSourceSpec(window.location.search);
 
 const LegacyApp = lazy(() => import('./App.tsx'));
 
@@ -26,7 +31,7 @@ createRoot(document.getElementById('root')!).render(
         <LegacyApp />
       </Suspense>
     ) : (
-      <DagApp />
+      <DagApp source={source} />
     )}
   </StrictMode>,
 );

--- a/test/source_spec.test.ts
+++ b/test/source_spec.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for parseSourceSpec — the startup source selection (Stream Applier M-A).
+ * The live acquisition (getUserMedia vs <video src>) is browser-only; this
+ * covers the pure URL→SourceSpec parsing that decides which path runs.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { parseSourceSpec, DEFAULT_SOURCE } from '../src/app/sourceSpec';
+
+describe('parseSourceSpec', () => {
+  it('defaults to the camera with no params', () => {
+    expect(parseSourceSpec('')).toEqual({ kind: 'camera' });
+    expect(parseSourceSpec('?engine=dag')).toEqual(DEFAULT_SOURCE);
+  });
+
+  it('selects a video file source from ?source=video&video=<url>', () => {
+    expect(parseSourceSpec('?source=video&video=/media/demo.mp4')).toEqual({
+      kind: 'video',
+      url: '/media/demo.mp4',
+    });
+  });
+
+  it('accepts the clip= alias for the url', () => {
+    expect(parseSourceSpec('?source=video&clip=/clips/a.webm')).toEqual({
+      kind: 'video',
+      url: '/clips/a.webm',
+    });
+    // video= wins when both are present.
+    expect(parseSourceSpec('?source=video&video=/v.mp4&clip=/c.mp4')).toEqual({
+      kind: 'video',
+      url: '/v.mp4',
+    });
+  });
+
+  it('preserves an absolute/remote url verbatim', () => {
+    expect(parseSourceSpec('?source=video&video=https://cdn.example.com/a%20b.mp4')).toEqual({
+      kind: 'video',
+      url: 'https://cdn.example.com/a b.mp4',
+    });
+  });
+
+  it('falls back to the camera (with a warning) when source=video has no url', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(parseSourceSpec('?source=video')).toEqual({ kind: 'camera' });
+    expect(warn).toHaveBeenCalledOnce();
+    warn.mockRestore();
+  });
+
+  it('treats a blank/whitespace url as missing (camera fallback)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(parseSourceSpec('?source=video&video=')).toEqual({ kind: 'camera' });
+    expect(parseSourceSpec('?source=video&video=%20%20')).toEqual({ kind: 'camera' });
+    warn.mockRestore();
+  });
+
+  it('trims surrounding whitespace from a url', () => {
+    expect(parseSourceSpec('?source=video&video=%20/clip.mp4%20')).toEqual({
+      kind: 'video',
+      url: '/clip.mp4',
+    });
+  });
+
+  it('documents that an unencoded & truncates the url (URLSearchParams semantics)', () => {
+    // A raw "&" starts a new param, so the url must be percent-encoded; this
+    // pins the contract so callers know to encode.
+    expect(parseSourceSpec('?source=video&video=/a.mp4&t=1')).toEqual({
+      kind: 'video',
+      url: '/a.mp4',
+    });
+  });
+
+  it('ignores an unknown source value', () => {
+    expect(parseSourceSpec('?source=midi')).toEqual({ kind: 'camera' });
+  });
+
+  it('tolerates a missing leading ?', () => {
+    expect(parseSourceSpec('source=video&video=/x.mp4')).toEqual({ kind: 'video', url: '/x.mp4' });
+  });
+});


### PR DESCRIPTION
Closes #102. First milestone of the Stream Applier (#101). Design: `docs/design/stream-applier.md` → M-A.

## What
Run the instrument **camera-free** from a pre-recorded clip so the #89 overlays + the Cmd/Ctrl-K palette can be verified without a webcam.

```
npm run dev        # http://localhost:3000
# drop a clip in public/, then open:
http://localhost:3000/?source=video&video=/your-clip.mp4
```

`?source=video&video=<url>` (alias `clip=`) makes `useEngine` skip `getUserMedia` and feed a `<video src loop muted>` into `ctx.resources.video` — the same element the webcam fills. The `webcam-hands`/`webcam-face` nodes read it origin-blind and timestamp MediaPipe off `performance.now()`, so **no engine/node code changed** and looping the clip is safe (`loop=true` is required — the detection gate freezes on a stopped clip).

## Changes
- **`src/app/sourceSpec.ts`** (new) — `parseSourceSpec`: trimmed url, camera fallback, CORS/percent-encoding/mirroring notes.
- **`src/app/useEngine.ts`** — branch acquisition (camera path bit-for-bit unchanged); shared `onloadedmetadata→play`; a **file-only load timeout** + `onerror→reject` (a bad/stalling URL surfaces an error instead of wedging on "loading"); cleanup pauses + resets a file clip.
- **`src/main.tsx` / `src/app/App.tsx`** — thread the spec; loading label reflects the source.
- **`test/source_spec.test.ts`** (new) — 10 parser tests.

## Adversarial review
3-lens review before PR: **ship-as-is, no must-fixes** (camera path proven additive/unchanged; video path fails cleanly). Folded in the load timeout, url trim, and CORS/mirroring docs it surfaced.

## Known limitation (documented)
The view **mirrors** (selfie assumption), so a non-mirror-image clip renders flipped with **Left/Right swapped**. Use a mirror-friendly clip or expect the flip; a per-source `mirror` flag is deferred to the M-C Source contract.

## Not covered (later milestones)
The `source` slot + async-iterator `Source` contract (M-C) retires the minimal `if (source==='video')` branch here.

## Verify
typecheck ✓ · 429 vitest (+10 parser) ✓ · build ✓ · catalog ✓. The live acquisition (getUserMedia vs `<video src>`) is browser-only — **manual browser check pending** (that's what M-A unblocks).

https://claude.ai/code/session_01JEoe7y1hA5KdEAvvpQXxxt