### PR TITLE
Recording v2: session-based multi-stream recorder (#88)

### DIFF
--- a/docs/design/recording-v2.md
+++ b/docs/design/recording-v2.md
@@ -1,0 +1,122 @@
+# Recording v2 — session-based multi-stream recorder
+
+> **Status:** implemented (2026-07, issue #88). This document is the single
+> source of truth for the recording subsystem. It supersedes the audio-only
+> `PerformanceRecorder` flow and is a superset of the older recording-settings
+> work (#49).
+
+## The idea in one line
+
+A recording is a **session** (a transient config that lives OUTSIDE the
+instrument), capturing any subset of **five streams** into **one folder** with a
+`manifest.json` that is the alignment SSOT — so a take is a self-describing,
+downstream-friendly artifact.
+
+## Why recording is not an instrument parameter
+
+Recording config (what to capture, where to save, output formats) is a *tooling
+preference*, not a musical setting. It must never live in a preset/instrument.
+So it is its own Zod schema (`RecordingSessionSchema`), persisted separately to
+`localStorage['recording.session.last']`, and the settings UI lives in a
+transient sheet, not the instrument panel.
+
+## The button-swap UX (`RecordButton`)
+
+```
+idle       →  [ ● Record ]
+settings   →  a "recording session" sheet in the same slot, with
+              [ ● Rec now ] exactly where Record was + a [ ✕ ] Close that
+              auto-saves (it's a settings surface, not a form to submit)
+recording  →  [ ■ Stop ]  ● 00:12   audio · overlay · features   (compact HUD)
+saving     →  the HUD, disabled, while the take converts + writes
+```
+
+All state lives in `useThoreminEngine().recording`; `RecordButton` is purely
+presentational.
+
+## The five streams (one `MediaRecorder` per media stream)
+
+| Stream | Source | Notes |
+|---|---|---|
+| **audio** | master-bus tap (`MediaStreamAudioDestinationNode`) | always available; converted to the selected formats (webm/wav) on stop |
+| **video + overlays** | `canvas.captureStream(fps)` muxed with the audio tap | "what you see" (mirrored, with landmarks) |
+| **pure webcam** | the raw camera `MediaStream` (else `video.captureStream()`) | overlay-free; per-stream "include audio" (default off) |
+| **overlay-only (alpha)** | a transparent offscreen canvas the overlay node redraws to with the backdrop suppressed | **Chromium-only**, experimental (alpha WebM); feature-gated |
+| **features → JSONL** | a live `FeatureJsonlTap` attached via `engine.addTap` | `{tick,t,key,value}` per edge; serialize-on-receipt (constant memory) |
+
+All streams share one **t0** — the DAG clock (`ctx.time`, which the engine drives
+from `performance.now()/1000`) at record start. Media recorders use `start(2000)`
+(2s timeslice) for constant-memory long takes.
+
+### Overlay-alpha without duplicating the overlay code
+
+The overlay is a single node (`canvas_overlay.ts`) that draws `OVERLAY_ELEMENTS`
+onto `ctx.resources.canvas`, with the webcam as a toggleable `backdrop` element.
+For the alpha stream, the `SessionRecorder` injects a transparent
+`ctx.resources.overlayAlphaCanvas`; the node, after its main draw, redraws the
+**same** element list onto it with `params.video.show = false` — reusing all
+drawing logic (no drift) and costing nothing when the resource is absent.
+
+## One folder per recording + naming (`plan.ts`, `naming.ts`)
+
+Always a folder (predictable model for downstream tooling; the `manifest.json`
+always exists). The **folder name = file stem**; the **primary ext = the type**,
+with a **secondary ext = the role** when streams share a primary ext:
+
+```
+demo-theremin-2026-07-05T14-30-12/
+  ….overlay.webm  ….camera.webm  ….alpha.webm
+  ….webm  ….wav  ….features.jsonl  ….tags.jsonl  ….manifest.json
+```
+
+`recordingStem()` + `fileName(stem,{role,ext})` are pure and unit-tested; every
+sink writes the identical names. An opt-in **single-file escape hatch** (one
+media stream, no features) saves a bare file with no folder.
+
+## Three-tier sink (`sink.ts`, `caps.ts`)
+
+Feature-detected, never UA-sniffed:
+
+1. **directory** — File System Access API `showDirectoryPicker` → a real folder,
+   N streamed files. The picked handle is reused from **IndexedDB** (`idb.ts`)
+   across takes (one re-grant).
+2. **zip** — one `.zip` (lazy `fflate`) = the whole folder, one download. Works
+   everywhere; lands in the browser's Downloads folder.
+3. **perFile** — per-file `saveBlob` (last resort).
+
+A `directory` request that is cancelled/unsupported degrades to a zip, so a take
+is never lost.
+
+## `manifest.json` — the alignment SSOT
+
+```jsonc
+{
+  "version": 1,
+  "startedAt": "2026-07-05T14:30:12.000Z",
+  "t0": 92.5,                       // performance.now()/1000 (DAG tick clock) at start
+  "instrument": "thoremin",
+  "stem": "demo-theremin-2026-07-05T14-30-12",
+  "streams": [
+    { "file": "….overlay.webm", "kind": "overlayVideo", "mime": "video/webm", "fps": 30 },
+    { "file": "….webm", "kind": "audio", "mime": "audio/webm;codecs=opus" },
+    { "file": "….features.jsonl", "kind": "features" }
+  ]
+}
+```
+
+Every stream's timestamps (`t` in the feature/tags JSONL) are relative to `t0`.
+
+## Forward-compat: the live-tagging `.tags.jsonl`
+
+The live-tagging stream (separate issue) is **just another stream** written into
+the same folder: same `{stem}`, the same `t0`/`ctx.time` clock, the same JSONL
+line-per-event convention (`kind: "tags"` in the manifest). No restructuring is
+needed — it drops in.
+
+## What is verified vs. browser-only
+
+Pure logic (naming, plan, manifest, schema, feature tap, sink selection) is
+unit-tested (`test/recording_*.test.ts`). The browser capture paths
+(`MediaRecorder` wiring, sink I/O, the alpha canvas, IndexedDB handle reuse) are
+build-checked and structured with feature detection + graceful fallback; they
+require a real browser + camera to exercise end-to-end.

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "acture-palette-react": "^1.0.0",
         "ai": "^4.3.19",
         "cmdk": "^1.1.1",
+        "fflate": "^0.8.3",
         "lucide-react": "^0.546.0",
         "motion": "^12.23.24",
         "react": "^19.0.0",
@@ -3304,6 +3305,12 @@
       "engines": {
         "node": "^12.20 || >= 14.13"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "acture-palette-react": "^1.0.0",
     "ai": "^4.3.19",
     "cmdk": "^1.1.1",
+    "fflate": "^0.8.3",
     "lucide-react": "^0.546.0",
     "motion": "^12.23.24",
     "react": "^19.0.0",

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -10,13 +10,14 @@
  * this component is purely presentational + lifecycle.
  */
 import { useEffect } from 'react';
-import { Play, BookOpen, Circle, Square, VolumeX } from 'lucide-react';
+import { Play, BookOpen, VolumeX } from 'lucide-react';
 import { useThoreminEngine } from './useEngine';
 import { DEFAULT_SOURCE, type SourceSpec } from './sourceSpec';
 import { installKeyboardShortcuts } from './keyboardShortcuts';
 import { useControls } from './store';
 import { useFaceStatus } from './faceStatus';
 import InstrumentsPanel from './dials/InstrumentsPanel';
+import RecordButton from './RecordButton';
 import Toaster from './Toaster';
 import CommandPaletteOverlay from './CommandPaletteOverlay';
 import AssistantOverlay from '@/plugins/assistant/AssistantOverlay';
@@ -70,7 +71,7 @@ function MutedBadge() {
 }
 
 export default function App({ source = DEFAULT_SOURCE }: { source?: SourceSpec }) {
-  const { videoRef, canvasRef, status, error, audioOn, isRecording, isSaving, startAudio, toggleRecording } =
+  const { videoRef, canvasRef, status, error, audioOn, startAudio, recording } =
     useThoreminEngine(source);
 
   // #90: install the keyboard shortcuts (octave / magnetism / mute) — an app-level
@@ -113,25 +114,10 @@ export default function App({ source = DEFAULT_SOURCE }: { source?: SourceSpec }
         <BookOpen className="h-3 w-3" /> manual
       </a>
 
-      {/* Bottom-right: record the live output to a downloadable audio file
-          (available once audio is running). */}
-      {audioOn && (
-        <button
-          onClick={toggleRecording}
-          disabled={isSaving}
-          aria-label={isRecording ? 'Stop recording' : isSaving ? 'Saving recording' : 'Record'}
-          className={`absolute bottom-3 right-3 flex items-center gap-2 rounded-full px-4 py-2 text-[10px] font-bold uppercase tracking-widest backdrop-blur transition ${
-            isRecording
-              ? 'animate-pulse bg-red-500 text-white'
-              : isSaving
-                ? 'bg-black/50 text-white/50'
-                : 'bg-black/50 text-white/80 hover:text-white'
-          }`}
-        >
-          {isRecording ? <Square className="h-3 w-3 fill-current" /> : <Circle className="h-3 w-3 fill-red-500 text-red-500" />}
-          {isRecording ? 'Stop' : isSaving ? 'Saving…' : 'Record'}
-        </button>
-      )}
+      {/* Bottom-right: the multi-stream recorder (#88) — a button that morphs into
+          a settings sheet (out-of-instrument config) then a compact HUD. Available
+          once audio is running. */}
+      {audioOn && <RecordButton recording={recording} />}
 
       {/* Top-right: the instruments surface (the list + the per-instrument editor). */}
       <InstrumentsPanel />

--- a/src/app/RecordButton.tsx
+++ b/src/app/RecordButton.tsx
@@ -1,0 +1,278 @@
+/**
+ * RecordButton (#88) — the bottom-right recording control, a button that morphs
+ * through the take's phases so recording settings live OUTSIDE the instrument:
+ *
+ *   idle       →  [ ● Record ]
+ *   settings   →  a transient "recording session" sheet in the same slot, with a
+ *                 [ ● Rec now ] primary button exactly where Record was and a
+ *                 [ ✕ ] Close that auto-saves the config (it's a settings surface,
+ *                 not a form to submit).
+ *   recording  →  a compact HUD:  [ ■ Stop ]  ● 00:12  audio · overlay · features
+ *   saving     →  the HUD, disabled, while the take converts + writes.
+ *
+ * All state lives in the engine hook (`useThoreminEngine().recording`); this is
+ * purely presentational. Part of the build-checked React layer (no @types/react).
+ */
+import { Circle, Square, X } from 'lucide-react';
+import { RECORDING_FORMATS } from './recording/formats';
+import { supportsOverlayAlpha } from './recording/caps';
+import type { RecordingSession } from './recording/schema';
+
+export interface RecordingControls {
+  phase: 'idle' | 'settings' | 'recording' | 'saving';
+  session: RecordingSession;
+  setSession: (next: RecordingSession | ((prev: RecordingSession) => RecordingSession)) => void;
+  open: (instrument?: string) => void;
+  close: () => void;
+  recNow: () => void | Promise<void>;
+  stop: () => void | Promise<void>;
+  elapsedMs: number;
+  activeStreams: string[];
+}
+
+const selectCls = 'rounded bg-white/10 px-2 py-1 text-xs outline-none focus:bg-white/20';
+
+function fmtElapsed(ms: number): string {
+  const s = Math.floor(ms / 1000);
+  const mm = Math.floor(s / 60);
+  const ss = s % 60;
+  return `${String(mm).padStart(2, '0')}:${String(ss).padStart(2, '0')}`;
+}
+
+function Check({
+  label,
+  checked,
+  onChange,
+  disabled,
+  hint,
+}: {
+  label: string;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  disabled?: boolean;
+  hint?: string;
+}) {
+  return (
+    <label
+      className={`flex items-center gap-2 text-xs ${disabled ? 'opacity-40' : ''}`}
+      title={hint}
+    >
+      <input
+        type="checkbox"
+        checked={checked}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.checked)}
+      />
+      {label}
+    </label>
+  );
+}
+
+/** The recording-session settings sheet (opens in place of the Record button). */
+function SettingsSheet({ recording }: { recording: RecordingControls }) {
+  const { session, setSession } = recording;
+  const s = session.streams;
+  const alphaOk = supportsOverlayAlpha();
+
+  const setStream = (key: keyof RecordingSession['streams'], v: boolean) =>
+    setSession((prev) => ({ ...prev, streams: { ...prev.streams, [key]: v } }));
+
+  const toggleFormat = (id: string, on: boolean) =>
+    setSession((prev) => {
+      const has = prev.formats.includes(id);
+      if (on && !has) return { ...prev, formats: [...prev.formats, id] };
+      if (!on && has) {
+        const next = prev.formats.filter((f) => f !== id);
+        return next.length ? { ...prev, formats: next } : prev; // keep ≥1
+      }
+      return prev;
+    });
+
+  return (
+    <div className="w-72 rounded-2xl bg-black/70 p-3 text-white/90 shadow-2xl backdrop-blur">
+      <div className="mb-2 flex items-center justify-between">
+        <span className="text-[10px] font-bold uppercase tracking-widest text-white/60">
+          Recording
+        </span>
+        <button
+          onClick={recording.close}
+          aria-label="Close recording settings"
+          className="rounded p-1 text-white/60 transition hover:bg-white/10 hover:text-white"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      </div>
+
+      <label className="mb-2 block">
+        <span className="text-[10px] uppercase tracking-widest text-white/50">Name</span>
+        <input
+          type="text"
+          value={session.name}
+          spellCheck={false}
+          onChange={(e) => setSession((prev) => ({ ...prev, name: e.target.value }))}
+          className="mt-1 w-full rounded bg-white/10 px-2 py-1 text-xs outline-none focus:bg-white/20"
+        />
+      </label>
+
+      <div className="mb-2">
+        <span className="text-[10px] uppercase tracking-widest text-white/50">Location</span>
+        <div className="mt-1 flex flex-col gap-1">
+          <label className="flex items-center gap-2 text-xs">
+            <input
+              type="radio"
+              name="rec-location"
+              checked={session.location === 'directory'}
+              onChange={() => setSession((prev) => ({ ...prev, location: 'directory' }))}
+            />
+            Choose folder…
+          </label>
+          <label className="flex items-center gap-2 text-xs">
+            <input
+              type="radio"
+              name="rec-location"
+              checked={session.location === 'downloads'}
+              onChange={() => setSession((prev) => ({ ...prev, location: 'downloads' }))}
+            />
+            Downloads (zip)
+          </label>
+        </div>
+      </div>
+
+      <div className="mb-2 space-y-1">
+        <span className="text-[10px] uppercase tracking-widest text-white/50">Record</span>
+        <Check label="Audio" checked={s.audio} onChange={(v) => setStream('audio', v)} />
+        <Check
+          label="Video + overlays (what you see)"
+          checked={s.overlayVideo}
+          onChange={(v) => setStream('overlayVideo', v)}
+        />
+        <Check
+          label="Pure webcam (no overlays)"
+          checked={s.pureVideo}
+          onChange={(v) => setStream('pureVideo', v)}
+          hint="The raw camera picture only — no tracking graphics. Useful as clean training/input footage."
+        />
+        {s.pureVideo && (
+          <div className="pl-5">
+            <Check
+              label="include audio"
+              checked={s.pureVideoAudio}
+              onChange={(v) => setStream('pureVideoAudio', v)}
+              hint="Mux the synth audio into the pure-webcam file (off = clean input footage)."
+            />
+          </div>
+        )}
+        <Check
+          label="Overlay only (transparent)"
+          checked={s.overlayAlpha && alphaOk}
+          disabled={!alphaOk}
+          onChange={(v) => setStream('overlayAlpha', v)}
+          hint={
+            alphaOk
+              ? 'Landmarks/cues on transparency (alpha WebM), for compositing later.'
+              : 'Transparent overlay export needs a Chromium browser (experimental).'
+          }
+        />
+        <Check
+          label="Feature stream (JSONL)"
+          checked={s.features}
+          onChange={(v) => setStream('features', v)}
+          hint="Every DAG edge value per tick → a .features.jsonl, aligned to the take's clock."
+        />
+      </div>
+
+      <div className="mb-2 flex items-center justify-between">
+        <span className="text-[10px] uppercase tracking-widest text-white/50">Formats</span>
+        <div className="flex gap-3">
+          {RECORDING_FORMATS.map((f) => (
+            <Check
+              key={f.id}
+              label={f.id.toUpperCase()}
+              checked={session.formats.includes(f.id)}
+              onChange={(v) => toggleFormat(f.id, v)}
+              disabled={!s.audio}
+              hint={f.label}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="mb-3 flex items-center justify-between">
+        <span className="text-[10px] uppercase tracking-widest text-white/50">Frame rate</span>
+        <select
+          className={selectCls}
+          value={session.fps}
+          onChange={(e) => setSession((prev) => ({ ...prev, fps: Number(e.target.value) }))}
+        >
+          {[24, 30, 60].map((f) => (
+            <option key={f} value={f}>
+              {f} fps
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <Check
+        label="Save a bare file when only one stream"
+        checked={session.singleFileWhenAlone}
+        onChange={(v) => setSession((prev) => ({ ...prev, singleFileWhenAlone: v }))}
+      />
+
+      {/* Rec now — exactly where the Record button was (same slot, stable target). */}
+      <div className="mt-3 flex justify-end">
+        <button
+          onClick={() => void recording.recNow()}
+          className="flex items-center gap-2 rounded-full bg-red-500 px-4 py-2 text-[10px] font-bold uppercase tracking-widest text-white transition hover:brightness-110"
+        >
+          <Circle className="h-3 w-3 fill-current" /> Rec now
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/** The compact in-take HUD (Stop, elapsed, active-stream chips). */
+function Hud({ recording }: { recording: RecordingControls }) {
+  const saving = recording.phase === 'saving';
+  return (
+    <button
+      onClick={() => void recording.stop()}
+      disabled={saving}
+      aria-label={saving ? 'Saving recording' : 'Stop recording'}
+      className={`flex items-center gap-2 rounded-full px-4 py-2 text-[10px] font-bold uppercase tracking-widest backdrop-blur transition ${
+        saving ? 'bg-black/50 text-white/50' : 'animate-pulse bg-red-500 text-white'
+      }`}
+    >
+      <Square className="h-3 w-3 fill-current" />
+      {saving ? 'Saving…' : 'Stop'}
+      {!saving && (
+        <>
+          <span className="tabular-nums">{fmtElapsed(recording.elapsedMs)}</span>
+          <span className="font-normal normal-case tracking-normal text-white/70">
+            {recording.activeStreams.join(' · ')}
+          </span>
+        </>
+      )}
+    </button>
+  );
+}
+
+export default function RecordButton({ recording }: { recording: RecordingControls }) {
+  return (
+    <div className="absolute bottom-3 right-3 flex flex-col items-end">
+      {recording.phase === 'idle' && (
+        <button
+          onClick={() => recording.open()}
+          aria-label="Record"
+          className="flex items-center gap-2 rounded-full bg-black/50 px-4 py-2 text-[10px] font-bold uppercase tracking-widest text-white/80 backdrop-blur transition hover:text-white"
+        >
+          <Circle className="h-3 w-3 fill-red-500 text-red-500" /> Record
+        </button>
+      )}
+      {recording.phase === 'settings' && <SettingsSheet recording={recording} />}
+      {(recording.phase === 'recording' || recording.phase === 'saving') && (
+        <Hud recording={recording} />
+      )}
+    </div>
+  );
+}

--- a/src/app/dials/DialsControlsPanel.tsx
+++ b/src/app/dials/DialsControlsPanel.tsx
@@ -9,9 +9,12 @@
  *
  * What is dials-driven: master volume / sync, both voices, the face-mapping chooser +
  * chord sound, the expression-mapping table, and the overlay element config. What is
- * NOT (kept verbatim, reading their own stores): Recording formats (a tooling pref) and
- * the Keyboard cheat-sheet. (Named saved configs are now the "instruments" flow that
- * hosts this panel — see InstrumentsPanel — so the old Presets section was removed.)
+ * NOT (kept verbatim, reading its own store): the Keyboard cheat-sheet. Recording is no
+ * longer here at all — its settings moved OUT of the instrument into the transient
+ * recording-session sheet (#88, see {@link RecordButton}), since recording config is a
+ * tooling preference, not an instrument parameter. (Named saved configs are now the
+ * "instruments" flow that hosts this panel — see InstrumentsPanel — so the old Presets
+ * section was removed.)
  *
  * Renders just the controls *content* (no outer card); the host (App) wraps it in a
  * collapsible translucent overlay so the video stays the focus.
@@ -30,7 +33,6 @@ import { ExpressionHelpButton } from '../ExpressionHelpPanel';
 import { POSE_MOVES } from '../poseControlsHelp';
 import { CalibrationWizard } from '../CalibrationWizard';
 import { useFaceStatus } from '../faceStatus';
-import { RECORDING_FORMATS } from '../recording/formats';
 import { EFFECTS, type HandMap, type FingerTarget } from '@/nodes/mapping/hand_map';
 import { FINGER_NAMES } from '@/nodes/domain';
 import { useDialsSettings } from './useDialsSettings';
@@ -619,28 +621,6 @@ function PoseMovesHelp() {
   );
 }
 
-function RecordingControls() {
-  const formats = useControls((s) => s.recordingFormats);
-  const setFormat = useControls((s) => s.setRecordingFormat);
-
-  return (
-    <div className="space-y-2">
-      {RECORDING_FORMATS.map((f) => (
-        <Toggle
-          key={f.id}
-          label={f.label}
-          checked={formats.includes(f.id)}
-          onChange={(v) => setFormat(f.id, v)}
-        />
-      ))}
-      <p className="text-[10px] leading-relaxed text-white/40">
-        On stop, your take is saved in each selected format. If your browser
-        supports it you'll be asked where to save; otherwise it lands in Downloads.
-      </p>
-    </div>
-  );
-}
-
 const EFFECT_LABELS: Record<FingerTarget, string> = {
   none: 'Off',
   brightness: 'Brightness',
@@ -788,10 +768,6 @@ export default function DialsControlsPanel() {
 
       <TopSection label="Overlay">
         <OverlayControls />
-      </TopSection>
-
-      <TopSection label="Recording">
-        <RecordingControls />
       </TopSection>
 
       <TopSection label="Keyboard">

--- a/src/app/recording/caps.ts
+++ b/src/app/recording/caps.ts
@@ -1,0 +1,85 @@
+/**
+ * Recording capability detection (#88) — feature-detect (never UA-sniff) which
+ * capture/save mechanisms the current browser supports, and pick MIME types. The
+ * one pure decision (`chooseSinkKind`) is unit-tested; the probes read live
+ * browser globals and are guarded so they no-op safely under the Node test
+ * runtime.
+ */
+import { pickMimeType } from '../recorder';
+import type { RecordingLocation } from './schema';
+
+/** The concrete sink backend a recording will use (see `./sink`). */
+export type SinkKind = 'directory' | 'zip' | 'perFile';
+
+/** Runtime capabilities that steer sink selection. */
+export interface RecordingCaps {
+  /** File System Access API directory picker (`showDirectoryPicker`). */
+  directoryPicker: boolean;
+  /** Single-file save picker (`showSaveFilePicker`). */
+  filePicker: boolean;
+}
+
+const g: typeof globalThis & {
+  showDirectoryPicker?: unknown;
+  showSaveFilePicker?: unknown;
+} = globalThis;
+
+/** Detect the current browser's save capabilities. */
+export function detectCaps(): RecordingCaps {
+  return {
+    directoryPicker: typeof g.showDirectoryPicker === 'function',
+    filePicker: typeof g.showSaveFilePicker === 'function',
+  };
+}
+
+/**
+ * Map the user's location preference + detected capabilities to a concrete sink
+ * backend (pure). `directory` uses the folder picker when available and otherwise
+ * degrades to a single zip; `downloads` always produces one zip (which lands in
+ * the browser's Downloads folder). Per-file is only the last resort when even a
+ * zip can't be assembled — currently unreachable since fflate is bundled lazily,
+ * but kept in the type so a future constrained target has a path.
+ */
+export function chooseSinkKind(location: RecordingLocation, caps: RecordingCaps): SinkKind {
+  if (location === 'directory') return caps.directoryPicker ? 'directory' : 'zip';
+  return 'zip';
+}
+
+const VIDEO_MIME_CANDIDATES = [
+  'video/webm;codecs=vp9,opus',
+  'video/webm;codecs=vp8,opus',
+  'video/webm',
+  'video/mp4',
+] as const;
+
+const ALPHA_MIME_CANDIDATES = ['video/webm;codecs=vp9', 'video/webm;codecs=vp8'] as const;
+
+function isTypeSupported(mime: string): boolean {
+  return typeof MediaRecorder !== 'undefined' && !!MediaRecorder.isTypeSupported?.(mime);
+}
+
+/** Pick the best supported audio-capture MIME (delegates to the recorder's). */
+export function pickAudioMime(): string {
+  return pickMimeType();
+}
+
+/** Pick the best supported video-capture MIME (VP9 → VP8 → webm → mp4). */
+export function pickVideoMime(): string {
+  for (const m of VIDEO_MIME_CANDIDATES) if (isTypeSupported(m)) return m;
+  return 'video/webm';
+}
+
+/** Best supported alpha (transparent) video MIME, or null if none — alpha WebM in
+ * MediaRecorder is effectively Chromium-only (Firefox flattens alpha, Safari has
+ * no alpha WebM), which `isTypeSupported` reflects on those engines. */
+export function pickAlphaMime(): string | null {
+  for (const m of ALPHA_MIME_CANDIDATES) if (isTypeSupported(m)) return m;
+  return null;
+}
+
+/** Whether the transparent overlay-only stream can be captured here. Feature-based
+ * (a supported alpha VP MIME) rather than a UA check; in practice this is true only
+ * on Chromium engines. */
+export function supportsOverlayAlpha(): boolean {
+  return pickAlphaMime() !== null;
+}

--- a/src/app/recording/featureTap.ts
+++ b/src/app/recording/featureTap.ts
@@ -1,0 +1,58 @@
+/**
+ * Feature-stream JSONL tap (#88) — a DAG {@link Tap} that serializes every
+ * observed edge value to one JSONL line `{tick,t,key,value}` on receipt, filtered
+ * to a chosen set of edges. Attached to the running engine via `engine.addTap`
+ * only while a take is in progress, then detached.
+ *
+ * Unlike `StreamRecorder` (`src/dag/recorder.ts`), which retains every value
+ * OBJECT in memory for the whole run, this serializes each value to a string
+ * immediately — so the value objects are freed as they arrive (the #49
+ * unbounded-accumulation caveat). `drain()` hands back the buffered lines and
+ * clears. Today the session calls it once on stop to write the `.features.jsonl`
+ * file; the string buffer therefore still grows over the take (much smaller than
+ * retained objects, fine for the minutes-long takes this instrument produces).
+ * `drain()` is already the seam for the follow-up: an appendable sink (FS Access
+ * `createWritable({keepExistingData:true})`) could flush it on a timer for
+ * hours-long, all-edge captures. Pure (no DOM/filesystem), unit-testable.
+ */
+import type { NodeContext, Tap } from '@/dag';
+
+export class FeatureJsonlTap implements Tap {
+  /** Only record these `"<node>.<port>"` keys; empty/undefined = all edges. */
+  private readonly only?: Set<string>;
+  private buffer: string[] = [];
+  private total = 0;
+  private readonly seen = new Set<string>();
+
+  constructor(edges: string[] = []) {
+    if (edges.length) this.only = new Set(edges);
+  }
+
+  onValue(key: string, value: unknown, ctx: NodeContext): void {
+    if (this.only && !this.only.has(key)) return;
+    this.seen.add(key);
+    // Serialize now so the (possibly large) value object can be GC'd immediately
+    // rather than retained until stop. One compact JSON object per line.
+    this.buffer.push(JSON.stringify({ tick: ctx.tick, t: ctx.time, key, value }));
+    this.total++;
+  }
+
+  /** Total lines recorded so far. */
+  get count(): number {
+    return this.total;
+  }
+
+  /** The distinct edge keys seen so far (for the manifest / diagnostics). */
+  keysSeen(): string[] {
+    return [...this.seen];
+  }
+
+  /** Take the buffered lines as a JSONL chunk and clear the buffer (for
+   * incremental flushing). Returns '' when nothing is buffered. */
+  drain(): string {
+    if (!this.buffer.length) return '';
+    const chunk = this.buffer.join('\n') + '\n';
+    this.buffer = [];
+    return chunk;
+  }
+}

--- a/src/app/recording/idb.ts
+++ b/src/app/recording/idb.ts
@@ -1,0 +1,73 @@
+/**
+ * Minimal IndexedDB store for the picked recording directory handle (#88). A
+ * `FileSystemDirectoryHandle` can't be JSON-serialized (so it can't live in the
+ * localStorage session config), but it IS structured-cloneable, so IndexedDB can
+ * persist it for silent reuse across takes — the user grants a folder once, then
+ * subsequent recordings reuse it after a single permission re-grant.
+ *
+ * This is the ONLY IndexedDB usage in the app; kept deliberately tiny and
+ * feature-detected (no-ops when IndexedDB is absent, e.g. the Node test runtime).
+ */
+
+const DB_NAME = 'thoremin-recording';
+const STORE = 'handles';
+const DIR_KEY = 'dir';
+
+function idbAvailable(): boolean {
+  return typeof indexedDB !== 'undefined';
+}
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, 1);
+    req.onupgradeneeded = () => {
+      if (!req.result.objectStoreNames.contains(STORE)) req.result.createObjectStore(STORE);
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+async function withStore<T>(mode: IDBTransactionMode, fn: (store: IDBObjectStore) => IDBRequest): Promise<T> {
+  const db = await openDb();
+  try {
+    return await new Promise<T>((resolve, reject) => {
+      const tx = db.transaction(STORE, mode);
+      const req = fn(tx.objectStore(STORE));
+      req.onsuccess = () => resolve(req.result as T);
+      req.onerror = () => reject(req.error);
+    });
+  } finally {
+    db.close();
+  }
+}
+
+/** Persist the picked directory handle for reuse (best-effort; swallows errors). */
+export async function saveDirHandle(handle: unknown): Promise<void> {
+  if (!idbAvailable()) return;
+  try {
+    await withStore('readwrite', (s) => s.put(handle, DIR_KEY));
+  } catch {
+    /* IndexedDB unavailable / private mode — non-fatal, we just re-pick. */
+  }
+}
+
+/** Load the previously-saved directory handle, or null if none / unavailable. */
+export async function loadDirHandle<T = unknown>(): Promise<T | null> {
+  if (!idbAvailable()) return null;
+  try {
+    return (await withStore<T | undefined>('readonly', (s) => s.get(DIR_KEY))) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** Forget the saved directory handle (e.g. after a permission failure). */
+export async function clearDirHandle(): Promise<void> {
+  if (!idbAvailable()) return;
+  try {
+    await withStore('readwrite', (s) => s.delete(DIR_KEY));
+  } catch {
+    /* non-fatal */
+  }
+}

--- a/src/app/recording/manifest.ts
+++ b/src/app/recording/manifest.ts
@@ -1,0 +1,71 @@
+/**
+ * Recording manifest (#88) — the per-folder alignment SSOT. Every recording is a
+ * folder containing a `{stem}.manifest.json` that records the shared clock origin
+ * (`startedAt`, `t0`), the instrument, and one entry per captured stream
+ * (`{file, kind, mime?, fps?}`). A future importer/aligner (and the live-tagging
+ * `.tags.jsonl`, which drops into the same folder on the same clock) reads this
+ * to line the streams up frame-accurately. Pure and unit-testable — no DOM, no
+ * filesystem.
+ */
+
+export const RECORDING_MANIFEST_VERSION = 1 as const;
+
+/** The kind of a captured stream (drives how a consumer decodes/aligns it). */
+export type RecordingStreamKind =
+  | 'audio'
+  | 'overlayVideo'
+  | 'pureVideo'
+  | 'overlayAlpha'
+  | 'features'
+  | 'tags';
+
+/** One stream's entry in the manifest. `file` is the name within the folder. */
+export interface RecordingStreamEntry {
+  file: string;
+  kind: RecordingStreamKind;
+  /** Media MIME (video/audio streams) — absent for JSONL streams. */
+  mime?: string;
+  /** Frames-per-second for canvas/video streams. */
+  fps?: number;
+}
+
+export interface RecordingManifest {
+  version: typeof RECORDING_MANIFEST_VERSION;
+  /** Wall-clock ISO time the take started. */
+  startedAt: string;
+  /** The DAG clock origin at record start, in seconds — the same clock the engine
+   * ticks on (`performance.now()/1000`), so every stream's JSONL `t` minus `t0`
+   * is its offset into the take. (NOT AudioContext.currentTime, a different
+   * origin.) */
+  t0: number;
+  /** The active instrument/sound id, for provenance. */
+  instrument?: string;
+  /** The recording stem (= folder name = file base name). */
+  stem: string;
+  streams: RecordingStreamEntry[];
+}
+
+/** Build a manifest from the take's clock + the list of streams actually
+ * captured. Pure: callers stamp `startedAt`/`t0` from the browser and pass them
+ * in, so this stays deterministic and testable. */
+export function buildManifest(input: {
+  startedAt: string;
+  t0: number;
+  stem: string;
+  instrument?: string;
+  streams: RecordingStreamEntry[];
+}): RecordingManifest {
+  return {
+    version: RECORDING_MANIFEST_VERSION,
+    startedAt: input.startedAt,
+    t0: input.t0,
+    instrument: input.instrument,
+    stem: input.stem,
+    streams: input.streams,
+  };
+}
+
+/** Serialize a manifest to pretty JSON (trailing newline, like the JSONL files). */
+export function serializeManifest(manifest: RecordingManifest): string {
+  return JSON.stringify(manifest, null, 2) + '\n';
+}

--- a/src/app/recording/naming.ts
+++ b/src/app/recording/naming.ts
@@ -1,0 +1,78 @@
+/**
+ * Recording naming — pure, browser-independent helpers that compose the
+ * folder/file names for a recording session (#88). The folder name IS the file
+ * stem, so every file self-identifies even when moved out of its folder. Kept
+ * pure and unit-testable, mirroring the existing `recordingFilename`/`extForMime`
+ * helpers in `../recorder` (which this supersedes for the multi-stream flow).
+ *
+ * Naming scheme (see issue #88 §3): an info-carrying stem + a type-carrying
+ * primary extension, with a role as a SECONDARY extension when several streams
+ * share a primary ext, e.g. `demo-theremin-2026-07-05T14-30-12.overlay.webm`.
+ */
+
+/** A filesystem-safe timestamp, e.g. `2026-07-05T14-30-12` (colons/millis
+ * dropped; the `T` and dashes are safe on every filesystem and stay sortable).
+ * Accepts a `Date` or an ISO string so callers can pass a deterministic stamp in
+ * tests (the runtime passes `new Date()`). */
+export function compactStamp(dateOrIso: Date | string): string {
+  const iso = typeof dateOrIso === 'string' ? dateOrIso : dateOrIso.toISOString();
+  return iso
+    .replace(/\.\d+Z?$/, '') // drop fractional seconds (+ trailing Z if present)
+    .replace(/Z$/, '') // drop a bare trailing Z (no millis case)
+    .replace(/:/g, '-'); // colons are illegal on Windows / awkward everywhere
+}
+
+/** Lowercase slug for an id-like token (tag / instrument), mirroring `presetId`. */
+function slugToken(token: string): string {
+  return token
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/**
+ * The prefilled recording name: `{tag?-}{instrument}-{stamp}`. The tag and
+ * instrument are slugged (id-like), the stamp is kept verbatim (already safe and
+ * sortable). Empty/absent tokens are skipped so a missing tag leaves no `--`.
+ */
+export function prefillName({
+  instrument,
+  tag,
+  date,
+}: {
+  instrument: string;
+  tag?: string;
+  date: Date | string;
+}): string {
+  const parts = [tag, instrument].map((t) => (t ? slugToken(t) : '')).filter(Boolean);
+  return recordingStem(`${parts.join('-')}-${compactStamp(date)}`);
+}
+
+/**
+ * Sanitize a (possibly user-overwritten) name into a filesystem-safe stem: keep
+ * `[A-Za-z0-9_-]` (so an uppercase `T` in the timestamp survives), turn any run
+ * of other characters — dots included, to keep the `stem.role.ext` structure
+ * unambiguous — into a single dash, and trim leading/trailing separators. Falls
+ * back to `recording` for an empty result.
+ */
+export function recordingStem(name: string): string {
+  return (
+    name
+      .trim()
+      .replace(/[^A-Za-z0-9_-]+/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^[-_]+|[-_]+$/g, '') || 'recording'
+  );
+}
+
+/**
+ * Compose one file name from a stem: `{stem}.{role?}.{ext}`. The role is the
+ * secondary extension that disambiguates streams sharing a primary ext (three
+ * `.webm` videos → `.overlay.webm` / `.camera.webm` / `.alpha.webm`); omit it
+ * for a stream whose primary ext is already unique (native audio `.webm`,
+ * `.wav`). `ext` is given without a leading dot.
+ */
+export function fileName(stem: string, { role, ext }: { role?: string; ext: string }): string {
+  return `${stem}${role ? `.${role}` : ''}.${ext}`;
+}

--- a/src/app/recording/plan.ts
+++ b/src/app/recording/plan.ts
@@ -1,0 +1,141 @@
+/**
+ * Recording plan (#88) — the pure function that turns a validated
+ * {@link RecordingSession} + a stem + the negotiated MIME types into the exact
+ * list of files a take will write, with correct primary/secondary extensions and
+ * the one-folder-per-recording rule (plus the opt-in single-file escape hatch).
+ *
+ * This is the browser-independent heart of the naming scheme, unit-tested in
+ * isolation; the browser {@link SessionRecorder} consumes the plan and does the
+ * actual capture + writing. Keeping it pure means the naming contract can't drift
+ * between the directory / zip / per-file sinks (they all write the same names).
+ */
+import { extForMime } from '../recorder';
+import { recordingFormat } from './formats';
+import { fileName } from './naming';
+import type { RecordingStreamKind } from './manifest';
+import type { RecordingSession } from './schema';
+
+/** File extension for a recorded VIDEO MIME type (`video/mp4` → mp4, else webm). */
+export function videoExtForMime(mime: string): string {
+  return mime.includes('mp4') ? 'mp4' : 'webm';
+}
+
+/** One file the take will produce. `kind==='manifest'` is a sidecar (not itself a
+ * stream in the manifest); every other kind is a captured stream. */
+export interface PlannedFile {
+  name: string;
+  kind: RecordingStreamKind | 'manifest';
+  role?: string;
+  ext: string;
+  mime?: string;
+  fps?: number;
+}
+
+export interface RecordingPlan {
+  stem: string;
+  /** Folder name (= stem) when {@link useFolder}; unused for a bare single file. */
+  folderName: string;
+  /** One-recording-one-folder (the default). False only for the single-file
+   * escape hatch (one media stream, no features, opted in). */
+  useFolder: boolean;
+  files: PlannedFile[];
+}
+
+export interface PlanInput {
+  session: RecordingSession;
+  stem: string;
+  /** Negotiated audio-capture MIME (native container, always WebM/Opus-ish). */
+  audioMime: string;
+  /** Negotiated overlay/pure-video MIME. */
+  videoMime: string;
+  /** Alpha (overlay-only) MIME — Chromium VP9; defaults to `video/webm;codecs=vp9`. */
+  alphaMime?: string;
+}
+
+/** Selected audio output formats, filtered to ids the registry knows (an unknown
+ * id in a stale saved session is dropped, not fatal); empty heals to `['webm']`. */
+function audioFormatIds(session: RecordingSession): string[] {
+  const ids = session.formats.filter((id) => recordingFormat(id));
+  return ids.length ? ids : ['webm'];
+}
+
+/** Number of selected MEDIA streams (audio counts once regardless of formats). */
+function mediaStreamCount(session: RecordingSession): number {
+  const s = session.streams;
+  return [s.audio, s.overlayVideo, s.pureVideo, s.overlayAlpha].filter(Boolean).length;
+}
+
+/**
+ * The one-file escape hatch is eligible only when the user opted in, exactly one
+ * media stream is selected, there is no feature stream, and — if that stream is
+ * audio — exactly one output format (two formats are two files, which needs a
+ * folder).
+ */
+function singleFileEligible(session: RecordingSession): boolean {
+  const s = session.streams;
+  if (!session.singleFileWhenAlone || s.features) return false;
+  if (mediaStreamCount(session) !== 1) return false;
+  if (s.audio) return audioFormatIds(session).length === 1;
+  return true;
+}
+
+function audioFiles(session: RecordingSession, stem: string, audioMime: string): PlannedFile[] {
+  return audioFormatIds(session).map((id) => {
+    const fmt = recordingFormat(id)!;
+    // Native webm derives its ext from the recorder MIME; converted formats use
+    // the registry ext. Audio files need no secondary ext: the native `.webm`
+    // and any converted `.wav`/`.mp3` differ by PRIMARY ext, and the video
+    // streams carry role secondary exts, so there is no collision.
+    const ext = id === 'webm' ? extForMime(audioMime) : fmt.ext;
+    return {
+      name: fileName(stem, { ext }),
+      kind: 'audio' as const,
+      ext,
+      mime: id === 'webm' ? audioMime : undefined,
+    };
+  });
+}
+
+/** Compute the full file plan for a take (pure). */
+export function planRecording(input: PlanInput): RecordingPlan {
+  const { session, stem, audioMime, videoMime } = input;
+  const alphaMime = input.alphaMime ?? 'video/webm;codecs=vp9';
+  const s = session.streams;
+  const fps = session.fps;
+  const videoExt = videoExtForMime(videoMime);
+
+  // --- single-file escape hatch: one bare media file, no folder, no manifest ---
+  if (singleFileEligible(session)) {
+    let file: PlannedFile;
+    if (s.audio) {
+      file = audioFiles(session, stem, audioMime)[0];
+    } else if (s.overlayVideo) {
+      file = { name: fileName(stem, { ext: videoExt }), kind: 'overlayVideo', ext: videoExt, mime: videoMime, fps };
+    } else if (s.pureVideo) {
+      file = { name: fileName(stem, { ext: videoExt }), kind: 'pureVideo', ext: videoExt, mime: videoMime, fps };
+    } else {
+      file = { name: fileName(stem, { ext: 'webm' }), kind: 'overlayAlpha', ext: 'webm', mime: alphaMime, fps };
+    }
+    return { stem, folderName: stem, useFolder: false, files: [file] };
+  }
+
+  // --- one folder per recording (the default) ---
+  const files: PlannedFile[] = [];
+  // Video streams share the `.webm`/`.mp4` primary ext, so each carries its role
+  // as a secondary ext (`.overlay.` / `.camera.` / `.alpha.`).
+  if (s.overlayVideo)
+    files.push({ name: fileName(stem, { role: 'overlay', ext: videoExt }), kind: 'overlayVideo', role: 'overlay', ext: videoExt, mime: videoMime, fps });
+  if (s.pureVideo)
+    files.push({ name: fileName(stem, { role: 'camera', ext: videoExt }), kind: 'pureVideo', role: 'camera', ext: videoExt, mime: videoMime, fps });
+  if (s.overlayAlpha)
+    files.push({ name: fileName(stem, { role: 'alpha', ext: 'webm' }), kind: 'overlayAlpha', role: 'alpha', ext: 'webm', mime: alphaMime, fps });
+  if (s.audio) files.push(...audioFiles(session, stem, audioMime));
+  if (s.features)
+    files.push({ name: fileName(stem, { role: 'features', ext: 'jsonl' }), kind: 'features', role: 'features', ext: 'jsonl' });
+
+  // The manifest is always present (provenance + alignment SSOT), so a folder has
+  // ≥ 2 files even for an audio-only take.
+  files.push({ name: fileName(stem, { role: 'manifest', ext: 'json' }), kind: 'manifest', role: 'manifest', ext: 'json' });
+
+  return { stem, folderName: stem, useFolder: true, files };
+}

--- a/src/app/recording/schema.ts
+++ b/src/app/recording/schema.ts
@@ -1,0 +1,92 @@
+/**
+ * Recording-session schema (#88) — the config for a recording take, modeled as
+ * its OWN Zod schema, deliberately separate from the instrument dials/presets
+ * (`src/settings/schema.ts`). Recording config is a tooling preference, not an
+ * instrument parameter, and must never live in a preset. The last-used session is
+ * persisted as a single JSON value under `recording.session.last` (localStorage),
+ * validated back through this schema on read (`parseSession`).
+ *
+ * Every field carries a `.default(...)` so a session blob saved by an older build
+ * still parses after new fields are added — the same forward-compat discipline as
+ * the settings schema. The picked directory handle is NOT stored here (handles
+ * can't be JSON-serialized); it lives in IndexedDB (`./idb`).
+ */
+import { z } from 'zod';
+
+/** localStorage key holding the last-used recording session config. */
+export const RECORDING_SESSION_KEY = 'recording.session.last';
+
+/** Which of the five streams to capture. Each is independently selectable; all
+ * default off except audio (the built, always-available stream). */
+export const RecordingStreamsSchema = z.object({
+  /** Master-bus audio (the built stream). */
+  audio: z.boolean().default(true),
+  /** Composited canvas: webcam + overlays, "what you see". */
+  overlayVideo: z.boolean().default(false),
+  /** Raw webcam, no overlays — clean training/input footage. */
+  pureVideo: z.boolean().default(false),
+  /** Include the synth audio in the pure-webcam file (default off — it's input,
+   * not output). */
+  pureVideoAudio: z.boolean().default(false),
+  /** Overlay landmarks on transparency (alpha WebM). Chromium-only; the UI
+   * disables it elsewhere. */
+  overlayAlpha: z.boolean().default(false),
+  /** DAG feature stream → JSONL. */
+  features: z.boolean().default(false),
+  /** Which DAG edges (`"<node>.<port>"`) to log; empty = all. */
+  featureEdges: z.array(z.string()).default([]),
+});
+export type RecordingStreams = z.infer<typeof RecordingStreamsSchema>;
+
+/** All-defaults streams (audio on, everything else off) — the value the parent
+ * `streams` field defaults to when absent (Zod 4's `.default` wants the full
+ * output type, so we materialize it once from the inner field defaults). */
+export const DEFAULT_RECORDING_STREAMS: RecordingStreams = RecordingStreamsSchema.parse({});
+
+/** Where the recording folder goes. `directory` = File System Access API folder
+ * picker (Chromium; falls back to a zip if unsupported); `downloads` = a single
+ * zip that lands in the browser's Downloads folder (works everywhere). */
+export const RecordingLocationSchema = z.enum(['directory', 'downloads']).default('downloads');
+export type RecordingLocation = z.infer<typeof RecordingLocationSchema>;
+
+export const RecordingSessionSchema = z.object({
+  /** Prefilled at open (`{tag?-}{instrument}-{stamp}`); fully overwritable. */
+  name: z.string().default(''),
+  location: RecordingLocationSchema,
+  /** Capture frame-rate for canvas/video streams. */
+  fps: z.number().int().min(1).max(60).default(30),
+  /** Output audio formats (ids from the RECORDING_FORMATS registry). Open list —
+   * a new format needs no schema change. Empty heals to `['webm']` in the UI. */
+  formats: z.array(z.string()).default(['webm']),
+  streams: RecordingStreamsSchema.default(() => structuredClone(DEFAULT_RECORDING_STREAMS)),
+  /** Escape hatch: when exactly one media stream (no features) is selected, save a
+   * bare file instead of a folder+manifest. Default off (one-recording-one-folder
+   * is the predictable model). */
+  singleFileWhenAlone: z.boolean().default(false),
+});
+export type RecordingSession = z.infer<typeof RecordingSessionSchema>;
+
+/** The shipped defaults (audio-only, downloads, 30fps, webm). */
+export const DEFAULT_RECORDING_SESSION: RecordingSession = RecordingSessionSchema.parse({});
+
+/**
+ * Validate a raw persisted blob back into a session config, healing any
+ * missing/invalid fields to their defaults (never throws). Mirrors the
+ * `safeParse`-with-fallback pattern the settings layer uses.
+ */
+export function parseSession(raw: unknown): RecordingSession {
+  const parsed = RecordingSessionSchema.safeParse(raw ?? {});
+  return parsed.success ? parsed.data : DEFAULT_RECORDING_SESSION;
+}
+
+/** True if at least one stream is selected (a take with nothing to record is a
+ * no-op the UI should block). */
+export function hasAnyStream(streams: RecordingStreams): boolean {
+  return (
+    streams.audio ||
+    streams.overlayVideo ||
+    streams.pureVideo ||
+    streams.overlayAlpha ||
+    streams.features
+  );
+}

--- a/src/app/recording/session.ts
+++ b/src/app/recording/session.ts
@@ -1,0 +1,427 @@
+/**
+ * SessionRecorder (#88) — the multi-stream recording orchestrator. Given the
+ * live host resources (AudioContext + master bus, the composited canvas, the
+ * webcam, the running Engine) and a validated {@link RecordingSession}, it spins
+ * up one `MediaRecorder` per selected media stream (the API can't multiplex
+ * several tracks of one kind), attaches a feature-JSONL tap to the engine, shares
+ * one `t0`/clock across all of them, and on stop converts the audio, writes every
+ * file + a `manifest.json` through a {@link RecordingSink}, and cleans up.
+ *
+ * The naming/what-files logic is the pure {@link planRecording}; this module only
+ * does the browser capture + wiring, so it is intentionally kept thin and is
+ * covered by the app's build (not the Node strict typecheck), like `useEngine`.
+ */
+import type { Engine } from '@/dag';
+import { recordingFormat } from './formats';
+import { recordingStem, prefillName } from './naming';
+import { planRecording, type RecordingPlan, type PlannedFile } from './plan';
+import { buildManifest, serializeManifest, type RecordingStreamEntry } from './manifest';
+import { detectCaps, chooseSinkKind, pickAudioMime, pickVideoMime, pickAlphaMime } from './caps';
+import { createRecordingSink, type RecordingSink, type SinkResult } from './sink';
+import { FeatureJsonlTap } from './featureTap';
+import { saveBlob } from './save';
+import { hasAnyStream, type RecordingSession } from './schema';
+
+/** Chunk media into ~2s slices so long takes stay constant-memory (#88 §1). */
+const TIMESLICE_MS = 2000;
+
+export interface SessionRecorderDeps {
+  audioContext: AudioContext;
+  /** Master-bus node to tap for audio (still reaches the speakers). */
+  masterGain: AudioNode;
+  /** The composited overlay canvas (webcam + overlays). */
+  canvas: HTMLCanvasElement;
+  /** The webcam/file `<video>` element (origin-blind pure-video capture). */
+  video: HTMLVideoElement;
+  /** The raw camera MediaStream if available (preferred pure-video source). */
+  cameraStream: MediaStream | null;
+  /** The running engine (for live feature tapping). */
+  engine: Engine;
+  /** The engine resources bag (to inject the transparent overlay canvas). */
+  resources: Record<string, unknown>;
+  /** Active instrument/sound id, for the manifest. */
+  instrument?: string;
+}
+
+interface Rec {
+  recorder: MediaRecorder;
+  chunks: Blob[];
+  mime: string;
+}
+
+function startRec(stream: MediaStream, mime: string): Rec {
+  const chunks: Blob[] = [];
+  const recorder = new MediaRecorder(stream, mime ? { mimeType: mime } : undefined);
+  recorder.ondataavailable = (e) => {
+    if (e.data.size > 0) chunks.push(e.data);
+  };
+  recorder.start(TIMESLICE_MS);
+  return { recorder, chunks, mime };
+}
+
+function stopRec(rec: Rec): Promise<Blob> {
+  return new Promise((resolve) => {
+    if (rec.recorder.state === 'inactive') {
+      resolve(new Blob(rec.chunks, { type: rec.mime }));
+      return;
+    }
+    rec.recorder.onstop = () => resolve(new Blob(rec.chunks, { type: rec.mime }));
+    rec.recorder.stop();
+  });
+}
+
+/** The raw (overlay-free) video stream for the pure-webcam file: prefer the raw
+ * camera stream; else capture the `<video>` element (origin-blind, also covers the
+ * pre-recorded ?source=video case). `owned` is false for the shared camera stream
+ * (its tracks are the LIVE feed and must NOT be stopped when the take ends) and
+ * true for a capture stream we created (and must stop). Null if neither exists. */
+function rawVideoStream(
+  video: HTMLVideoElement,
+  cameraStream: MediaStream | null,
+): { stream: MediaStream; owned: boolean } | null {
+  if (cameraStream && cameraStream.getVideoTracks().length) return { stream: cameraStream, owned: false };
+  const v = video as HTMLVideoElement & {
+    captureStream?: () => MediaStream;
+    mozCaptureStream?: () => MediaStream;
+  };
+  const capture = v.captureStream?.bind(v) ?? v.mozCaptureStream?.bind(v);
+  return capture ? { stream: capture(), owned: true } : null;
+}
+
+/** Human labels for the active streams, for the recording HUD. */
+export function activeStreamLabels(session: RecordingSession): string[] {
+  const s = session.streams;
+  const out: string[] = [];
+  if (s.audio) out.push('audio');
+  if (s.overlayVideo) out.push('overlay');
+  if (s.pureVideo) out.push('camera');
+  if (s.overlayAlpha) out.push('alpha');
+  if (s.features) out.push('features');
+  return out;
+}
+
+export class SessionRecorder {
+  private readonly deps: SessionRecorderDeps;
+  private readonly session: RecordingSession;
+
+  private audioDest: MediaStreamAudioDestinationNode | null = null;
+  private audioRec: Rec | null = null;
+  private overlayRec: Rec | null = null;
+  private pureRec: Rec | null = null;
+  private alphaRec: Rec | null = null;
+  private alphaCanvas: HTMLCanvasElement | null = null;
+  private tap: FeatureJsonlTap | null = null;
+  private detachTap: (() => void) | null = null;
+  /** Capture streams WE created (canvas/alpha/element capture) — their tracks must
+   * be stopped on teardown. Never includes the shared live camera stream. */
+  private ownedStreams: MediaStream[] = [];
+  /** Set if a bare single-file save was dismissed (so stop() reports cancellation
+   * instead of a false "saved"). */
+  private lastSaveCancelled = false;
+
+  private plan!: RecordingPlan;
+  private sink: RecordingSink | null = null;
+  private audioMime = '';
+  private videoMime = '';
+  private alphaMime: string | null = null;
+  private stem = '';
+  private startedAt = '';
+  private t0 = 0;
+  private startPerf = 0;
+  private running = false;
+
+  constructor(deps: SessionRecorderDeps, session: RecordingSession) {
+    this.deps = deps;
+    this.session = session;
+  }
+
+  get recording(): boolean {
+    return this.running;
+  }
+
+  get elapsedMs(): number {
+    return this.running ? performance.now() - this.startPerf : 0;
+  }
+
+  get activeStreams(): string[] {
+    return activeStreamLabels(this.session);
+  }
+
+  /**
+   * Begin capture. Negotiates MIME types, plans the files, acquires the sink
+   * (which may prompt for a folder), then starts every selected recorder on a
+   * shared clock. Throws if no stream is selected.
+   */
+  async start(): Promise<void> {
+    if (this.running) return;
+    if (!hasAnyStream(this.session.streams)) throw new Error('No streams selected to record');
+    const { audioContext, masterGain, canvas, video, cameraStream, engine, resources } = this.deps;
+    const s = this.session.streams;
+
+    this.audioMime = pickAudioMime();
+    this.videoMime = pickVideoMime();
+    this.alphaMime = pickAlphaMime();
+
+    const name = this.session.name.trim()
+      ? recordingStem(this.session.name)
+      : prefillName({ instrument: this.deps.instrument ?? 'thoremin', date: new Date() });
+    this.stem = name;
+
+    this.plan = planRecording({
+      session: this.session,
+      stem: this.stem,
+      audioMime: this.audioMime,
+      videoMime: this.videoMime,
+      alphaMime: this.alphaMime ?? undefined,
+    });
+
+    // A folder take goes through a sink (dir/zip); the single-file escape hatch
+    // saves one bare blob directly on stop, so it needs no sink (and no folder
+    // prompt). Acquire the sink up-front so a directory prompt appears at start.
+    if (this.plan.useFolder) {
+      const kind = chooseSinkKind(this.session.location, detectCaps());
+      this.sink = await createRecordingSink(kind, this.plan.folderName);
+    }
+
+    // Shared audio tap: needed by the audio stream and by overlay-video (which
+    // muxes the synth audio) and optionally the pure-video stream.
+    const needAudioTap = s.audio || s.overlayVideo || (s.pureVideo && s.pureVideoAudio);
+    if (needAudioTap) {
+      this.audioDest = audioContext.createMediaStreamDestination();
+      masterGain.connect(this.audioDest);
+    }
+    const audioTracks = this.audioDest ? this.audioDest.stream.getAudioTracks() : [];
+
+    this.startedAt = new Date().toISOString();
+    this.startPerf = performance.now();
+    // t0 is the alignment origin every stream's JSONL `t` is relative to (the
+    // manifest SSOT). The feature tap records ctx.time, which the engine drives
+    // from performance.now()/1000 (useEngine's rAF loop) — so t0 MUST be on that
+    // same clock, NOT audioContext.currentTime (a different origin), or `t - t0`
+    // would be skewed by the whole page-load→audio-start gap.
+    this.t0 = this.startPerf / 1000;
+
+    if (s.audio && this.audioDest) {
+      this.audioRec = startRec(this.audioDest.stream, this.audioMime);
+    }
+    if (s.overlayVideo) {
+      const canvasStream = canvas.captureStream(this.session.fps);
+      this.ownedStreams.push(canvasStream);
+      const muxed = new MediaStream([...canvasStream.getVideoTracks(), ...audioTracks]);
+      this.overlayRec = startRec(muxed, this.videoMime);
+    }
+    if (s.pureVideo) {
+      const raw = rawVideoStream(video, cameraStream);
+      if (raw) {
+        const tracks = [...raw.stream.getVideoTracks()];
+        if (s.pureVideoAudio) tracks.push(...audioTracks);
+        if (raw.owned) this.ownedStreams.push(raw.stream);
+        this.pureRec = startRec(new MediaStream(tracks), this.videoMime);
+      }
+    }
+    if (s.overlayAlpha && this.alphaMime) {
+      // A dedicated transparent canvas the overlay node draws to (backdrop
+      // suppressed) — injected via resources so the node redraws onto it each tick.
+      const ac = document.createElement('canvas');
+      ac.width = canvas.width;
+      ac.height = canvas.height;
+      this.alphaCanvas = ac;
+      resources.overlayAlphaCanvas = ac;
+      const alphaStream = ac.captureStream(this.session.fps);
+      this.ownedStreams.push(alphaStream);
+      this.alphaRec = startRec(alphaStream, this.alphaMime);
+    }
+    if (s.features) {
+      this.tap = new FeatureJsonlTap(this.session.streams.featureEdges);
+      this.detachTap = engine.addTap(this.tap);
+    }
+
+    // If every selected stream turned out to be uncapturable here (e.g. an
+    // alpha-only session reopened on a non-Chromium browser, or pure-video with no
+    // reachable camera), fail fast instead of "saving" an empty folder.
+    if (!this.audioRec && !this.overlayRec && !this.pureRec && !this.alphaRec && !this.tap) {
+      throw new Error('None of the selected streams can be captured in this browser');
+    }
+
+    this.running = true;
+  }
+
+  /**
+   * Stop every recorder, convert audio to the selected formats, write all files +
+   * the manifest through the sink (or save one bare file), and clean up. Returns
+   * the sink result for a "saved …" toast.
+   */
+  async stop(): Promise<SinkResult> {
+    if (!this.running) throw new Error('Not recording');
+    this.running = false;
+
+    // Detach the tap first so no more feature lines arrive after t-stop.
+    this.detachTap?.();
+    this.detachTap = null;
+
+    const [audioBlob, overlayBlob, pureBlob, alphaBlob] = await Promise.all([
+      this.audioRec ? stopRec(this.audioRec) : Promise.resolve(null),
+      this.overlayRec ? stopRec(this.overlayRec) : Promise.resolve(null),
+      this.pureRec ? stopRec(this.pureRec) : Promise.resolve(null),
+      this.alphaRec ? stopRec(this.alphaRec) : Promise.resolve(null),
+    ]);
+
+    // Release the master-bus tap, the transparent overlay canvas, and every
+    // capture stream we created (but never the shared live camera stream).
+    if (this.audioDest) {
+      try {
+        this.deps.masterGain.disconnect(this.audioDest);
+      } catch {
+        /* already disconnected */
+      }
+    }
+    if (this.alphaCanvas) delete this.deps.resources.overlayAlphaCanvas;
+    this.stopOwnedStreams();
+
+    // Convert audio to each selected format (decode once if any needs it).
+    const audioOutputs = audioBlob
+      ? await this.convertAudio(audioBlob)
+      : [];
+
+    // Map plan files → captured bytes and write them.
+    const written: RecordingStreamEntry[] = [];
+    let audioIdx = 0;
+    const putFile = async (file: PlannedFile, data: Blob | string) => {
+      await this.writeFile(file.name, data);
+      if (file.kind !== 'manifest')
+        written.push({ file: file.name, kind: file.kind, mime: file.mime, fps: file.fps });
+    };
+
+    for (const file of this.plan.files) {
+      switch (file.kind) {
+        case 'audio': {
+          const out = audioOutputs[audioIdx++];
+          if (out) await putFile(file, out);
+          break;
+        }
+        case 'overlayVideo':
+          if (overlayBlob) await putFile(file, overlayBlob);
+          break;
+        case 'pureVideo':
+          if (pureBlob) await putFile(file, pureBlob);
+          break;
+        case 'overlayAlpha':
+          if (alphaBlob) await putFile(file, alphaBlob);
+          break;
+        case 'features':
+          await putFile(file, this.tap?.drain() ?? '');
+          break;
+        case 'manifest': {
+          const manifest = buildManifest({
+            startedAt: this.startedAt,
+            t0: this.t0,
+            stem: this.stem,
+            instrument: this.deps.instrument,
+            streams: written,
+          });
+          await this.writeFile(file.name, serializeManifest(manifest));
+          break;
+        }
+      }
+    }
+
+    this.tap = null;
+
+    if (this.sink) return this.sink.close();
+    // Single-file escape hatch: exactly one bare file was written via saveBlob in
+    // writeFile; report it (honoring a dismissed Save-As dialog as a cancellation
+    // rather than a false success).
+    const only = this.plan.files[0];
+    return {
+      label: only?.name ?? this.stem,
+      count: this.lastSaveCancelled ? 0 : 1,
+      viaPicker: false,
+      cancelled: this.lastSaveCancelled,
+    };
+  }
+
+  /** Write one file: through the sink (folder mode) or directly via saveBlob
+   * (single-file mode). */
+  private async writeFile(name: string, data: Blob | string): Promise<void> {
+    if (this.sink) {
+      await this.sink.add(name, data);
+      return;
+    }
+    const blob =
+      typeof data === 'string' ? new Blob([data], { type: 'application/octet-stream' }) : data;
+    // saveBlob returns null when the user dismisses the Save-As dialog — record it
+    // so stop() reports a cancellation instead of a phantom "Saved".
+    const res = await saveBlob(blob, name);
+    if (res === null) this.lastSaveCancelled = true;
+  }
+
+  /** Convert the native audio blob to each selected output format, decoding once
+   * if any format needs it. Returns blobs in the SAME order as the plan's audio
+   * files (= `audioFormatIds` order). */
+  private async convertAudio(native: Blob): Promise<Blob[]> {
+    const ids = this.session.formats.filter((id) => recordingFormat(id));
+    const effectiveIds = ids.length ? ids : ['webm'];
+    let audio: AudioBuffer | null = null;
+    if (effectiveIds.some((id) => recordingFormat(id)?.needsDecode)) {
+      try {
+        audio = await this.deps.audioContext.decodeAudioData(await native.arrayBuffer());
+      } catch (e) {
+        console.error('[thoremin] could not decode recording for conversion', e);
+      }
+    }
+    const out: Blob[] = [];
+    for (const id of effectiveIds) {
+      const fmt = recordingFormat(id);
+      if (!fmt) continue;
+      try {
+        const convert = await fmt.load();
+        out.push(await convert({ native, audio }));
+      } catch (e) {
+        console.error(`[thoremin] failed to convert recording to ${id}`, e);
+        // Keep alignment with the plan: on failure fall back to the native blob so
+        // the file slot is still filled (a corrupt-but-present file beats a
+        // shifted mapping).
+        out.push(native);
+      }
+    }
+    return out;
+  }
+
+  /** Stop the tracks of every capture stream we created (canvas/alpha/element
+   * capture). The shared live camera stream is deliberately excluded. */
+  private stopOwnedStreams(): void {
+    for (const stream of this.ownedStreams) {
+      for (const track of stream.getTracks()) {
+        try {
+          track.stop();
+        } catch {
+          /* already stopped */
+        }
+      }
+    }
+    this.ownedStreams = [];
+  }
+
+  /** Best-effort teardown if a take is abandoned without a clean stop. */
+  dispose(): void {
+    this.detachTap?.();
+    this.detachTap = null;
+    for (const rec of [this.audioRec, this.overlayRec, this.pureRec, this.alphaRec]) {
+      try {
+        if (rec && rec.recorder.state !== 'inactive') rec.recorder.stop();
+      } catch {
+        /* already stopped */
+      }
+    }
+    if (this.audioDest) {
+      try {
+        this.deps.masterGain.disconnect(this.audioDest);
+      } catch {
+        /* already disconnected */
+      }
+    }
+    if (this.alphaCanvas) delete this.deps.resources.overlayAlphaCanvas;
+    this.stopOwnedStreams();
+    this.running = false;
+  }
+}

--- a/src/app/recording/sink.ts
+++ b/src/app/recording/sink.ts
@@ -1,0 +1,195 @@
+/**
+ * RecordingSink (#88) — a three-tier destination for the files of one recording
+ * folder, generalizing the single-file `saveBlob` (`./save`) into an interface
+ * with `add(name, data)` + `close()`:
+ *
+ *   1. directory — File System Access API: a real folder with N streamed files
+ *      (Chromium). The picked handle is reused from IndexedDB across takes.
+ *   2. zip       — one `.zip` (lazy `fflate`) = the whole folder, one download.
+ *      Works everywhere (the honest fallback where no folder picker exists) and
+ *      lands in the browser's Downloads folder.
+ *   3. perFile   — per-file `saveBlob` (last resort).
+ *
+ * The backend is chosen by `chooseSinkKind` (`./caps`, feature-detected). All
+ * three write the identical file names from the pure {@link planRecording}, so the
+ * naming contract can't drift between them.
+ */
+import { saveBlob } from './save';
+import { loadDirHandle, saveDirHandle, clearDirHandle } from './idb';
+import type { SinkKind } from './caps';
+
+/** A recording session was cancelled by the user (e.g. dismissed the folder
+ * picker). Thrown by the directory sink factory so the caller can fall back. */
+export class SinkCancelled extends Error {
+  constructor() {
+    super('recording sink cancelled by user');
+    this.name = 'SinkCancelled';
+  }
+}
+
+export interface SinkResult {
+  /** User-facing label for the toast (folder name, or `NAME.zip`). */
+  label: string;
+  /** How many files were written. */
+  count: number;
+  /** True if a native picker was used (folder / save-as), false for a download. */
+  viaPicker: boolean;
+  /** True if the user dismissed the final Save-As dialog — nothing was written, so
+   * callers must report a cancellation, not a success. */
+  cancelled?: boolean;
+}
+
+export interface RecordingSink {
+  /** The concrete backend, for the manifest/HUD and tests. */
+  readonly kind: SinkKind;
+  /** Write one file into the recording folder. */
+  add(name: string, data: Blob | string): Promise<void>;
+  /** Finalize (flush/close/download) and return a toast label + file count. */
+  close(): Promise<SinkResult>;
+}
+
+// ---- File System Access API surface (not in the TS DOM lib) -----------------
+interface FsWritable {
+  write(data: Blob | string | BufferSource): Promise<void>;
+  close(): Promise<void>;
+}
+interface FsFileHandle {
+  createWritable(): Promise<FsWritable>;
+}
+interface FsDirHandle {
+  name?: string;
+  getDirectoryHandle(name: string, opts?: { create?: boolean }): Promise<FsDirHandle>;
+  getFileHandle(name: string, opts?: { create?: boolean }): Promise<FsFileHandle>;
+  queryPermission?(desc: { mode: 'read' | 'readwrite' }): Promise<PermissionState>;
+  requestPermission?(desc: { mode: 'read' | 'readwrite' }): Promise<PermissionState>;
+}
+type DirPicker = (opts?: {
+  mode?: 'read' | 'readwrite';
+  startIn?: string;
+  id?: string;
+}) => Promise<FsDirHandle>;
+
+function toBytes(data: Blob | string): Promise<Uint8Array> {
+  if (typeof data === 'string') return Promise.resolve(new TextEncoder().encode(data));
+  return data.arrayBuffer().then((b) => new Uint8Array(b));
+}
+
+async function ensurePermission(handle: FsDirHandle): Promise<boolean> {
+  try {
+    const opts = { mode: 'readwrite' as const };
+    if ((await handle.queryPermission?.(opts)) === 'granted') return true;
+    return (await handle.requestPermission?.(opts)) === 'granted';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Directory sink: acquire a base folder (reused from IndexedDB, else the picker
+ * opened at Downloads), create the recording subfolder, and stream each file into
+ * it. Acquires the handle up-front (at construction) so the folder prompt appears
+ * when recording starts, not on stop. Throws {@link SinkCancelled} if the user
+ * dismisses the picker so the caller can fall back to a zip.
+ */
+async function createDirectorySink(folderName: string): Promise<RecordingSink> {
+  const picker = (globalThis as unknown as { showDirectoryPicker?: DirPicker }).showDirectoryPicker;
+  if (!picker) throw new SinkCancelled();
+
+  // Reuse a previously-picked folder when its permission is still (re-)grantable.
+  let base = await loadDirHandle<FsDirHandle>();
+  if (base && !(await ensurePermission(base))) {
+    await clearDirHandle();
+    base = null;
+  }
+  if (!base) {
+    try {
+      base = await picker({ mode: 'readwrite', startIn: 'downloads', id: 'thoremin-recording' });
+    } catch (e) {
+      if (e instanceof DOMException && e.name === 'AbortError') throw new SinkCancelled();
+      throw e;
+    }
+    await saveDirHandle(base);
+  }
+
+  const dir = await base.getDirectoryHandle(folderName, { create: true });
+  let count = 0;
+  return {
+    kind: 'directory',
+    async add(name, data) {
+      const fh = await dir.getFileHandle(name, { create: true });
+      const w = await fh.createWritable();
+      await w.write(data);
+      await w.close();
+      count++;
+    },
+    async close() {
+      return { label: folderName, count, viaPicker: true };
+    },
+  };
+}
+
+/** Zip sink: accumulate `{folderName/name: bytes}` and, on close, lazily zip
+ * (fflate) into one download. The zip preserves the one-folder mental model. */
+function createZipSink(folderName: string): RecordingSink {
+  const files: Record<string, Uint8Array> = {};
+  let count = 0;
+  return {
+    kind: 'zip',
+    async add(name, data) {
+      files[`${folderName}/${name}`] = await toBytes(data);
+      count++;
+    },
+    async close() {
+      const { zipSync } = await import('fflate');
+      const zipped = zipSync(files, { level: 6 });
+      // Copy into a fresh ArrayBuffer so the Blob owns contiguous bytes (avoids a
+      // SharedArrayBuffer/subarray-view type mismatch across TS lib versions).
+      const buf = new Uint8Array(zipped.length);
+      buf.set(zipped);
+      const blob = new Blob([buf], { type: 'application/zip' });
+      const res = await saveBlob(blob, `${folderName}.zip`);
+      return {
+        label: res?.filename ?? `${folderName}.zip`,
+        count,
+        viaPicker: res?.viaPicker ?? false,
+        cancelled: res === null,
+      };
+    },
+  };
+}
+
+/** Per-file sink (last resort): save each file separately, offering the picker
+ * only for the first (mirrors the multi-format save in the old flow). */
+function createPerFileSink(folderName: string): RecordingSink {
+  const pending: { name: string; data: Blob | string }[] = [];
+  return {
+    kind: 'perFile',
+    async add(name, data) {
+      pending.push({ name, data });
+    },
+    async close() {
+      let first = true;
+      let viaPicker = false;
+      for (const { name, data } of pending) {
+        const blob = typeof data === 'string' ? new Blob([data], { type: 'application/octet-stream' }) : data;
+        const res = await saveBlob(blob, name, { allowPicker: first });
+        if (res?.viaPicker) viaPicker = true;
+        first = false;
+      }
+      return { label: `${folderName} (${pending.length} files)`, count: pending.length, viaPicker };
+    },
+  };
+}
+
+/**
+ * Build the sink for a take. `chooseSinkKind` already picks `zip` when no folder
+ * picker exists, so a `directory` kind means the picker IS available — dismissing
+ * it here is a deliberate user cancel (this happens at record START, before
+ * anything is captured), so {@link SinkCancelled} propagates for the caller to
+ * abort the take rather than silently recording somewhere the user didn't choose.
+ */
+export async function createRecordingSink(kind: SinkKind, folderName: string): Promise<RecordingSink> {
+  if (kind === 'directory') return createDirectorySink(folderName);
+  if (kind === 'perFile') return createPerFileSink(folderName);
+  return createZipSink(folderName);
+}

--- a/src/app/useEngine.ts
+++ b/src/app/useEngine.ts
@@ -11,10 +11,16 @@ import { createAppRegistry } from '@/nodes/browser';
 import { defaultGraph } from './graph';
 import { DEFAULT_SOURCE, type SourceSpec } from './sourceSpec';
 import { useControls } from './store';
-import { PerformanceRecorder, recordingFilename, extForMime } from './recorder';
-import { recordingFormat } from './recording/formats';
-import { saveBlob } from './recording/save';
 import { useToasts } from './toasts';
+import { SessionRecorder, activeStreamLabels } from './recording/session';
+import { SinkCancelled } from './recording/sink';
+import {
+  parseSession,
+  DEFAULT_RECORDING_SESSION,
+  RECORDING_SESSION_KEY,
+  type RecordingSession,
+} from './recording/schema';
+import { prefillName } from './recording/naming';
 import { useFaceStatus } from './faceStatus';
 import type { FaceStatus } from '@/nodes';
 import type { ExpressionScores } from '@/music/expression';
@@ -33,52 +39,19 @@ const FACE_REPORT_MS = 100;
  */
 const VIDEO_LOAD_TIMEOUT_MS = 15000;
 
-/**
- * Convert the native (WebM/Opus) recording into each selected output format and
- * save it, surfacing a toast per saved file. Decodes the audio once if any
- * selected format needs it. Never throws — a per-format failure toasts and the
- * remaining formats still save.
- */
-async function saveRecording(
-  native: Blob,
-  mimeType: string,
-  audioContext: AudioContext | undefined,
-): Promise<void> {
-  const { push } = useToasts.getState();
-  const ids = useControls.getState().recordingFormats;
-  const stamp = new Date().toISOString();
-
-  let audio: AudioBuffer | null = null;
-  if (audioContext && ids.some((id) => recordingFormat(id)?.needsDecode)) {
-    try {
-      // arrayBuffer() returns a fresh copy each call, so decoding here never
-      // detaches the buffer the native passthrough reuses.
-      audio = await audioContext.decodeAudioData(await native.arrayBuffer());
-    } catch (e) {
-      console.error('[thoremin] could not decode recording for conversion', e);
-      push('Could not decode audio for conversion');
-    }
-  }
-
-  // Offer the "Save As" picker for the first saved file only; the rest download
-  // directly, so selecting several formats doesn't trigger one dialog per format.
-  let first = true;
-  for (const id of ids) {
-    const fmt = recordingFormat(id);
-    if (!fmt) continue;
-    try {
-      const convert = await fmt.load();
-      const out = await convert({ native, audio });
-      const ext = id === 'webm' ? extForMime(mimeType) : fmt.ext;
-      const result = await saveBlob(out, recordingFilename(stamp, ext), { allowPicker: first });
-      first = false;
-      if (result) push(`Saved ${result.filename}`);
-    } catch (e) {
-      console.error(`[thoremin] failed to save recording as ${fmt.id}`, e);
-      push(`Couldn't save ${fmt.label}`);
-    }
+/** Read the persisted last-used recording session (validated), or the default. */
+function loadRecordingSession(): RecordingSession {
+  try {
+    const raw = typeof localStorage !== 'undefined' ? localStorage.getItem(RECORDING_SESSION_KEY) : null;
+    return parseSession(raw ? JSON.parse(raw) : null);
+  } catch {
+    return DEFAULT_RECORDING_SESSION;
   }
 }
+
+/** Which phase the recording UI is in: the idle button, the settings sheet, an
+ * active take (HUD), or the brief save/convert step after Stop. */
+export type RecordingPhase = 'idle' | 'settings' | 'recording' | 'saving';
 
 export function useThoreminEngine(source: SourceSpec = DEFAULT_SOURCE) {
   const videoRef = useRef<HTMLVideoElement>(null);
@@ -86,15 +59,20 @@ export function useThoreminEngine(source: SourceSpec = DEFAULT_SOURCE) {
   const engineRef = useRef<Engine | null>(null);
   const resourcesRef = useRef<Record<string, unknown>>({});
   const masterGainRef = useRef<GainNode | null>(null);
-  const recorderRef = useRef<PerformanceRecorder | null>(null);
+  // The raw camera MediaStream (camera source only), kept reachable for the
+  // pure-webcam recording stream (#88); null for a file source.
+  const cameraStreamRef = useRef<MediaStream | null>(null);
+  const sessionRecRef = useRef<SessionRecorder | null>(null);
+  const recInstrumentRef = useRef<string>('thoremin');
   const recBusyRef = useRef(false);
   const rafRef = useRef<number | null>(null);
 
   const [status, setStatus] = useState<EngineStatus>('idle');
   const [error, setError] = useState<string | null>(null);
   const [audioOn, setAudioOn] = useState(false);
-  const [isRecording, setIsRecording] = useState(false);
-  const [isSaving, setIsSaving] = useState(false);
+  const [recPhase, setRecPhase] = useState<RecordingPhase>('idle');
+  const [recElapsedMs, setRecElapsedMs] = useState(0);
+  const [recSession, setRecSessionState] = useState<RecordingSession>(loadRecordingSession);
 
   const masterVolume = useControls((s) => s.masterVolume);
   const muted = useControls((s) => s.muted);
@@ -149,6 +127,8 @@ export function useThoreminEngine(source: SourceSpec = DEFAULT_SOURCE) {
             return;
           }
           video.srcObject = stream;
+          // Expose the raw camera stream for the pure-webcam recording stream (#88).
+          cameraStreamRef.current = stream;
         }
         await new Promise<void>((resolve, reject) => {
           // File path only: a stalling clip fires neither event, so bound the
@@ -274,8 +254,9 @@ export function useThoreminEngine(source: SourceSpec = DEFAULT_SOURCE) {
       engineRef.current?.dispose();
       engineRef.current = null;
       useFaceStatus.getState().reset();
-      recorderRef.current?.dispose();
-      recorderRef.current = null;
+      sessionRecRef.current?.dispose();
+      sessionRecRef.current = null;
+      cameraStreamRef.current = null;
       stream?.getTracks().forEach((t) => t.stop());
       // Symmetric to stopping camera tracks: pause a file clip so an aborted
       // (StrictMode) or unmounted run stops decoding instead of playing on, and
@@ -325,41 +306,150 @@ export function useThoreminEngine(source: SourceSpec = DEFAULT_SOURCE) {
       masterGainRef.current = master;
     }
     if (ac.state === 'suspended') await ac.resume();
-    // Set up the recorder once audio exists, tapping the master bus.
-    if (!recorderRef.current && masterGainRef.current) {
-      recorderRef.current = new PerformanceRecorder({ audioContext: ac, source: masterGainRef.current });
-    }
+    // The SessionRecorder (#88) creates its own master-bus tap when a take starts,
+    // so no persistent recorder is set up here — audio just needs to be running.
     setAudioOn(true);
   }, []);
 
-  // Start/stop recording the live output; stopping downloads the audio file.
-  // recBusyRef guards against a double-click racing stop() against a new
-  // start() (which would clear the chunks mid-stop and download an empty file).
-  const toggleRecording = useCallback(async () => {
-    const r = recorderRef.current;
-    if (!r || recBusyRef.current) return;
-    recBusyRef.current = true;
-    try {
-      if (r.recording) {
-        const native = await r.stop();
-        setIsRecording(false);
-        const ac = resourcesRef.current.audioContext as AudioContext | undefined;
-        // Converting + the save dialog can take a moment; surface a "saving"
-        // state so the UI is honest while a new record is briefly blocked.
-        setIsSaving(true);
+  // ---- Recording session (#88): out-of-instrument multi-stream recorder --------
+
+  /** Update the working session config and persist it (auto-save — the sheet is a
+   * settings surface, not a form to submit). */
+  const setRecSession = useCallback(
+    (next: RecordingSession | ((prev: RecordingSession) => RecordingSession)) => {
+      setRecSessionState((prev) => {
+        const value = typeof next === 'function' ? (next as (p: RecordingSession) => RecordingSession)(prev) : next;
         try {
-          await saveRecording(native, r.mimeType, ac);
-        } finally {
-          setIsSaving(false);
+          localStorage.setItem(RECORDING_SESSION_KEY, JSON.stringify(value));
+        } catch {
+          /* localStorage full/unavailable — the take still records this session. */
         }
+        return value;
+      });
+    },
+    [],
+  );
+
+  /** Click Record → the settings sheet. Prefills a fresh, overwritable name (a new
+   * timestamp each open, since a recording name is inherently per-take). */
+  const openRecording = useCallback(
+    (instrument?: string) => {
+      recInstrumentRef.current = instrument || 'thoremin';
+      setRecSession((prev) => ({
+        ...prev,
+        name: prefillName({ instrument: recInstrumentRef.current, date: new Date() }),
+      }));
+      setRecPhase('settings');
+    },
+    [setRecSession],
+  );
+
+  /** Close the sheet without recording (config already auto-saved on every edit). */
+  const closeRecording = useCallback(() => setRecPhase('idle'), []);
+
+  /** "Rec now": build the session recorder from the live host resources and start
+   * capture. Falls back to the sheet (not a crash) if audio isn't running yet or a
+   * stream fails to start. */
+  const recNow = useCallback(async () => {
+    if (recBusyRef.current) return;
+    const ac = resourcesRef.current.audioContext as AudioContext | undefined;
+    const master = masterGainRef.current;
+    const canvas = canvasRef.current;
+    const video = videoRef.current;
+    const engine = engineRef.current;
+    if (!ac || !master || !canvas || !video || !engine) {
+      useToasts.getState().push('Start audio before recording', 4000, 'error');
+      return;
+    }
+    recBusyRef.current = true;
+    const rec = new SessionRecorder(
+      {
+        audioContext: ac,
+        masterGain: master,
+        canvas,
+        video,
+        cameraStream: cameraStreamRef.current,
+        engine,
+        resources: resourcesRef.current,
+        instrument: recInstrumentRef.current,
+      },
+      recSession,
+    );
+    sessionRecRef.current = rec;
+    try {
+      await rec.start();
+      setRecElapsedMs(0);
+      setRecPhase('recording');
+    } catch (e) {
+      rec.dispose();
+      sessionRecRef.current = null;
+      setRecPhase('settings');
+      // A dismissed folder picker is a deliberate cancel (nothing recorded yet),
+      // not an error — return to the sheet quietly.
+      if (e instanceof SinkCancelled) {
+        useToasts.getState().push('Recording cancelled', 3000);
       } else {
-        r.start();
-        setIsRecording(true);
+        console.error('[thoremin] could not start recording', e);
+        useToasts.getState().push("Couldn't start recording", 6000, 'error');
       }
     } finally {
       recBusyRef.current = false;
     }
+  }, [recSession]);
+
+  /** Stop the take: convert audio, write every file + the manifest, toast the
+   * result. `saving` covers the convert/write window (honest UI while it works). */
+  const stopRecording = useCallback(async () => {
+    if (recBusyRef.current) return;
+    const rec = sessionRecRef.current;
+    if (!rec) return;
+    recBusyRef.current = true;
+    setRecPhase('saving');
+    try {
+      const res = await rec.stop();
+      if (res.cancelled) {
+        // The take recorded fine but the user dismissed the Save-As dialog — be
+        // honest that nothing was written rather than toasting a false "Saved".
+        useToasts.getState().push('Recording not saved (save cancelled)', 5000, 'error');
+      } else {
+        const suffix = res.count > 1 ? ` (${res.count} files)` : '';
+        useToasts.getState().push(`Saved ${res.label}${suffix}`);
+      }
+    } catch (e) {
+      console.error('[thoremin] recording save failed', e);
+      useToasts.getState().push("Couldn't save the recording", 6000, 'error');
+    } finally {
+      rec.dispose();
+      sessionRecRef.current = null;
+      recBusyRef.current = false;
+      setRecPhase('idle');
+    }
   }, []);
 
-  return { videoRef, canvasRef, status, error, audioOn, isRecording, isSaving, startAudio, toggleRecording };
+  // Tick the elapsed-time readout for the HUD while a take is running.
+  useEffect(() => {
+    if (recPhase !== 'recording') return;
+    const id = setInterval(() => setRecElapsedMs(sessionRecRef.current?.elapsedMs ?? 0), 250);
+    return () => clearInterval(id);
+  }, [recPhase]);
+
+  return {
+    videoRef,
+    canvasRef,
+    status,
+    error,
+    audioOn,
+    startAudio,
+    recording: {
+      phase: recPhase,
+      session: recSession,
+      setSession: setRecSession,
+      open: openRecording,
+      close: closeRecording,
+      recNow,
+      stop: stopRecording,
+      elapsedMs: recElapsedMs,
+      activeStreams: activeStreamLabels(recSession),
+    },
+  };
 }

--- a/src/dag/engine.ts
+++ b/src/dag/engine.ts
@@ -64,6 +64,26 @@ export class Engine {
     this.build(spec, registry);
   }
 
+  /**
+   * Attach a {@link Tap} after construction and get back a detach function.
+   * Constructor `opts.taps` covers the headless record/replay path (a fixed set
+   * of taps for the whole run); this is its live counterpart — a running engine
+   * (e.g. the browser rAF loop) can start/stop tapping mid-session without a
+   * rebuild (which would reload the ML model). Used by recording-v2 (#88) to
+   * capture a feature stream to JSONL only while a take is in progress. Idempotent
+   * per tap; the returned function removes exactly this registration.
+   */
+  addTap(tap: Tap): () => void {
+    this.taps.push(tap);
+    return () => this.removeTap(tap);
+  }
+
+  /** Detach a previously {@link addTap}'d tap (no-op if not attached). */
+  removeTap(tap: Tap): void {
+    const i = this.taps.indexOf(tap);
+    if (i >= 0) this.taps.splice(i, 1);
+  }
+
   // ---- build ------------------------------------------------------------
 
   private build(spec: GraphSpec, registry: NodeRegistry): void {

--- a/src/nodes/output/canvas_overlay.ts
+++ b/src/nodes/output/canvas_overlay.ts
@@ -1101,6 +1101,28 @@ export const canvasOverlayNode = defineNode<Params>({
         view.layout = layoutCues(view);
         for (const element of OVERLAY_ELEMENTS) element.draw(g, view);
 
+        // Overlay-only (alpha) pass (#88): when a transparent overlay canvas is
+        // injected via resources (only while the overlay-alpha stream is being
+        // recorded — Chromium alpha-WebM), redraw the SAME elements onto it with
+        // the webcam backdrop suppressed, so the landmarks/cues sit on
+        // transparency. Reuses the exact element draw list (no duplicated drawing
+        // logic, no drift) and is a no-op — zero cost — whenever the resource is
+        // absent (i.e. always, except during an alpha take).
+        const alphaCanvas = ctx.resources.overlayAlphaCanvas as HTMLCanvasElement | undefined;
+        if (alphaCanvas) {
+          const ga = alphaCanvas.getContext('2d');
+          if (ga) {
+            ga.clearRect(0, 0, alphaCanvas.width, alphaCanvas.height);
+            const alphaView: OverlayView = {
+              ...view,
+              W: alphaCanvas.width,
+              H: alphaCanvas.height,
+              params: { ...view.params, video: { ...view.params.video, show: false } },
+            };
+            for (const element of OVERLAY_ELEMENTS) element.draw(ga, alphaView);
+          }
+        }
+
         return {};
       },
     };

--- a/test/recording_caps.test.ts
+++ b/test/recording_caps.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Recording sink-selection (#88): the pure capability→backend decision and the
+ * Node-safe capability probe. The actual sink I/O is browser-only (build-checked).
+ */
+import { describe, it, expect } from 'vitest';
+import { chooseSinkKind, detectCaps, type RecordingCaps } from '@/app/recording/caps';
+
+const caps = (over: Partial<RecordingCaps> = {}): RecordingCaps => ({
+  directoryPicker: false,
+  filePicker: false,
+  ...over,
+});
+
+describe('chooseSinkKind', () => {
+  it('uses a real folder when the directory picker exists', () => {
+    expect(chooseSinkKind('directory', caps({ directoryPicker: true }))).toBe('directory');
+  });
+  it('degrades a directory request to a zip when unsupported', () => {
+    expect(chooseSinkKind('directory', caps())).toBe('zip');
+  });
+  it('always zips for the downloads preference', () => {
+    expect(chooseSinkKind('downloads', caps({ directoryPicker: true }))).toBe('zip');
+    expect(chooseSinkKind('downloads', caps())).toBe('zip');
+  });
+});
+
+describe('detectCaps', () => {
+  it('reports no pickers under the Node test runtime (no globals)', () => {
+    const c = detectCaps();
+    expect(c.directoryPicker).toBe(false);
+    expect(c.filePicker).toBe(false);
+  });
+});

--- a/test/recording_feature_tap.test.ts
+++ b/test/recording_feature_tap.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Feature-stream JSONL tap (#88): serialize-on-receipt, edge filtering, and the
+ * drain-to-file contract. A pure DAG Tap, so it tests headlessly.
+ */
+import { describe, it, expect } from 'vitest';
+import { FeatureJsonlTap } from '@/app/recording/featureTap';
+import type { NodeContext } from '@/dag';
+
+const ctx = (tick: number, time: number): NodeContext => ({ tick, time, dt: 1 / 60, resources: {} });
+
+describe('FeatureJsonlTap', () => {
+  it('records every edge as one JSONL line {tick,t,key,value}', () => {
+    const tap = new FeatureJsonlTap();
+    tap.onValue('pitch.freq', 440, ctx(0, 0));
+    tap.onValue('pitch.freq', 442, ctx(1, 0.016));
+    expect(tap.count).toBe(2);
+    const lines = tap.drain().trim().split('\n');
+    expect(JSON.parse(lines[0])).toEqual({ tick: 0, t: 0, key: 'pitch.freq', value: 440 });
+    expect(JSON.parse(lines[1])).toEqual({ tick: 1, t: 0.016, key: 'pitch.freq', value: 442 });
+  });
+
+  it('filters to the selected edges when a set is given', () => {
+    const tap = new FeatureJsonlTap(['a.x']);
+    tap.onValue('a.x', 1, ctx(0, 0));
+    tap.onValue('b.y', 2, ctx(0, 0)); // ignored
+    expect(tap.count).toBe(1);
+    expect(tap.keysSeen()).toEqual(['a.x']);
+  });
+
+  it('drain clears the buffer (so a second drain is empty)', () => {
+    const tap = new FeatureJsonlTap();
+    tap.onValue('a.x', 1, ctx(0, 0));
+    expect(tap.drain()).toBe('{"tick":0,"t":0,"key":"a.x","value":1}\n');
+    expect(tap.drain()).toBe('');
+  });
+
+  it('an empty stream drains to the empty string', () => {
+    expect(new FeatureJsonlTap().drain()).toBe('');
+  });
+});

--- a/test/recording_manifest.test.ts
+++ b/test/recording_manifest.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Recording manifest (#88): the per-folder alignment SSOT. Pure build + serialize.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  buildManifest,
+  serializeManifest,
+  RECORDING_MANIFEST_VERSION,
+  type RecordingStreamEntry,
+} from '@/app/recording/manifest';
+
+const streams: RecordingStreamEntry[] = [
+  { file: 's.overlay.webm', kind: 'overlayVideo', mime: 'video/webm', fps: 30 },
+  { file: 's.webm', kind: 'audio', mime: 'audio/webm;codecs=opus' },
+  { file: 's.features.jsonl', kind: 'features' },
+];
+
+describe('buildManifest', () => {
+  it('captures the version, clock origin, instrument, stem, and streams', () => {
+    const m = buildManifest({
+      startedAt: '2026-07-05T14:30:12.000Z',
+      t0: 12.5,
+      stem: 's',
+      instrument: 'theremin',
+      streams,
+    });
+    expect(m.version).toBe(RECORDING_MANIFEST_VERSION);
+    expect(m.startedAt).toBe('2026-07-05T14:30:12.000Z');
+    expect(m.t0).toBe(12.5);
+    expect(m.instrument).toBe('theremin');
+    expect(m.stem).toBe('s');
+    expect(m.streams).toHaveLength(3);
+  });
+});
+
+describe('serializeManifest', () => {
+  it('round-trips through JSON with a trailing newline', () => {
+    const m = buildManifest({ startedAt: 'x', t0: 0, stem: 's', streams });
+    const text = serializeManifest(m);
+    expect(text.endsWith('\n')).toBe(true);
+    expect(JSON.parse(text)).toEqual(m);
+  });
+});

--- a/test/recording_naming.test.ts
+++ b/test/recording_naming.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Recording naming helpers (#88): the pure stem/timestamp/filename composition
+ * that all sinks share. Mirrors the style of test/recording.test.ts for the
+ * older `recordingFilename` helper it supersedes.
+ */
+import { describe, it, expect } from 'vitest';
+import { compactStamp, prefillName, recordingStem, fileName } from '@/app/recording/naming';
+
+const ISO = '2026-07-05T14:30:12.345Z';
+
+describe('compactStamp', () => {
+  it('drops colons and fractional seconds, keeps the sortable T form', () => {
+    expect(compactStamp(ISO)).toBe('2026-07-05T14-30-12');
+  });
+  it('accepts a Date as well as an ISO string', () => {
+    expect(compactStamp(new Date(ISO))).toBe('2026-07-05T14-30-12');
+  });
+  it('handles a stamp without fractional seconds', () => {
+    expect(compactStamp('2026-07-05T14:30:12Z')).toBe('2026-07-05T14-30-12');
+  });
+});
+
+describe('prefillName', () => {
+  it('composes {tag-}{instrument}-{stamp}, slugging id tokens', () => {
+    expect(prefillName({ instrument: 'theremin', tag: 'demo', date: ISO })).toBe(
+      'demo-theremin-2026-07-05T14-30-12',
+    );
+  });
+  it('omits the tag cleanly when absent (no double dash)', () => {
+    expect(prefillName({ instrument: 'theremin', date: ISO })).toBe('theremin-2026-07-05T14-30-12');
+  });
+  it('slugs a spaced/cased instrument id', () => {
+    expect(prefillName({ instrument: 'Swing Piano', date: ISO })).toBe(
+      'swing-piano-2026-07-05T14-30-12',
+    );
+  });
+});
+
+describe('recordingStem', () => {
+  it('preserves case and the timestamp T, collapsing unsafe runs to one dash', () => {
+    expect(recordingStem('My Take!! 2026-07-05T14-30-12')).toBe('My-Take-2026-07-05T14-30-12');
+  });
+  it('replaces path separators and dots', () => {
+    expect(recordingStem('a/b\\c.d')).toBe('a-b-c-d');
+  });
+  it('falls back to "recording" for an empty/blank name', () => {
+    expect(recordingStem('   ')).toBe('recording');
+    expect(recordingStem('!!!')).toBe('recording');
+  });
+});
+
+describe('fileName', () => {
+  it('composes a bare primary-ext name with no role', () => {
+    expect(fileName('stem', { ext: 'webm' })).toBe('stem.webm');
+  });
+  it('inserts the role as a secondary extension', () => {
+    expect(fileName('stem', { role: 'overlay', ext: 'webm' })).toBe('stem.overlay.webm');
+    expect(fileName('stem', { role: 'features', ext: 'jsonl' })).toBe('stem.features.jsonl');
+  });
+});

--- a/test/recording_plan.test.ts
+++ b/test/recording_plan.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Recording plan (#88): the pure file-planning that encodes the naming scheme
+ * (§3) — secondary exts, always-a-folder + manifest, and the single-file escape
+ * hatch. This is the contract every sink writes against, so it is tested hard.
+ */
+import { describe, it, expect } from 'vitest';
+import { planRecording, videoExtForMime } from '@/app/recording/plan';
+import { RecordingSessionSchema, type RecordingSession } from '@/app/recording/schema';
+
+const STEM = 'demo-theremin-2026-07-05T14-30-12';
+const AUDIO_MIME = 'audio/webm;codecs=opus';
+const VIDEO_MIME = 'video/webm;codecs=vp9,opus';
+
+/** Build a session from a partial input blob; the schema fills the rest with
+ * defaults (so a test can name just the stream flags it cares about). */
+function session(overrides: Record<string, unknown> = {}): RecordingSession {
+  return RecordingSessionSchema.parse(overrides);
+}
+
+const plan = (s: RecordingSession) =>
+  planRecording({ session: s, stem: STEM, audioMime: AUDIO_MIME, videoMime: VIDEO_MIME });
+
+const names = (s: RecordingSession) => plan(s).files.map((f) => f.name);
+
+describe('videoExtForMime', () => {
+  it('maps mp4 and defaults to webm', () => {
+    expect(videoExtForMime('video/mp4')).toBe('mp4');
+    expect(videoExtForMime('video/webm;codecs=vp9,opus')).toBe('webm');
+  });
+});
+
+describe('planRecording — folder mode (default)', () => {
+  it('audio-only take is a folder with the audio file + a manifest', () => {
+    const p = plan(session());
+    expect(p.useFolder).toBe(true);
+    expect(p.folderName).toBe(STEM);
+    expect(p.files.map((f) => f.name)).toEqual([`${STEM}.webm`, `${STEM}.manifest.json`]);
+  });
+
+  it('each selected format adds an audio file (bare primary ext)', () => {
+    expect(names(session({ formats: ['webm', 'wav'] }))).toEqual([
+      `${STEM}.webm`,
+      `${STEM}.wav`,
+      `${STEM}.manifest.json`,
+    ]);
+  });
+
+  it('video streams carry role secondary exts; the manifest is always last', () => {
+    const p = plan(
+      session({
+        streams: { overlayVideo: true, pureVideo: true, overlayAlpha: true, features: true },
+      }),
+    );
+    expect(p.files.map((f) => f.name)).toEqual([
+      `${STEM}.overlay.webm`,
+      `${STEM}.camera.webm`,
+      `${STEM}.alpha.webm`,
+      `${STEM}.webm`, // audio (still on, default)
+      `${STEM}.features.jsonl`,
+      `${STEM}.manifest.json`,
+    ]);
+    // Kinds are carried for the manifest builder.
+    expect(p.files.find((f) => f.role === 'overlay')?.kind).toBe('overlayVideo');
+    expect(p.files.find((f) => f.role === 'camera')?.kind).toBe('pureVideo');
+    expect(p.files.find((f) => f.role === 'alpha')?.kind).toBe('overlayAlpha');
+  });
+
+  it('honors an mp4 video mime in the secondary-ext names', () => {
+    const p = planRecording({
+      session: session({ streams: { overlayVideo: true, audio: false } }),
+      stem: STEM,
+      audioMime: AUDIO_MIME,
+      videoMime: 'video/mp4',
+    });
+    expect(p.files.map((f) => f.name)).toEqual([`${STEM}.overlay.mp4`, `${STEM}.manifest.json`]);
+  });
+
+  it('drops an unknown format id but still produces the native webm', () => {
+    expect(names(session({ formats: ['bogus'] }))).toEqual([
+      `${STEM}.webm`,
+      `${STEM}.manifest.json`,
+    ]);
+  });
+});
+
+describe('planRecording — single-file escape hatch', () => {
+  it('one media stream + opt-in ⇒ bare file, no folder, no manifest', () => {
+    const p = plan(session({ singleFileWhenAlone: true }));
+    expect(p.useFolder).toBe(false);
+    expect(p.files.map((f) => f.name)).toEqual([`${STEM}.webm`]);
+  });
+
+  it('a lone overlay video saves bare (role omitted, no collision)', () => {
+    const p = plan(
+      session({ singleFileWhenAlone: true, streams: { audio: false, overlayVideo: true } }),
+    );
+    expect(p.useFolder).toBe(false);
+    expect(p.files.map((f) => f.name)).toEqual([`${STEM}.webm`]);
+  });
+
+  it('is NOT eligible when a feature stream is also selected', () => {
+    const p = plan(session({ singleFileWhenAlone: true, streams: { features: true } }));
+    expect(p.useFolder).toBe(true);
+    expect(p.files.some((f) => f.kind === 'manifest')).toBe(true);
+  });
+
+  it('is NOT eligible with two audio formats (two files need a folder)', () => {
+    const p = plan(session({ singleFileWhenAlone: true, formats: ['webm', 'wav'] }));
+    expect(p.useFolder).toBe(true);
+  });
+
+  it('is NOT eligible with two media streams', () => {
+    const p = plan(
+      session({ singleFileWhenAlone: true, streams: { audio: true, overlayVideo: true } }),
+    );
+    expect(p.useFolder).toBe(true);
+  });
+});

--- a/test/recording_schema.test.ts
+++ b/test/recording_schema.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Recording-session schema (#88): defaults, forward-compat (`.default` on every
+ * field), and the safeParse-with-fallback the persistence layer relies on.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  RecordingSessionSchema,
+  DEFAULT_RECORDING_SESSION,
+  parseSession,
+  hasAnyStream,
+} from '@/app/recording/schema';
+
+describe('DEFAULT_RECORDING_SESSION', () => {
+  it('is audio-only, downloads, 30fps, webm', () => {
+    expect(DEFAULT_RECORDING_SESSION.location).toBe('downloads');
+    expect(DEFAULT_RECORDING_SESSION.fps).toBe(30);
+    expect(DEFAULT_RECORDING_SESSION.formats).toEqual(['webm']);
+    expect(DEFAULT_RECORDING_SESSION.streams.audio).toBe(true);
+    expect(DEFAULT_RECORDING_SESSION.streams.overlayVideo).toBe(false);
+    expect(DEFAULT_RECORDING_SESSION.singleFileWhenAlone).toBe(false);
+  });
+});
+
+describe('parseSession', () => {
+  it('heals null/garbage to the default', () => {
+    expect(parseSession(null)).toEqual(DEFAULT_RECORDING_SESSION);
+    expect(parseSession('nope')).toEqual(DEFAULT_RECORDING_SESSION);
+  });
+
+  it('fills missing stream fields with their defaults (partial blob)', () => {
+    const s = parseSession({ streams: { overlayVideo: true } });
+    expect(s.streams.overlayVideo).toBe(true);
+    expect(s.streams.audio).toBe(true); // default preserved
+    expect(s.streams.featureEdges).toEqual([]);
+  });
+
+  it('keeps a valid overwritten name + location', () => {
+    const s = parseSession({ name: 'my-take', location: 'directory' });
+    expect(s.name).toBe('my-take');
+    expect(s.location).toBe('directory');
+  });
+});
+
+describe('schema forward-compat', () => {
+  it('an empty object parses to the full default (every field defaulted)', () => {
+    expect(RecordingSessionSchema.parse({})).toEqual(DEFAULT_RECORDING_SESSION);
+  });
+});
+
+describe('hasAnyStream', () => {
+  it('is true for the default (audio on) and false when everything is off', () => {
+    expect(hasAnyStream(DEFAULT_RECORDING_SESSION.streams)).toBe(true);
+    expect(
+      hasAnyStream({
+        audio: false,
+        overlayVideo: false,
+        pureVideo: false,
+        pureVideoAudio: false,
+        overlayAlpha: false,
+        features: false,
+        featureEdges: [],
+      }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
Implements #88 — recording redesigned as a transient **recording session** that lives *outside* the instrument, capturing any subset of five streams into one self-describing folder.

## What changed

**Out-of-instrument settings + button-swap UX** (`RecordButton`)
- `● Record` → a settings sheet in the same slot, with `● Rec now` exactly where Record was + a `✕` Close that **auto-saves** (it's a settings surface, not a form) → a compact HUD (`■ Stop · mm:ss · audio·overlay·features`).
- Recording settings **removed** from the instrument panel (`DialsControlsPanel`). `RecordingSession` is its own Zod schema (separate from presets/dials), persisted to `localStorage['recording.session.last']`.

**Five independently-selectable streams** (one `MediaRecorder` per media stream)
- **audio** (built) — converted to selected formats (webm/wav) on stop.
- **video + overlays** — `canvas.captureStream(fps)` muxed with the master-bus audio tap.
- **pure webcam** — the raw camera stream (origin-blind `video.captureStream` fallback), with an opt-in "include audio".
- **overlay-only (alpha)** — a transparent canvas the overlay node redraws to with the backdrop suppressed (reuses the exact element-draw list). **Chromium-only, experimental**, feature-gated.
- **feature stream → JSONL** — a live `FeatureJsonlTap` attached via the new `Engine.addTap`; `{tick,t,key,value}` per edge, serialize-on-receipt.

**One folder per recording + manifest** (`plan`, `naming`, `manifest`)
- Always a folder; `manifest.json` is the alignment SSOT (shared `t0` on the DAG tick clock). Info-carrying names: stem + role secondary exts (`.overlay.webm`, `.camera.webm`, `.features.jsonl`). Opt-in single-file escape hatch.
- Forward-compat: the live-tagging `.tags.jsonl` drops into the same folder/stem/clock.

**Three-tier `RecordingSink`** (feature-detected)
- File System Access API directory (handle reused via IndexedDB) → single zip (`fflate`, lazy) → per-file. A dismissed folder picker **cancels** the take; a dismissed Save-As is reported honestly, not a false "Saved".

## Verification
- Strict typecheck (`npm run typecheck`) ✓ · **505 unit tests** (`npm test`, +38 new for the pure logic: naming, plan, manifest, schema, feature tap, sink selection) ✓ · production build (`npm run build`) ✓.
- Adversarial multi-lens review (correctness / lifecycle / wiring / acceptance) run; all confirmed findings fixed — notably the manifest `t0` clock (now the DAG tick clock, matching the JSONL `t`), save-cancel honesty, fail-fast on uncapturable streams, and capture-stream track cleanup.
- **Not exercised headlessly:** the browser capture paths (`MediaRecorder` wiring, sink I/O, the alpha canvas, IndexedDB handle reuse) need a real browser + camera. They're structured with feature detection + graceful fallback; recommend a live smoke after deploy.

Design: `docs/design/recording-v2.md`.

Note: `useControls.recordingFormats` is now vestigial (the session config owns formats) — left in place so its existing test stays green; safe to remove in a follow-up.

Closes #88.

https://claude.ai/code/session_01CsgzkomRvG97p6qmdyCRec