### PR TITLE
AI assistant (#87 Phase 3): operate the instrument via the command registry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "thoremin",
       "version": "0.0.0",
       "dependencies": {
+        "@ai-sdk/anthropic": "^1.2.12",
+        "@ai-sdk/google": "^1.2.22",
+        "@ai-sdk/openai": "^1.3.24",
         "@google/genai": "^1.29.0",
         "@mediapipe/hands": "^0.4.1675469240",
         "@mediapipe/tasks-vision": "^0.10.35",
@@ -24,8 +27,10 @@
         "@zodal/store-localstorage": "^0.1.0",
         "@zodal/ui": "^0.1.2",
         "acture": "^1.3.0",
+        "acture-ai-vercel": "^1.1.0",
         "acture-forms-autoform": "^1.0.1",
         "acture-palette-react": "^1.0.0",
+        "ai": "^4.3.19",
         "cmdk": "^1.1.1",
         "lucide-react": "^0.546.0",
         "motion": "^12.23.24",
@@ -45,6 +50,124 @@
         "typescript": "~5.8.2",
         "vite": "^6.2.0",
         "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-1.2.12.tgz",
+      "integrity": "sha512-YSzjlko7JvuiyQFmI9RN1tNZdEiZxc+6xld/0tq/VkJaHpEzGAb1yiNxxvmYVcjvfu/PcvCxAAYXmTYQQ63IHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      }
+    },
+    "node_modules/@ai-sdk/google": {
+      "version": "1.2.22",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-1.2.22.tgz",
+      "integrity": "sha512-Ppxu3DIieF1G9pyQ5O1Z646GYR0gkC57YdBqXJ82qvCdhEhZHu0TWhmnOoeIWe2olSbuDeoOY+MfJrW8dzS3Hw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      }
+    },
+    "node_modules/@ai-sdk/openai": {
+      "version": "1.3.24",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-1.3.24.tgz",
+      "integrity": "sha512-GYXnGJTHRTZc4gJMSmFRgEQudjqd4PUN0ZjQhPwOAYH1yOAvQoG/Ikqs+HyISRbLPCrhbZnPKCNHuRU4OfpW0Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.1.3.tgz",
+      "integrity": "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.2.8.tgz",
+      "integrity": "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "nanoid": "^3.3.8",
+        "secure-json-parse": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@ai-sdk/react": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-1.2.12.tgz",
+      "integrity": "sha512-jK1IZZ22evPZoQW3vlkZ7wvjYGYF+tRBKXtrcolduIkQ/m/sOAVcVeVDUDvh1T91xCnWCdUGCPZg2avZ90mv3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider-utils": "2.2.8",
+        "@ai-sdk/ui-utils": "1.2.11",
+        "swr": "^2.2.5",
+        "throttleit": "2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ai-sdk/ui-utils": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/ui-utils/-/ui-utils-1.2.11.tgz",
+      "integrity": "sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.23.8"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -822,6 +945,15 @@
       "resolved": "https://registry.npmjs.org/@mediapipe/tasks-vision/-/tasks-vision-0.10.35.tgz",
       "integrity": "sha512-HOvadwVRE6JC+45nyYhmnywnr5h/J8KZvOeUNVOG9q/0875pZgItznFB9bRTvLc264YSJqiZ1NsIpCStJw/egg==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -2313,6 +2445,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/diff-match-patch": {
+      "version": "1.0.36",
+      "resolved": "https://registry.npmjs.org/@types/diff-match-patch/-/diff-match-patch-1.0.36.tgz",
+      "integrity": "sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2562,6 +2700,17 @@
         "zod": "^4.0.0"
       }
     },
+    "node_modules/acture-ai-vercel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/acture-ai-vercel/-/acture-ai-vercel-1.1.0.tgz",
+      "integrity": "sha512-VFo+RvP31DcTNPc/tvtg2HdHTUdtBrRliPBueBuRbzN8g0zfHZgfpykbIRXd81iKxSobZgfvT+ubbM64QO2y+A==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "acture": "^1.0.0",
+        "ai": "^4.0.0",
+        "zod": "^4.0.0"
+      }
+    },
     "node_modules/acture-forms-autoform": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/acture-forms-autoform/-/acture-forms-autoform-1.0.1.tgz",
@@ -2591,6 +2740,32 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/ai": {
+      "version": "4.3.19",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-4.3.19.tgz",
+      "integrity": "sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8",
+        "@ai-sdk/react": "1.2.12",
+        "@ai-sdk/ui-utils": "1.2.11",
+        "@opentelemetry/api": "1.9.0",
+        "jsondiffpatch": "0.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-regex": {
@@ -2818,6 +2993,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/check-error": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
@@ -2924,6 +3111,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2938,6 +3134,12 @@
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
+    },
+    "node_modules/diff-match-patch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
+      "license": "Apache-2.0"
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -3401,6 +3603,12 @@
         "bignumber.js": "^9.0.0"
       }
     },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -3411,6 +3619,23 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsondiffpatch": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/jsondiffpatch/-/jsondiffpatch-0.6.0.tgz",
+      "integrity": "sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/diff-match-patch": "^1.0.36",
+        "chalk": "^5.3.0",
+        "diff-match-patch": "^1.0.5"
+      },
+      "bin": {
+        "jsondiffpatch": "bin/jsondiffpatch.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
       }
     },
     "node_modules/jwa": {
@@ -4221,6 +4446,12 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
+    "node_modules/secure-json-parse": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/seedrandom": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
@@ -4415,6 +4646,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/swr": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.2.tgz",
+      "integrity": "sha512-ej644Y2bvkIajfR32KGeSSdBXQW+ScjGjkybZgSE7kFpk9eGnV44XY9FJylXi+W75pavSX1PVNB57W5EbhGIYw==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
@@ -4432,6 +4676,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tinybench": {
@@ -4657,6 +4913,15 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/vite": {
@@ -5474,6 +5739,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/zustand": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "catalog": "vite-node scripts/gen_catalog.ts"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^1.2.12",
+    "@ai-sdk/google": "^1.2.22",
+    "@ai-sdk/openai": "^1.3.24",
     "@google/genai": "^1.29.0",
     "@mediapipe/hands": "^0.4.1675469240",
     "@mediapipe/tasks-vision": "^0.10.35",
@@ -32,8 +35,10 @@
     "@zodal/store-localstorage": "^0.1.0",
     "@zodal/ui": "^0.1.2",
     "acture": "^1.3.0",
+    "acture-ai-vercel": "^1.1.0",
     "acture-forms-autoform": "^1.0.1",
     "acture-palette-react": "^1.0.0",
+    "ai": "^4.3.19",
     "cmdk": "^1.1.1",
     "lucide-react": "^0.546.0",
     "motion": "^12.23.24",
@@ -53,5 +58,8 @@
     "typescript": "~5.8.2",
     "vite": "^6.2.0",
     "vitest": "^3.0.0"
+  },
+  "overrides": {
+    "zod": "$zod"
   }
 }

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -19,6 +19,7 @@ import { useFaceStatus } from './faceStatus';
 import InstrumentsPanel from './dials/InstrumentsPanel';
 import Toaster from './Toaster';
 import CommandPaletteOverlay from './CommandPaletteOverlay';
+import AssistantOverlay from '@/plugins/assistant/AssistantOverlay';
 import VersionBadge from './VersionBadge';
 
 /** A compact face-status chip, visible even when the controls panel is collapsed
@@ -180,6 +181,10 @@ export default function App({ source = DEFAULT_SOURCE }: { source?: SourceSpec }
 
       {/* Cmd/Ctrl-K command palette — set any dial by name (#87). */}
       <CommandPaletteOverlay />
+
+      {/* AI assistant — chat that parametrizes the instrument via the same command
+          registry, behind a BYO-key multi-provider client-side backend (#87 Phase 3). */}
+      <AssistantOverlay />
 
       {/* Unobtrusive "what's deployed" badge (commit + date), read from /_meta. */}
       <VersionBadge />

--- a/src/app/commands/confirmation.ts
+++ b/src/app/commands/confirmation.ts
@@ -1,0 +1,120 @@
+/**
+ * Confirmation gate for destructive commands (#87 Phase 3) — the human-in-the-loop
+ * boundary for the AI assistant. Following acture's `hand-written-assistant-runtime`
+ * pattern: risk is an EXTERNAL convention (`getRisk`, keyed by command id) so the
+ * closed `CommandRecord` stays closed, and the gate WRAPS `registry.dispatch`.
+ *
+ * A destructive command dispatched on the ASSISTANT surface (`context.channel ===
+ * 'assistant'`) does not run — it returns a `confirmation_required` Result (errors-as-
+ * data, carrying `{command, params}` and NO token). The runtime turns that into an
+ * approve/deny card; only when a HUMAN approves does it mint a one-use token and
+ * re-dispatch. The token is never handed back to the model, so the model can never
+ * self-approve. Human dispatches (palette / hotkeys — no assistant channel) pass
+ * through ungated, so this is invisible to every non-AI surface.
+ */
+import { err, type Registry, type Result } from 'acture';
+
+/** A rough risk class for a command; only `destructive` gates by default. */
+export type SideEffect = 'query' | 'additive' | 'destructive';
+
+/** Risk metadata for one command — a convention, not a `CommandRecord` field. */
+export interface RiskMeta {
+  sideEffect?: SideEffect;
+  /** Force (or waive) confirmation regardless of `sideEffect`. */
+  requiresConfirmation?: boolean;
+}
+
+/** The thoremin commands that mutate SAVED state (not just the live working layer),
+ *  so they need the user's approval when the assistant proposes them:
+ *   - instrument.load  discards unsaved edits in the current working layer
+ *   - instrument.save  overwrites an existing saved instrument
+ *   - instrument.create commits under a name (a collision clobbers a saved instrument) */
+const DESTRUCTIVE_COMMANDS = new Set<string>(['instrument.load', 'instrument.save', 'instrument.create']);
+
+/** The default thoremin risk map: destructive for the instrument mutations above,
+ *  additive for reversible dial edits, query for everything else. */
+export function defaultGetRisk(id: string): RiskMeta {
+  if (DESTRUCTIVE_COMMANDS.has(id)) return { sideEffect: 'destructive' };
+  return { sideEffect: id.startsWith('dial.') ? 'additive' : 'query' };
+}
+
+/** One-use approval token store. `approve` is called by the runtime AFTER a human
+ *  approves (never by the model); `consume` is called by the gate on re-dispatch and
+ *  is valid only for the exact `{command, params}` it was minted for. */
+export interface ApprovalStore {
+  approve(command: string, params: unknown): string;
+  consume(token: string, command: string, params: unknown): boolean;
+}
+
+function randomToken(): string {
+  return globalThis.crypto?.randomUUID?.() ?? `tok_${Math.random().toString(36).slice(2)}${Date.now?.() ?? ''}`;
+}
+
+/** Build a fresh one-use approval store. */
+export function createApprovalStore(): ApprovalStore {
+  const issued = new Map<string, string>(); // token → key(command, params)
+  const key = (command: string, params: unknown) => `${command} ${JSON.stringify(params ?? null)}`;
+  return {
+    approve(command, params) {
+      const token = randomToken();
+      issued.set(token, key(command, params));
+      return token;
+    },
+    consume(token, command, params) {
+      if (issued.get(token) !== key(command, params)) return false;
+      issued.delete(token); // one-use
+      return true;
+    },
+  };
+}
+
+/** The dispatch-context fields the gate reads. `channel:'assistant'` marks an
+ *  AI-originated dispatch; `approvedToken` is the one-use token minted after approval. */
+export interface AssistantDispatchContext {
+  channel?: string;
+  approvedToken?: string;
+  [k: string]: unknown;
+}
+
+/** The shape of `registry.dispatch` the gate wraps (a local alias, not an acture export).
+ *  Trailing args (acture's `options`, e.g. an internal token) are forwarded untouched. */
+type Dispatch = (command: string, params?: unknown, context?: unknown, ...rest: unknown[]) => Promise<Result<unknown>>;
+
+/**
+ * Build a dispatch middleware that gates destructive commands on the assistant surface.
+ * A gated call without a valid one-use token returns a `confirmation_required` Result
+ * (no token in it); everything else — non-destructive commands, and ALL non-assistant
+ * dispatches — passes straight through to `next`.
+ */
+export function confirmationGate(
+  getRisk: (id: string) => RiskMeta,
+  approvals: ApprovalStore,
+): (next: Dispatch) => Dispatch {
+  return (next) => async (command, params, context, ...rest) => {
+    const risk = getRisk(command);
+    const needs = risk.requiresConfirmation ?? risk.sideEffect === 'destructive';
+    const ctx = context as AssistantDispatchContext | undefined;
+    if (!needs || ctx?.channel !== 'assistant') return next(command, params, context, ...rest);
+    if (ctx.approvedToken && approvals.consume(ctx.approvedToken, command, params)) {
+      return next(command, params, context, ...rest);
+    }
+    return err('confirmation_required', `"${command}" needs your approval before it runs.`, { command, params });
+  };
+}
+
+/**
+ * Install the confirmation gate onto a registry by reassigning its `dispatch` in place
+ * (the same idiom acture's `recordSequence` uses). Returns the `ApprovalStore` the
+ * runtime uses to mint tokens on human approval. Idempotent per registry is NOT
+ * guaranteed — call once per registry.
+ */
+export function installConfirmationGate(
+  registry: Registry,
+  options: { getRisk?: (id: string) => RiskMeta; approvals?: ApprovalStore } = {},
+): { approvals: ApprovalStore } {
+  const getRisk = options.getRisk ?? defaultGetRisk;
+  const approvals = options.approvals ?? createApprovalStore();
+  const original = registry.dispatch.bind(registry) as Dispatch;
+  registry.dispatch = confirmationGate(getRisk, approvals)(original) as typeof registry.dispatch;
+  return { approvals };
+}

