### PR TITLE
feat(dag): Clock abstraction + speed multiplier — M-B

### DIFF
--- a/docs/design/stream-applier.md
+++ b/docs/design/stream-applier.md
@@ -122,11 +122,15 @@ interface Clock {
 - **`BatchClock(ticks)`** — as fast as possible, deterministic. Calls `onTick()`
   **with no argument** so the engine synthesizes `tickIndex * nominalDt`
   (the regression goldens depend on this exact call).
-- **`RealtimeClock(speed = 1)`** — wall-clock paced. Seeds `base` on the first
-  tick so the first `dt` is `0` in **both** modes (batch tick-0 has `dt=0`; a
-  naive paced clock would pass a large garbage first `dt`). Passes
-  `base + (nowReal - base) * speed`; control-rate `dt` scales for free. Speed ≠ 1
-  is gated to recorded/generated sources and obeys boundary B for audio.
+- **`RealtimeClock({ speed = 1, now, schedule })`** — wall-clock paced. Passes
+  `base + (nowReal - base) * speed`, seeding `base` to the first frame's time so
+  engine time starts at that wall-clock value and advances at `speed×` (and the
+  first frame's delta is `0`, matching the engine's own tick-0 `dt === 0`, which
+  it forces for any clock). Control-rate `dt` scales for free. `now`/`schedule`
+  are injectable so the clock is fully headless-testable. Speed ≠ 1 is gated to
+  recorded/generated sources and obeys boundary B for audio; a **non-positive
+  speed** collapses to a frozen clock (`dt = 0`) — validated when `RealtimeClock`
+  is adopted into the app (M-D).
 
 ### Applier — applies an Engine to a SourceSet under a Clock
 
@@ -190,10 +194,13 @@ boundaries allow.
   still loads (not free). Known limitation: the instrument mirrors the video
   (selfie assumption), so a non-mirror-image clip renders flipped with Left/Right
   swapped — a per-source `mirror` flag is deferred to the M-C Source contract.
-- **M-B — Clock + speed multiplier (R5 control-rate core).** `src/dag/clock.ts`;
-  refit `useEngine` rAF → `RealtimeClock(1)`, `runHeadless` loop →
-  `BatchClock(ticks)` (preserve the no-arg `tick()` call). Seed first `dt=0` in
-  both modes. No engine change.
+- **M-B — Clock + speed multiplier (R5 control-rate core). ✅ shipped.**
+  `src/dag/clock.ts` (`Clock` / `BatchClock` / `RealtimeClock`); refit the
+  **`runHeadless`** loop → `BatchClock(ticks)` (preserve the no-arg `tick()`
+  call). No engine change. The live `useEngine` rAF adoption of `RealtimeClock`
+  is **deferred to M-D** — it is the untested live surface and lands with the
+  Applier + a browser smoke test; M-B ships the abstraction + the fully-tested
+  `BatchClock` path and a headless `RealtimeClock`.
 - **M-C — Source contract + `source` slot + conformance (R1/R4 foundation).**
   The async-iterable `Source` (signal/event); a `source` slot with a
   `SOURCE_SLOT_CONTRACT` guaranteeing `hands`/`hands-frame`; `PortSpec.schema?`
@@ -201,9 +208,11 @@ boundaries allow.
   `videoFileSource` becomes a slot candidate; M-A's `if` retires.
 - **M-D — The Applier (R4 complete, R5 orthogonality). ⚠ untested live surface.**
   `runHeadless` delegates (BatchClock + bounded recorder tap, no audio sink);
-  `useEngine`'s effect becomes a thin Applier config. **Gate on a browser smoke
-  test** — the effect (StrictMode guards, face bridge, mute mirror, AudioContext
-  lifecycle) has no headless coverage.
+  `useEngine`'s effect becomes a thin Applier config — **this is where the live
+  rAF loop adopts `RealtimeClock(1)`** (deferred from M-B). Also validate
+  `speed > 0` on adoption (a non-positive speed collapses to a frozen clock).
+  **Gate on a browser smoke test** — the effect (StrictMode guards, face bridge,
+  mute mirror, AudioContext lifecycle) has no headless coverage.
 - **M-E — Composition + timestamp-aware replay (R2).** `defineMergeNode`; event
   sources buffer→list; a **separate** time-based `replay-source-timed` reading
   `StreamRecord.t` (index-by-tick stays canonical for CI goldens).

--- a/src/dag/clock.ts
+++ b/src/dag/clock.ts
@@ -1,0 +1,96 @@
+/**
+ * Clock — the execution-mode seam for driving an {@link Engine}, the one place
+ * pacing lives (Stream Applier milestone M-B; see docs/design/stream-applier.md).
+ *
+ * A `Clock` decides *when* the engine advances a tick; it is orthogonal to
+ * *where* the data comes from (sources) and *what* we do with the outputs (taps
+ * for recording, sinks for view/hear). The engine's `tick(time?)` already
+ * accepts either an explicit wall-clock time or none (synthesizing
+ * `tickIndex * nominalDt`), so swapping the clock swaps batch-vs-paced without
+ * touching the engine.
+ *
+ *   - {@link BatchClock}    — as fast as possible, deterministic (tests, offline
+ *                             recording). Calls `onTick()` with NO argument so
+ *                             the engine synthesizes its own time.
+ *   - {@link RealtimeClock} — wall-clock paced, with a speed multiplier
+ *                             (real-time playback, accelerated/slowed scrub).
+ *
+ * A future `Applier` (M-D) will own building the engine, wiring sources/sinks
+ * and picking a clock; for now `runHeadless` uses `BatchClock` and the live
+ * `useEngine` rAF loop is refit onto `RealtimeClock` when the Applier lands
+ * (deferred here because that surface has no headless test — see the design doc).
+ */
+
+/** Drives an engine tick callback until a stop condition is met. */
+export interface Clock {
+  /**
+   * Run the loop. `onTick` advances the engine one step (optionally at an
+   * explicit time in seconds); `shouldStop` is polled before each tick and the
+   * returned promise resolves once it is true (or the batch count is reached).
+   */
+  run(onTick: (time?: number) => void, shouldStop: () => boolean): Promise<void>;
+}
+
+/**
+ * As-fast-as-possible, deterministic clock: runs exactly `ticks` times (or until
+ * `shouldStop`), calling `onTick()` with **no argument** so the engine
+ * synthesizes `tickIndex * nominalDt`. Keeping the call argument-free is load
+ * bearing — the recorded-fixture goldens depend on that synthesized time.
+ */
+export class BatchClock implements Clock {
+  constructor(private readonly ticks: number) {}
+
+  async run(onTick: (time?: number) => void, shouldStop: () => boolean): Promise<void> {
+    for (let i = 0; i < this.ticks && !shouldStop(); i++) onTick();
+  }
+}
+
+/** Options for {@link RealtimeClock}. */
+export interface RealtimeClockOptions {
+  /** Playback speed multiplier: 1 = real time, 2 = twice as fast, 0.5 = half. */
+  speed?: number;
+  /** Wall-clock reader in **seconds**. Injectable for tests; default `performance.now()/1000`. */
+  now?: () => number;
+  /** Frame scheduler. Injectable for tests/Node; default `requestAnimationFrame`. */
+  schedule?: (cb: () => void) => void;
+}
+
+/**
+ * Wall-clock-paced clock with a speed multiplier. On each scheduled frame it
+ * feeds the engine `base + (now - base) * speed`, where `base` is seeded to the
+ * first frame's time — so engine time starts at that wall-clock value and
+ * advances at `speed×` (and the first frame's delta is 0, matching the engine's
+ * own tick-0 `dt === 0`). Control-rate `dt` therefore scales for free; audio is
+ * *not* a time-multiply (see the design doc's boundary B) and is handled
+ * separately.
+ */
+export class RealtimeClock implements Clock {
+  private readonly speed: number;
+  private readonly now: () => number;
+  private readonly schedule: (cb: () => void) => void;
+
+  constructor(opts: RealtimeClockOptions = {}) {
+    this.speed = opts.speed ?? 1;
+    this.now = opts.now ?? (() => performance.now() / 1000);
+    // Referenced lazily inside run(), so importing this module in Node (where
+    // requestAnimationFrame is absent but only BatchClock is used) is safe.
+    this.schedule = opts.schedule ?? ((cb) => void requestAnimationFrame(cb));
+  }
+
+  run(onTick: (time?: number) => void, shouldStop: () => boolean): Promise<void> {
+    return new Promise<void>((resolve) => {
+      let base: number | null = null;
+      const frame = () => {
+        if (shouldStop()) {
+          resolve();
+          return;
+        }
+        const real = this.now();
+        if (base === null) base = real; // first paced frame: (real - base) === 0
+        onTick(base + (real - base) * this.speed);
+        this.schedule(frame);
+      };
+      this.schedule(frame);
+    });
+  }
+}

--- a/src/dag/index.ts
+++ b/src/dag/index.ts
@@ -18,10 +18,13 @@ export {
   replayNode,
 } from './recorder';
 export type { ReplayOptions } from './recorder';
+export { BatchClock, RealtimeClock } from './clock';
+export type { Clock, RealtimeClockOptions } from './clock';
 
 import { Engine, type EngineOptions } from './engine';
 import { NodeRegistry } from './registry';
 import { StreamRecorder } from './recorder';
+import { BatchClock } from './clock';
 import type { GraphSpec } from './types';
 
 /**
@@ -37,6 +40,8 @@ export async function runHeadless(
   const recorder = new StreamRecorder({ only: opts.recordOnly });
   const engine = new Engine(spec, registry, { ...opts, taps: [recorder] });
   await engine.init();
-  for (let i = 0; i < opts.ticks; i++) engine.tick();
+  // BatchClock calls engine.tick() with no argument, exactly as the previous
+  // inline for-loop did, so recorded goldens are byte-identical.
+  await new BatchClock(opts.ticks).run(() => engine.tick(), () => false);
   return { engine, recorder };
 }

--- a/test/clock.test.ts
+++ b/test/clock.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Tests for the Clock abstraction (Stream Applier M-B): BatchClock determinism,
+ * RealtimeClock time-mapping + speed multiplier, and an end-to-end check that
+ * driving an Engine through each clock yields the expected ctx.dt stream (so
+ * speed scales control-rate time for free).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { z } from 'zod';
+import { BatchClock, RealtimeClock, Engine, defineNode, createRegistry, type Tap } from '../src/dag';
+
+// A controllable stand-in for requestAnimationFrame: stores the next frame
+// callback so a test can drive frames one at a time.
+function fakeScheduler() {
+  let pending: (() => void) | null = null;
+  return {
+    schedule: (cb: () => void) => {
+      pending = cb;
+    },
+    /** Invoke up to n queued frames (stops early if the loop stops rescheduling). */
+    flush(n: number) {
+      for (let i = 0; i < n; i++) {
+        const cb = pending;
+        pending = null;
+        if (!cb) return;
+        cb();
+      }
+    },
+    get pending() {
+      return pending;
+    },
+  };
+}
+
+describe('BatchClock', () => {
+  it('calls onTick exactly `ticks` times, always with no argument', async () => {
+    const args: (number | undefined)[] = [];
+    await new BatchClock(4).run((t) => args.push(t), () => false);
+    expect(args).toEqual([undefined, undefined, undefined, undefined]);
+  });
+
+  it('runs zero times for ticks=0', async () => {
+    const spy = vi.fn();
+    await new BatchClock(0).run(spy, () => false);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('stops early when shouldStop becomes true', async () => {
+    let n = 0;
+    await new BatchClock(100).run(
+      () => {
+        n++;
+      },
+      () => n >= 3,
+    );
+    expect(n).toBe(3);
+  });
+});
+
+describe('RealtimeClock', () => {
+  it('feeds the engine wall-clock time (speed 1): first tick is the base, then real deltas', async () => {
+    const sched = fakeScheduler();
+    const times = [100, 100.016, 100.032, 100.05];
+    let i = 0;
+    const captured: number[] = [];
+    const clock = new RealtimeClock({ now: () => times[Math.min(i++, times.length - 1)], schedule: sched.schedule });
+    const done = clock.run((t) => captured.push(t as number), () => captured.length >= 4);
+    sched.flush(10);
+    await done;
+    expect(captured).toEqual([100, 100.016, 100.032, 100.05]);
+  });
+
+  it('scales elapsed time by the speed multiplier (base held fixed)', async () => {
+    const sched = fakeScheduler();
+    const times = [100, 100.1, 100.2, 100.3];
+    let i = 0;
+    const captured: number[] = [];
+    const clock = new RealtimeClock({
+      speed: 2,
+      now: () => times[Math.min(i++, times.length - 1)],
+      schedule: sched.schedule,
+    });
+    const done = clock.run((t) => captured.push(t as number), () => captured.length >= 4);
+    sched.flush(10);
+    await done;
+    // base = 100; t = base + (real - base) * 2  →  100, 100.2, 100.4, 100.6
+    expect(captured[0]).toBeCloseTo(100, 10);
+    expect(captured[1]).toBeCloseTo(100.2, 10);
+    expect(captured[2]).toBeCloseTo(100.4, 10);
+    expect(captured[3]).toBeCloseTo(100.6, 10);
+  });
+
+  it('resolves without ticking if shouldStop is already true', async () => {
+    const sched = fakeScheduler();
+    const spy = vi.fn();
+    const done = new RealtimeClock({ now: () => 0, schedule: sched.schedule }).run(spy, () => true);
+    sched.flush(5);
+    await done;
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+describe('Clock → Engine integration (ctx.dt)', () => {
+  // A probe node that emits ctx.dt every tick so a tap can capture the stream.
+  const probe = defineNode({
+    type: 'probe-dt',
+    title: 'dt probe',
+    description: 'Emits the current tick dt.',
+    inputs: [],
+    outputs: [{ name: 'dt', kind: 'number' }],
+    params: z.object({}),
+    make() {
+      return { process: (_inputs, ctx) => ({ dt: ctx.dt }) };
+    },
+  });
+
+  const spec = { nodes: [{ id: 'p', type: 'probe-dt' }], edges: [] };
+  const registryWith = () => {
+    const r = createRegistry();
+    r.register(probe);
+    return r;
+  };
+  const capture = (): { tap: Tap; dts: number[] } => {
+    const dts: number[] = [];
+    return { tap: { onValue: (key, value) => key === 'p.dt' && dts.push(value as number) }, dts };
+  };
+
+  it('BatchClock drives synthesized time: dt is 0 then nominalDt', async () => {
+    const { tap, dts } = capture();
+    const engine = new Engine(spec, registryWith(), { taps: [tap], nominalDt: 1 / 60 });
+    await engine.init();
+    await new BatchClock(4).run(() => engine.tick(), () => false);
+    expect(dts[0]).toBe(0); // engine forces tick-0 dt = 0
+    // Successive synthesized dts are nominalDt (within float tolerance — the
+    // engine subtracts accumulated times, e.g. 2/60 - 1/60, not exactly 1/60).
+    expect(dts).toHaveLength(4);
+    for (const d of dts.slice(1)) expect(d).toBeCloseTo(1 / 60, 10);
+  });
+
+  it('RealtimeClock at speed 2 doubles ctx.dt vs the real frame interval', async () => {
+    const sched = fakeScheduler();
+    const step = 1 / 60; // real seconds per frame
+    const times = [10, 10 + step, 10 + 2 * step, 10 + 3 * step];
+    let i = 0;
+    const { tap, dts } = capture();
+    const engine = new Engine(spec, registryWith(), { taps: [tap] });
+    await engine.init();
+    const done = new RealtimeClock({
+      speed: 2,
+      now: () => times[Math.min(i++, times.length - 1)],
+      schedule: sched.schedule,
+    }).run((t) => engine.tick(t), () => dts.length >= 4);
+    sched.flush(10);
+    await done;
+    expect(dts[0]).toBe(0); // tick-0 dt forced to 0
+    // Each subsequent real frame is `step`; at speed 2 the engine sees 2*step.
+    expect(dts[1]).toBeCloseTo(2 * step, 10);
+    expect(dts[2]).toBeCloseTo(2 * step, 10);
+    expect(dts[3]).toBeCloseTo(2 * step, 10);
+  });
+
+  it('batch and a perfectly-paced realtime(speed 1) yield an identical ctx.dt stream', async () => {
+    // The seam M-B exists to protect: swap the clock, don't touch the engine.
+    const nominalDt = 1 / 60;
+    const N = 5;
+
+    const batch = capture();
+    const be = new Engine(spec, registryWith(), { taps: [batch.tap], nominalDt });
+    await be.init();
+    // (t) => engine.tick(t): BatchClock passes no arg, so t is undefined and the
+    // engine synthesizes time — this also exercises the tick-forwarding path.
+    await new BatchClock(N).run((t) => be.tick(t), () => false);
+
+    const sched = fakeScheduler();
+    // A flawless real clock ticking exactly nominalDt per frame reproduces the
+    // batch times: base=0, t = k*nominalDt.
+    const times = Array.from({ length: N }, (_, k) => k * nominalDt);
+    let i = 0;
+    const paced = capture();
+    const pe = new Engine(spec, registryWith(), { taps: [paced.tap], nominalDt });
+    await pe.init();
+    const done = new RealtimeClock({
+      speed: 1,
+      now: () => times[Math.min(i++, times.length - 1)],
+      schedule: sched.schedule,
+    }).run((t) => pe.tick(t), () => paced.dts.length >= N);
+    sched.flush(N + 2);
+    await done;
+
+    expect(batch.dts).toHaveLength(N);
+    expect(paced.dts).toEqual(batch.dts);
+  });
+});


### PR DESCRIPTION
Closes #103. Stream Applier milestone **M-B** (#101). Design: `docs/design/stream-applier.md` → Clock section + M-B.

## What
The execution-mode seam — the one place pacing lives — so batch-vs-paced execution swaps **without touching the engine** (`tick(time?)` already accepts explicit or synthesized time).

- **`src/dag/clock.ts`**
  - `Clock` — `run(onTick, shouldStop)`.
  - `BatchClock(ticks)` — as-fast-as-possible, deterministic; calls `onTick()` with **no arg** so the engine synthesizes `tickIndex*nominalDt` (goldens depend on it).
  - `RealtimeClock({speed, now, schedule})` — wall-clock paced with a speed multiplier; base-seeded so engine time starts at the first frame and advances `speed×`. `now`/`schedule` injectable (fully headless-testable); `requestAnimationFrame` referenced lazily so Node import is safe.
- **`runHeadless`** refit onto `BatchClock` — **fixture goldens byte-identical** (fixture_replay/dag_core/music_logic/conductor all green).
- **`test/clock.test.ts`** — 9 tests: batch determinism/early-stop, realtime time-mapping, **speed×2 doubles `ctx.dt`** end-to-end, and a **batch-vs-paced dt-parity** test (the exact seam M-B protects).

## Scope decision (validated by review)
The live **`useEngine` rAF adoption of `RealtimeClock` is deferred to M-D** — the architecture review flagged that effect as an untested live surface to gate on a browser smoke test, and it can't be verified headlessly now. M-B ships the abstraction + the fully-tested `BatchClock` path + a headless `RealtimeClock`. The design doc M-B/M-D bullets were corrected to match this split.

## Adversarial review
2-lens review before PR: **ship after a 2-line doc-truthfulness fix** (applied) — no code bugs. Folded in the dt-parity test it recommended and documented the `speed<=0` caveat (validation deferred to M-D adoption).

## Verify
typecheck ✓ · 438 vitest (+9 clock) ✓ · build ✓ · catalog ✓. All headless.

https://claude.ai/code/session_01JEoe7y1hA5KdEAvvpQXxxt