### PR TITLE
feat(commands): discrete panel writes → registry.dispatch (#87 Phase 1)

### DIFF
--- a/src/app/commands/instruments.ts
+++ b/src/app/commands/instruments.ts
@@ -1,0 +1,64 @@
+/**
+ * Instrument commands (#87 Phase 1) — load / save / create a named instrument as
+ * `acture` commands, so the settings panel's DISCRETE instrument actions go
+ * through the one dispatch surface (alongside the palette + future hotkeys/AI)
+ * instead of calling the orchestration directly.
+ *
+ * The #87 design lists "apply / save / load an instrument or preset" as commands
+ * (a param-mutation of the whole dials layer), distinct from the per-tick / audio
+ * path which is never a command. Handlers reach state ONLY through the dials
+ * layer's orchestration (`@/app/dials/instruments`), which writes the dials store
+ * (`setLayer` / `markSaved`) — so the import firewall holds. The React-only
+ * bookkeeping (the optimistic highlight + list refresh) stays in the
+ * `useInstruments` hook, which dispatches these.
+ */
+import { z } from 'zod';
+import { defineCommand, ok, err } from 'acture';
+import { selectInstrument, commitToInstrument, setSelectedName } from '@/app/dials/instruments';
+
+/** Load a saved instrument as the current sound and make it the clean baseline. */
+export const loadInstrumentCmd = defineCommand({
+  id: 'instrument.load',
+  title: 'Load instrument',
+  description: 'Load a saved instrument as the current sound.',
+  category: 'Instruments',
+  params: z.object({ name: z.string().min(1).describe('The instrument name to load.') }),
+  execute: async ({ name }) => {
+    const layer = await selectInstrument(name);
+    if (!layer) return err('instrument_not_found', `No instrument named "${name}".`, { name });
+    setSelectedName(name); // persist the selection only once the load succeeded
+    return ok({ name });
+  },
+});
+
+/** Overwrite a saved instrument with the current working layer (clears dirty). */
+export const saveInstrumentCmd = defineCommand({
+  id: 'instrument.save',
+  title: 'Save instrument',
+  description: 'Overwrite a saved instrument with the current settings.',
+  category: 'Instruments',
+  params: z.object({ name: z.string().min(1).describe('The instrument name to overwrite.') }),
+  execute: async ({ name }) => {
+    await commitToInstrument(name);
+    return ok({ name });
+  },
+});
+
+/** Save the current working layer as a NEW named instrument and select it. */
+export const createInstrumentCmd = defineCommand({
+  id: 'instrument.create',
+  title: 'Create instrument',
+  description: 'Save the current settings as a new named instrument.',
+  category: 'Instruments',
+  params: z.object({ name: z.string().min(1).describe('The new instrument name.') }),
+  execute: async ({ name }) => {
+    const trimmed = name.trim();
+    if (!trimmed) return err('empty_name', 'An instrument name is required.', { name });
+    await commitToInstrument(trimmed); // save the working layer under the new name
+    setSelectedName(trimmed);
+    return ok({ name: trimmed });
+  },
+});
+
+/** All instrument commands, registered together. */
+export const INSTRUMENT_COMMANDS = [loadInstrumentCmd, saveInstrumentCmd, createInstrumentCmd] as const;

--- a/src/app/commands/registry.ts
+++ b/src/app/commands/registry.ts
@@ -12,13 +12,16 @@
 import { createRegistry, type Registry } from 'acture';
 import { DIAL_COMMANDS } from './dials';
 import { DIAL_FIELD_COMMANDS } from './perDial';
+import { INSTRUMENT_COMMANDS } from './instruments';
 
-/** Build a registry with all thoremin commands registered: the generic dial verbs
- *  plus one typed `set` command per dial, generated from the dials SSOT. */
+/** Build a registry with all thoremin commands registered: the generic dial verbs,
+ *  one typed `set` command per dial (generated from the dials SSOT), and the
+ *  instrument load/save/create commands. */
 export function createThoreminRegistry(): Registry {
   const r = createRegistry();
   r.registerAll(DIAL_COMMANDS);
   r.registerAll(DIAL_FIELD_COMMANDS);
+  r.registerAll(INSTRUMENT_COMMANDS);
   return r;
 }
 

--- a/src/app/dials/DialsControlsPanel.tsx
+++ b/src/app/dials/DialsControlsPanel.tsx
@@ -24,6 +24,7 @@ import { EXPRESSIONS, EMOTIONS, DEFAULT_EXPRESSION_TO_DEGREE, SILENCE_DEGREE } f
 import { OVERLAY_ELEMENTS, OVERLAY_CATEGORIES, type OverlayParams } from '@/nodes/output/canvas_overlay';
 import type { FaceMapping } from '@/nodes';
 import { useControls } from '../store';
+import { dispatchDialSet } from '../dispatchDial';
 import { OVERLAY_CONTROLS, type OverlayControlDesc } from '../overlayControls';
 import { ExpressionHelpButton } from '../ExpressionHelpPanel';
 import { POSE_MOVES } from '../poseControlsHelp';
@@ -570,7 +571,7 @@ function FaceControls() {
         <select
           className={selectCls}
           value={faceMapping}
-          onChange={(e) => set('face.mapping', e.target.value as FaceMapping)}
+          onChange={(e) => dispatchDialSet('face.mapping', e.target.value as FaceMapping)}
         >
           {FACE_MODE_OPTIONS.map((o) => (
             <option key={o.value} value={o.value} disabled={needsSevenNote(o.value) && !sevenNote}>
@@ -770,7 +771,7 @@ export default function DialsControlsPanel() {
           />
         </label>
         <label className="flex items-center gap-2 text-xs">
-          <input type="checkbox" checked={syncHands} onChange={(e) => set('master.syncHands', e.target.checked)} />
+          <input type="checkbox" checked={syncHands} onChange={(e) => dispatchDialSet('master.syncHands', e.target.checked)} />
           Sync both hands
         </label>
         <VoiceControls side="right" />

--- a/src/app/dials/useInstruments.ts
+++ b/src/app/dials/useInstruments.ts
@@ -17,13 +17,12 @@ import type { ProfileMeta } from '@zodal/dials-ui';
 import {
   instruments,
   LAST_MODIFIED,
-  setSelectedName,
-  selectInstrument,
-  commitToInstrument,
   restoreSession,
   getDefaultName,
   setDefaultName,
 } from './instruments';
+import { registry } from '@/app/commands/registry';
+import { useToasts } from '@/app/toasts';
 
 export interface InstrumentsApi {
   /** Named instruments (excludes the reserved LAST_MODIFIED legacy autosave). */
@@ -76,17 +75,21 @@ export function useInstruments(): InstrumentsApi {
     };
   }, [refresh]);
 
+  // The DISCRETE instrument actions now go through the command registry (#87
+  // Phase 1) — the single write path shared with the palette/hotkeys/AI. The
+  // command owns the mutation (dials layer + persisted selection); the hook keeps
+  // only the React bookkeeping (the optimistic highlight, the revert, the list
+  // refresh) and surfaces a failure as a toast.
   const select = useCallback(
     (name: string) => {
       const prev = selectedRef.current;
-      setSelected(name);
-      setSelectedName(name); // immediate feedback (tw-frontend-ux #1)
-      void selectInstrument(name).then((layer) => {
-        if (layer) return;
-        // The instrument vanished (e.g. removed in another tab) — undo the optimistic pick.
+      setSelected(name); // optimistic highlight (tw-frontend-ux #1)
+      void registry.dispatch('instrument.load', { name }).then((result) => {
+        if (result.ok) return; // the command persisted the selection
+        // The instrument vanished (e.g. removed in another tab) — undo the pick.
         setSelected(prev);
-        setSelectedName(prev ?? '');
         refresh();
+        useToasts.getState().push(result.error.message, 5000, 'error');
       });
     },
     [refresh],
@@ -94,7 +97,8 @@ export function useInstruments(): InstrumentsApi {
 
   const save = useCallback(
     async (name: string) => {
-      await commitToInstrument(name);
+      const result = await registry.dispatch('instrument.save', { name });
+      if (!result.ok) useToasts.getState().push(result.error.message, 5000, 'error');
       refresh();
     },
     [refresh],
@@ -104,9 +108,12 @@ export function useInstruments(): InstrumentsApi {
     async (name: string) => {
       const trimmed = name.trim();
       if (!trimmed) return;
-      await commitToInstrument(trimmed); // saves the current working layer under the new name
+      const result = await registry.dispatch('instrument.create', { name: trimmed });
+      if (!result.ok) {
+        useToasts.getState().push(result.error.message, 5000, 'error');
+        return;
+      }
       setSelected(trimmed);
-      setSelectedName(trimmed);
       refresh();
     },
     [refresh],

--- a/src/app/dispatchDial.ts
+++ b/src/app/dispatchDial.ts
@@ -1,0 +1,29 @@
+/**
+ * dispatchDialSet — route a settings panel's DISCRETE dial write (a mode/sync
+ * toggle, a select) through the command registry (#87 Phase 1), the single write
+ * path shared with the palette / hotkeys / AI. A failure surfaces as a toast.
+ *
+ * This is fire-and-forget: a discrete toggle does not need to await, and the
+ * controlled input re-derives from the store once the dial lands. Panel
+ * **live-drag** (sliders, continuous inputs) deliberately stays a direct
+ * `setDial` for latency (Decision B) and does NOT use this.
+ *
+ * It lives outside `src/app/commands/` on purpose: it imports the toast store,
+ * which the command import-firewall forbids inside a command. Commands stay pure
+ * (they only write a dial); this is a UI-layer dispatcher.
+ *
+ * Phase-1 scope: only the two named mode/sync controls (`face.mapping`,
+ * `master.syncHands`) are rerouted through here. The other one-shot `<select>`s
+ * (voice sound/root/scale, chord sound/voicing/rendering, overlay position, …)
+ * are discrete by the same logic but are DEFERRED — they stay a direct `set()`
+ * for now, to be swept in a follow-up once this pattern is proven.
+ */
+import { registry } from './commands/registry';
+import { useToasts } from './toasts';
+
+/** Dispatch `dial.set` for a discrete panel write, toasting a validation error. */
+export function dispatchDialSet(key: string, value: unknown): void {
+  void registry.dispatch('dial.set', { key, value }).then((result) => {
+    if (!result.ok) useToasts.getState().push(result.error.message, 5000, 'error');
+  });
+}

--- a/test/commands_instruments.test.ts
+++ b/test/commands_instruments.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Instrument commands (#87 Phase 1): loading / saving / creating a named
+ * instrument via `registry.dispatch` mutates the dials store exactly as the
+ * direct orchestration did, and reports success/failure as data. The profile
+ * store falls back to in-memory storage in Node, so this runs headlessly. The
+ * import firewall over these command files is covered by commands_firewall.test.
+ */
+import { describe, it, expect } from 'vitest';
+import { createThoreminRegistry } from '@/app/commands/registry';
+import { ensureSeeded, instruments, LAST_MODIFIED } from '@/app/dials/instruments';
+import { dialsStore } from '@/app/dials/settingsStore';
+
+const reg = createThoreminRegistry();
+const namedInstruments = async () =>
+  (await instruments.list()).filter((p) => p.name !== LAST_MODIFIED).map((p) => p.name);
+
+describe('instrument commands (#87 Phase 1)', () => {
+  it('instrument.load loads the layer as a clean baseline and returns ok', async () => {
+    await ensureSeeded();
+    const r = await reg.dispatch('instrument.load', { name: 'Split Voices' });
+    expect(r.ok).toBe(true);
+    const s = dialsStore.getState();
+    expect(s.effective['right.type']).toBe('major');
+    expect(s.effective['right.sound']).toBe('organ');
+    expect(s.dirty.length).toBe(0);
+  });
+
+  it('instrument.load errors for a missing instrument, leaving the store unchanged', async () => {
+    await ensureSeeded();
+    await reg.dispatch('instrument.load', { name: 'Pentatonic' });
+    const before = dialsStore.getState().effective['right.type'];
+    const r = await reg.dispatch('instrument.load', { name: 'Does Not Exist' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.code).toBe('instrument_not_found');
+    expect(dialsStore.getState().effective['right.type']).toBe(before);
+  });
+
+  it('instrument.save overwrites the named instrument and clears dirty', async () => {
+    await ensureSeeded();
+    await reg.dispatch('instrument.load', { name: 'Split Voices' });
+    dialsStore.set('master.volume', 0.9);
+    expect(dialsStore.getState().dirty.length).toBeGreaterThan(0);
+    const r = await reg.dispatch('instrument.save', { name: 'Split Voices' });
+    expect(r.ok).toBe(true);
+    expect(dialsStore.getState().dirty.length).toBe(0);
+    const reloaded = await instruments.load('Split Voices');
+    expect(reloaded?.['master.volume']).toBe(0.9);
+  });
+
+  it('instrument.create saves the working layer as a new (trimmed) named instrument', async () => {
+    await ensureSeeded();
+    await reg.dispatch('instrument.load', { name: 'Pentatonic' });
+    dialsStore.set('master.volume', 0.42);
+    const r = await reg.dispatch<{ name: string }>('instrument.create', { name: '  My New Inst  ' });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value.name).toBe('My New Inst'); // trimmed
+    expect(await namedInstruments()).toContain('My New Inst');
+    const saved = await instruments.load('My New Inst');
+    expect(saved?.['master.volume']).toBe(0.42);
+  });
+
+  it('instrument.create rejects a whitespace-only name', async () => {
+    const r = await reg.dispatch('instrument.create', { name: '   ' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('instrument.create on an existing name overwrites it (documents current behavior)', async () => {
+    // Save-as does not guard duplicates today — creating with an existing name
+    // clobbers it (same as the pre-Phase-1 hook). Pinned here; whether the UI
+    // should warn on a duplicate is a deferred product decision, not Phase 1.
+    await ensureSeeded();
+    await reg.dispatch('instrument.load', { name: 'Split Voices' });
+    dialsStore.set('master.volume', 0.271);
+    const r = await reg.dispatch('instrument.create', { name: 'Split Voices' });
+    expect(r.ok).toBe(true);
+    const reloaded = await instruments.load('Split Voices');
+    expect(reloaded?.['master.volume']).toBe(0.271);
+  });
+});


### PR DESCRIPTION
Part of #87 (**Phase 1** — the hard cut). Builds on the merged command-dispatch foundation (#97/#98).

## What
The settings panel's **discrete** writes now go through the `acture` command registry — the single write path shared with the palette / future hotkeys / AI — while **live-drag stays a direct `setDial`** for latency (Decision B).

- **`instrument.load` / `instrument.save` / `instrument.create`** commands (`src/app/commands/instruments.ts`) — firewall-clean (import only the dials-layer orchestration). `useInstruments`' `select`/`save`/`create` now dispatch these; the hook keeps only React bookkeeping (optimistic highlight, revert, refresh) + toasts failures. `setSelectedName` moved into the load command (on success) — removing the old optimistic-persist-then-revert.
- **Face-mapping mode select + sync-hands toggle** → `dispatchDialSet` (`src/app/dispatchDial.ts`, a UI-layer dispatcher kept out of `commands/` so it can toast). Volume + all continuous controls stay direct.
- **6 headless instrument-command tests**; the existing firewall test auto-covers the new command file.

## Scope
Phase 1 = the two named mode/sync controls + instrument load/save/create. Other one-shot `<select>`s (voice/chord/overlay) are discrete by the same logic but **deferred to a follow-up** (noted in `dispatchDial.ts`). No reset control exists in the panel, so `dial.reset` has nothing to reroute.

## Adversarial review
2-lens review before PR: **ship-as-is, no must-fixes.** Confirmed: no controlled-input flicker (`dispatch` runs `dial.set`'s synchronous `execute`→`setDial` before its first `await`, so the store write lands in the same tick as the old direct `set()`); no lingering direct-mutation bypass (strangler-fig check); and completeness (no missed discrete write / reset action / mis-classification). Folded in the scope note + a create-overwrite documentation test it recommended.

## Not covered (later)
Sweeping the remaining discrete selects; `#90` hotkeys (raw tinykeys) and Phase 3 AI are separate.

## Verify
typecheck ✓ · 444 vitest (+6) ✓ · build ✓ · catalog ✓. The live hook/panel handlers are browser-only (statically verified; runnable camera-free via M-A's `?source=video`).

https://claude.ai/code/session_01JEoe7y1hA5KdEAvvpQXxxt