--- a/src/app/commands/dials.ts
+++ b/src/app/commands/dials.ts
@@ -16,8 +16,39 @@
 import { z } from 'zod';
 import { defineCommand, ok, err, type Result } from 'acture';
 import type { SettingKey } from '@zodal/dials-core';
-import { dialsStore, setDial, resetDial } from '@/app/dials/settingsStore';
+import { dialsStore, setDial, resetDial, fieldByKey } from '@/app/dials/settingsStore';
 import { thoreminDials, layerToSettings } from '@/settings/dials';
+
+/** A dial value on the generic verbs — a JSON-Schema-representable union (string, number,
+ *  or boolean), NOT `z.unknown()`. The `z.unknown()`/`z.tuple()` shapes emit an untyped
+ *  (`{}`) or tuple-`items` JSON Schema that Gemini's function-calling validator rejects
+ *  ("items.items: missing field"); a plain union of scalars is accepted by every provider.
+ *  Structured dials aren't set through these verbs, so scalars cover the whole surface. */
+const DIAL_VALUE = z.union([z.string(), z.number(), z.boolean()]);
+
+/**
+ * Coerce a STRING value to the dial's declared scalar type. The palette's typed inputs and
+ * the app's programmatic callers already pass a number/boolean, so those pass through
+ * untouched; but an AI model often sends a numeric/boolean dial as a STRING ("0.3", "true"),
+ * so we convert it against the dial's SSOT type before validation. An unparseable string is
+ * left as-is, so the downstream settings-schema check reports it as `invalid_value`.
+ */
+function coerceDialValue(key: string, value: unknown): unknown {
+  if (typeof value !== 'string') return value;
+  const field = fieldByKey[key];
+  if (!field || field.enumValues?.length) return value; // enum members are strings
+  if (field.zodType === 'number') {
+    const n = Number(value);
+    return value.trim() !== '' && !Number.isNaN(n) ? n : value;
+  }
+  if (field.zodType === 'boolean') {
+    const t = value.trim().toLowerCase();
+    if (t === 'true' || t === '1') return true;
+    if (t === 'false' || t === '0') return false;
+    return value;
+  }
+  return value; // a string dial
+}
 
 /** The DECLARED dial keyspace — the SSOT for "is this a real dial". Keyed off the
  *  dials definition, NOT the resolved `effective` map (which omits any future
@@ -55,10 +86,11 @@ function invalidWritesReason(writes: ReadonlyArray<readonly [string, unknown]>):
  */
 export function applyDialSet(key: string, value: unknown): Result<{ key: string; value: unknown }> {
   if (!isDial(key)) return err('unknown_dial', `No dial named "${key}".`, { key });
-  const reason = invalidWritesReason([[key, value]]);
-  if (reason) return err('invalid_value', `Invalid value for "${key}": ${reason}`, { key, value });
-  setDial(key as SettingKey, value);
-  return ok({ key, value });
+  const coerced = coerceDialValue(key, value);
+  const reason = invalidWritesReason([[key, coerced]]);
+  if (reason) return err('invalid_value', `Invalid value for "${key}": ${reason}`, { key, value: coerced });
+  setDial(key as SettingKey, coerced);
+  return ok({ key, value: coerced });
 }
 
 /** Set one dial to a value. The value is validated against the settings schema before
@@ -71,7 +103,7 @@ export const setDialCmd = defineCommand({
   category: 'Dials',
   params: z.object({
     key: z.string().describe('The dial key, e.g. "right.baseOctave" or "face.mapping".'),
-    value: z.unknown().describe('The new value for that dial.'),
+    value: DIAL_VALUE.describe('The new value: a number, a boolean, or a string (an enum member / note name, or a stringified number that is coerced to the dial\'s type).'),
   }),
   execute: ({ key, value }) => applyDialSet(key, value),
 });
@@ -102,15 +134,21 @@ export const patchDialsCmd = defineCommand({
   category: 'Dials',
   params: z.object({
     writes: z
-      .array(z.tuple([z.string(), z.unknown()]))
-      .describe('Ordered [key, value] writes, applied in sequence.'),
+      .array(
+        z.object({
+          key: z.string().describe('The dial key.'),
+          value: DIAL_VALUE.describe('The new value (number/boolean/string, coerced to the dial\'s type).'),
+        }),
+      )
+      .describe('An ordered list of { key, value } dial writes, applied in sequence.'),
   }),
   execute: ({ writes }) => {
-    const bad = writes.find(([k]) => !isDial(k));
-    if (bad) return err('unknown_dial', `No dial named "${bad[0]}".`, { key: bad[0] });
-    const reason = invalidWritesReason(writes);
+    const bad = writes.find((w) => !isDial(w.key));
+    if (bad) return err('unknown_dial', `No dial named "${bad.key}".`, { key: bad.key });
+    const pairs = writes.map((w) => [w.key, coerceDialValue(w.key, w.value)] as [string, unknown]);
+    const reason = invalidWritesReason(pairs);
     if (reason) return err('invalid_value', `Invalid dial values: ${reason}`, { writes });
-    for (const [k, v] of writes) setDial(k as SettingKey, v);
+    for (const [k, v] of pairs) setDial(k as SettingKey, v);
     return ok({ count: writes.length });
   },
 });

--- a/src/app/commands/index.ts
+++ b/src/app/commands/index.ts
@@ -4,6 +4,17 @@
  * command definitions. See `dials.ts` for the hard command/hot-path boundary and
  * `test/commands_firewall.test.ts` for the import firewall that enforces it.
  */
-export { registry, createThoreminRegistry } from './registry';
+export { registry, createThoreminRegistry, approvals } from './registry';
 export { DIAL_COMMANDS, setDialCmd, resetDialCmd, patchDialsCmd, applyDialSet } from './dials';
 export { DIAL_FIELD_COMMANDS, generateDialCommands, setCommandIdFor } from './perDial';
+export { INSTRUMENT_COMMANDS, loadInstrumentCmd, saveInstrumentCmd, createInstrumentCmd } from './instruments';
+export {
+  installConfirmationGate,
+  createApprovalStore,
+  confirmationGate,
+  defaultGetRisk,
+  type ApprovalStore,
+  type RiskMeta,
+  type SideEffect,
+  type AssistantDispatchContext,
+} from './confirmation';

--- a/src/app/commands/registry.ts
+++ b/src/app/commands/registry.ts
@@ -13,6 +13,7 @@ import { createRegistry, type Registry } from 'acture';
 import { DIAL_COMMANDS } from './dials';
 import { DIAL_FIELD_COMMANDS } from './perDial';
 import { INSTRUMENT_COMMANDS } from './instruments';
+import { installConfirmationGate, type ApprovalStore } from './confirmation';
 
 /** Build a registry with all thoremin commands registered: the generic dial verbs,
  *  one typed `set` command per dial (generated from the dials SSOT), and the
@@ -27,3 +28,15 @@ export function createThoreminRegistry(): Registry {
 
 /** The app-wide command registry singleton. */
 export const registry: Registry = createThoreminRegistry();
+
+/**
+ * The human-in-the-loop approval store for the AI assistant (#87 Phase 3). Installing
+ * the gate wraps the singleton's `dispatch`: a destructive command (instrument
+ * load/save/create) dispatched with `context.channel === 'assistant'` returns a
+ * `confirmation_required` Result instead of running, until the runtime re-dispatches
+ * it with a one-use token from THIS store (minted only after a human approves). Every
+ * other surface — the palette and hotkeys, which never set the assistant channel —
+ * dispatches ungated, so the gate is invisible to them. Tests that want an ungated
+ * registry use `createThoreminRegistry()` (raw) and install the gate explicitly.
+ */
+export const approvals: ApprovalStore = installConfirmationGate(registry).approvals;

--- a/src/plugins/assistant/AssistantChat.tsx
+++ b/src/plugins/assistant/AssistantChat.tsx
@@ -1,0 +1,51 @@
+/**
+ * The assistant's app-layer mount (#87 Phase 3) — the HEAVY half, lazily loaded by
+ * {@link ./AssistantOverlay} the first time the user opens the assistant (so the AI SDK
+ * stays out of the initial bundle). Owns the single {@link AssistantSession} + persisted
+ * settings, seeds/persists the transcript in localStorage, and renders the chat card.
+ */
+import { useEffect, useMemo } from 'react';
+import { useLocalStorage } from '../../hooks/useLocalStorage';
+import { AssistantSession } from './AssistantSession';
+import { AssistantOverlayPanel } from './AssistantOverlayPanel';
+import { DEFAULT_ASSISTANT_SETTINGS, type AssistantSettings, type ChatMessage } from './types';
+
+const HISTORY_KEY = 'thoremin:plugin:assistant:history';
+const MAX_PERSISTED = 50;
+
+export default function AssistantChat({ onClose }: { onClose: () => void }) {
+  const session = useMemo(() => new AssistantSession(), []);
+  const [settings, setSettings] = useLocalStorage<AssistantSettings>(
+    'thoremin:plugin:assistant:settings',
+    DEFAULT_ASSISTANT_SETTINGS,
+  );
+
+  // Seed from persisted history once; persist the settled transcript on every change.
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(HISTORY_KEY);
+      if (raw) session.loadHistory(JSON.parse(raw) as ChatMessage[]);
+    } catch {
+      /* ignore malformed history */
+    }
+    const persist = () => {
+      if (session.busy) return; // wait for the turn to settle before writing
+      localStorage.setItem(HISTORY_KEY, JSON.stringify(session.messages.slice(-MAX_PERSISTED)));
+    };
+    session.addEventListener('change', persist);
+    return () => {
+      session.removeEventListener('change', persist);
+      session.dispose();
+      // Flush unconditionally on teardown: closing mid-turn aborts it, but a turn may have
+      // already applied additive dial edits to the instrument, so persist the partial
+      // record too (loadHistory clears the `pending` flag on the next open).
+      try {
+        localStorage.setItem(HISTORY_KEY, JSON.stringify(session.messages.slice(-MAX_PERSISTED)));
+      } catch {
+        /* ignore */
+      }
+    };
+  }, [session]);
+
+  return <AssistantOverlayPanel session={session} settings={settings} onSettings={setSettings} onClose={onClose} />;
+}

--- a/src/plugins/assistant/AssistantOverlay.tsx
+++ b/src/plugins/assistant/AssistantOverlay.tsx
@@ -1,0 +1,40 @@
+/**
+ * The assistant's app-layer mount (#87 Phase 3) — the LIGHT half. Like the command
+ * palette, this is a consumer of the acture command registry that lives in the DAG app
+ * (the default experience, where the registry and instrument live) rather than in the
+ * legacy-only PluginProvider. It renders a floating launcher and, on open, lazily loads
+ * the actual chat ({@link ./AssistantChat}) so the heavy AI SDK never enters the initial
+ * bundle — the same lazy-import discipline the ai-dj plugin uses for its overlay. Drop
+ * `<AssistantOverlay/>` beside `<CommandPaletteOverlay/>` in the app shell.
+ */
+import { lazy, Suspense, useState } from 'react';
+import { Bot, Loader2 } from 'lucide-react';
+
+const AssistantChat = lazy(() => import('./AssistantChat'));
+
+export default function AssistantOverlay() {
+  const [open, setOpen] = useState(false);
+
+  if (!open) {
+    return (
+      <button
+        onClick={() => setOpen(true)}
+        aria-label="Open assistant"
+        className="absolute bottom-16 right-4 z-40 flex h-11 w-11 items-center justify-center rounded-full bg-emerald-500 text-black shadow-2xl transition hover:bg-emerald-400"
+      >
+        <Bot className="h-5 w-5" />
+      </button>
+    );
+  }
+  return (
+    <Suspense
+      fallback={
+        <div className="absolute bottom-16 right-4 z-40 flex h-11 w-11 items-center justify-center rounded-full bg-emerald-500/80 text-black shadow-2xl">
+          <Loader2 className="h-5 w-5 animate-spin" />
+        </div>
+      }
+    >
+      <AssistantChat onClose={() => setOpen(false)} />
+    </Suspense>
+  );
+}

--- a/src/plugins/assistant/AssistantOverlayPanel.tsx
+++ b/src/plugins/assistant/AssistantOverlayPanel.tsx
@@ -1,0 +1,334 @@
+/**
+ * The assistant chat HUD (#87 Phase 3) — a collapsible bottom-right card (the ai-dj
+ * overlay's visual shell) that renders the conversation, an inline trace line per
+ * command the assistant dispatched, approve/deny cards for destructive commands, and
+ * the provider/model + BYO-key controls. It is a thin subscriber to {@link
+ * AssistantSession}: it re-renders on the session's coarse `change` event and reads
+ * the current state each render. Per the app's UX rules, a turn shows immediate
+ * feedback (a "thinking…" pulse), streams text live, and states errors honestly.
+ */
+import { useEffect, useMemo, useReducer, useRef, useState } from 'react';
+import { ChevronDown, Settings as SettingsIcon, Send, Loader2, Check, X, ExternalLink, Trash2 } from 'lucide-react';
+import type { AssistantSession } from './AssistantSession';
+import { PROVIDERS, PROVIDER_LIST, getStoredKey, setStoredKey, removeStoredKey } from './providers';
+import type { AssistantSettings, ChatMessage, ProviderId, ToolTrace, PendingApproval } from './types';
+
+interface Props {
+  session: AssistantSession;
+  settings: AssistantSettings;
+  onSettings: (next: AssistantSettings) => void;
+  onClose: () => void;
+}
+
+export function AssistantOverlayPanel({ session, settings, onSettings, onClose }: Props) {
+  const [, force] = useReducer((n: number) => n + 1, 0);
+  const [keyTick, bumpKey] = useReducer((n: number) => n + 1, 0);
+  const [input, setInput] = useState('');
+  const [showSettings, setShowSettings] = useState(false);
+  const [keyDraft, setKeyDraft] = useState('');
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+
+  // Re-render whenever the session changes (messages stream, traces land, approvals appear).
+  useEffect(() => {
+    const h = () => force();
+    session.addEventListener('change', h);
+    return () => session.removeEventListener('change', h);
+  }, [session]);
+
+  const provider = PROVIDERS[settings.provider];
+  const hasKey = useMemo(() => !!getStoredKey(settings.provider), [settings.provider, keyTick]);
+
+  // Keep the conversation pinned to the latest content. The last message grows as text
+  // streams in and as tool traces land WITHOUT the message count changing, so track that
+  // growth explicitly — otherwise the view wouldn't follow a reply while it streams.
+  const lastMsg = session.messages[session.messages.length - 1];
+  const lastGrowth = (lastMsg?.text.length ?? 0) + (lastMsg?.traces?.length ?? 0);
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
+  }, [session.messages.length, lastGrowth, session.busy, session.pendingApprovals.length]);
+
+  const selectProvider = (id: ProviderId) => {
+    onSettings({ provider: id, model: PROVIDERS[id].defaultModel });
+    setKeyDraft('');
+  };
+
+  const saveKey = () => {
+    const k = keyDraft.trim();
+    if (!k) return;
+    setStoredKey(settings.provider, k);
+    setKeyDraft('');
+    bumpKey();
+  };
+
+  const removeKey = () => {
+    removeStoredKey(settings.provider);
+    bumpKey();
+  };
+
+  const submit = () => {
+    if (!input.trim() || session.busy || !hasKey) return;
+    void session.send(input, settings);
+    setInput('');
+  };
+
+  return (
+    <div className="absolute bottom-16 right-4 z-40 flex max-h-[70vh] w-80 flex-col overflow-hidden rounded-2xl border border-white/10 bg-[#111]/95 shadow-2xl backdrop-blur-sm">
+      {/* Header */}
+      <div className="flex shrink-0 items-center justify-between border-b border-white/5 px-4 py-3">
+        <span className="text-xs font-bold uppercase tracking-widest">Assistant</span>
+        <div className="flex items-center gap-1">
+          <span className="text-[9px] uppercase tracking-widest text-white/30">{provider.label}</span>
+          <button
+            onClick={() => setShowSettings((s) => !s)}
+            aria-label="Assistant settings"
+            className={`rounded p-1 transition-colors ${showSettings ? 'bg-emerald-500/20 text-emerald-400' : 'text-white/40 hover:bg-white/10'}`}
+          >
+            <SettingsIcon className="h-4 w-4" />
+          </button>
+          <button onClick={onClose} aria-label="Close assistant" className="rounded p-1 text-white/40 transition-colors hover:bg-white/10">
+            <ChevronDown className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+
+      {/* Settings sub-panel */}
+      {showSettings && (
+        <div className="shrink-0 space-y-3 border-b border-white/5 px-4 py-3">
+          <div className="space-y-1">
+            <label className="text-[9px] uppercase tracking-widest text-white/30">Provider</label>
+            <select
+              value={settings.provider}
+              onChange={(e) => selectProvider(e.target.value as ProviderId)}
+              className="w-full rounded-lg border border-white/10 bg-white/5 px-2 py-1.5 text-xs focus:border-emerald-500 focus:outline-none"
+            >
+              {PROVIDER_LIST.map((p) => (
+                <option key={p.id} value={p.id}>{p.label}</option>
+              ))}
+            </select>
+          </div>
+          <div className="space-y-1">
+            <label className="text-[9px] uppercase tracking-widest text-white/30">Model</label>
+            <select
+              value={settings.model}
+              onChange={(e) => onSettings({ ...settings, model: e.target.value })}
+              className="w-full rounded-lg border border-white/10 bg-white/5 px-2 py-1.5 text-xs focus:border-emerald-500 focus:outline-none"
+            >
+              {provider.models.map((m) => (
+                <option key={m} value={m}>{m}</option>
+              ))}
+            </select>
+          </div>
+          {hasKey && (
+            <button onClick={removeKey} className="text-[9px] uppercase tracking-widest text-red-400/50 transition-colors hover:text-red-400">
+              Remove {provider.label} key
+            </button>
+          )}
+          <button
+            onClick={() => session.clear()}
+            className="flex items-center gap-1 text-[9px] uppercase tracking-widest text-white/30 transition-colors hover:text-white/60"
+          >
+            <Trash2 className="h-3 w-3" /> Clear chat
+          </button>
+        </div>
+      )}
+
+      {/* Body */}
+      <div ref={scrollRef} className="flex-1 space-y-3 overflow-y-auto px-4 py-3">
+        {!hasKey ? (
+          <KeyGate
+            providerId={settings.provider}
+            keyDraft={keyDraft}
+            setKeyDraft={setKeyDraft}
+            onSave={saveKey}
+          />
+        ) : session.messages.length === 0 ? (
+          <p className="pt-6 text-center text-[11px] leading-relaxed text-white/30">
+            Ask me to tune the instrument — e.g. “make the right hand a warm pad two octaves down and turn sync on”.
+          </p>
+        ) : (
+          session.messages.map((m) => (
+            <div key={m.id}>
+              <MessageBubble message={m} />
+            </div>
+          ))
+        )}
+
+        {/* Pending approvals for destructive commands */}
+        {session.pendingApprovals.map((p) => (
+          <div key={p.id}>
+            <ApprovalCard approval={p} onApprove={() => void session.approve(p.id)} onDeny={() => session.deny(p.id)} />
+          </div>
+        ))}
+
+        {session.busy && (
+          <div className="flex items-center gap-2 text-[11px] text-white/40" aria-busy="true">
+            <Loader2 className="h-3 w-3 animate-spin" /> thinking…
+          </div>
+        )}
+      </div>
+
+      {/* Error */}
+      {session.error && (
+        <div className="shrink-0 border-t border-red-500/20 bg-red-500/10 px-4 py-2">
+          <p className="text-[10px] text-red-400">{session.error}</p>
+        </div>
+      )}
+
+      {/* Input */}
+      {hasKey && (
+        <div className="flex shrink-0 items-end gap-2 border-t border-white/5 px-3 py-2">
+          <textarea
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault();
+                submit();
+              }
+            }}
+            rows={1}
+            placeholder="Tell the instrument what to do…"
+            className="max-h-24 flex-1 resize-none rounded-lg border border-white/10 bg-white/5 px-2 py-1.5 text-xs placeholder-white/20 focus:border-emerald-500 focus:outline-none"
+          />
+          <button
+            onClick={submit}
+            disabled={!input.trim() || session.busy}
+            aria-label="Send"
+            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-emerald-500 text-black transition-colors hover:bg-emerald-400 disabled:opacity-30"
+          >
+            <Send className="h-4 w-4" />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function KeyGate({
+  providerId,
+  keyDraft,
+  setKeyDraft,
+  onSave,
+}: {
+  providerId: ProviderId;
+  keyDraft: string;
+  setKeyDraft: (v: string) => void;
+  onSave: () => void;
+}) {
+  const provider = PROVIDERS[providerId];
+  return (
+    <div className="space-y-3 pt-2">
+      <p className="text-xs leading-relaxed text-white/60">
+        Connect <strong className="text-white">{provider.label}</strong> to let the assistant play the instrument. Your key
+        is stored only in this browser and sent only to {provider.label} — thoremin has no backend.
+      </p>
+      <a
+        href={provider.keyHelpUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center gap-1 text-[10px] uppercase tracking-widest text-emerald-400 underline"
+      >
+        Get a {provider.label} key <ExternalLink className="h-3 w-3" />
+      </a>
+      <input
+        type="password"
+        value={keyDraft}
+        onChange={(e) => setKeyDraft(e.target.value)}
+        onKeyDown={(e) => e.key === 'Enter' && onSave()}
+        placeholder={provider.keyPlaceholder}
+        className="w-full rounded-lg border border-white/10 bg-white/5 p-2 font-mono text-xs placeholder-white/20 focus:border-emerald-500 focus:outline-none"
+        autoFocus
+      />
+      <button
+        onClick={onSave}
+        disabled={!keyDraft.trim()}
+        className="w-full rounded-lg bg-emerald-500 py-2 text-[10px] font-bold uppercase tracking-widest text-black transition-colors hover:bg-emerald-400 disabled:opacity-30"
+      >
+        Connect
+      </button>
+    </div>
+  );
+}
+
+function MessageBubble({ message }: { message: ChatMessage }) {
+  const isUser = message.role === 'user';
+  return (
+    <div className={isUser ? 'flex justify-end' : 'flex flex-col items-start gap-1'}>
+      {message.text && (
+        <div
+          className={`max-w-[85%] whitespace-pre-wrap rounded-2xl px-3 py-1.5 text-xs leading-relaxed ${
+            isUser ? 'bg-emerald-500/90 text-black' : 'bg-white/10 text-white/90'
+          }`}
+        >
+          {message.text}
+        </div>
+      )}
+      {message.traces && message.traces.length > 0 && (
+        <div className="space-y-0.5 pl-1">
+          {message.traces.map((t) => (
+            <div key={t.id}>
+              <TraceLine trace={t} />
+            </div>
+          ))}
+        </div>
+      )}
+      {!isUser && message.pending && !message.text && (
+        <span className="pl-1 text-[11px] text-white/30">…</span>
+      )}
+    </div>
+  );
+}
+
+function TraceLine({ trace }: { trace: ToolTrace }) {
+  return (
+    <div className="flex items-center gap-1.5 font-mono text-[10px] text-white/40">
+      {trace.ok ? (
+        <Check className="h-3 w-3 text-emerald-400" />
+      ) : (
+        <X className="h-3 w-3 text-red-400" />
+      )}
+      <span className="text-white/50">{trace.command}</span>
+      <span className={trace.ok ? 'text-white/30' : 'text-red-400/70'}>{trace.detail}</span>
+    </div>
+  );
+}
+
+function ApprovalCard({
+  approval,
+  onApprove,
+  onDeny,
+}: {
+  approval: PendingApproval;
+  onApprove: () => void;
+  onDeny: () => void;
+}) {
+  return (
+    <div className="space-y-2 rounded-xl border border-amber-500/30 bg-amber-500/10 p-3">
+      <p className="text-[11px] text-amber-200/90">
+        The assistant wants to <strong>{approval.title.toLowerCase()}</strong>
+        {isNamed(approval.params) ? ` “${namedOf(approval.params)}”` : ''}. This can overwrite saved work.
+      </p>
+      <div className="flex gap-2">
+        <button
+          onClick={onApprove}
+          className="flex-1 rounded-lg bg-amber-500 py-1.5 text-[10px] font-bold uppercase tracking-widest text-black transition-colors hover:bg-amber-400"
+        >
+          Approve
+        </button>
+        <button
+          onClick={onDeny}
+          className="flex-1 rounded-lg border border-white/10 py-1.5 text-[10px] font-bold uppercase tracking-widest text-white/60 transition-colors hover:bg-white/5"
+        >
+          Deny
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function isNamed(params: unknown): boolean {
+  return !!params && typeof params === 'object' && 'name' in (params as Record<string, unknown>);
+}
+function namedOf(params: unknown): string {
+  return String((params as Record<string, unknown>).name);
+}

--- a/src/plugins/assistant/AssistantOverlayPanel.tsx
+++ b/src/plugins/assistant/AssistantOverlayPanel.tsx
@@ -118,6 +118,17 @@ export function AssistantOverlayPanel({ session, settings, onSettings, onClose }
               ))}
             </select>
           </div>
+          <div className="flex items-center justify-between">
+            <a
+              href={provider.keyHelpUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-[9px] uppercase tracking-widest text-emerald-400 underline"
+            >
+              Get a {provider.label} key <ExternalLink className="h-3 w-3" />
+            </a>
+            <span className="text-[9px] uppercase tracking-widest text-white/30">{hasKey ? 'key set' : 'no key'}</span>
+          </div>
           {hasKey && (
             <button onClick={removeKey} className="text-[9px] uppercase tracking-widest text-red-400/50 transition-colors hover:text-red-400">
               Remove {provider.label} key
@@ -140,6 +151,7 @@ export function AssistantOverlayPanel({ session, settings, onSettings, onClose }
             keyDraft={keyDraft}
             setKeyDraft={setKeyDraft}
             onSave={saveKey}
+            onSelectProvider={selectProvider}
           />
         ) : session.messages.length === 0 ? (
           <p className="pt-6 text-center text-[11px] leading-relaxed text-white/30">
@@ -209,19 +221,40 @@ function KeyGate({
   keyDraft,
   setKeyDraft,
   onSave,
+  onSelectProvider,
 }: {
   providerId: ProviderId;
   keyDraft: string;
   setKeyDraft: (v: string) => void;
   onSave: () => void;
+  onSelectProvider: (id: ProviderId) => void;
 }) {
   const provider = PROVIDERS[providerId];
   return (
     <div className="space-y-3 pt-2">
       <p className="text-xs leading-relaxed text-white/60">
-        Connect <strong className="text-white">{provider.label}</strong> to let the assistant play the instrument. Your key
-        is stored only in this browser and sent only to {provider.label} — thoremin has no backend.
+        Connect an AI provider to let the assistant play the instrument. Your key is stored only in
+        this browser and sent only to the provider you pick — thoremin has no backend.
       </p>
+
+      {/* Make the provider CHOICE obvious right here. */}
+      <div className="space-y-1">
+        <p className="text-[9px] uppercase tracking-widest text-white/30">Choose a provider</p>
+        <div className="flex gap-1.5">
+          {PROVIDER_LIST.map((p) => (
+            <button
+              key={p.id}
+              onClick={() => onSelectProvider(p.id)}
+              className={`flex-1 rounded-lg px-2 py-1.5 text-[10px] font-bold uppercase tracking-wider transition-colors ${
+                p.id === providerId ? 'bg-emerald-500 text-black' : 'bg-white/5 text-white/50 hover:text-white/80'
+              }`}
+            >
+              {p.label.replace(/\s*\(.*\)/, '')}
+            </button>
+          ))}
+        </div>
+      </div>
+
       <a
         href={provider.keyHelpUrl}
         target="_blank"
@@ -244,8 +277,12 @@ function KeyGate({
         disabled={!keyDraft.trim()}
         className="w-full rounded-lg bg-emerald-500 py-2 text-[10px] font-bold uppercase tracking-widest text-black transition-colors hover:bg-emerald-400 disabled:opacity-30"
       >
-        Connect
+        Connect {provider.label}
       </button>
+      <p className="text-[10px] leading-relaxed text-white/30">
+        You can switch provider or model anytime from the{' '}
+        <SettingsIcon className="inline h-3 w-3 align-text-bottom" /> settings.
+      </p>
     </div>
   );
 }

--- a/src/plugins/assistant/AssistantSession.ts
+++ b/src/plugins/assistant/AssistantSession.ts
@@ -1,0 +1,222 @@
+/**
+ * The assistant runtime (#87 Phase 3) — an `EventTarget` (mirroring the ai-dj
+ * `LyriaSessionManager`) that owns the chat transcript and drives one model turn per
+ * {@link send} through a pluggable {@link ChatBackend}. The model's tool calls flow
+ * through the acture command registry (the SAME single write path the palette and
+ * hotkeys use), and destructive commands are mediated by the confirmation gate: they
+ * return `confirmation_required` (errors-as-data), the session raises a pending
+ * approval, and only on the user's {@link approve} does it mint a one-use token and
+ * re-dispatch. Being framework-agnostic, the React overlay is a thin subscriber to the
+ * single coarse `change` event.
+ */
+import type { CoreMessage } from 'ai';
+import type { AnyCommandRecord } from 'acture';
+import { registry, approvals } from '@/app/commands';
+import { buildSystemPrompt } from './systemPrompt';
+import { buildAssistantTools } from './aiTools';
+import { createVercelChatBackend, type ChatBackend } from './backend';
+import { PROVIDERS, getStoredKey } from './providers';
+import type { AssistantSettings, ChatMessage, PendingApproval, ToolTrace } from './types';
+
+function uid(prefix: string): string {
+  const rand = globalThis.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2);
+  return `${prefix}_${rand}`;
+}
+
+/** A short human summary of a successful dispatch, from its Result value. */
+function describeOk(cmdId: string, value: unknown): string {
+  if (value && typeof value === 'object') {
+    const v = value as Record<string, unknown>;
+    if ('key' in v && 'value' in v) return `${String(v.key)} → ${JSON.stringify(v.value)}`;
+    if ('count' in v) return `${String(v.count)} dials set`;
+    if ('name' in v) return `${cmdId.split('.').pop() ?? cmdId} "${String(v.name)}"`;
+  }
+  return cmdId;
+}
+
+const approvalKey = (command: string, params: unknown): string => `${command} ${JSON.stringify(params ?? null)}`;
+
+/** True for an assistant message with neither text nor a tool trace — an aborted or
+ *  pre-text-error turn that carries nothing to show or re-send. */
+const isEmptyAssistantTurn = (m: ChatMessage): boolean =>
+  m.role === 'assistant' && m.text.trim() === '' && (m.traces?.length ?? 0) === 0;
+
+/** A permissive structural view of an acture Result — reads ok/value/error WITHOUT
+ *  relying on discriminated-union narrowing, which the loose whole-project tsc (no
+ *  strictNullChecks) won't perform across a ternary or an `&&`. */
+type LooseResult = { ok: boolean; value?: unknown; error?: { code: string; message: string; details?: unknown } };
+const asLoose = (r: unknown): LooseResult => r as LooseResult;
+
+/** Build the default (browser, BYO-key) backend for the given settings + key. */
+function defaultBackendFactory(settings: AssistantSettings, apiKey: string): ChatBackend {
+  return createVercelChatBackend({
+    provider: settings.provider,
+    model: settings.model,
+    apiKey,
+    buildTools: (onDispatched) => buildAssistantTools(onDispatched),
+  });
+}
+
+export class AssistantSession extends EventTarget {
+  private _messages: ChatMessage[] = [];
+  private _pending: PendingApproval[] = [];
+  private _busy = false;
+  private _error: string | null = null;
+  private abort: AbortController | null = null;
+
+  /** `makeBackend` is injectable so tests can drive the session with a scripted mock. */
+  constructor(private makeBackend: (settings: AssistantSettings, apiKey: string) => ChatBackend = defaultBackendFactory) {
+    super();
+  }
+
+  get messages(): ReadonlyArray<ChatMessage> {
+    return this._messages;
+  }
+  get pendingApprovals(): ReadonlyArray<PendingApproval> {
+    return this._pending;
+  }
+  get busy(): boolean {
+    return this._busy;
+  }
+  get error(): string | null {
+    return this._error;
+  }
+
+  private emit(): void {
+    this.dispatchEvent(new CustomEvent('change'));
+  }
+
+  /** Seed the transcript from persisted history, dropping any empty, trace-less assistant
+   *  turns (pure noise from a past abort/error that would otherwise re-send as an empty
+   *  content block the provider rejects). */
+  loadHistory(messages: ChatMessage[]): void {
+    this._messages = messages.filter((m) => !isEmptyAssistantTurn(m)).map((m) => ({ ...m, pending: false }));
+    this.emit();
+  }
+
+  clear(): void {
+    this._messages = [];
+    this._pending = [];
+    this._error = null;
+    this.emit();
+  }
+
+  /** Run one turn: append the user message, stream the assistant reply, dispatch any
+   *  tool calls through the registry, and raise approvals for gated commands. */
+  async send(text: string, settings: AssistantSettings): Promise<void> {
+    const trimmed = text.trim();
+    if (!trimmed || this._busy) return;
+    const apiKey = getStoredKey(settings.provider);
+    if (!apiKey) {
+      this._error = `No API key set for ${PROVIDERS[settings.provider].label}.`;
+      this.emit();
+      return;
+    }
+
+    this._error = null;
+    const userMsg: ChatMessage = { id: uid('u'), role: 'user', text: trimmed };
+    const assistantMsg: ChatMessage = { id: uid('a'), role: 'assistant', text: '', pending: true, traces: [] };
+    this._messages = [...this._messages, userMsg, assistantMsg];
+    this._busy = true;
+    this.emit();
+
+    // The model sees prior settled turns + the new user turn. A tool-only turn (dispatches
+    // but no narration) has empty text — it is EXCLUDED from the model input (its effect is
+    // already reflected in the read-side dial catalog in the system prompt), because an
+    // empty-content assistant message is rejected by Anthropic/Gemini (OpenAI tolerates it).
+    const coreMessages: CoreMessage[] = this._messages
+      .filter((m) => !m.pending && m.text.trim() !== '')
+      .map((m) => ({ role: m.role, content: m.text }));
+
+    this.abort = new AbortController();
+    const backend = this.makeBackend(settings, apiKey);
+    try {
+      await backend.runTurn(
+        { system: buildSystemPrompt(), messages: coreMessages, signal: this.abort.signal },
+        {
+          onTextDelta: (delta) => {
+            assistantMsg.text += delta;
+            this.touch(assistantMsg);
+          },
+          onDispatch: (cmd, result) => this.handleDispatch(assistantMsg, cmd, result),
+          onError: (e) => {
+            this._error = e.message;
+            this.emit();
+          },
+        },
+      );
+    } catch (e) {
+      this._error = e instanceof Error ? e.message : String(e);
+    } finally {
+      assistantMsg.pending = false;
+      this._busy = false;
+      this.abort = null;
+      // Drop a turn that produced neither text nor a tool trace (an abort or pre-text
+      // error) so it doesn't linger as noise or poison the next turn's model input.
+      if (isEmptyAssistantTurn(assistantMsg)) {
+        this._messages = this._messages.filter((m) => m.id !== assistantMsg.id);
+        this.emit();
+      } else {
+        this.touch(assistantMsg);
+      }
+    }
+  }
+
+  /** Replace the message object (new reference) so subscribers re-render. */
+  private touch(msg: ChatMessage): void {
+    this._messages = this._messages.map((m) => (m.id === msg.id ? { ...msg } : m));
+    this.emit();
+  }
+
+  private handleDispatch(assistantMsg: ChatMessage, cmd: AnyCommandRecord, result: unknown): void {
+    const r = asLoose(result);
+    if (!r.ok && r.error?.code === 'confirmation_required') {
+      const details = (r.error.details ?? {}) as { command?: string; params?: unknown };
+      const command = details.command ?? cmd.id;
+      const params = details.params;
+      const key = approvalKey(command, params);
+      if (!this._pending.some((p) => approvalKey(p.command, p.params) === key)) {
+        this._pending = [...this._pending, { id: uid('p'), command, params, title: cmd.title ?? command }];
+      }
+    }
+    const trace: ToolTrace = {
+      id: uid('t'),
+      command: cmd.id,
+      ok: r.ok,
+      detail: r.ok ? describeOk(cmd.id, r.value) : (r.error?.message ?? 'error'),
+    };
+    assistantMsg.traces = [...(assistantMsg.traces ?? []), trace];
+    this.touch(assistantMsg);
+  }
+
+  /** Approve a pending destructive command: mint a one-use token and re-dispatch. */
+  async approve(id: string): Promise<void> {
+    const p = this._pending.find((x) => x.id === id);
+    if (!p) return;
+    this._pending = this._pending.filter((x) => x.id !== id);
+    this.emit();
+    const token = approvals.approve(p.command, p.params);
+    const result = asLoose(await registry.dispatch(p.command, p.params, { channel: 'assistant', approvedToken: token }));
+    const text = result.ok ? `Done: ${p.title}.` : `Couldn't complete "${p.title}": ${result.error?.message ?? 'failed'}`;
+    this._messages = [...this._messages, { id: uid('a'), role: 'assistant', text }];
+    this.emit();
+  }
+
+  /** Deny a pending destructive command (nothing is dispatched). */
+  deny(id: string): void {
+    const p = this._pending.find((x) => x.id === id);
+    if (!p) return;
+    this._pending = this._pending.filter((x) => x.id !== id);
+    this._messages = [...this._messages, { id: uid('a'), role: 'assistant', text: `Cancelled: ${p.title}.` }];
+    this.emit();
+  }
+
+  /** Abort an in-flight turn. */
+  stop(): void {
+    this.abort?.abort();
+  }
+
+  dispose(): void {
+    this.abort?.abort();
+  }
+}

--- a/src/plugins/assistant/aiTools.ts
+++ b/src/plugins/assistant/aiTools.ts
@@ -1,0 +1,42 @@
+/**
+ * Tool projection (#87 Phase 3) — projects the thoremin command registry as
+ * Vercel-AI-SDK tools via `acture-ai-vercel`, so the same registry the palette and
+ * hotkeys dispatch IS the assistant's tool surface (one projection, no drift). Every
+ * dispatch is tagged `channel:'assistant'` so the confirmation gate only gates the AI
+ * surface, and `onDispatched` reports each dispatch so the UI can trace it live.
+ *
+ * The generated per-dial `dial.<key>.set` commands are EXCLUDED from the model's tools:
+ * the model uses the generic `dial.set`/`dial.patch`/`dial.reset` verbs plus the
+ * system-prompt dial catalog (which it needs for relative edits anyway) — a small,
+ * clear tool set instead of 30-plus near-duplicate typed setters. The instrument
+ * commands (destructive, gated) and the generic dial verbs remain.
+ */
+import type { Tool } from 'ai';
+import { toAITools, toToolNameMap } from 'acture-ai-vercel';
+import type { AnyCommandRecord } from 'acture';
+import { registry, DIAL_FIELD_COMMANDS } from '@/app/commands';
+
+/** Reported to the UI after each assistant dispatch (the canonical command + its Result). */
+export type DispatchListener = (command: AnyCommandRecord, result: unknown) => void;
+
+/** The per-dial command ids to hide from the AI (kept for the palette, not the model). */
+const PER_DIAL_IDS = new Set<string>((DIAL_FIELD_COMMANDS as AnyCommandRecord[]).map((c) => c.id));
+
+/** Tier/when options — must be identical for `toAITools` and `toToolNameMap` so the
+ *  wire-name → id map lines up with the projected tools. */
+const PROJECTION_OPTS = { tiers: ['stable'] as const };
+
+/**
+ * Build the assistant's tool set from the registry. `onDispatched` fires (with the
+ * canonical command + acture Result) after each tool the model calls is dispatched.
+ */
+export function buildAssistantTools(onDispatched: DispatchListener): Record<string, Tool> {
+  const all = toAITools(registry, { ...PROJECTION_OPTS, context: { channel: 'assistant' }, onDispatched });
+  const nameToId = toToolNameMap(registry, PROJECTION_OPTS);
+  const tools: Record<string, Tool> = {};
+  for (const [toolName, tool] of Object.entries(all)) {
+    if (PER_DIAL_IDS.has(nameToId[toolName])) continue; // drop the per-dial setters
+    tools[toolName] = tool;
+  }
+  return tools;
+}

--- a/src/plugins/assistant/backend.ts
+++ b/src/plugins/assistant/backend.ts
@@ -1,0 +1,69 @@
+/**
+ * The model-call seam (#87 Phase 3). `ChatBackend.runTurn` runs one assistant turn and
+ * reports back through callbacks; it is the ONE place the actual LLM call lives, so:
+ *  - the default {@link createVercelChatBackend} runs entirely in the browser with the
+ *    user's BYO key (no backend — thoremin's promise stays intact), and
+ *  - a future server-side backend (e.g. behind a hosted gateway) can implement the same
+ *    interface without touching {@link AssistantSession} or the UI, and
+ *  - tests inject a scripted mock backend, so the session's state machine and the
+ *    approval flow are exercised with no network.
+ */
+import { streamText, type CoreMessage, type Tool } from 'ai';
+import type { AnyCommandRecord } from 'acture';
+import { PROVIDERS } from './providers';
+import type { ProviderId } from './types';
+
+export interface AssistantTurnInput {
+  system: string;
+  messages: CoreMessage[];
+  signal?: AbortSignal;
+}
+
+export interface AssistantTurnCallbacks {
+  onTextDelta(delta: string): void;
+  onDispatch(command: AnyCommandRecord, result: unknown): void;
+  onError(error: Error): void;
+}
+
+export interface ChatBackend {
+  runTurn(input: AssistantTurnInput, callbacks: AssistantTurnCallbacks): Promise<void>;
+}
+
+/** Bound the tool-call loop so a confused model can't spin: a few dial edits + a reply. */
+const MAX_STEPS = 6;
+
+/** Build the assistant's tool set, wiring `onDispatch` into each tool. Injected so the
+ *  backend stays decoupled from the registry/projection (and mockable in tests). */
+export type ToolBuilder = (onDispatched: (command: AnyCommandRecord, result: unknown) => void) => Record<string, Tool>;
+
+/** The default backend: the Vercel AI SDK run client-side against the chosen provider. */
+export function createVercelChatBackend(opts: {
+  provider: ProviderId;
+  model: string;
+  apiKey: string;
+  buildTools: ToolBuilder;
+}): ChatBackend {
+  return {
+    async runTurn(input, callbacks) {
+      const model = await PROVIDERS[opts.provider].createModel(opts.apiKey, opts.model);
+      const tools = opts.buildTools(callbacks.onDispatch);
+      const result = streamText({
+        model,
+        system: input.system,
+        messages: input.messages,
+        tools,
+        maxSteps: MAX_STEPS,
+        abortSignal: input.signal,
+      });
+      // The tools execute inside streamText and report via onDispatch; here we only
+      // stream the model's text and surface any hard stream/model error as data.
+      for await (const part of result.fullStream) {
+        if (part.type === 'text-delta') callbacks.onTextDelta(part.textDelta);
+        else if (part.type === 'error') {
+          const e = part.error;
+          callbacks.onError(e instanceof Error ? e : new Error(String(e)));
+        }
+      }
+    },
+  };
+}

--- a/src/plugins/assistant/dialsContext.ts
+++ b/src/plugins/assistant/dialsContext.ts
@@ -1,0 +1,42 @@
+/**
+ * The read side for the assistant (#87 Phase 3) — a compact catalog of every settable
+ * dial with its type and CURRENT value, built fresh each turn from the dials SSOT. The
+ * model needs this to make RELATIVE edits ("an octave lower", "warmer", "brighter"): it
+ * reads the current value here, computes the new one, and dispatches `dial.set`. This
+ * is a pure read of the dials settings layer (the same layer the commands write) — it
+ * never touches the hot store, the DAG, the nodes, or the audio path.
+ */
+import { settingsForm, dialsStore } from '@/app/dials/settingsStore';
+
+/** Describe a dial's accepted values: its enum members, numeric range, or base type. */
+function describeType(field: {
+  enumValues?: readonly string[];
+  zodType?: string;
+  bounds?: { min?: number; max?: number };
+}): string {
+  if (field.enumValues?.length) return `one of [${field.enumValues.join(', ')}]`;
+  if (field.zodType === 'number') {
+    const { min, max } = field.bounds ?? {};
+    if (typeof min === 'number' && typeof max === 'number') return `number ${min}..${max}`;
+    return 'number';
+  }
+  return field.zodType ?? 'value';
+}
+
+/**
+ * A newline-delimited catalog — one line per settable dial:
+ *   `- <key> — <label> (<type>); current: <value>`
+ * Structured, hidden, and read-only dials are omitted (they aren't a single settable
+ * scalar the model should target with `dial.set`).
+ */
+export function buildDialCatalog(): string {
+  const effective = dialsStore.getState().effective;
+  const lines: string[] = [];
+  for (const field of settingsForm.fields) {
+    if (field.hidden || field.readOnly || field.isStructured) continue;
+    lines.push(
+      `- ${field.key} — ${field.label} (${describeType(field)}); current: ${JSON.stringify(effective[field.key])}`,
+    );
+  }
+  return lines.join('\n');
+}

--- a/src/plugins/assistant/providers.ts
+++ b/src/plugins/assistant/providers.ts
@@ -59,8 +59,10 @@ export const PROVIDERS: Record<ProviderId, ProviderSpec> = {
   google: {
     id: 'google',
     label: 'Google (Gemini)',
-    models: ['gemini-2.5-flash', 'gemini-2.0-flash'],
-    defaultModel: 'gemini-2.5-flash',
+    // gemini-3.5-flash is the current GA flash (what `gemini-flash-latest` points to);
+    // gemini-2.0-flash was shut down 2026-06-01, so it is intentionally omitted.
+    models: ['gemini-3.5-flash', 'gemini-flash-latest', 'gemini-2.5-flash'],
+    defaultModel: 'gemini-3.5-flash',
     keyHelpUrl: 'https://aistudio.google.com/app/apikey',
     keyPlaceholder: 'AIza...',
     async createModel(apiKey, modelId) {

--- a/src/plugins/assistant/providers.ts
+++ b/src/plugins/assistant/providers.ts
@@ -1,0 +1,81 @@
+/**
+ * Multi-provider LLM registry (#87 Phase 3) — a data-driven, open-closed table of the
+ * chat providers the assistant can use. Each entry lazily imports its Vercel-AI-SDK
+ * provider package (`@ai-sdk/*`, the AI-SDK v4 line) and builds a model handle for
+ * `streamText`. thoremin stays 100% client-side: the model call runs in the browser
+ * with the USER'S OWN key (BYO-key), stored per provider in localStorage and sent only
+ * to that provider — the same trust model as the existing Lyria (ai-dj) plugin.
+ *
+ * To add a provider: install its `@ai-sdk/<name>` on the AI-SDK v4 (`^1`) line and add
+ * an entry. Mistral (`@ai-sdk/mistral`) and xAI (`@ai-sdk/xai`) work directly in the
+ * browser and are drop-in. OpenRouter (one key → hundreds of models) currently ships
+ * only for AI-SDK v5+, so it waits until thoremin moves off `ai@4`.
+ */
+import type { LanguageModel } from 'ai';
+import type { ProviderId } from './types';
+
+/** A provider's identity, model choices, key metadata, and lazy model factory. */
+export interface ProviderSpec {
+  id: ProviderId;
+  label: string;
+  models: string[];
+  defaultModel: string;
+  keyHelpUrl: string;
+  keyPlaceholder: string;
+  /** Lazily import the provider SDK and build a model handle for `streamText`. */
+  createModel(apiKey: string, modelId: string): Promise<LanguageModel>;
+}
+
+export const PROVIDERS: Record<ProviderId, ProviderSpec> = {
+  openai: {
+    id: 'openai',
+    label: 'OpenAI',
+    models: ['gpt-4o', 'gpt-4o-mini', 'gpt-4.1'],
+    defaultModel: 'gpt-4o',
+    keyHelpUrl: 'https://platform.openai.com/api-keys',
+    keyPlaceholder: 'sk-...',
+    async createModel(apiKey, modelId) {
+      const { createOpenAI } = await import('@ai-sdk/openai');
+      return createOpenAI({ apiKey })(modelId);
+    },
+  },
+  anthropic: {
+    id: 'anthropic',
+    label: 'Anthropic (Claude)',
+    models: ['claude-sonnet-5', 'claude-opus-4-8', 'claude-haiku-4-5'],
+    defaultModel: 'claude-sonnet-5',
+    keyHelpUrl: 'https://console.anthropic.com/settings/keys',
+    keyPlaceholder: 'sk-ant-...',
+    async createModel(apiKey, modelId) {
+      const { createAnthropic } = await import('@ai-sdk/anthropic');
+      // Anthropic gates direct browser calls behind this header (the key stays in the
+      // browser and is sent only to Anthropic — deliberately named to flag that).
+      return createAnthropic({
+        apiKey,
+        headers: { 'anthropic-dangerous-direct-browser-access': 'true' },
+      })(modelId);
+    },
+  },
+  google: {
+    id: 'google',
+    label: 'Google (Gemini)',
+    models: ['gemini-2.5-flash', 'gemini-2.0-flash'],
+    defaultModel: 'gemini-2.5-flash',
+    keyHelpUrl: 'https://aistudio.google.com/app/apikey',
+    keyPlaceholder: 'AIza...',
+    async createModel(apiKey, modelId) {
+      const { createGoogleGenerativeAI } = await import('@ai-sdk/google');
+      return createGoogleGenerativeAI({ apiKey })(modelId);
+    },
+  },
+};
+
+/** All providers, in display order. */
+export const PROVIDER_LIST: ProviderSpec[] = Object.values(PROVIDERS);
+
+/** The localStorage key holding a provider's API key. */
+const keyStorageKey = (id: ProviderId): string => `thoremin:plugin:assistant:apiKey:${id}`;
+
+export const getStoredKey = (id: ProviderId): string | null => localStorage.getItem(keyStorageKey(id));
+export const setStoredKey = (id: ProviderId, key: string): void => localStorage.setItem(keyStorageKey(id), key.trim());
+export const removeStoredKey = (id: ProviderId): void => localStorage.removeItem(keyStorageKey(id));

--- a/src/plugins/assistant/systemPrompt.ts
+++ b/src/plugins/assistant/systemPrompt.ts
@@ -15,7 +15,7 @@ export function buildSystemPrompt(): string {
     '',
     'HOW TO ACT',
     '- Change one dial with dial.set({ key, value }); change several at once with',
-    '  dial.patch({ writes: [[key, value], ...] }); restore a default with dial.reset({ key }).',
+    '  dial.patch({ writes: [{ key, value }, ...] }); restore a default with dial.reset({ key }).',
     '- Every value must respect the dial\'s type and range (listed below). For relative requests',
     '  ("an octave lower", "brighter", "warmer"), compute the new value from the CURRENT value below.',
     '- After changing dials, briefly say what you did in plain language.',

--- a/src/plugins/assistant/systemPrompt.ts
+++ b/src/plugins/assistant/systemPrompt.ts
@@ -1,0 +1,31 @@
+/**
+ * The assistant system prompt (#87 Phase 3). Rebuilt each turn so the model always
+ * sees the CURRENT dial state (the read side, {@link buildDialCatalog}). It frames the
+ * assistant as a parameter operator — it changes dials through tools, exactly like a
+ * human moving the settings sliders; the live gesture/audio engine is never touched —
+ * and states the confirmation contract for destructive (instrument) commands.
+ */
+import { buildDialCatalog } from './dialsContext';
+
+export function buildSystemPrompt(): string {
+  return [
+    'You are the Thoremin Assistant. Thoremin is a gesture-controlled, theremin-like instrument.',
+    'You operate it by adjusting its parameters ("dials") through tool calls. You never touch the',
+    'live gesture or audio engine — changing a dial is exactly like a human moving a settings slider.',
+    '',
+    'HOW TO ACT',
+    '- Change one dial with dial.set({ key, value }); change several at once with',
+    '  dial.patch({ writes: [[key, value], ...] }); restore a default with dial.reset({ key }).',
+    '- Every value must respect the dial\'s type and range (listed below). For relative requests',
+    '  ("an octave lower", "brighter", "warmer"), compute the new value from the CURRENT value below.',
+    '- After changing dials, briefly say what you did in plain language.',
+    '- Errors are returned as data (never thrown). If a tool result is { ok: false, error }, read',
+    '  error.message and correct the value or ask the user — do not repeat the same failing call.',
+    '- Loading, saving, or creating an instrument is DESTRUCTIVE and needs the user\'s approval. If',
+    '  such a tool returns error.code "confirmation_required", do NOT retry: tell the user what needs',
+    '  approving and stop — an approve/deny control appears for them.',
+    '',
+    'CURRENT INSTRUMENT STATE (dial key — label (type); current value):',
+    buildDialCatalog(),
+  ].join('\n');
+}

--- a/src/plugins/assistant/types.ts
+++ b/src/plugins/assistant/types.ts
@@ -1,0 +1,52 @@
+/**
+ * Assistant plugin types (#87 Phase 3) — the data model for the in-app AI assistant
+ * that operates the instrument by dispatching acture commands. A chat message, the
+ * tool-call trace shown inline, a pending human approval, and the persisted settings.
+ * Kept React-free and dependency-light so the runtime + tests import it in Node.
+ */
+
+/** The LLM providers thoremin ships. Each is called directly from the browser with
+ *  the user's own API key (no backend). See {@link ./providers}. */
+export type ProviderId = 'openai' | 'anthropic' | 'google';
+
+/** Persisted assistant settings (the active provider + model). API keys live
+ *  separately, per provider, under `thoremin:plugin:assistant:apiKey:<provider>`. */
+export interface AssistantSettings {
+  provider: ProviderId;
+  model: string;
+}
+
+/** Default: OpenAI gpt-4o (a widely-available tool-use model). */
+export const DEFAULT_ASSISTANT_SETTINGS: AssistantSettings = {
+  provider: 'openai',
+  model: 'gpt-4o',
+};
+
+export type ChatRole = 'user' | 'assistant';
+
+/** One dispatch the assistant made during a turn, rendered as an inline trace line so
+ *  the user sees exactly what changed (and any refusal). `command` is the canonical id. */
+export interface ToolTrace {
+  id: string;
+  command: string;
+  ok: boolean;
+  detail: string;
+}
+
+/** A single chat message. An assistant message may carry the tool-call traces from its
+ *  turn and a `pending` flag while it is still streaming. */
+export interface ChatMessage {
+  id: string;
+  role: ChatRole;
+  text: string;
+  traces?: ToolTrace[];
+  pending?: boolean;
+}
+
+/** A destructive command the assistant proposed that awaits the user's approval. */
+export interface PendingApproval {
+  id: string;
+  command: string;
+  params: unknown;
+  title: string;
+}

--- a/src/plugins/assistant/types.ts
+++ b/src/plugins/assistant/types.ts
@@ -16,10 +16,10 @@ export interface AssistantSettings {
   model: string;
 }
 
-/** Default: OpenAI gpt-4o (a widely-available tool-use model). */
+/** Default: Google Gemini 3.5 Flash — near-Pro capability at Flash cost/speed. */
 export const DEFAULT_ASSISTANT_SETTINGS: AssistantSettings = {
-  provider: 'openai',
-  model: 'gpt-4o',
+  provider: 'google',
+  model: 'gemini-3.5-flash',
 };
 
 export type ChatRole = 'user' | 'assistant';

--- a/test/assistant_session.test.ts
+++ b/test/assistant_session.test.ts
@@ -1,0 +1,161 @@
+/**
+ * The assistant session state machine (#87 Phase 3) — driven by a scripted mock
+ * ChatBackend (no network), so we exercise text streaming, inline tool traces, the
+ * BYO-key gate, and the human approval flow for destructive commands in the headless
+ * node env. The real Vercel backend implements the same seam; tests never touch an SDK.
+ */
+// Minimal browser-global shims for the node test env (the session is browser code).
+if (typeof (globalThis as { localStorage?: unknown }).localStorage === 'undefined') {
+  const store = new Map<string, string>();
+  (globalThis as { localStorage?: unknown }).localStorage = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => void store.set(k, String(v)),
+    removeItem: (k: string) => void store.delete(k),
+    clear: () => store.clear(),
+  };
+}
+if (typeof (globalThis as { CustomEvent?: unknown }).CustomEvent === 'undefined') {
+  (globalThis as { CustomEvent?: unknown }).CustomEvent = class extends Event {
+    detail: unknown;
+    constructor(type: string, init?: { detail?: unknown }) {
+      super(type);
+      this.detail = init?.detail;
+    }
+  };
+}
+
+import { describe, it, expect } from 'vitest';
+import { AssistantSession } from '@/plugins/assistant/AssistantSession';
+import { setStoredKey, removeStoredKey } from '@/plugins/assistant/providers';
+import type { ChatBackend, AssistantTurnCallbacks } from '@/plugins/assistant/backend';
+import type { AssistantSettings } from '@/plugins/assistant/types';
+
+const SETTINGS: AssistantSettings = { provider: 'openai', model: 'gpt-4o' };
+
+/** A backend that runs a canned script over the callbacks instead of calling a model. */
+function scriptedBackend(script: (cb: AssistantTurnCallbacks) => void | Promise<void>) {
+  return (): ChatBackend => ({
+    runTurn: async (_input, cb) => {
+      await script(cb);
+    },
+  });
+}
+
+describe('AssistantSession (#87 Phase 3)', () => {
+  it('streams assistant text and records an inline tool trace', async () => {
+    setStoredKey('openai', 'test-key');
+    const session = new AssistantSession(
+      scriptedBackend((cb) => {
+        cb.onTextDelta('Making it ');
+        cb.onTextDelta('warmer.');
+        cb.onDispatch({ id: 'dial.set', title: 'Set dial' } as never, {
+          ok: true,
+          value: { key: 'right.sound', value: 'pad' },
+        });
+      }),
+    );
+    await session.send('make it warmer', SETTINGS);
+
+    const last = session.messages.at(-1);
+    expect(session.messages.at(-2)?.role).toBe('user');
+    expect(last?.role).toBe('assistant');
+    expect(last?.text).toBe('Making it warmer.');
+    expect(last?.pending).toBe(false);
+    expect(last?.traces?.[0]).toMatchObject({ command: 'dial.set', ok: true });
+    expect(session.busy).toBe(false);
+  });
+
+  it('never sends an empty-content assistant message after a tool-only turn', async () => {
+    // Regression for the empty-text bug: a turn where the model dispatches a command but
+    // narrates nothing leaves text=''. It must NOT be re-sent to the model as an empty
+    // assistant content block (Anthropic/Gemini reject it with a 400 and brick the chat).
+    setStoredKey('openai', 'test-key');
+    const captured: unknown[][] = [];
+    const session = new AssistantSession(
+      () => ({
+        runTurn: async (input, cb) => {
+          captured.push(input.messages);
+          if (captured.length === 1) {
+            // Turn 1: tool-only — a dispatch, no text.
+            cb.onDispatch({ id: 'dial.set', title: 'Set dial' } as never, {
+              ok: true,
+              value: { key: 'right.sound', value: 'pad' },
+            });
+          } else {
+            cb.onTextDelta('done');
+          }
+        },
+      }),
+    );
+    await session.send('make it warmer', SETTINGS); // tool-only turn (empty text)
+    await session.send('and brighter', SETTINGS); // second turn
+
+    const secondTurnInput = captured[1] as Array<{ role: string; content: string }>;
+    // No assistant message with empty content reaches the provider.
+    expect(secondTurnInput.some((m) => m.role === 'assistant' && (m.content ?? '').trim() === '')).toBe(false);
+    // The tool-only turn's trace is still visible in the transcript (UI shows what changed).
+    expect(session.messages.some((m) => (m.traces?.length ?? 0) > 0)).toBe(true);
+  });
+
+  it('refuses to send with no API key for the active provider', async () => {
+    removeStoredKey('openai');
+    let ran = false;
+    const session = new AssistantSession(
+      scriptedBackend(() => {
+        ran = true;
+      }),
+    );
+    await session.send('hello', SETTINGS);
+    expect(ran).toBe(false);
+    expect(session.error).toMatch(/No API key/);
+  });
+
+  it('raises a pending approval on confirmation_required and clears it on deny', async () => {
+    setStoredKey('openai', 'test-key');
+    const session = new AssistantSession(
+      scriptedBackend((cb) => {
+        cb.onDispatch({ id: 'instrument.save', title: 'Save instrument' } as never, {
+          ok: false,
+          error: {
+            code: 'confirmation_required',
+            message: 'needs approval',
+            details: { command: 'instrument.save', params: { name: 'X' } },
+          },
+        });
+      }),
+    );
+    await session.send('save it as X', SETTINGS);
+
+    expect(session.pendingApprovals.length).toBe(1);
+    expect(session.pendingApprovals[0]).toMatchObject({ command: 'instrument.save' });
+
+    session.deny(session.pendingApprovals[0].id);
+    expect(session.pendingApprovals.length).toBe(0);
+    expect(session.messages.at(-1)?.text).toContain('Cancelled');
+  });
+
+  it('approve mints a token, clears the pending, and reports an outcome', async () => {
+    setStoredKey('openai', 'test-key');
+    const session = new AssistantSession(
+      scriptedBackend((cb) => {
+        cb.onDispatch({ id: 'instrument.save', title: 'Save instrument' } as never, {
+          ok: false,
+          error: {
+            code: 'confirmation_required',
+            message: 'needs approval',
+            details: { command: 'instrument.save', params: { name: 'ApprovalTest' } },
+          },
+        });
+      }),
+    );
+    await session.send('save as ApprovalTest', SETTINGS);
+    const pid = session.pendingApprovals[0].id;
+
+    await session.approve(pid);
+    expect(session.pendingApprovals.length).toBe(0);
+    const last = session.messages.at(-1);
+    expect(last?.role).toBe('assistant');
+    // The re-dispatch happened through the real gated registry; either outcome is fine here.
+    expect(last?.text).toMatch(/Done:|Couldn't/);
+  });
+});

--- a/test/assistant_tools.test.ts
+++ b/test/assistant_tools.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Assistant tool projection (#87 Phase 3) — the registry → Vercel-AI-SDK tools bridge.
+ * Verifies the projected tool set (generic dial verbs + instrument commands, per-dial
+ * setters excluded) and that a projected tool dispatches through the SAME registry the
+ * palette uses, with errors returned as data (never thrown across the tool boundary).
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { buildAssistantTools } from '@/plugins/assistant/aiTools';
+import { dialsStore } from '@/app/dials/settingsStore';
+import { useControls } from '@/app/store';
+
+/** Run a projected tool's execute (arity/typing of the AI-SDK Tool relaxed for the test). */
+const run = (tool: unknown, args: unknown): Promise<{ ok: boolean; error?: { code: string } }> =>
+  (tool as { execute: (a: unknown) => Promise<{ ok: boolean; error?: { code: string } }> }).execute(args);
+
+describe('assistant tool projection (#87 Phase 3)', () => {
+  beforeEach(() => {
+    useControls.setState(useControls.getInitialState(), true);
+  });
+
+  it('projects the generic dial + instrument verbs and excludes the per-dial setters', () => {
+    const names = Object.keys(buildAssistantTools(() => {}));
+    // Generic verbs present (wire-safe names: dots → underscores).
+    expect(names).toContain('dial_set');
+    expect(names).toContain('dial_patch');
+    expect(names).toContain('dial_reset');
+    expect(names).toContain('instrument_save');
+    expect(names).toContain('instrument_load');
+    // The generated per-dial `dial.<key>.set` → `dial_<key>_set` tools are hidden from the model.
+    expect(names.some((n) => /^dial_.+_set$/.test(n))).toBe(false);
+  });
+
+  it('a projected tool dispatches through the registry, with errors-as-data', async () => {
+    let reported: { ok: boolean } | null = null;
+    const tools = buildAssistantTools((_cmd, result) => {
+      reported = result as { ok: boolean };
+    });
+    const key = 'right.baseOctave';
+    const current = dialsStore.getState().effective[key];
+
+    // Setting a dial to a valid value succeeds and fires onDispatched with the Result.
+    const okRes = await run(tools['dial_set'], { key, value: current });
+    expect(okRes.ok).toBe(true);
+    expect(reported).not.toBeNull();
+    expect(reported!.ok).toBe(true);
+
+    // An unknown dial comes back as errors-as-data — no throw across the tool boundary.
+    const badRes = await run(tools['dial_set'], { key: 'nope.not_a_dial', value: 1 });
+    expect(badRes.ok).toBe(false);
+    expect(badRes.error?.code).toBe('unknown_dial');
+  });
+});

--- a/test/assistant_tools.test.ts
+++ b/test/assistant_tools.test.ts
@@ -49,4 +49,21 @@ describe('assistant tool projection (#87 Phase 3)', () => {
     expect(badRes.ok).toBe(false);
     expect(badRes.error?.code).toBe('unknown_dial');
   });
+
+  it('coerces a stringified numeric value from the AI to the dial\'s real type', async () => {
+    // Gemini-safe fix: the AI often passes a numeric dial as a STRING; it must land as a number.
+    const tools = buildAssistantTools(() => {});
+    const okRes = await run(tools['dial_set'], { key: 'master.volume', value: '0.5' });
+    expect(okRes.ok).toBe(true);
+    expect(dialsStore.getState().effective['master.volume']).toBe(0.5);
+  });
+
+  it('dial_patch takes { key, value } objects (not tuples) and coerces string values', async () => {
+    // The tuple + z.unknown() shape broke Gemini's function-calling schema; the object shape
+    // with a typed value union is Gemini-safe. Verify the new shape dispatches + coerces.
+    const tools = buildAssistantTools(() => {});
+    const r = await run(tools['dial_patch'], { writes: [{ key: 'master.volume', value: '0.25' }] });
+    expect(r.ok).toBe(true);
+    expect(dialsStore.getState().effective['master.volume']).toBe(0.25);
+  });
 });

--- a/test/commands_confirmation.test.ts
+++ b/test/commands_confirmation.test.ts
@@ -1,0 +1,87 @@
+/**
+ * The confirmation gate (#87 Phase 3) — human-in-the-loop for destructive commands.
+ * Tests the middleware in isolation (a fake `next`, so no dependence on the instrument
+ * handlers) plus that `installConfirmationGate` actually wraps a registry's dispatch.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  createThoreminRegistry,
+  installConfirmationGate,
+  confirmationGate,
+  createApprovalStore,
+  defaultGetRisk,
+} from '@/app/commands';
+
+/** Read a Result's error branch structurally (the loose whole-project tsc won't narrow
+ *  a `Result` union across `if (!r.ok)`). */
+const errOf = (r: { ok: boolean }) => (r as unknown as { error: { code: string; message: string; details?: unknown } }).error;
+
+describe('confirmation gate (#87 Phase 3)', () => {
+  it('classifies instrument mutations as destructive, dial edits as reversible', () => {
+    expect(defaultGetRisk('instrument.save').sideEffect).toBe('destructive');
+    expect(defaultGetRisk('instrument.load').sideEffect).toBe('destructive');
+    expect(defaultGetRisk('instrument.create').sideEffect).toBe('destructive');
+    expect(defaultGetRisk('dial.set').sideEffect).toBe('additive');
+    expect(defaultGetRisk('dial.reset').sideEffect).toBe('additive');
+    expect(defaultGetRisk('mode.toggle').sideEffect).toBe('query');
+  });
+
+  it('gates a destructive assistant call until a matching one-use token is presented', async () => {
+    const approvals = createApprovalStore();
+    const next = vi.fn(async () => ({ ok: true, value: 'ran' }));
+    const gated = confirmationGate(defaultGetRisk, approvals)(next as never);
+
+    // Assistant proposes a destructive command with no token → proposal, next NOT called.
+    const proposal = await gated('instrument.save', { name: 'X' }, { channel: 'assistant' });
+    expect(proposal.ok).toBe(false);
+    expect(errOf(proposal).code).toBe('confirmation_required');
+    expect((errOf(proposal).details as { command?: string }).command).toBe('instrument.save');
+    expect(next).not.toHaveBeenCalled();
+
+    // A human approves → token → the exact call passes through to next.
+    const token = approvals.approve('instrument.save', { name: 'X' });
+    const run = await gated('instrument.save', { name: 'X' }, { channel: 'assistant', approvedToken: token });
+    expect(run.ok).toBe(true);
+    expect(next).toHaveBeenCalledTimes(1);
+
+    // The token is one-use: a replay is gated again.
+    const replay = await gated('instrument.save', { name: 'X' }, { channel: 'assistant', approvedToken: token });
+    expect(replay.ok).toBe(false);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('a token is bound to the exact params (cannot be replayed against different args)', async () => {
+    const approvals = createApprovalStore();
+    const next = vi.fn(async () => ({ ok: true, value: 'ran' }));
+    const gated = confirmationGate(defaultGetRisk, approvals)(next as never);
+    const token = approvals.approve('instrument.save', { name: 'A' });
+    const mismatched = await gated('instrument.save', { name: 'B' }, { channel: 'assistant', approvedToken: token });
+    expect(mismatched.ok).toBe(false);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('never gates a human surface, nor reversible commands even on the assistant channel', async () => {
+    const approvals = createApprovalStore();
+    const next = vi.fn(async () => ({ ok: true, value: 'ran' }));
+    const gated = confirmationGate(defaultGetRisk, approvals)(next as never);
+    // Human dispatch (no assistant channel) → ungated even for a destructive command.
+    expect((await gated('instrument.save', { name: 'X' })).ok).toBe(true);
+    // Reversible command on the assistant channel → ungated.
+    expect((await gated('dial.set', { key: 'x', value: 1 }, { channel: 'assistant' })).ok).toBe(true);
+    expect(next).toHaveBeenCalledTimes(2);
+  });
+
+  it('installConfirmationGate wraps a registry\'s dispatch', async () => {
+    const reg = createThoreminRegistry(); // a raw (ungated) registry for isolation
+    // Mark a harmless, headless-safe command destructive so we don't lean on instrument handlers.
+    installConfirmationGate(reg, {
+      getRisk: (id) => ({ sideEffect: id === 'dial.reset' ? 'destructive' : 'query' }),
+    });
+    const proposal = await reg.dispatch('dial.reset', { key: 'right.baseOctave' }, { channel: 'assistant' });
+    expect(proposal.ok).toBe(false);
+    expect(errOf(proposal).code).toBe('confirmation_required');
+    // The same command from a human surface runs ungated.
+    const human = await reg.dispatch('dial.reset', { key: 'right.baseOctave' });
+    expect(human.ok).toBe(true);
+  });
+});

--- a/test/commands_dispatch.test.ts
+++ b/test/commands_dispatch.test.ts
@@ -35,8 +35,8 @@ describe('command dispatch (#87)', () => {
   it('dispatch dial.patch sets several dials in order (a synced-voice edit)', async () => {
     const r = await registry.dispatch('dial.patch', {
       writes: [
-        ['right.root', 7],
-        ['left.root', 7],
+        { key: 'right.root', value: 7 },
+        { key: 'left.root', value: 7 },
       ],
     });
     expect(r.ok).toBe(true);
@@ -71,8 +71,8 @@ describe('command dispatch (#87)', () => {
     const rootBefore = dialsStore.getState().effective['right.root'];
     const r = await registry.dispatch('dial.patch', {
       writes: [
-        ['right.root', 6], // valid
-        ['right.octaves', 99], // valid KEY, invalid VALUE (max 4) → rejects the batch
+        { key: 'right.root', value: 6 }, // valid
+        { key: 'right.octaves', value: 99 }, // valid KEY, invalid VALUE (max 4) → rejects the batch
       ],
     });
     expect(r.ok).toBe(false);

--- a/test/commands_firewall.test.ts
+++ b/test/commands_firewall.test.ts
@@ -9,6 +9,11 @@
  *    accidentally acquire dispatch overhead.
  *  - Nothing under `src/dag/` or `src/nodes/` may import the command registry, so a
  *    per-tick / audio event can never be routed through dispatch.
+ *  - The AI assistant (`src/plugins/assistant/`, #87 Phase 3) is a registry CONSUMER —
+ *    it may import React / the AI SDK / the registry / the dials read-side freely, but
+ *    it must reach SOUND only by dispatching a command (which writes a dial). So it is
+ *    forbidden the hot store / DAG / nodes / audio-host modules (a DENYlist, since a
+ *    consumer's legitimate import surface is open-ended, unlike a command handler's).
  *
  * Enforced over import specifiers (not raw text), so a comment mentioning a module
  * doesn't trip it.
@@ -63,6 +68,25 @@ const COMMAND_IMPORT_ALLOWLIST: RegExp[] = [
 const isAllowedFromCommands = (spec: string): boolean =>
   COMMAND_IMPORT_ALLOWLIST.some((re) => re.test(spec));
 
+/**
+ * Modules the AI assistant must NEVER import: it changes sound only by dispatching a
+ * command (which writes a dial), so the real-time path stays out of its reach. This is
+ * the same forbidden set the command allowlist refuses, expressed as a denylist because
+ * a UI consumer legitimately imports React / cmdk / the AI SDK / the registry / the
+ * dials read-side (`@/app/dials/*`) — an allowlist would be endless and wrong here.
+ */
+const FORBIDDEN_FROM_ASSISTANT: RegExp[] = [
+  /(^|\/)nodes(\/|$)/, // the node library
+  /(^|\/)dag(\/|$)/, // the DAG engine
+  /^@\/app\/store(\.tsx?)?$/, // the hot useControls store (@/ alias)
+  /^\.{1,2}\/store(\.tsx?)?$/, // ../store / ./store (relative hot store) — RELATIVE only, so it can't
+  //                              swallow the sanctioned `@zodal/store` package or `@/app/dials/settingsStore`
+  /(^|\/)useControls(\/|$)/, // the hot store hook by name
+  /(^|\/)(useEngine|recorder|useAudioEngine)(\.tsx?)?$/, // the audio/engine host — BOTH the `@/` alias
+  //                                                        AND a relative reach-out (`../../app/useEngine`)
+];
+const isForbiddenFromAssistant = (spec: string): boolean => FORBIDDEN_FROM_ASSISTANT.some((re) => re.test(spec));
+
 describe('command-dispatch import firewall (#87)', () => {
   it('commands import ONLY the sanctioned surface (never the hot store / DAG / nodes / audio)', () => {
     const files = tsFiles('src/app/commands');
@@ -105,6 +129,35 @@ describe('command-dispatch import firewall (#87)', () => {
           expect(/(^|\/)commands(\/|$)/.test(spec), `${f} imports "${spec}" — the real-time path must not route through dispatch`).toBe(false);
         }
       }
+    }
+  });
+
+  it('the AI assistant reaches sound only via dispatch (never the hot store / DAG / nodes / audio)', () => {
+    const files = tsFiles('src/plugins/assistant');
+    expect(files.length).toBeGreaterThan(0); // guard: the assistant exists and is scanned
+    for (const f of files) {
+      for (const spec of importSpecifiers(readFileSync(f, 'utf8'))) {
+        expect(
+          isForbiddenFromAssistant(spec),
+          `${f} imports "${spec}" — the assistant must change sound by dispatching a command, not by reaching the hot store / DAG / nodes / audio directly.`,
+        ).toBe(false);
+      }
+    }
+  });
+
+  it('the assistant denylist refuses the hot-path modules (alias AND relative) but allows its real consumer surface', () => {
+    // Guard the guard: forbid the real-time path in both its `@/` alias and relative forms.
+    for (const spec of [
+      '@/app/store', '@/app/store.ts', '../store', './store',
+      '@/app/useEngine', '@/app/recorder', '@/hooks/useAudioEngine',
+      '../../app/useEngine', '../../app/recorder', '../../hooks/useAudioEngine', // relative reach-outs
+      '@/dag', '@/nodes/output/webaudio_synth',
+    ]) {
+      expect(isForbiddenFromAssistant(spec), `"${spec}" must be firewalled from the assistant`).toBe(true);
+    }
+    // ...while the assistant's legitimate imports stay allowed (incl. the sanctioned @zodal/store package).
+    for (const spec of ['react', 'ai', 'acture', 'acture-ai-vercel', '@ai-sdk/openai', '@/app/commands', '@/app/dials/settingsStore', '@zodal/store', 'lucide-react', '../../hooks/useLocalStorage']) {
+      expect(isForbiddenFromAssistant(spec), `"${spec}" is a sanctioned assistant import and must be allowed`).toBe(false);
     }
   });
 });


### PR DESCRIPTION
Implements **#87 Phase 3** — an in-app AI **Assistant** that plays/configures the instrument by dispatching the existing acture command registry (the same single write path the palette and hotkeys use). 100% client-side, no backend, BYO-key, multi-provider.

## What's here
- **New Assistant plugin** (`src/plugins/assistant/`): data-driven provider registry (OpenAI / Anthropic / **Google — default: Gemini 3.5 Flash**, open-closed), tool projection via `acture-ai-vercel`, a read-side dial catalog for relative edits, a pluggable `ChatBackend` seam (Vercel AI SDK backend; a future server-side path can slot in), an `EventTarget` session runtime, and a chat HUD. Mounted in the DAG app beside the command palette; **lazy-loaded** so the AI SDK stays out of the initial bundle.
- **Confirmation gate** (`src/app/commands/confirmation.ts`): human-in-the-loop for the destructive `instrument.*` commands (one-use tokens, gated only on the assistant channel — palette/hotkeys stay ungated; the model can't self-approve).
- **Gemini-safe dial schema**: `dial.set`/`dial.patch` use a typed scalar union + string→type coercion instead of `z.unknown()`/`z.tuple()` (which broke Gemini function-calling).
- **Import firewall** (a vitest test) extended with an assistant denylist (reach sound only via dispatch).
- `ai@4` + `zod@4` reconciled via an npm `overrides` (not `--legacy-peer-deps`).

## Rigor
- 467 tests pass (23 new), strict typecheck clean, build OK.
- Adversarial multi-agent review (each finding independently verified) → 5 bugs found + fixed, incl. an empty-text tool-only turn that 400s Anthropic/Gemini.

No aix (dropped — thoremin stays client-side; the seam is left for a future server-side move).

https://claude.ai/code/session_01PDxa4RNfk9UpdQK3PopEeT