### PR TITLE
Instrument library UX: favorites, tags, system tags, tooltips (#116)

### DIFF
--- a/src/app/dials/InstrumentsPanel.tsx
+++ b/src/app/dials/InstrumentsPanel.tsx
@@ -1,34 +1,67 @@
 /**
- * InstrumentsPanel — the top-right surface for the "instruments" flow (Phase 4),
- * replacing the old gear/settings button. Closed, it is a single instrument icon.
- * Open, it shows either:
- *  - the LIST: the named instruments; clicking a name selects & plays it (immediate
- *    feedback), the gear opens that instrument's editor;
+ * InstrumentsPanel — the top-right surface for the instruments flow. Closed, it is a
+ * single instrument icon. Open, it shows one of three sub-views:
+ *  - the LIST: the instrument library — each row selects & plays on click, shows its
+ *    derived system tags + custom tags, a favorite star, and (on hover) a compact
+ *    parametrization tooltip; the header carries a name filter, a sort control, and a
+ *    "manage tags" entry (Instrument library UX epic #116: #112 starring/sort/filter,
+ *    #113 tags column, #114 system tags, #115 tooltip);
  *  - the EDITOR: the dials-rendered {@link DialsControlsPanel} for the selected
- *    instrument, with a back arrow, an unsaved-edits dot, and a Save-with-confirm that
- *    commits the working layer into the selected instrument.
+ *    instrument, preceded by its Tags section and a "Set as default" toggle (default is
+ *    now a per-instrument setting, decoupled from the star — #112), with a back arrow, an
+ *    unsaved-edits dot, and a Save-with-confirm;
+ *  - the TAG MANAGER: rename / re-emoji / delete custom tags ({@link TagManager}).
  *
- * Edits flow into the dials store and are continuously autosaved to a hidden
- * "Last modified" layer ({@link useInstruments}); the named instrument is only
- * overwritten on an explicit, confirmed Save. Re-selecting an instrument reverts.
+ * Live edits flow into the dials store; the named instrument is only overwritten on an
+ * explicit, confirmed Save. Library metadata (favorites, tags, associations) persists via
+ * {@link useLibrary}; the single default pointer via {@link useInstruments}.
  */
-import { useState } from 'react';
-import { Music2, Settings, X, ArrowLeft, Star, Search } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import type { ProfileMeta } from '@zodal/dials-ui';
+import { Music2, Settings, X, ArrowLeft, Star, Search, Tags, Check } from 'lucide-react';
 import DialsControlsPanel from './DialsControlsPanel';
 import { useInstruments } from './useInstruments';
 import { useDialsSettings } from './useDialsSettings';
+import { useLibrary } from '@/app/library/useLibrary';
+import InstrumentTags from '@/app/library/InstrumentTags';
+import TagsEditor from '@/app/library/TagsEditor';
+import TagManager from '@/app/library/TagManager';
+import { summaryLines } from '@/app/library/summarize';
 
 const cardCls =
   'absolute right-3 top-3 flex max-h-[calc(100dvh-1.5rem)] w-96 max-w-[calc(100vw-1.5rem)] flex-col overflow-hidden rounded-2xl border border-white/10 bg-black/60 backdrop-blur';
 
+type SortMode = 'default' | 'star' | 'name';
+
+/** Filter (by name substring) then sort the instrument list for display. Sort is stable,
+ *  so 'star' keeps the underlying order within the starred / unstarred groups. */
+function orderInstruments(
+  list: ProfileMeta[],
+  query: string,
+  sort: SortMode,
+  isStarred: (name: string) => boolean,
+): ProfileMeta[] {
+  const q = query.trim().toLowerCase();
+  const filtered = q ? list.filter((p) => p.name.toLowerCase().includes(q)) : list;
+  const arr = [...filtered];
+  if (sort === 'name') arr.sort((a, b) => a.name.localeCompare(b.name));
+  else if (sort === 'star') arr.sort((a, b) => Number(isStarred(b.name)) - Number(isStarred(a.name)));
+  return arr;
+}
+
 export default function InstrumentsPanel() {
   const [open, setOpen] = useState(true);
-  const [view, setView] = useState<'list' | 'editor'>('list');
+  const [view, setView] = useState<'list' | 'editor' | 'tags'>('list');
   const [confirming, setConfirming] = useState(false);
   const [newName, setNewName] = useState('');
   const [query, setQuery] = useState('');
+  const [sort, setSort] = useState<SortMode>('default');
   const { list, selected, ready, select, save, create, defaultName, setDefault } = useInstruments();
-  const shown = list.filter((p) => p.name.toLowerCase().includes(query.trim().toLowerCase()));
+  const library = useLibrary(list);
+  const shown = useMemo(
+    () => orderInstruments(list, query, sort, library.starred),
+    [list, query, sort, library.starred],
+  );
   const { state } = useDialsSettings();
   const dirty = state.dirty.length > 0;
 
@@ -56,6 +89,15 @@ export default function InstrumentsPanel() {
     setConfirming(false);
   };
 
+  /** The parametrization tooltip text for a row (issue #115), or a fallback hint. */
+  const tooltipFor = (name: string): string => {
+    const summary = library.summaryOf(name);
+    if (!summary) return 'Click to play';
+    return summaryLines(summary)
+      .map((l) => `${l.label}: ${l.value}`)
+      .join('\n');
+  };
+
   if (!open) {
     return (
       <button
@@ -68,169 +110,239 @@ export default function InstrumentsPanel() {
     );
   }
 
-  return (
-    <div className={cardCls}>
-      {view === 'list' ? (
-        <>
-          <div className="flex items-center justify-between border-b border-white/10 px-4 py-2">
-            <span className="flex items-center gap-2 text-[11px] font-bold uppercase tracking-widest text-white/70">
-              <Music2 className="h-3.5 w-3.5" /> Instruments
-            </span>
-            <button
-              onClick={close}
-              aria-label="Close"
-              className="rounded p-1 text-white/60 transition hover:bg-white/10 hover:text-white"
-            >
-              <X className="h-4 w-4" />
-            </button>
-          </div>
-          <div className="overflow-auto p-2" aria-busy={!ready}>
-            {!ready ? (
-              <p className="px-2 py-3 text-[11px] text-white/40">Loading instruments…</p>
-            ) : (
-              <>
-                {list.length > 6 && (
-                  <div className="mb-1 flex items-center gap-1.5 rounded-lg bg-white/5 px-2">
-                    <Search className="h-3 w-3 shrink-0 text-white/30" aria-hidden />
-                    <input
-                      className="w-full bg-transparent py-1.5 text-xs text-white/80 outline-none placeholder:text-white/30"
-                      placeholder="Search instruments…"
-                      value={query}
-                      onChange={(e) => setQuery(e.target.value)}
-                      aria-label="Search instruments"
-                    />
-                  </div>
-                )}
-                <ul className="space-y-0.5">
-                  {shown.map((p) => {
-                    const isSel = p.name === selected;
-                    const isDefault = p.name === defaultName;
-                    return (
-                      <li
-                        key={p.name}
-                        className={`flex items-center gap-1 rounded-lg ${isSel ? 'bg-white/10' : 'hover:bg-white/5'}`}
-                      >
-                        <button
-                          className={`flex flex-1 items-center gap-2 truncate px-2 py-2 text-left text-xs transition ${
-                            isSel ? 'text-emerald-300' : 'text-white/80 hover:text-white'
-                          }`}
-                          title="Select & play"
-                          onClick={() => select(p.name)}
-                        >
-                          <span
-                            className={`inline-block h-1.5 w-1.5 shrink-0 rounded-full ${isSel ? 'bg-emerald-400' : 'bg-white/20'}`}
-                            aria-hidden
-                          />
-                          <span className="truncate">{p.name}</span>
-                          {isSel && dirty && (
-                            <span className="ml-1 shrink-0 text-[9px] uppercase tracking-widest text-amber-300/80">edited</span>
-                          )}
-                        </button>
-                        <button
-                          className={`rounded p-1.5 transition hover:bg-white/10 ${isDefault ? 'text-amber-300' : 'text-white/25 hover:text-white/70'}`}
-                          title={isDefault ? 'Default instrument (click to clear)' : 'Set as default'}
-                          aria-label={isDefault ? `${p.name} is the default instrument` : `Set ${p.name} as default`}
-                          onClick={() => setDefault(p.name)}
-                        >
-                          <Star className={`h-3.5 w-3.5 ${isDefault ? 'fill-current' : ''}`} />
-                        </button>
-                        <button
-                          className="rounded p-2 text-white/40 transition hover:bg-white/10 hover:text-white"
-                          title={`Edit ${p.name}`}
-                          aria-label={`Edit ${p.name}`}
-                          onClick={() => openEditor(p.name)}
-                        >
-                          <Settings className="h-3.5 w-3.5" />
-                        </button>
-                      </li>
-                    );
-                  })}
-                  {shown.length === 0 && (
-                    <li className="px-2 py-3 text-[11px] text-white/40">No instruments match “{query}”.</li>
-                  )}
-                </ul>
-              </>
+  if (view === 'tags') {
+    return (
+      <div className={cardCls}>
+        <TagManager api={library} onBack={() => setView('list')} onClose={close} />
+      </div>
+    );
+  }
+
+  if (view === 'editor') {
+    const isDefault = selected != null && selected === defaultName;
+    return (
+      <div className={cardCls}>
+        <div className="flex items-center gap-2 border-b border-white/10 px-3 py-2">
+          <button
+            onClick={() => {
+              setView('list');
+              setConfirming(false);
+            }}
+            aria-label="Back to instruments"
+            className="rounded p-1 text-white/60 transition hover:bg-white/10 hover:text-white"
+          >
+            <ArrowLeft className="h-4 w-4" />
+          </button>
+          <span className="flex flex-1 items-center gap-1.5 truncate text-[11px] font-bold uppercase tracking-widest text-white/70">
+            <span className="truncate">{selected ?? 'Settings'}</span>
+            {dirty && (
+              <span className="h-2 w-2 shrink-0 rounded-full bg-amber-400" title="Unsaved edits" aria-label="Unsaved edits" />
             )}
-            <p className="px-2 pb-2 pt-3 text-[10px] leading-relaxed text-white/40">
-              Click a name to play it. ★ sets your default (loaded next time); the gear edits an
-              instrument (tweaks kept until you Save).
-            </p>
-            <div className="mt-1 flex gap-1 border-t border-white/10 px-2 pt-2">
-              <input
-                className="flex-1 rounded bg-white/10 px-2 py-1 text-xs outline-none placeholder:text-white/30 focus:bg-white/20"
-                placeholder="Save current sound as…"
-                value={newName}
-                onChange={(e) => setNewName(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') void doCreate();
-                }}
-              />
+          </span>
+          <button
+            onClick={() => setConfirming(true)}
+            disabled={!dirty || !selected}
+            className="rounded bg-white/10 px-2 py-1 text-[11px] font-bold uppercase tracking-widest text-white/80 transition hover:bg-white/20 hover:text-white disabled:opacity-40"
+          >
+            Save
+          </button>
+          <button
+            onClick={close}
+            aria-label="Close"
+            className="rounded p-1 text-white/60 transition hover:bg-white/10 hover:text-white"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+        {confirming && (
+          <div className="flex items-center justify-between gap-2 border-b border-amber-300/20 bg-amber-300/5 px-3 py-1.5 text-[10px]">
+            <span className="truncate text-amber-200/80">Override “{selected}” with these settings?</span>
+            <span className="flex shrink-0 gap-1">
               <button
-                className="rounded bg-white/10 px-2 py-1 text-xs text-white/80 transition hover:bg-white/20 disabled:opacity-40"
-                disabled={!newName.trim()}
-                onClick={() => void doCreate()}
+                onClick={() => void doSave()}
+                className="rounded bg-emerald-500/80 px-2 py-0.5 font-bold text-black transition hover:bg-emerald-400"
               >
                 Save
               </button>
-            </div>
-          </div>
-        </>
-      ) : (
-        <>
-          <div className="flex items-center gap-2 border-b border-white/10 px-3 py-2">
-            <button
-              onClick={() => {
-                setView('list');
-                setConfirming(false);
-              }}
-              aria-label="Back to instruments"
-              className="rounded p-1 text-white/60 transition hover:bg-white/10 hover:text-white"
-            >
-              <ArrowLeft className="h-4 w-4" />
-            </button>
-            <span className="flex flex-1 items-center gap-1.5 truncate text-[11px] font-bold uppercase tracking-widest text-white/70">
-              <span className="truncate">{selected ?? 'Settings'}</span>
-              {dirty && <span className="h-2 w-2 shrink-0 rounded-full bg-amber-400" title="Unsaved edits" aria-label="Unsaved edits" />}
+              <button
+                onClick={() => setConfirming(false)}
+                className="rounded bg-white/10 px-2 py-0.5 text-white/80 transition hover:bg-white/20"
+              >
+                Cancel
+              </button>
             </span>
-            <button
-              onClick={() => setConfirming(true)}
-              disabled={!dirty || !selected}
-              className="rounded bg-white/10 px-2 py-1 text-[11px] font-bold uppercase tracking-widest text-white/80 transition hover:bg-white/20 hover:text-white disabled:opacity-40"
-            >
-              Save
-            </button>
-            <button
-              onClick={close}
-              aria-label="Close"
-              className="rounded p-1 text-white/60 transition hover:bg-white/10 hover:text-white"
-            >
-              <X className="h-4 w-4" />
-            </button>
           </div>
-          {confirming && (
-            <div className="flex items-center justify-between gap-2 border-b border-amber-300/20 bg-amber-300/5 px-3 py-1.5 text-[10px]">
-              <span className="truncate text-amber-200/80">Override “{selected}” with these settings?</span>
-              <span className="flex shrink-0 gap-1">
-                <button
-                  onClick={() => void doSave()}
-                  className="rounded bg-emerald-500/80 px-2 py-0.5 font-bold text-black transition hover:bg-emerald-400"
+        )}
+        <div className="space-y-4 overflow-auto p-4">
+          {selected && (
+            <div className="space-y-3">
+              <button
+                onClick={() => setDefault(selected)}
+                className={`flex w-full items-center gap-2 rounded-lg border px-3 py-2 text-left text-xs transition ${
+                  isDefault
+                    ? 'border-amber-300/40 bg-amber-300/10 text-amber-200'
+                    : 'border-white/10 bg-white/5 text-white/70 hover:bg-white/10'
+                }`}
+                title={isDefault ? 'This instrument opens on load — click to clear' : 'Open this instrument on load'}
+              >
+                <span
+                  className={`flex h-4 w-4 shrink-0 items-center justify-center rounded-full border ${
+                    isDefault ? 'border-amber-300 bg-amber-300 text-black' : 'border-white/30'
+                  }`}
                 >
-                  Save
-                </button>
-                <button
-                  onClick={() => setConfirming(false)}
-                  className="rounded bg-white/10 px-2 py-0.5 text-white/80 transition hover:bg-white/20"
-                >
-                  Cancel
-                </button>
-              </span>
+                  {isDefault && <Check className="h-3 w-3" />}
+                </span>
+                {isDefault ? 'Default instrument (opens on load)' : 'Set as default (opens on load)'}
+              </button>
+              <TagsEditor instrument={selected} api={library} />
             </div>
           )}
-          <div className="overflow-auto p-4">
+          <div className="border-t border-white/10 pt-3">
             <DialsControlsPanel />
           </div>
-        </>
-      )}
+        </div>
+      </div>
+    );
+  }
+
+  // --- LIST view ---------------------------------------------------------------------
+  return (
+    <div className={cardCls}>
+      <div className="flex items-center justify-between border-b border-white/10 px-4 py-2">
+        <span className="flex items-center gap-2 text-[11px] font-bold uppercase tracking-widest text-white/70">
+          <Music2 className="h-3.5 w-3.5" /> Instruments
+        </span>
+        <span className="flex items-center gap-1">
+          <button
+            onClick={() => setView('tags')}
+            aria-label="Manage tags"
+            title="Manage tags"
+            className="rounded p-1 text-white/50 transition hover:bg-white/10 hover:text-white"
+          >
+            <Tags className="h-4 w-4" />
+          </button>
+          <button
+            onClick={close}
+            aria-label="Close"
+            className="rounded p-1 text-white/60 transition hover:bg-white/10 hover:text-white"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </span>
+      </div>
+      <div className="overflow-auto p-2" aria-busy={!ready}>
+        {!ready ? (
+          <p className="px-2 py-3 text-[11px] text-white/40">Loading instruments…</p>
+        ) : (
+          <>
+            {list.length > 3 && (
+              <div className="mb-1.5 flex items-center gap-1.5">
+                <div className="flex flex-1 items-center gap-1.5 rounded-lg bg-white/5 px-2">
+                  <Search className="h-3 w-3 shrink-0 text-white/30" aria-hidden />
+                  <input
+                    className="w-full bg-transparent py-1.5 text-xs text-white/80 outline-none placeholder:text-white/30"
+                    placeholder="Filter instruments…"
+                    value={query}
+                    onChange={(e) => setQuery(e.target.value)}
+                    aria-label="Filter instruments"
+                  />
+                </div>
+                <select
+                  value={sort}
+                  onChange={(e) => setSort(e.target.value as SortMode)}
+                  aria-label="Sort instruments"
+                  className="rounded-lg bg-white/5 px-1.5 py-1.5 text-[11px] text-white/70 outline-none transition hover:bg-white/10"
+                >
+                  <option value="default">Sort: default</option>
+                  <option value="star">Sort: starred</option>
+                  <option value="name">Sort: name</option>
+                </select>
+              </div>
+            )}
+            <ul className="space-y-0.5">
+              {shown.map((p) => {
+                const isSel = p.name === selected;
+                const isDefault = p.name === defaultName;
+                const isStar = library.starred(p.name);
+                return (
+                  <li
+                    key={p.name}
+                    className={`rounded-lg ${isSel ? 'bg-white/10' : 'hover:bg-white/5'}`}
+                  >
+                    <div className="flex items-center gap-1">
+                      <button
+                        className={`flex flex-1 items-center gap-2 truncate px-2 py-2 text-left text-xs transition ${
+                          isSel ? 'text-emerald-300' : 'text-white/80 hover:text-white'
+                        }`}
+                        title={tooltipFor(p.name)}
+                        onClick={() => select(p.name)}
+                      >
+                        <span
+                          className={`inline-block h-1.5 w-1.5 shrink-0 rounded-full ${isSel ? 'bg-emerald-400' : 'bg-white/20'}`}
+                          aria-hidden
+                        />
+                        <span className="truncate">{p.name}</span>
+                        {isDefault && (
+                          <span className="shrink-0 text-[9px] uppercase tracking-widest text-amber-300/70">(default)</span>
+                        )}
+                        {isSel && dirty && (
+                          <span className="ml-1 shrink-0 text-[9px] uppercase tracking-widest text-amber-300/80">edited</span>
+                        )}
+                      </button>
+                      <button
+                        className={`rounded p-1.5 transition hover:bg-white/10 ${isStar ? 'text-amber-300' : 'text-white/25 hover:text-white/70'}`}
+                        title={isStar ? 'Unfavorite' : 'Favorite'}
+                        aria-label={isStar ? `Unfavorite ${p.name}` : `Favorite ${p.name}`}
+                        aria-pressed={isStar}
+                        onClick={() => library.toggleStar(p.name)}
+                      >
+                        <Star className={`h-3.5 w-3.5 ${isStar ? 'fill-current' : ''}`} />
+                      </button>
+                      <button
+                        className="rounded p-2 text-white/40 transition hover:bg-white/10 hover:text-white"
+                        title={`Edit ${p.name}`}
+                        aria-label={`Edit ${p.name}`}
+                        onClick={() => openEditor(p.name)}
+                      >
+                        <Settings className="h-3.5 w-3.5" />
+                      </button>
+                    </div>
+                    <InstrumentTags
+                      systemTags={library.systemTagsOf(p.name)}
+                      customTags={library.customTagsOf(p.name)}
+                    />
+                  </li>
+                );
+              })}
+              {shown.length === 0 && (
+                <li className="px-2 py-3 text-[11px] text-white/40">No instruments match “{query}”.</li>
+              )}
+            </ul>
+          </>
+        )}
+        <p className="px-2 pb-2 pt-3 text-[10px] leading-relaxed text-white/40">
+          Click a name to play it. ★ favorites an instrument; the gear opens its editor (tags,
+          default, and settings — kept until you Save).
+        </p>
+        <div className="mt-1 flex gap-1 border-t border-white/10 px-2 pt-2">
+          <input
+            className="flex-1 rounded bg-white/10 px-2 py-1 text-xs outline-none placeholder:text-white/30 focus:bg-white/20"
+            placeholder="Save current sound as…"
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') void doCreate();
+            }}
+          />
+          <button
+            className="rounded bg-white/10 px-2 py-1 text-xs text-white/80 transition hover:bg-white/20 disabled:opacity-40"
+            disabled={!newName.trim()}
+            onClick={() => void doCreate()}
+          >
+            Save
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/app/library/EmojiPicker.tsx
+++ b/src/app/library/EmojiPicker.tsx
@@ -1,0 +1,52 @@
+/**
+ * EmojiPicker — pick a tag's emoji by text search over the curated pool (issue #113):
+ * "type cat, click the cat". A search box filters {@link searchEmoji}; an empty query
+ * shows the whole pool as a scrollable grid. Fully client-side (no dataset fetch), so it
+ * opens instantly. Used by the tag manager to (re)assign a tag's glyph.
+ */
+import { useMemo, useState } from 'react';
+import { searchEmoji } from './emoji';
+
+export default function EmojiPicker({
+  value,
+  onPick,
+}: {
+  value?: string;
+  onPick: (emoji: string) => void;
+}) {
+  const [query, setQuery] = useState('');
+  const results = useMemo(() => searchEmoji(query), [query]);
+
+  return (
+    <div className="rounded-lg border border-white/10 bg-black/40 p-2">
+      <input
+        autoFocus
+        className="mb-2 w-full rounded bg-white/10 px-2 py-1 text-xs text-white/80 outline-none placeholder:text-white/30 focus:bg-white/20"
+        placeholder="Search emoji (e.g. cat, fire, star)…"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        aria-label="Search emoji"
+      />
+      {results.length === 0 ? (
+        <p className="px-1 py-2 text-[11px] text-white/40">No emoji match “{query}”.</p>
+      ) : (
+        <div className="grid max-h-40 grid-cols-8 gap-0.5 overflow-auto">
+          {results.map((e) => (
+            <button
+              key={e.char}
+              type="button"
+              onClick={() => onPick(e.char)}
+              title={e.keywords[0]}
+              aria-label={`Pick ${e.keywords[0]}`}
+              className={`rounded p-1 text-lg leading-none transition hover:bg-white/15 ${
+                e.char === value ? 'bg-white/20 ring-1 ring-emerald-400/60' : ''
+              }`}
+            >
+              {e.char}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/library/InstrumentTags.tsx
+++ b/src/app/library/InstrumentTags.tsx
@@ -1,0 +1,41 @@
+/**
+ * InstrumentTags — the tags column for one instrument row (issues #113/#114): the
+ * derived system-tag emojis first, then the custom-tag emojis, each a single glyph with
+ * a native tooltip = its label. Read-only; the row's edit gear opens tagging. Kept a tiny
+ * presentational component so the list row stays legible.
+ */
+import type { Tag } from './model';
+import type { SystemTag } from './systemTags';
+
+export default function InstrumentTags({
+  systemTags,
+  customTags,
+}: {
+  systemTags: SystemTag[];
+  customTags: Tag[];
+}) {
+  if (systemTags.length === 0 && customTags.length === 0) return null;
+  return (
+    <div className="flex flex-wrap items-center gap-1 pl-6 pr-2 pb-1.5">
+      {systemTags.map((t) => (
+        <span
+          key={t.id}
+          role="img"
+          title={t.label}
+          className="text-xs leading-none opacity-90"
+          aria-label={t.label}
+        >
+          {t.emoji}
+        </span>
+      ))}
+      {systemTags.length > 0 && customTags.length > 0 && (
+        <span className="mx-0.5 h-2.5 w-px bg-white/15" aria-hidden />
+      )}
+      {customTags.map((t) => (
+        <span key={t.id} role="img" title={t.label} className="text-xs leading-none" aria-label={t.label}>
+          {t.emoji}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/src/app/library/TagManager.tsx
+++ b/src/app/library/TagManager.tsx
@@ -1,0 +1,153 @@
+/**
+ * TagManager — the tag-manager sub-view (issue #113): list every custom tag and let the
+ * user rename its label (the hidden id — and every association — is preserved), change
+ * its emoji by text search ({@link EmojiPicker}), or delete it (guarded with a confirm
+ * when the tag is still applied to instruments, since deleting strips it everywhere).
+ * System tags are derived, not listed here — they cannot be edited.
+ */
+import { useState } from 'react';
+import { ArrowLeft, X, Trash2 } from 'lucide-react';
+import type { LibraryApi } from './useLibrary';
+import EmojiPicker from './EmojiPicker';
+
+export default function TagManager({
+  api,
+  onBack,
+  onClose,
+}: {
+  api: LibraryApi;
+  onBack: () => void;
+  onClose: () => void;
+}) {
+  const [pickerFor, setPickerFor] = useState<string | null>(null);
+  const [drafts, setDrafts] = useState<Record<string, string>>({});
+  const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+
+  const draftFor = (id: string, label: string) => drafts[id] ?? label;
+  const setDraft = (id: string, value: string) => setDrafts((d) => ({ ...d, [id]: value }));
+
+  const commitRename = (id: string, label: string) => {
+    const next = draftFor(id, label).trim();
+    if (next && next !== label) void api.renameTag(id, next);
+    setDrafts((d) => {
+      const { [id]: _, ...rest } = d;
+      return rest;
+    });
+  };
+
+  return (
+    <>
+      <div className="flex items-center gap-2 border-b border-white/10 px-3 py-2">
+        <button
+          onClick={onBack}
+          aria-label="Back to instruments"
+          className="rounded p-1 text-white/60 transition hover:bg-white/10 hover:text-white"
+        >
+          <ArrowLeft className="h-4 w-4" />
+        </button>
+        <span className="flex-1 text-[11px] font-bold uppercase tracking-widest text-white/70">
+          Manage tags
+        </span>
+        <button
+          onClick={onClose}
+          aria-label="Close"
+          className="rounded p-1 text-white/60 transition hover:bg-white/10 hover:text-white"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      <div className="overflow-auto p-2">
+        {api.tags.length === 0 ? (
+          <p className="px-2 py-4 text-[11px] leading-relaxed text-white/40">
+            No tags yet. Open an instrument’s editor and add tags in its Tags section — they’ll
+            appear here to rename, re-emoji, or delete.
+          </p>
+        ) : (
+          <ul className="space-y-1">
+            {api.tags.map((t) => {
+              const uses = api.usageCount(t.id);
+              return (
+                <li key={t.id} className="rounded-lg bg-white/5">
+                  <div className="flex items-center gap-1.5 px-2 py-1.5">
+                    <button
+                      onClick={() => setPickerFor(pickerFor === t.id ? null : t.id)}
+                      title="Change emoji"
+                      aria-label={`Change emoji for ${t.label}`}
+                      className={`rounded p-1 text-lg leading-none transition hover:bg-white/10 ${
+                        pickerFor === t.id ? 'bg-white/15' : ''
+                      }`}
+                    >
+                      {t.emoji}
+                    </button>
+                    <input
+                      className="min-w-0 flex-1 rounded bg-transparent px-1 py-0.5 text-xs text-white/80 outline-none focus:bg-white/10"
+                      value={draftFor(t.id, t.label)}
+                      onChange={(e) => setDraft(t.id, e.target.value)}
+                      onBlur={() => commitRename(t.id, t.label)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') e.currentTarget.blur();
+                      }}
+                      aria-label={`Rename tag ${t.label}`}
+                    />
+                    <span className="shrink-0 text-[10px] text-white/30" title={`Used by ${uses} instrument(s)`}>
+                      {uses > 0 ? `${uses}×` : ''}
+                    </span>
+                    <button
+                      onClick={() => (uses > 0 ? setConfirmDelete(t.id) : void api.deleteTag(t.id))}
+                      title={uses > 0 ? `Used by ${uses} — delete` : 'Delete tag'}
+                      aria-label={`Delete tag ${t.label}`}
+                      className="rounded p-1 text-white/30 transition hover:bg-white/10 hover:text-red-300"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </button>
+                  </div>
+
+                  {confirmDelete === t.id && (
+                    <div className="flex items-center justify-between gap-2 border-t border-red-300/20 bg-red-300/5 px-2 py-1.5 text-[10px]">
+                      <span className="truncate text-red-200/80">
+                        Delete “{t.label}”? It’s on {uses} instrument{uses === 1 ? '' : 's'}.
+                      </span>
+                      <span className="flex shrink-0 gap-1">
+                        <button
+                          onClick={() => {
+                            setConfirmDelete(null);
+                            void api.deleteTag(t.id);
+                          }}
+                          className="rounded bg-red-500/80 px-2 py-0.5 font-bold text-black transition hover:bg-red-400"
+                        >
+                          Delete
+                        </button>
+                        <button
+                          onClick={() => setConfirmDelete(null)}
+                          className="rounded bg-white/10 px-2 py-0.5 text-white/80 transition hover:bg-white/20"
+                        >
+                          Cancel
+                        </button>
+                      </span>
+                    </div>
+                  )}
+
+                  {pickerFor === t.id && (
+                    <div className="px-2 pb-2">
+                      <EmojiPicker
+                        value={t.emoji}
+                        onPick={(emoji) => {
+                          void api.setTagEmoji(t.id, emoji);
+                          setPickerFor(null);
+                        }}
+                      />
+                    </div>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+        <p className="px-2 pb-1 pt-3 text-[10px] leading-relaxed text-white/40">
+          Renaming keeps a tag’s identity — every instrument using it updates automatically.
+        </p>
+      </div>
+    </>
+  );
+}

--- a/src/app/library/TagsEditor.tsx
+++ b/src/app/library/TagsEditor.tsx
@@ -1,0 +1,148 @@
+/**
+ * TagsEditor — the instrument editor's Tags section (issue #113): the custom tags applied
+ * to the current instrument as removable chips, plus a comma-separated input that adds
+ * tags. While typing, existing tags matching the current token are offered as autosuggest;
+ * a typed label with no match creates a new tag (auto-assigned an emoji) on commit
+ * (Enter or comma). System tags are shown read-only for context but are not editable here.
+ */
+import { useMemo, useState } from 'react';
+import { X } from 'lucide-react';
+import type { LibraryApi } from './useLibrary';
+import { normalizeLabel } from './model';
+
+export default function TagsEditor({ instrument, api }: { instrument: string; api: LibraryApi }) {
+  const [input, setInput] = useState('');
+  const [activeIndex, setActiveIndex] = useState(-1); // highlighted autosuggest row (-1 = none)
+  const applied = api.customTagsOf(instrument);
+  const appliedIds = useMemo(() => new Set(applied.map((t) => t.id)), [applied]);
+  const systemTags = api.systemTagsOf(instrument);
+
+  // Autosuggest on the segment after the last comma (the token being typed).
+  const token = input.slice(input.lastIndexOf(',') + 1).trim();
+  const suggestions = useMemo(() => {
+    const q = normalizeLabel(token);
+    if (!q) return [];
+    return api.tags
+      .filter((t) => !appliedIds.has(t.id) && normalizeLabel(t.label).includes(q))
+      .slice(0, 6);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [token, api.tags, appliedIds]);
+
+  const commit = async (csv: string) => {
+    const text = csv.trim();
+    if (!text) return;
+    setInput('');
+    await api.addTags(instrument, text);
+  };
+
+  const pickSuggestion = async (label: string) => {
+    // Replace the in-progress token with the chosen label, then commit the whole input.
+    const head = input.slice(0, input.lastIndexOf(',') + 1);
+    await commit(`${head}${label}`);
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-1.5 text-[11px] font-bold uppercase tracking-widest text-white/50">
+        Tags
+      </div>
+
+      {systemTags.length > 0 && (
+        <div className="flex flex-wrap items-center gap-1">
+          {systemTags.map((t) => (
+            <span
+              key={t.id}
+              title={t.label}
+              className="inline-flex items-center gap-1 rounded-full bg-white/5 px-1.5 py-0.5 text-[10px] text-white/45"
+            >
+              <span>{t.emoji}</span>
+              <span className="truncate">{t.label}</span>
+            </span>
+          ))}
+        </div>
+      )}
+
+      <div className="flex flex-wrap gap-1">
+        {applied.map((t) => (
+          <span
+            key={t.id}
+            className="inline-flex items-center gap-1 rounded-full bg-white/10 px-2 py-0.5 text-[11px] text-white/80"
+          >
+            <span>{t.emoji}</span>
+            <span>{t.label}</span>
+            <button
+              type="button"
+              onClick={() => api.removeTag(instrument, t.id)}
+              aria-label={`Remove tag ${t.label}`}
+              className="rounded-full p-0.5 text-white/40 transition hover:bg-white/10 hover:text-white"
+            >
+              <X className="h-2.5 w-2.5" />
+            </button>
+          </span>
+        ))}
+        {applied.length === 0 && <span className="text-[11px] text-white/30">No tags yet.</span>}
+      </div>
+
+      <div className="relative">
+        <input
+          className="w-full rounded bg-white/10 px-2 py-1 text-xs text-white/80 outline-none placeholder:text-white/30 focus:bg-white/20"
+          placeholder="Add tags (comma-separated)…"
+          value={input}
+          role="combobox"
+          aria-expanded={suggestions.length > 0}
+          aria-controls="tag-suggestions"
+          aria-activedescendant={activeIndex >= 0 ? `tag-suggestion-${activeIndex}` : undefined}
+          onChange={(e) => {
+            setInput(e.target.value);
+            setActiveIndex(-1);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === 'ArrowDown' && suggestions.length > 0) {
+              e.preventDefault();
+              setActiveIndex((i) => Math.min(i + 1, suggestions.length - 1));
+            } else if (e.key === 'ArrowUp' && suggestions.length > 0) {
+              e.preventDefault();
+              setActiveIndex((i) => Math.max(i - 1, -1));
+            } else if (e.key === 'Escape') {
+              setActiveIndex(-1);
+            } else if (e.key === 'Enter' || e.key === ',') {
+              e.preventDefault();
+              // Enter accepts the highlighted suggestion (keyboard pick); otherwise Enter
+              // and comma both commit the typed token(s) as-is (a new tag if unmatched).
+              if (e.key === 'Enter' && activeIndex >= 0 && activeIndex < suggestions.length) {
+                void pickSuggestion(suggestions[activeIndex].label);
+              } else {
+                void commit(input);
+              }
+              setActiveIndex(-1);
+            }
+          }}
+          aria-label="Add tags"
+        />
+        {suggestions.length > 0 && (
+          <ul
+            id="tag-suggestions"
+            role="listbox"
+            className="absolute left-0 right-0 top-full z-10 mt-1 overflow-hidden rounded-lg border border-white/10 bg-black/80 backdrop-blur"
+          >
+            {suggestions.map((t, i) => (
+              <li key={t.id} id={`tag-suggestion-${i}`} role="option" aria-selected={i === activeIndex}>
+                <button
+                  type="button"
+                  onClick={() => void pickSuggestion(t.label)}
+                  onMouseEnter={() => setActiveIndex(i)}
+                  className={`flex w-full items-center gap-2 px-2 py-1.5 text-left text-xs text-white/80 transition ${
+                    i === activeIndex ? 'bg-white/15' : 'hover:bg-white/10'
+                  }`}
+                >
+                  <span>{t.emoji}</span>
+                  <span className="truncate">{t.label}</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/library/derive.ts
+++ b/src/app/library/derive.ts
@@ -1,0 +1,65 @@
+/**
+ * Instrument -> derived-view bridge: the glue that turns a *saved* instrument (a sparse
+ * dials {@link Layer} in the profile store) into the {@link InstrumentSummary} and the
+ * {@link SystemTag}s the list renders. Kept apart from the pure `summarize`/`systemTags`
+ * modules (which speak only {@link Settings}) because it reaches the dials defaults and
+ * the instruments profile store — the one place the library's read side touches them.
+ *
+ * A saved layer is sparse and may carry the dials UNSET sentinel (a symbol) for keys the
+ * user reset; both are resolved by merging the layer over the flat dials defaults and
+ * dropping any symbol value, so the projection sees the same EFFECTIVE settings the live
+ * engine would — without mutating the live dials store.
+ */
+import type { Layer } from '@zodal/dials-core';
+import { instruments } from '@/app/dials/instruments';
+import { thoreminDials, layerToSettings } from '@/settings/dials';
+import type { Settings } from '@/settings/schema';
+import { summarizeInstrument, type InstrumentSummary } from './summarize';
+import { deriveSystemTags, type SystemTag } from './systemTags';
+
+/** The flat dials defaults (every key set), the base a sparse profile layer merges over. */
+const DEFAULTS_LAYER = thoreminDials.defaults as Record<string, unknown>;
+
+/**
+ * Resolve a saved (sparse, possibly UNSET-bearing) layer to full effective {@link Settings}.
+ * UNSET keys (symbols) abstain, so the default wins — matching the dials cascade.
+ */
+export function settingsFromLayer(layer: Layer): Settings {
+  const merged: Record<string, unknown> = { ...DEFAULTS_LAYER };
+  for (const [key, value] of Object.entries(layer)) {
+    if (typeof value !== 'symbol') merged[key] = value; // skip the UNSET sentinel
+  }
+  return layerToSettings(merged);
+}
+
+/** The derived read-view of one instrument. */
+export interface InstrumentDerived {
+  summary: InstrumentSummary;
+  systemTags: SystemTag[];
+}
+
+/** Derive the summary + system tags for one saved instrument, or null if it is gone or
+ *  its layer cannot be projected (defensive — a bad instrument never breaks the list). */
+export async function deriveForName(name: string): Promise<InstrumentDerived | null> {
+  try {
+    const layer = await instruments.load(name);
+    if (!layer) return null;
+    const summary = summarizeInstrument(settingsFromLayer(layer));
+    return { summary, systemTags: deriveSystemTags(summary) };
+  } catch {
+    return null;
+  }
+}
+
+/** Derive summary + system tags for every named instrument, in parallel. Instruments
+ *  that fail to project are simply omitted from the map. */
+export async function deriveForNames(names: readonly string[]): Promise<Record<string, InstrumentDerived>> {
+  const entries = await Promise.all(
+    names.map(async (name) => [name, await deriveForName(name)] as const),
+  );
+  const out: Record<string, InstrumentDerived> = {};
+  for (const [name, derived] of entries) {
+    if (derived) out[name] = derived;
+  }
+  return out;
+}

--- a/src/app/library/emoji.ts
+++ b/src/app/library/emoji.ts
@@ -1,0 +1,229 @@
+/**
+ * Emoji picking for custom tags (issue #113), fully client-side and dependency-free —
+ * honoring thoremin's no-backend ethos and the repo's dependency-lock caution (no new
+ * npm dep for a tags feature). A single curated {@link EMOJI_POOL} of ~110 high-contrast,
+ * single-glyph emojis serves BOTH roles the issue asks for:
+ *  - the auto-assign pool (a new tag gets a random unused emoji), and
+ *  - the keyword search corpus ("type cat -> select the cat"), via each entry's
+ *    hand-written `keywords`.
+ *
+ * The pool is deliberately biased toward mutual contrast at small size (distinct
+ * animals / foods / objects / nature / shapes) so a row of tag emojis in the list stays
+ * easy to tell apart. The exact set is a PROPOSAL flagged for the maintainer's sign-off
+ * (see the PR); tweaking it is a one-line edit here. System-tag glyphs (see
+ * {@link ./systemTags}) are intentionally EXCLUDED so a custom emoji never collides with
+ * a derived one in the same column.
+ *
+ * If broader "search any emoji" is ever wanted, swapping the search corpus for a lazy
+ * `emojilib` import is a drop-in change behind {@link searchEmoji} — the pool stays the
+ * auto-assign source.
+ */
+
+/** One curated emoji: the glyph plus lowercase search keywords (label included). */
+export interface EmojiEntry {
+  char: string;
+  keywords: string[];
+}
+
+/**
+ * The curated pool (PROPOSAL — sign-off pending). ~110 visually distinct single glyphs.
+ * Grouped only for readability; order is otherwise irrelevant. Deliberately avoids the
+ * system-tag glyphs (colored circles, face/pose/hand cues) to prevent column collisions.
+ */
+export const EMOJI_POOL: readonly EmojiEntry[] = [
+  // Animals — distinct silhouettes.
+  { char: '🐱', keywords: ['cat', 'kitten', 'meow'] },
+  { char: '🐶', keywords: ['dog', 'puppy', 'woof'] },
+  { char: '🦊', keywords: ['fox'] },
+  { char: '🐼', keywords: ['panda', 'bear'] },
+  { char: '🦁', keywords: ['lion'] },
+  { char: '🐸', keywords: ['frog', 'toad'] },
+  { char: '🐵', keywords: ['monkey', 'ape'] },
+  { char: '🐰', keywords: ['rabbit', 'bunny', 'hare'] },
+  { char: '🐷', keywords: ['pig', 'oink'] },
+  { char: '🐔', keywords: ['chicken', 'hen'] },
+  { char: '🦉', keywords: ['owl'] },
+  { char: '🦋', keywords: ['butterfly'] },
+  { char: '🐙', keywords: ['octopus'] },
+  { char: '🦈', keywords: ['shark'] },
+  { char: '🐢', keywords: ['turtle', 'tortoise'] },
+  { char: '🦩', keywords: ['flamingo'] },
+  { char: '🦥', keywords: ['sloth'] },
+  { char: '🐝', keywords: ['bee', 'honey'] },
+  { char: '🐬', keywords: ['dolphin'] },
+  { char: '🦄', keywords: ['unicorn'] },
+  { char: '🐺', keywords: ['wolf'] },
+  { char: '🐧', keywords: ['penguin'] },
+  { char: '🐴', keywords: ['horse'] },
+  { char: '🐮', keywords: ['cow', 'moo'] },
+  { char: '🐍', keywords: ['snake', 'serpent'] },
+  { char: '🦖', keywords: ['dinosaur', 'dino', 'rex'] },
+  { char: '🐳', keywords: ['whale'] },
+  { char: '🐞', keywords: ['ladybug', 'beetle', 'bug'] },
+  // Food & fruit.
+  { char: '🍎', keywords: ['apple', 'red'] },
+  { char: '🍋', keywords: ['lemon', 'citrus'] },
+  { char: '🍇', keywords: ['grapes', 'grape'] },
+  { char: '🍑', keywords: ['peach'] },
+  { char: '🍒', keywords: ['cherry', 'cherries'] },
+  { char: '🥝', keywords: ['kiwi'] },
+  { char: '🥑', keywords: ['avocado'] },
+  { char: '🌶️', keywords: ['pepper', 'chili', 'hot', 'spicy'] },
+  { char: '🍄', keywords: ['mushroom', 'fungus'] },
+  { char: '🥕', keywords: ['carrot'] },
+  { char: '🌽', keywords: ['corn', 'maize'] },
+  { char: '🍔', keywords: ['burger', 'hamburger'] },
+  { char: '🍕', keywords: ['pizza'] },
+  { char: '🍩', keywords: ['donut', 'doughnut'] },
+  { char: '🍰', keywords: ['cake', 'slice'] },
+  { char: '🍓', keywords: ['strawberry', 'berry'] },
+  { char: '🍌', keywords: ['banana'] },
+  { char: '🍉', keywords: ['watermelon', 'melon'] },
+  { char: '🍍', keywords: ['pineapple'] },
+  { char: '🥥', keywords: ['coconut'] },
+  { char: '🥨', keywords: ['pretzel'] },
+  { char: '🧀', keywords: ['cheese'] },
+  { char: '🍦', keywords: ['icecream', 'ice', 'cream', 'soft', 'serve'] },
+  { char: '🍭', keywords: ['lollipop', 'candy', 'sweet'] },
+  { char: '🍫', keywords: ['chocolate', 'choc'] },
+  { char: '🫐', keywords: ['blueberry', 'berries'] },
+  { char: '🥐', keywords: ['croissant'] },
+  // Objects & instruments.
+  { char: '🔑', keywords: ['key', 'unlock'] },
+  { char: '🔔', keywords: ['bell', 'ring'] },
+  { char: '🎈', keywords: ['balloon', 'party'] },
+  { char: '🎁', keywords: ['gift', 'present', 'box'] },
+  { char: '🎯', keywords: ['target', 'dart', 'bullseye', 'aim'] },
+  { char: '🎲', keywords: ['dice', 'die', 'random', 'roll'] },
+  { char: '🧩', keywords: ['puzzle', 'jigsaw', 'piece'] },
+  { char: '🪁', keywords: ['kite'] },
+  { char: '🔨', keywords: ['hammer', 'tool', 'build'] },
+  { char: '🧲', keywords: ['magnet', 'magnetism', 'attract'] },
+  { char: '🕯️', keywords: ['candle', 'flame', 'wax'] },
+  { char: '🔦', keywords: ['flashlight', 'torch', 'light'] },
+  { char: '🎸', keywords: ['guitar', 'rock', 'strings'] },
+  { char: '🎹', keywords: ['piano', 'keyboard', 'keys'] },
+  { char: '🎺', keywords: ['trumpet', 'brass', 'horn'] },
+  { char: '🥁', keywords: ['drum', 'drums', 'beat', 'percussion'] },
+  { char: '🎻', keywords: ['violin', 'fiddle', 'strings'] },
+  { char: '🎤', keywords: ['microphone', 'mic', 'sing', 'vocal'] },
+  { char: '🎧', keywords: ['headphones', 'audio', 'listen'] },
+  { char: '🚀', keywords: ['rocket', 'launch', 'space'] },
+  { char: '⏰', keywords: ['clock', 'alarm', 'time', 'tempo'] },
+  { char: '📎', keywords: ['clip', 'paperclip'] },
+  { char: '✏️', keywords: ['pencil', 'write', 'edit'] },
+  { char: '📌', keywords: ['pin', 'pushpin', 'mark'] },
+  { char: '🔮', keywords: ['crystal', 'ball', 'magic', 'fortune'] },
+  { char: '🪀', keywords: ['yoyo', 'toy'] },
+  { char: '🎳', keywords: ['bowling', 'strike'] },
+  { char: '🧪', keywords: ['test', 'tube', 'lab', 'experiment', 'science'] },
+  { char: '🪘', keywords: ['conga', 'drum', 'percussion'] },
+  // Nature & weather.
+  { char: '⚡', keywords: ['lightning', 'bolt', 'electric', 'zap', 'energy'] },
+  { char: '🔥', keywords: ['fire', 'flame', 'hot', 'lit'] },
+  { char: '❄️', keywords: ['snowflake', 'snow', 'cold', 'ice', 'winter'] },
+  { char: '🌈', keywords: ['rainbow', 'color', 'pride'] },
+  { char: '🌙', keywords: ['moon', 'crescent', 'night'] },
+  { char: '⭐', keywords: ['star', 'favorite'] },
+  { char: '🍀', keywords: ['clover', 'luck', 'lucky', 'four'] },
+  { char: '🌵', keywords: ['cactus', 'desert'] },
+  { char: '🌸', keywords: ['blossom', 'flower', 'cherry', 'sakura', 'pink'] },
+  { char: '🌊', keywords: ['wave', 'water', 'ocean', 'sea'] },
+  { char: '🌻', keywords: ['sunflower', 'flower', 'sun'] },
+  { char: '🌴', keywords: ['palm', 'tree', 'tropical', 'beach'] },
+  { char: '🍁', keywords: ['maple', 'leaf', 'autumn', 'fall'] },
+  { char: '🌷', keywords: ['tulip', 'flower', 'spring'] },
+  { char: '🌲', keywords: ['tree', 'evergreen', 'pine', 'forest'] },
+  { char: '🌰', keywords: ['chestnut', 'nut', 'acorn'] },
+  { char: '🐚', keywords: ['shell', 'seashell', 'spiral'] },
+  { char: '☄️', keywords: ['comet', 'meteor', 'space'] },
+  // Shapes & symbols — very high contrast small.
+  { char: '🔺', keywords: ['triangle', 'red', 'up'] },
+  { char: '🔻', keywords: ['triangle', 'down', 'red'] },
+  { char: '🟦', keywords: ['blue', 'square', 'box'] },
+  { char: '🟩', keywords: ['green', 'square', 'box'] },
+  { char: '🟨', keywords: ['yellow', 'square', 'box'] },
+  { char: '🟧', keywords: ['orange', 'square', 'box'] },
+  { char: '🟫', keywords: ['brown', 'square', 'box'] },
+  { char: '💎', keywords: ['gem', 'diamond', 'jewel', 'crystal'] },
+  { char: '🎵', keywords: ['music', 'note', 'melody', 'tune'] },
+  { char: '🎨', keywords: ['palette', 'art', 'paint', 'color'] },
+  { char: '❤️', keywords: ['heart', 'red', 'love'] },
+  { char: '💙', keywords: ['heart', 'blue'] },
+  { char: '💚', keywords: ['heart', 'green'] },
+  { char: '💛', keywords: ['heart', 'yellow'] },
+  { char: '🧡', keywords: ['heart', 'orange'] },
+  { char: '💜', keywords: ['heart', 'purple'] },
+  { char: '🖤', keywords: ['heart', 'black', 'dark'] },
+  { char: '🟠', keywords: ['orange', 'circle', 'dot'] },
+] as const;
+
+/** Every glyph currently in the pool (for de-duping / collision checks). */
+export const POOL_CHARS: readonly string[] = EMOJI_POOL.map((e) => e.char);
+
+/**
+ * Keyword/substring search over the curated pool. Ranks whole-keyword matches
+ * (`cat` === `cat`) above prefix matches (`cat` starts `catfish`) above looser
+ * substring hits, so the most obvious glyph surfaces first. An empty query returns the
+ * whole pool (the picker's default grid). Pure — no dependency, no network.
+ */
+export function searchEmoji(query: string): EmojiEntry[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return [...EMOJI_POOL];
+  const scored: Array<{ e: EmojiEntry; score: number }> = [];
+  for (const e of EMOJI_POOL) {
+    let best = 0;
+    for (const k of e.keywords) {
+      if (k === q) best = Math.max(best, 3);
+      else if (k.startsWith(q)) best = Math.max(best, 2);
+      else if (k.includes(q)) best = Math.max(best, 1);
+    }
+    if (best > 0) scored.push({ e, score: best });
+  }
+  return scored.sort((a, b) => b.score - a.score).map((s) => s.e);
+}
+
+/** The confident name-based match for a label (a whole- or prefix-keyword hit), or
+ *  null when nothing in the pool clearly matches. Used to prefer a meaningful emoji
+ *  over a random one when a tag is created (e.g. a "cat" tag -> the cat). */
+export function suggestEmojiForLabel(label: string): string | null {
+  const q = normalizeForSuggest(label);
+  if (!q) return null;
+  for (const e of EMOJI_POOL) {
+    if (e.keywords.some((k) => k === q)) return e.char;
+  }
+  for (const e of EMOJI_POOL) {
+    // A single-token label that prefixes a keyword (or vice-versa) still counts as
+    // confident (e.g. "cats" -> "cat"); multi-word labels fall through to random.
+    if (e.keywords.some((k) => k.startsWith(q) || q.startsWith(k))) return e.char;
+  }
+  return null;
+}
+
+/** First word, lowercased alpha-only — the token a name-based suggestion matches on. */
+function normalizeForSuggest(label: string): string {
+  return (label.trim().toLowerCase().match(/[a-z]+/) ?? [''])[0];
+}
+
+/**
+ * Auto-assign an emoji for a brand-new tag: prefer a confident name match
+ * ({@link suggestEmojiForLabel}); otherwise pick a random glyph from the pool minus
+ * those already `used`, so a fresh set of tags stays easy to tell apart. Falls back to
+ * a random pool glyph once every one is used (the pool is finite), then to the first
+ * glyph if the pool were ever empty. `rng` is injectable so the pick is deterministic
+ * under test (dependency injection over a hidden `Math.random`).
+ */
+export function autoAssignEmoji(
+  label: string,
+  used: Iterable<string>,
+  rng: () => number = Math.random,
+): string {
+  const usedSet = new Set(used);
+  const suggestion = suggestEmojiForLabel(label);
+  if (suggestion && !usedSet.has(suggestion)) return suggestion;
+  const free = POOL_CHARS.filter((c) => !usedSet.has(c));
+  const from = free.length > 0 ? free : POOL_CHARS;
+  if (from.length === 0) return '🏷️'; // pool never empty in practice; a safe label glyph
+  const i = Math.min(from.length - 1, Math.max(0, Math.floor(rng() * from.length)));
+  return from[i];
+}

--- a/src/app/library/model.ts
+++ b/src/app/library/model.ts
@@ -1,0 +1,100 @@
+/**
+ * Instrument-library metadata model — the SSOT (a Zod schema, per the zodal project
+ * rule) for the browsable-collection layer that sits *beside* the instruments: custom
+ * {@link Tag}s, and the per-instrument {@link InstrumentMeta} (a favorite flag + the
+ * ids of the tags applied to it). Instruments themselves stay in the dials profile
+ * store (`@/app/dials/instruments`); this module owns only the metadata *about* them.
+ *
+ * Two identity rules make the model robust to editing:
+ *  - A tag's `id` is a stable, hidden slug that never changes; only its `label` (and
+ *    `emoji`) are editable. Instruments reference tags by `id`, so a rename can never
+ *    orphan an association (issue #113).
+ *  - System tags (issue #114) are read-only, derived-on-read, and namespaced `sys:*`;
+ *    they are NOT persisted here — only *custom* tag ids ever land in `tagIds`. The
+ *    {@link SYSTEM_TAG_PREFIX} guard keeps a derived id from being mistaken for a
+ *    custom one (and is asserted when reading associations back).
+ *
+ * Storage targets live in {@link ./store}; this file is pure (schema + helpers) so it
+ * is unit-testable and strict-typechecked transitively via the library tests.
+ */
+import { z } from 'zod';
+
+/** Prefix marking a read-only, derived system-tag id (issue #114). Custom tags never
+ *  use it, so association reads can filter defensively against a stale persisted id. */
+export const SYSTEM_TAG_PREFIX = 'sys:';
+
+/**
+ * A custom tag: a stable hidden `id`, an editable display `label`, and a single-glyph
+ * `emoji`. The id is the association key (renaming edits only the label), so it must
+ * never collide with a system-tag id — hence the `.refine` guard.
+ */
+export const TagSchema = z.object({
+  id: z
+    .string()
+    .min(1)
+    .refine((s) => !s.startsWith(SYSTEM_TAG_PREFIX), {
+      message: 'A custom tag id must not use the reserved system-tag prefix.',
+    }),
+  label: z.string().min(1),
+  emoji: z.string().min(1),
+});
+export type Tag = z.infer<typeof TagSchema>;
+
+/**
+ * Per-instrument library metadata, keyed (in the store) by the instrument's name — the
+ * same key the dials profile store uses. `starred` is a free multi-favorite flag (any
+ * number of instruments may be starred; distinct from the single default pointer).
+ * `tagIds` are the *custom* tag ids applied to the instrument (system tags are derived,
+ * never stored). Both default empty so a never-touched instrument needs no record.
+ */
+export const InstrumentMetaSchema = z.object({
+  starred: z.boolean().default(false),
+  tagIds: z.array(z.string()).default([]),
+});
+export type InstrumentMeta = z.infer<typeof InstrumentMetaSchema>;
+
+/** The empty metadata for an instrument with no library record yet. */
+export const EMPTY_INSTRUMENT_META: InstrumentMeta = { starred: false, tagIds: [] };
+
+/** The persisted instrument-metadata map (instrument name -> its metadata). A plain,
+ *  serializable record so it round-trips cleanly; unknown/blank entries are healed by
+ *  the per-field defaults on parse. */
+export const InstrumentMetaMapSchema = z.record(z.string(), InstrumentMetaSchema).default({});
+export type InstrumentMetaMap = z.infer<typeof InstrumentMetaMapSchema>;
+
+/**
+ * Derive a stable, hidden tag id from a display label: a lowercase slug plus a short
+ * suffix, so two tags typed with the same casing collide (and are treated as one) while
+ * a later rename of the label leaves the id — and every association — untouched. Pure
+ * and deterministic (no time/random), so it is safe in tests and reproducible.
+ */
+export function tagIdForLabel(label: string): string {
+  const slug =
+    label
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '') || 'tag';
+  return `${slug}`;
+}
+
+/** Case/space-insensitive normal form of a label, for de-duping "Jazz" vs "jazz ". */
+export function normalizeLabel(label: string): string {
+  return label.trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+/** Split a comma-separated tag input into clean, de-duplicated (case-insensitive)
+ *  labels, preserving the typed order — the parse for the comma-input tagging field. */
+export function parseTagLabels(csv: string): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of csv.split(',')) {
+    const label = raw.trim();
+    const key = normalizeLabel(label);
+    if (label && !seen.has(key)) {
+      seen.add(key);
+      out.push(label);
+    }
+  }
+  return out;
+}

--- a/src/app/library/store.ts
+++ b/src/app/library/store.ts
@@ -1,0 +1,235 @@
+/**
+ * The instrument-library persistence layer — the zodal storage targets behind the
+ * library metadata model ({@link ./model}). Two persistence shapes, matching what each
+ * datum actually is:
+ *
+ *  - **Custom tags** are a browsable collection of named things the tag manager
+ *    lists / creates / renames / deletes — so they live behind a `@zodal/store`
+ *    `DataProvider<Tag>` (the `@zodal/store-localstorage` adapter in the browser, an
+ *    in-memory provider in the Node test runtime). This is the project's "zodal way"
+ *    for a collection, exercised end-to-end here.
+ *  - **Per-instrument metadata** (a favorite flag + applied custom-tag ids, keyed by
+ *    instrument name) is an attribute map, not a browsable list, so it is a single
+ *    Zod-validated JSON blob behind a tiny localStorage seam (mirroring how the existing
+ *    `getDefaultName`/selected-name scalars persist in `@/app/dials/instruments`). The
+ *    single **default** pointer stays where it already lives (that module).
+ *
+ * Everything here is framework-agnostic and unit-tested (the pure map helpers directly;
+ * the async ops against the in-memory provider), so the React binding
+ * ({@link ./useLibrary}) stays a thin adapter.
+ */
+import { createInMemoryProvider, type DataProvider } from '@zodal/store';
+import { createLocalStorageProvider } from '@zodal/store-localstorage';
+import {
+  TagSchema,
+  InstrumentMetaSchema,
+  InstrumentMetaMapSchema,
+  EMPTY_INSTRUMENT_META,
+  tagIdForLabel,
+  normalizeLabel,
+  type Tag,
+  type InstrumentMeta,
+  type InstrumentMetaMap,
+} from './model';
+import { autoAssignEmoji } from './emoji';
+
+const TAGS_KEY = 'thoremin.library.tags';
+const META_KEY = 'thoremin.library.instrumentMeta';
+
+/** Whether a real `localStorage` is available (false in the Node test runtime). */
+function hasLocalStorage(): boolean {
+  try {
+    return typeof localStorage !== 'undefined' && localStorage !== null;
+  } catch {
+    return false;
+  }
+}
+
+/** The tags collection provider — localStorage in the browser, in-memory otherwise so
+ *  importing this module never throws where storage is absent. */
+function makeTagsProvider(): DataProvider<Tag> {
+  if (hasLocalStorage()) {
+    try {
+      return createLocalStorageProvider<Tag>({ storageKey: TAGS_KEY, idField: 'id' });
+    } catch {
+      /* fall through to in-memory */
+    }
+  }
+  return createInMemoryProvider<Tag>([]);
+}
+
+export const tagsProvider: DataProvider<Tag> = makeTagsProvider();
+
+// --- Tags collection ops ----------------------------------------------------------
+
+/** All custom tags (validated). */
+export async function listTags(): Promise<Tag[]> {
+  const { data } = await tagsProvider.getList({});
+  return data.map((t) => TagSchema.parse(t));
+}
+
+/** A tag id not already taken, derived from `label` with a numeric suffix on collision. */
+function uniqueTagId(label: string, existing: ReadonlySet<string>): string {
+  const base = tagIdForLabel(label);
+  if (!existing.has(base)) return base;
+  for (let n = 2; ; n++) {
+    const candidate = `${base}-${n}`;
+    if (!existing.has(candidate)) return candidate;
+  }
+}
+
+/**
+ * Find the tag matching `label` (by id slug or normalized label) or create a new one.
+ * A new tag gets an auto-assigned emoji ({@link autoAssignEmoji}) preferring a confident
+ * name match, else a random unused pool glyph. Returns the resolved (existing or created)
+ * tag, so the caller can associate it with an instrument by id. `rng` is injectable for
+ * deterministic tests.
+ */
+export async function resolveOrCreateTag(
+  label: string,
+  opts: { rng?: () => number } = {},
+): Promise<Tag> {
+  const trimmed = label.trim();
+  if (!trimmed) throw new Error('A tag label is required.');
+  const tags = await listTags();
+  const norm = normalizeLabel(trimmed);
+  // Match ONLY on the current label — not the id slug. After a rename the id no longer
+  // equals `tagIdForLabel(label)`, so an id-slug match would resolve a since-renamed tag
+  // when the user retypes its ORIGINAL label (attaching the wrong tag). Label-only match
+  // + uniqueTagId means retyping the old label creates a fresh, correctly-labeled tag.
+  const existing = tags.find((t) => normalizeLabel(t.label) === norm);
+  if (existing) return existing;
+
+  const id = uniqueTagId(trimmed, new Set(tags.map((t) => t.id)));
+  const emoji = autoAssignEmoji(trimmed, tags.map((t) => t.emoji), opts.rng);
+  const created = TagSchema.parse({ id, label: trimmed, emoji });
+  await tagsProvider.create(created);
+  return created;
+}
+
+/** Rename a tag's display label (its id — and every association — is untouched). Rejects
+ *  a label already used by another tag, so the one-tag-per-label invariant that
+ *  {@link resolveOrCreateTag} and the autosuggest rely on cannot be broken by a rename. */
+export async function renameTag(id: string, label: string): Promise<Tag> {
+  const trimmed = label.trim();
+  if (!trimmed) throw new Error('A tag label is required.');
+  const norm = normalizeLabel(trimmed);
+  const clash = (await listTags()).find((t) => t.id !== id && normalizeLabel(t.label) === norm);
+  if (clash) throw new Error(`A tag labeled "${clash.label}" already exists.`);
+  return TagSchema.parse(await tagsProvider.update(id, { label: trimmed }));
+}
+
+/** Change a tag's emoji (from the picker or a text search pick). */
+export async function setTagEmoji(id: string, emoji: string): Promise<Tag> {
+  if (!emoji) throw new Error('An emoji is required.');
+  return TagSchema.parse(await tagsProvider.update(id, { emoji }));
+}
+
+/**
+ * Delete a tag and strip its id from every instrument's associations, so an association
+ * can never dangle. Returns the updated instrument-meta map (already persisted).
+ */
+export async function deleteTag(id: string): Promise<InstrumentMetaMap> {
+  // Tolerate an absent id (a double-click / already-deleted tag): the provider throws
+  // "Item not found" on a missing id, and the delete is idempotent, so swallow it.
+  await tagsProvider.delete(id).catch(() => {});
+  const map = stripTagIdEverywhere(await readInstrumentMeta(), id);
+  await writeInstrumentMeta(map);
+  return map;
+}
+
+// --- Instrument metadata (blob) ---------------------------------------------------
+
+/** Read the per-instrument metadata map (empty + healed if absent/corrupt). */
+export async function readInstrumentMeta(): Promise<InstrumentMetaMap> {
+  if (!hasLocalStorage()) return { ...memoryMeta };
+  try {
+    const raw = localStorage.getItem(META_KEY);
+    if (!raw) return {};
+    return healInstrumentMetaMap(JSON.parse(raw));
+  } catch {
+    return {}; // unparseable JSON degrades to empty rather than throwing on every read
+  }
+}
+
+/**
+ * Validate a parsed metadata blob RECORD-BY-RECORD, keeping the valid instruments and
+ * dropping only the malformed ones — so one bad (hand-edited or foreign-schema) record
+ * can never discard every star + tag association (a whole-map `.parse` would throw and
+ * lose them all). Pure, so it is unit-tested directly.
+ */
+export function healInstrumentMetaMap(raw: unknown): InstrumentMetaMap {
+  if (!raw || typeof raw !== 'object') return {};
+  const out: InstrumentMetaMap = {};
+  for (const [name, value] of Object.entries(raw as Record<string, unknown>)) {
+    const parsed = InstrumentMetaSchema.safeParse(value);
+    if (parsed.success) out[name] = parsed.data;
+  }
+  return out;
+}
+
+/** Persist the per-instrument metadata map. */
+export async function writeInstrumentMeta(map: InstrumentMetaMap): Promise<void> {
+  const validated = InstrumentMetaMapSchema.parse(map);
+  if (!hasLocalStorage()) {
+    memoryMeta = { ...validated };
+    return;
+  }
+  try {
+    localStorage.setItem(META_KEY, JSON.stringify(validated));
+  } catch {
+    /* storage full / disabled — metadata is best-effort */
+  }
+}
+
+/** In-memory fallback for the meta blob (Node runtime / disabled storage). */
+let memoryMeta: InstrumentMetaMap = {};
+
+// --- Pure map helpers (unit-tested directly) --------------------------------------
+
+/** The metadata for one instrument, or the empty default (never undefined). */
+export function metaFor(map: InstrumentMetaMap, name: string): InstrumentMeta {
+  return map[name] ?? EMPTY_INSTRUMENT_META;
+}
+
+/** A copy of `map` with `name`'s starred flag set. Prunes a now-empty record so the
+ *  blob stays sparse (a default-everything instrument keeps no entry). */
+export function withStarred(map: InstrumentMetaMap, name: string, starred: boolean): InstrumentMetaMap {
+  return pruneEmpty({ ...map, [name]: { ...metaFor(map, name), starred } });
+}
+
+/** A copy of `map` with `name`'s custom-tag id list replaced (de-duped, order kept). */
+export function withTagIds(map: InstrumentMetaMap, name: string, tagIds: string[]): InstrumentMetaMap {
+  const deduped = [...new Set(tagIds)];
+  return pruneEmpty({ ...map, [name]: { ...metaFor(map, name), tagIds: deduped } });
+}
+
+/** A copy of `map` with `tagId` removed from every instrument's associations. */
+export function stripTagIdEverywhere(map: InstrumentMetaMap, tagId: string): InstrumentMetaMap {
+  const out: InstrumentMetaMap = {};
+  for (const [name, meta] of Object.entries(map)) {
+    out[name] = { ...meta, tagIds: meta.tagIds.filter((t) => t !== tagId) };
+  }
+  return pruneEmpty(out);
+}
+
+/** Instrument names currently associated with `tagId` (for the delete-in-use guard). */
+export function instrumentsUsingTag(map: InstrumentMetaMap, tagId: string): string[] {
+  return Object.entries(map)
+    .filter(([, meta]) => meta.tagIds.includes(tagId))
+    .map(([name]) => name);
+}
+
+/** Drop records that carry no information (not starred, no tags), keeping the blob small. */
+function pruneEmpty(map: InstrumentMetaMap): InstrumentMetaMap {
+  const out: InstrumentMetaMap = {};
+  for (const [name, meta] of Object.entries(map)) {
+    if (meta.starred || meta.tagIds.length > 0) out[name] = meta;
+  }
+  return out;
+}
+
+/** Test-only: reset the in-memory meta fallback between cases. */
+export function __resetMemoryMeta(): void {
+  memoryMeta = {};
+}

--- a/src/app/library/summarize.ts
+++ b/src/app/library/summarize.ts
@@ -1,0 +1,211 @@
+/**
+ * summarizeInstrument — a pure `Settings -> InstrumentSummary` reduction: the compact,
+ * human-facing "what is this instrument" projection shared by the parametrization
+ * tooltip (issue #115) and the system-tag derivation (issue #114, which reads the same
+ * scale-quality / face-mode / note-source facts). Kept dependency-free and framework-
+ * agnostic so it is unit-tested directly and reused wherever an instrument must be
+ * described without opening its full settings editor.
+ *
+ * "More than the list row, less than the settings": it names the scale, the two voices,
+ * the control sources (note source, face mode, finger FX), and only the *non-default*
+ * master tweaks — so the tooltip stays a glance, not a second editor.
+ */
+import { NOTES, SCALE_TYPES, type ScaleTypeId } from '@/music/theory';
+import { SOUNDS, type SoundId } from '@/music/sounds';
+import type { Settings } from '@/settings/schema';
+import type { PositionSource, FingerTarget } from '@/nodes/mapping/hand_map';
+import type { FingerName } from '@/nodes/domain';
+
+/** The coarse scale quality used for the scale-quality system tag + the tooltip. */
+export type ScaleQuality =
+  | 'major'
+  | 'minor'
+  | 'pentatonicMajor'
+  | 'pentatonicMinor'
+  | 'blues'
+  | 'chromatic';
+
+/** What the face drives, collapsed to the four meaningful modes (see FACE_MAPPINGS). */
+export type FaceMode = 'none' | 'expression' | 'chord' | 'pose';
+
+/** One active finger->effect routing (only fingers whose target is not `none`). */
+export interface FingerFx {
+  finger: FingerName;
+  target: FingerTarget;
+}
+
+/** The compact projection of an instrument's settings. */
+export interface InstrumentSummary {
+  /** Right-hand root pitch class (0..11) and its note name. */
+  root: number;
+  rootName: string;
+  /** Coarse quality + the scale's display name + the combined "D Minor Pentatonic". */
+  scaleQuality: ScaleQuality;
+  scaleName: string;
+  scaleLabel: string;
+  /** The two voices' sound display names + whether the hands are synced. */
+  rightSound: string;
+  leftSound: string;
+  syncHands: boolean;
+  /** Right-hand voicing extent (base octave + how many octaves it spans). */
+  baseOctave: number;
+  octaves: number;
+  /** Note-selection source (index fingertip vs wrist) and the face mode. */
+  noteSource: PositionSource;
+  faceMode: FaceMode;
+  /** Active finger->effect routings (empty when no finger is routed). */
+  fingerFx: FingerFx[];
+  /** Master tweaks (the caller decides which to show — see {@link summaryLines}). */
+  masterVolume: number;
+  magnetism: number;
+  octaveShift: number;
+}
+
+/** Coarse quality of a scale type; exhaustive over {@link ScaleTypeId}. */
+export function scaleQualityOf(type: ScaleTypeId): ScaleQuality {
+  switch (type) {
+    case 'major':
+      return 'major';
+    case 'minor':
+    case 'minorHarmonic':
+      return 'minor';
+    case 'pentatonic':
+      return 'pentatonicMajor';
+    case 'minorPentatonic':
+      return 'pentatonicMinor';
+    case 'blues':
+      return 'blues';
+    case 'chromatic':
+      return 'chromatic';
+    default: {
+      // Exhaustiveness guard: a new scale id must extend the mapping above.
+      const _never: never = type;
+      return _never;
+    }
+  }
+}
+
+/** Collapse the four-value face mapping onto the tooltip/system-tag mode vocabulary. */
+export function faceModeOf(faceMapping: Settings['faceMapping']): FaceMode {
+  switch (faceMapping) {
+    case 'none':
+      return 'none';
+    case 'timbre':
+      return 'expression';
+    case 'chord':
+      return 'chord';
+    case 'controls':
+      return 'pose';
+    default: {
+      const _never: never = faceMapping;
+      return _never;
+    }
+  }
+}
+
+const FINGER_ORDER: readonly FingerName[] = ['index', 'middle', 'ring', 'pinky'];
+
+/** The active finger->effect routings, in a stable finger order. */
+export function activeFingerFx(handMap: Settings['handMap']): FingerFx[] {
+  return FINGER_ORDER.flatMap((finger) => {
+    const target = handMap.fingers[finger]?.target;
+    return target && target !== 'none' ? [{ finger, target }] : [];
+  });
+}
+
+/** The compact projection of one instrument's settings. */
+export function summarizeInstrument(s: Settings): InstrumentSummary {
+  const scaleName = SCALE_TYPES[s.right.type].name;
+  const rootName = NOTES[((s.right.root % 12) + 12) % 12];
+  return {
+    root: s.right.root,
+    rootName,
+    scaleQuality: scaleQualityOf(s.right.type),
+    scaleName,
+    scaleLabel: `${rootName} ${scaleName}`,
+    rightSound: soundName(s.right.sound),
+    leftSound: soundName(s.left.sound),
+    syncHands: s.syncHands,
+    baseOctave: s.right.baseOctave,
+    octaves: s.right.octaves,
+    noteSource: s.handMap.positionSource,
+    faceMode: faceModeOf(s.faceMapping),
+    fingerFx: activeFingerFx(s.handMap),
+    masterVolume: s.masterVolume,
+    magnetism: s.magnetism,
+    octaveShift: s.octaveShift,
+  };
+}
+
+/** Display name for a sound id (falls back to the raw id if ever unknown). */
+function soundName(id: SoundId): string {
+  return SOUNDS[id]?.name ?? id;
+}
+
+/** Human label for a finger->effect target (e.g. `pitchBend` -> "pitch bend"). */
+export function fingerTargetLabel(target: FingerTarget): string {
+  return target.replace(/([a-z])([A-Z])/g, '$1 $2').toLowerCase();
+}
+
+/** Human label for the face mode. */
+export function faceModeLabel(mode: FaceMode): string {
+  switch (mode) {
+    case 'none':
+      return 'none';
+    case 'expression':
+      return 'expression → timbre';
+    case 'chord':
+      return 'emotion → chord';
+    case 'pose':
+      return 'head/face pose';
+  }
+}
+
+/** One label/value row of the tooltip. */
+export interface SummaryLine {
+  label: string;
+  value: string;
+}
+
+/** Master-field defaults — a field is shown in the tooltip only when it differs. */
+const MASTER_DEFAULTS = { masterVolume: 0.4, magnetism: 0.8, octaveShift: 0 } as const;
+
+/**
+ * Format a summary as the compact tooltip rows (issue #115): scale, voices, controls,
+ * and only the *non-default* master tweaks. Pure, so the exact wording is unit-tested.
+ */
+export function summaryLines(sum: InstrumentSummary): SummaryLine[] {
+  const lines: SummaryLine[] = [];
+  lines.push({ label: 'Scale', value: sum.scaleLabel });
+
+  // Each hand always keeps its OWN sound (syncHands only syncs scale/root/octaves), so
+  // the voices line is driven by whether the two SOUNDS differ — not by syncHands. The
+  // sync state is a separate range annotation, never a claim that the timbres match.
+  const both =
+    sum.rightSound === sum.leftSound ? sum.rightSound : `${sum.rightSound} / ${sum.leftSound}`;
+  lines.push({ label: 'Voices', value: sum.syncHands ? `${both} (synced range)` : both });
+  lines.push({
+    label: 'Range',
+    value: `octave ${sum.baseOctave}, ${sum.octaves} oct${sum.octaves === 1 ? '' : 's'}`,
+  });
+
+  lines.push({ label: 'Notes', value: `${sum.noteSource}-controlled` });
+  if (sum.faceMode !== 'none') lines.push({ label: 'Face', value: faceModeLabel(sum.faceMode) });
+  if (sum.fingerFx.length > 0) {
+    lines.push({
+      label: 'Finger FX',
+      value: sum.fingerFx.map((f) => `${f.finger}→${fingerTargetLabel(f.target)}`).join(', '),
+    });
+  }
+
+  if (sum.masterVolume !== MASTER_DEFAULTS.masterVolume) {
+    lines.push({ label: 'Volume', value: `${Math.round(sum.masterVolume * 100)}%` });
+  }
+  if (sum.magnetism !== MASTER_DEFAULTS.magnetism) {
+    lines.push({ label: 'Magnetism', value: `${Math.round(sum.magnetism * 100)}%` });
+  }
+  if (sum.octaveShift !== MASTER_DEFAULTS.octaveShift) {
+    lines.push({ label: 'Octave shift', value: sum.octaveShift > 0 ? `+${sum.octaveShift}` : `${sum.octaveShift}` });
+  }
+  return lines;
+}

--- a/src/app/library/systemTags.ts
+++ b/src/app/library/systemTags.ts
@@ -1,0 +1,96 @@
+/**
+ * System tags (issue #114) — read-only tags DERIVED from an instrument's parametrization,
+ * never hand-edited. They surface the few facts that genuinely distinguish instruments
+ * at a glance (scale quality, note-control source, face mode, split voices, finger FX)
+ * as emoji chips in the list's tags column, rendered exactly like custom tags but with a
+ * `sys:*` id so they can never be renamed, deleted, or stored in an instrument's
+ * associations (see {@link ../model.SYSTEM_TAG_PREFIX}).
+ *
+ * Derivation is a pure function of the shared {@link InstrumentSummary} (so it stays in
+ * lockstep with the tooltip, issue #115) and is recomputed on read — a stale value is
+ * impossible. The emoji/label set is an SSOT map below and is a PROPOSAL flagged for the
+ * maintainer's sign-off (colored circles read cleanly at small size; the M/m/P/p letter
+ * cue lives in the tooltip).
+ */
+import { SYSTEM_TAG_PREFIX } from './model';
+import {
+  summarizeInstrument,
+  type InstrumentSummary,
+  type ScaleQuality,
+  type FaceMode,
+} from './summarize';
+import type { Settings } from '@/settings/schema';
+import type { PositionSource } from '@/nodes/mapping/hand_map';
+
+/** A derived, read-only tag: a `sys:*` id, an emoji, and a tooltip label. Shape-
+ *  compatible with how custom tags render (emoji + tooltip), differing only in source. */
+export interface SystemTag {
+  id: string;
+  emoji: string;
+  label: string;
+}
+
+/** Scale-quality tag set (PROPOSAL). Colored circles + the letter cue in the label. */
+export const SCALE_QUALITY_TAGS = {
+  major: { emoji: '🟢', label: 'Major (M)' },
+  minor: { emoji: '🔵', label: 'Minor (m)' },
+  pentatonicMajor: { emoji: '🟡', label: 'Pentatonic major (P)' },
+  pentatonicMinor: { emoji: '🟣', label: 'Pentatonic minor (p)' },
+  blues: { emoji: '🔴', label: 'Blues' },
+  chromatic: { emoji: '⚪', label: 'Chromatic' },
+} as const satisfies Record<ScaleQuality, { emoji: string; label: string }>;
+
+/** Face-mode tag set (PROPOSAL); `none` yields no tag. */
+export const FACE_MODE_TAGS = {
+  expression: { emoji: '😀', label: 'Face expression → timbre' },
+  chord: { emoji: '🎭', label: 'Face emotion → chord' },
+  pose: { emoji: '🧭', label: 'Head/face pose control' },
+} as const satisfies Record<Exclude<FaceMode, 'none'>, { emoji: string; label: string }>;
+
+/** Note-control-source tag set (PROPOSAL). */
+export const NOTE_SOURCE_TAGS = {
+  index: { emoji: '👆', label: 'Index-controlled notes' },
+  wrist: { emoji: '🤚', label: 'Wrist-controlled notes' },
+} as const satisfies Record<PositionSource, { emoji: string; label: string }>;
+
+/** Standalone flags (PROPOSAL): independent (unsynced) voices + any active finger routing.
+ *  The tag fires on `!syncHands` (independent scale/root/octaves per hand), so the label
+ *  names that — sounds can differ per hand even when synced, so "different sound" would
+ *  mislabel the condition. */
+export const SPLIT_VOICES_TAG = { emoji: '🎚️', label: 'Independent voices (hands unsynced)' } as const;
+export const FINGER_FX_TAG = { emoji: '🎛️', label: 'Finger FX routing active' } as const;
+
+/**
+ * Derive the ordered system tags for an instrument summary. Order is deterministic —
+ * scale quality, note source, face mode, split voices, finger FX — so the column reads
+ * consistently across rows.
+ */
+export function deriveSystemTags(sum: InstrumentSummary): SystemTag[] {
+  const tags: SystemTag[] = [];
+
+  const scale = SCALE_QUALITY_TAGS[sum.scaleQuality];
+  tags.push({ id: `${SYSTEM_TAG_PREFIX}scale:${sum.scaleQuality}`, ...scale });
+
+  const note = NOTE_SOURCE_TAGS[sum.noteSource];
+  tags.push({ id: `${SYSTEM_TAG_PREFIX}note:${sum.noteSource}`, ...note });
+
+  if (sum.faceMode !== 'none') {
+    const face = FACE_MODE_TAGS[sum.faceMode];
+    tags.push({ id: `${SYSTEM_TAG_PREFIX}face:${sum.faceMode}`, ...face });
+  }
+
+  if (!sum.syncHands) {
+    tags.push({ id: `${SYSTEM_TAG_PREFIX}voices:split`, ...SPLIT_VOICES_TAG });
+  }
+
+  if (sum.fingerFx.length > 0) {
+    tags.push({ id: `${SYSTEM_TAG_PREFIX}fingerfx`, ...FINGER_FX_TAG });
+  }
+
+  return tags;
+}
+
+/** Convenience: summarize + derive in one call, for a raw {@link Settings}. */
+export function systemTagsForSettings(s: Settings): SystemTag[] {
+  return deriveSystemTags(summarizeInstrument(s));
+}

--- a/src/app/library/useLibrary.ts
+++ b/src/app/library/useLibrary.ts
@@ -1,0 +1,204 @@
+/**
+ * useLibrary — the React binding for the instrument-library metadata (issues #112-#115).
+ * The pure model, persistence, emoji, derivation and system-tag logic live in the
+ * framework-agnostic library modules (all unit-tested); this hook owns only the React
+ * state and wires them to the panel:
+ *  - loads the custom tags + the per-instrument metadata blob once on mount;
+ *  - re-derives each instrument's summary + system tags whenever the instrument `list`
+ *    it is given changes (a save/create/delete refreshes that list upstream);
+ *  - exposes favorite (star) toggling, custom-tag association (comma input + chip
+ *    removal), and the tag-manager mutations (rename / re-emoji / delete).
+ *
+ * Mutation reads go through a ref so the memoized callbacks stay stable while always
+ * seeing the latest map (the pattern `useInstruments` uses for its optimistic selection);
+ * read predicates the UI SORTS/RENDERS on (`starred`, `customTagsOf`) depend on the map
+ * state so a change re-renders and re-orders the list.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { ProfileMeta } from '@zodal/dials-ui';
+import { parseTagLabels, type Tag, type InstrumentMetaMap } from './model';
+import type { InstrumentSummary } from './summarize';
+import type { SystemTag } from './systemTags';
+import {
+  listTags,
+  resolveOrCreateTag,
+  renameTag as renameTagRecord,
+  setTagEmoji as setTagEmojiRecord,
+  deleteTag as deleteTagRecord,
+  readInstrumentMeta,
+  writeInstrumentMeta,
+  withStarred,
+  withTagIds,
+  instrumentsUsingTag,
+} from './store';
+import { deriveForNames, type InstrumentDerived } from './derive';
+import { useToasts } from '@/app/toasts';
+
+export interface LibraryApi {
+  /** False until tags + metadata have loaded. */
+  ready: boolean;
+  /** All custom tags. */
+  tags: Tag[];
+  /** Whether an instrument is a favorite. */
+  starred: (name: string) => boolean;
+  /** Toggle an instrument's favorite flag (several may be starred). */
+  toggleStar: (name: string) => void;
+  /** The resolved custom tags applied to an instrument (existing tags only). */
+  customTagsOf: (name: string) => Tag[];
+  /** Add tags from a comma-separated input (existing tags reused, new ones created). */
+  addTags: (name: string, csv: string) => Promise<void>;
+  /** Remove one custom-tag association from an instrument. */
+  removeTag: (name: string, tagId: string) => void;
+  /** The derived, read-only system tags for an instrument. */
+  systemTagsOf: (name: string) => SystemTag[];
+  /** The derived compact summary for an instrument (undefined until derived). */
+  summaryOf: (name: string) => InstrumentSummary | undefined;
+  /** Rename a tag's label (id + associations preserved). */
+  renameTag: (id: string, label: string) => Promise<void>;
+  /** Change a tag's emoji. */
+  setTagEmoji: (id: string, emoji: string) => Promise<void>;
+  /** Delete a tag (also stripped from every instrument). */
+  deleteTag: (id: string) => Promise<void>;
+  /** How many instruments currently use a tag (for the delete-in-use guard). */
+  usageCount: (id: string) => number;
+}
+
+export function useLibrary(list: ProfileMeta[]): LibraryApi {
+  const [tags, setTags] = useState<Tag[]>([]);
+  const [metaMap, setMetaMap] = useState<InstrumentMetaMap>({});
+  const [derived, setDerived] = useState<Record<string, InstrumentDerived>>({});
+  const [ready, setReady] = useState(false);
+
+  const metaRef = useRef<InstrumentMetaMap>(metaMap);
+  metaRef.current = metaMap;
+
+  // Load tags + metadata once.
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const [loadedTags, loadedMeta] = await Promise.all([listTags(), readInstrumentMeta()]);
+      if (cancelled) return;
+      setTags(loadedTags);
+      setMetaMap(loadedMeta);
+      setReady(true);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Re-derive each instrument's summary + system tags whenever the instrument list
+  // changes — including a save that keeps the same names but changes a layer, since the
+  // upstream refresh hands us a fresh `list` reference on every save/create/delete.
+  useEffect(() => {
+    let cancelled = false;
+    void deriveForNames(list.map((p) => p.name)).then((d) => {
+      if (!cancelled) setDerived(d);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [list]);
+
+  const tagByIdMap = useMemo(() => new Map(tags.map((t) => [t.id, t])), [tags]);
+
+  const persistMeta = useCallback((next: InstrumentMetaMap) => {
+    metaRef.current = next;
+    setMetaMap(next);
+    void writeInstrumentMeta(next);
+  }, []);
+
+  const reloadTags = useCallback(async () => {
+    setTags(await listTags());
+  }, []);
+
+  // Depends on the map state (not the ref) so a star toggle re-renders and re-sorts.
+  const starred = useCallback((name: string) => metaMap[name]?.starred ?? false, [metaMap]);
+
+  const toggleStar = useCallback(
+    (name: string) => persistMeta(withStarred(metaRef.current, name, !(metaRef.current[name]?.starred ?? false))),
+    [persistMeta],
+  );
+
+  const customTagsOf = useCallback(
+    (name: string): Tag[] => {
+      const ids = metaMap[name]?.tagIds ?? [];
+      return ids.map((id) => tagByIdMap.get(id)).filter((t): t is Tag => Boolean(t));
+    },
+    [metaMap, tagByIdMap],
+  );
+
+  const addTags = useCallback(
+    async (name: string, csv: string) => {
+      const labels = parseTagLabels(csv);
+      if (labels.length === 0) return;
+      const resolved: Tag[] = [];
+      for (const label of labels) resolved.push(await resolveOrCreateTag(label));
+      await reloadTags();
+      const current = metaRef.current[name]?.tagIds ?? [];
+      persistMeta(withTagIds(metaRef.current, name, [...current, ...resolved.map((t) => t.id)]));
+    },
+    [persistMeta, reloadTags],
+  );
+
+  const removeTag = useCallback(
+    (name: string, tagId: string) => {
+      const current = metaRef.current[name]?.tagIds ?? [];
+      persistMeta(withTagIds(metaRef.current, name, current.filter((id) => id !== tagId)));
+    },
+    [persistMeta],
+  );
+
+  const systemTagsOf = useCallback((name: string) => derived[name]?.systemTags ?? [], [derived]);
+  const summaryOf = useCallback((name: string) => derived[name]?.summary, [derived]);
+
+  const renameTag = useCallback(
+    async (id: string, label: string) => {
+      try {
+        await renameTagRecord(id, label);
+      } catch (e) {
+        // A label collision (or empty label) is rejected by the store; surface it and
+        // reload so the manager's input reverts to the tag's unchanged label.
+        useToasts.getState().push(e instanceof Error ? e.message : 'Rename failed', 4000, 'error');
+      }
+      await reloadTags();
+    },
+    [reloadTags],
+  );
+
+  const setTagEmoji = useCallback(
+    async (id: string, emoji: string) => {
+      await setTagEmojiRecord(id, emoji);
+      await reloadTags();
+    },
+    [reloadTags],
+  );
+
+  const deleteTag = useCallback(
+    async (id: string) => {
+      const nextMeta = await deleteTagRecord(id);
+      metaRef.current = nextMeta;
+      setMetaMap(nextMeta);
+      await reloadTags();
+    },
+    [reloadTags],
+  );
+
+  const usageCount = useCallback((id: string) => instrumentsUsingTag(metaMap, id).length, [metaMap]);
+
+  return {
+    ready,
+    tags,
+    starred,
+    toggleStar,
+    customTagsOf,
+    addTags,
+    removeTag,
+    systemTagsOf,
+    summaryOf,
+    renameTag,
+    setTagEmoji,
+    deleteTag,
+    usageCount,
+  };
+}

--- a/test/library_derive.test.ts
+++ b/test/library_derive.test.ts
@@ -1,0 +1,47 @@
+/**
+ * The instrument -> derived-view bridge (issues #114/#115), exercised against the REAL
+ * seeded profile store: after seeding, every shipped instrument projects to a summary +
+ * system tags, and the derivation resolves a sparse/UNSET-bearing saved layer to the same
+ * effective facts the engine would see.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { ensureSeeded, SEED_INSTRUMENTS, instruments } from '@/app/dials/instruments';
+import { deriveForName, deriveForNames, settingsFromLayer } from '@/app/library/derive';
+import { UNSET } from '@zodal/dials-core';
+
+const NAMES = SEED_INSTRUMENTS.map((s) => s.name);
+
+describe('deriveForNames (seeded store)', () => {
+  beforeAll(async () => {
+    await ensureSeeded();
+  });
+
+  it('projects every seeded instrument to a summary + system tags', async () => {
+    const derived = await deriveForNames(NAMES);
+    for (const name of NAMES) {
+      expect(derived[name]).toBeDefined();
+      expect(derived[name].systemTags.length).toBeGreaterThan(0);
+      expect(derived[name].summary.scaleLabel.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('deriveForName returns null for a missing instrument', async () => {
+    expect(await deriveForName('No Such Instrument')).toBeNull();
+  });
+
+  it('Split Voices derives the split-voices system tag', async () => {
+    const d = await deriveForName('Split Voices');
+    expect(d?.systemTags.some((t) => t.id === 'sys:voices:split')).toBe(true);
+  });
+});
+
+describe('settingsFromLayer', () => {
+  it('lets a default win where the saved layer UNSETs a key', async () => {
+    const layer = await instruments.load('Pentatonic');
+    expect(layer).toBeTruthy();
+    // Reset the right-hand scale in the saved layer -> the dials default (pentatonic) wins.
+    const withUnset = { ...(layer as Record<string, unknown>), 'right.type': UNSET };
+    const s = settingsFromLayer(withUnset as never);
+    expect(s.right.type).toBe('pentatonic');
+  });
+});

--- a/test/library_emoji.test.ts
+++ b/test/library_emoji.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Emoji pool + search + auto-assign (issue #113). Locks the two invariants the tags
+ * column depends on — the curated pool has no duplicate glyphs and shares no glyph with
+ * the system-tag set (so a custom emoji can never be confused for a derived one) — and
+ * pins the search/auto-assign behaviour (name match preferred, random-unused fallback,
+ * deterministic under an injected rng).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  EMOJI_POOL,
+  POOL_CHARS,
+  searchEmoji,
+  suggestEmojiForLabel,
+  autoAssignEmoji,
+} from '@/app/library/emoji';
+import {
+  SCALE_QUALITY_TAGS,
+  FACE_MODE_TAGS,
+  NOTE_SOURCE_TAGS,
+  SPLIT_VOICES_TAG,
+  FINGER_FX_TAG,
+} from '@/app/library/systemTags';
+
+const SYSTEM_GLYPHS = new Set<string>([
+  ...Object.values(SCALE_QUALITY_TAGS).map((t) => t.emoji),
+  ...Object.values(FACE_MODE_TAGS).map((t) => t.emoji),
+  ...Object.values(NOTE_SOURCE_TAGS).map((t) => t.emoji),
+  SPLIT_VOICES_TAG.emoji,
+  FINGER_FX_TAG.emoji,
+]);
+
+describe('emoji pool', () => {
+  it('is a decent-sized, de-duplicated set', () => {
+    expect(EMOJI_POOL.length).toBeGreaterThanOrEqual(100);
+    expect(new Set(POOL_CHARS).size).toBe(POOL_CHARS.length);
+  });
+
+  it('shares no glyph with the system-tag set (no column collisions)', () => {
+    for (const c of POOL_CHARS) expect(SYSTEM_GLYPHS.has(c)).toBe(false);
+  });
+
+  it('every entry has at least one keyword', () => {
+    for (const e of EMOJI_POOL) expect(e.keywords.length).toBeGreaterThan(0);
+  });
+});
+
+describe('searchEmoji', () => {
+  it('ranks a whole-keyword hit first', () => {
+    expect(searchEmoji('cat')[0].char).toBe('🐱');
+    expect(searchEmoji('lemon')[0].char).toBe('🍋');
+  });
+
+  it('returns the whole pool for an empty query', () => {
+    expect(searchEmoji('  ').length).toBe(EMOJI_POOL.length);
+  });
+
+  it('returns nothing for an unmatched query', () => {
+    expect(searchEmoji('qwxyz')).toEqual([]);
+  });
+});
+
+describe('suggestEmojiForLabel', () => {
+  it('matches an exact keyword', () => {
+    expect(suggestEmojiForLabel('cat')).toBe('🐱');
+    expect(suggestEmojiForLabel('Fire')).toBe('🔥');
+  });
+
+  it('matches a prefix ("cats" -> cat)', () => {
+    expect(suggestEmojiForLabel('cats')).toBe('🐱');
+  });
+
+  it('returns null when nothing confidently matches', () => {
+    expect(suggestEmojiForLabel('zzznope')).toBeNull();
+    expect(suggestEmojiForLabel('')).toBeNull();
+  });
+});
+
+describe('autoAssignEmoji', () => {
+  it('prefers a confident name match when it is unused', () => {
+    expect(autoAssignEmoji('cat', [], () => 0)).toBe('🐱');
+  });
+
+  it('falls back to a random unused glyph when the match is taken', () => {
+    const picked = autoAssignEmoji('cat', ['🐱'], () => 0);
+    expect(picked).not.toBe('🐱');
+    expect(POOL_CHARS).toContain(picked);
+  });
+
+  it('is deterministic under an injected rng and avoids used glyphs', () => {
+    const used = new Set<string>();
+    for (let i = 0; i < 20; i++) {
+      // A label with no name match forces the random path; a fixed fractional rng
+      // walks distinct free slots as `used` grows.
+      const e = autoAssignEmoji('zzznomatch', used, () => 0.5);
+      expect(used.has(e)).toBe(false);
+      used.add(e);
+    }
+    expect(used.size).toBe(20);
+  });
+});

--- a/test/library_model.test.ts
+++ b/test/library_model.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Library model helpers (issue #113): stable-id derivation, label normalization, the
+ * comma-input parse, and the schema guard that keeps a custom tag from stealing a
+ * system-tag id.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  tagIdForLabel,
+  normalizeLabel,
+  parseTagLabels,
+  TagSchema,
+  SYSTEM_TAG_PREFIX,
+} from '@/app/library/model';
+
+describe('tagIdForLabel', () => {
+  it('slugs to a stable, lowercase, hyphenated id', () => {
+    expect(tagIdForLabel('Jazz')).toBe('jazz');
+    expect(tagIdForLabel('  Lo-Fi Beats! ')).toBe('lo-fi-beats');
+    expect(tagIdForLabel('Jazz')).toBe(tagIdForLabel(' jazz ')); // casing/space irrelevant
+  });
+  it('never yields an empty id', () => {
+    expect(tagIdForLabel('!!!')).toBe('tag');
+  });
+});
+
+describe('normalizeLabel', () => {
+  it('collapses case + whitespace', () => {
+    expect(normalizeLabel('  Warm   Pad ')).toBe('warm pad');
+  });
+});
+
+describe('parseTagLabels', () => {
+  it('splits, trims, drops empties, de-dupes case-insensitively, keeps order', () => {
+    expect(parseTagLabels('Jazz, ambient ,, Jazz , Lead')).toEqual(['Jazz', 'ambient', 'Lead']);
+  });
+  it('returns [] for a blank input', () => {
+    expect(parseTagLabels('  , ,')).toEqual([]);
+  });
+});
+
+describe('TagSchema', () => {
+  it('rejects a custom tag id that steals the system-tag prefix', () => {
+    expect(TagSchema.safeParse({ id: `${SYSTEM_TAG_PREFIX}x`, label: 'x', emoji: '🐱' }).success).toBe(false);
+    expect(TagSchema.safeParse({ id: 'jazz', label: 'Jazz', emoji: '🎷' }).success).toBe(true);
+  });
+});

--- a/test/library_store.test.ts
+++ b/test/library_store.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Library store (issue #112/#113): the tags DataProvider ops + the instrument-meta blob
+ * seam + the pure map helpers. Runs against the in-memory provider the store falls back
+ * to in the Node runtime (no localStorage), so it exercises the real code path without a
+ * browser. Tags are cleared before each case since the provider is a module singleton.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  tagsProvider,
+  listTags,
+  resolveOrCreateTag,
+  renameTag,
+  setTagEmoji,
+  deleteTag,
+  readInstrumentMeta,
+  writeInstrumentMeta,
+  healInstrumentMetaMap,
+  metaFor,
+  withStarred,
+  withTagIds,
+  stripTagIdEverywhere,
+  instrumentsUsingTag,
+  __resetMemoryMeta,
+} from '@/app/library/store';
+import { EMPTY_INSTRUMENT_META, type InstrumentMetaMap } from '@/app/library/model';
+
+beforeEach(async () => {
+  for (const t of await listTags()) await tagsProvider.delete(t.id);
+  __resetMemoryMeta();
+});
+
+describe('tags collection', () => {
+  it('resolveOrCreateTag creates a tag with a stable slug id + an emoji', async () => {
+    const tag = await resolveOrCreateTag('Jazz', { rng: () => 0 });
+    expect(tag.id).toBe('jazz');
+    expect(tag.label).toBe('Jazz');
+    expect(tag.emoji.length).toBeGreaterThan(0);
+    expect(await listTags()).toHaveLength(1);
+  });
+
+  it('resolving the same label (any casing) returns the existing tag, no duplicate', async () => {
+    const a = await resolveOrCreateTag('Jazz', { rng: () => 0 });
+    const b = await resolveOrCreateTag('  jazz ', { rng: () => 0 });
+    expect(b.id).toBe(a.id);
+    expect(await listTags()).toHaveLength(1);
+  });
+
+  it('renameTag changes the label but keeps the id (associations survive)', async () => {
+    const tag = await resolveOrCreateTag('Ambient', { rng: () => 0 });
+    const renamed = await renameTag(tag.id, 'Chill');
+    expect(renamed.id).toBe(tag.id);
+    expect(renamed.label).toBe('Chill');
+  });
+
+  it('setTagEmoji changes only the emoji', async () => {
+    const tag = await resolveOrCreateTag('Ambient', { rng: () => 0 });
+    const updated = await setTagEmoji(tag.id, '🌙');
+    expect(updated.id).toBe(tag.id);
+    expect(updated.emoji).toBe('🌙');
+  });
+
+  it('auto-assigned emojis stay distinct across several new tags', async () => {
+    const labels = ['zzza', 'zzzb', 'zzzc', 'zzzd', 'zzze'];
+    let n = 0;
+    const emojis: string[] = [];
+    for (const l of labels) {
+      const t = await resolveOrCreateTag(l, { rng: () => (n++ % 7) / 7 });
+      emojis.push(t.emoji);
+    }
+    expect(new Set(emojis).size).toBe(labels.length);
+  });
+
+  it('deleteTag removes the tag and strips it from every instrument', async () => {
+    const tag = await resolveOrCreateTag('Lead', { rng: () => 0 });
+    await writeInstrumentMeta(withTagIds({}, 'Wrist Theremin', [tag.id]));
+    const map = await deleteTag(tag.id);
+    expect(await listTags()).toHaveLength(0);
+    expect(instrumentsUsingTag(map, tag.id)).toEqual([]);
+    expect(await readInstrumentMeta()).toEqual({});
+  });
+
+  it('deleteTag is idempotent — a second delete of an absent id does not throw', async () => {
+    const tag = await resolveOrCreateTag('Lead', { rng: () => 0 });
+    await deleteTag(tag.id);
+    await expect(deleteTag(tag.id)).resolves.toBeDefined();
+  });
+
+  it('retyping a RENAMED tag original label creates a fresh tag, not the renamed one', async () => {
+    const rock = await resolveOrCreateTag('rock', { rng: () => 0 }); // id 'rock', label 'rock'
+    await renameTag(rock.id, 'Metal'); // id stays 'rock', label -> 'Metal'
+    const retyped = await resolveOrCreateTag('rock', { rng: () => 0.3 });
+    expect(retyped.id).not.toBe(rock.id); // no id-slug match to the renamed tag
+    expect(retyped.label).toBe('rock');
+    expect((await listTags()).map((t) => t.label).sort()).toEqual(['Metal', 'rock']);
+  });
+
+  it('renameTag rejects a label already used by another tag', async () => {
+    await resolveOrCreateTag('warm', { rng: () => 0 });
+    const b = await resolveOrCreateTag('warmth', { rng: () => 0.3 });
+    await expect(renameTag(b.id, 'warm')).rejects.toThrow(/already exists/);
+    await expect(renameTag(b.id, 'Warmth')).resolves.toBeTruthy(); // not a collision with itself
+  });
+});
+
+describe('healInstrumentMetaMap', () => {
+  it('keeps valid records, heals blanks, drops malformed ones', () => {
+    const healed = healInstrumentMetaMap({
+      Piano: { starred: true, tagIds: ['jazz'] },
+      Bad: { starred: 'yes' }, // wrong type -> dropped (not the whole map)
+      Blank: {}, // healed by per-field defaults
+    });
+    expect(healed.Piano).toEqual({ starred: true, tagIds: ['jazz'] });
+    expect(healed.Bad).toBeUndefined();
+    expect(healed.Blank).toEqual({ starred: false, tagIds: [] });
+  });
+
+  it('returns empty for non-object input', () => {
+    expect(healInstrumentMetaMap(null)).toEqual({});
+    expect(healInstrumentMetaMap('nope')).toEqual({});
+  });
+});
+
+describe('instrument-meta blob', () => {
+  it('round-trips through the in-memory fallback', async () => {
+    const map = withStarred({}, 'Bell & Strings', true);
+    await writeInstrumentMeta(map);
+    expect(await readInstrumentMeta()).toEqual(map);
+  });
+
+  it('empty (never-touched) instruments have the empty default', () => {
+    expect(metaFor({}, 'Anything')).toEqual(EMPTY_INSTRUMENT_META);
+  });
+});
+
+describe('pure map helpers', () => {
+  it('withStarred / withTagIds prune a record back to nothing when empty', () => {
+    let map: InstrumentMetaMap = withStarred({}, 'X', true);
+    expect(map.X.starred).toBe(true);
+    map = withStarred(map, 'X', false); // now default-everything -> pruned
+    expect(map.X).toBeUndefined();
+  });
+
+  it('withTagIds de-duplicates while preserving order', () => {
+    const map = withTagIds({}, 'X', ['a', 'b', 'a', 'c']);
+    expect(map.X.tagIds).toEqual(['a', 'b', 'c']);
+  });
+
+  it('stripTagIdEverywhere removes an id across all instruments', () => {
+    let map: InstrumentMetaMap = withTagIds({}, 'X', ['a', 'b']);
+    map = withTagIds(map, 'Y', ['b', 'c']);
+    const stripped = stripTagIdEverywhere(map, 'b');
+    expect(stripped.X.tagIds).toEqual(['a']);
+    expect(stripped.Y.tagIds).toEqual(['c']);
+  });
+
+  it('instrumentsUsingTag lists the instruments carrying a tag', () => {
+    let map: InstrumentMetaMap = withTagIds({}, 'X', ['a']);
+    map = withTagIds(map, 'Y', ['a', 'b']);
+    expect(instrumentsUsingTag(map, 'a').sort()).toEqual(['X', 'Y']);
+    expect(instrumentsUsingTag(map, 'b')).toEqual(['Y']);
+  });
+});

--- a/test/library_summarize.test.ts
+++ b/test/library_summarize.test.ts
@@ -1,0 +1,112 @@
+/**
+ * summarizeInstrument + summaryLines (issue #115), exercised against the REAL shipped
+ * instruments (the seed fixtures) so the projection stays true to actual configs, not a
+ * hand-built stub. Confirms the scale/voice/control facts each seed encodes and that the
+ * tooltip lines show only non-default master tweaks.
+ */
+import { describe, it, expect } from 'vitest';
+import { SEED_INSTRUMENTS } from '@/app/dials/instruments';
+import { layerToSettings } from '@/settings/dials';
+import {
+  summarizeInstrument,
+  summaryLines,
+  fingerTargetLabel,
+  scaleQualityOf,
+  faceModeOf,
+} from '@/app/library/summarize';
+import type { InstrumentSummary } from '@/app/library/summarize';
+
+const sumOf = (name: string): InstrumentSummary => {
+  const seed = SEED_INSTRUMENTS.find((s) => s.name === name);
+  if (!seed) throw new Error(`seed not found: ${name}`);
+  return summarizeInstrument(layerToSettings(seed.layer));
+};
+
+describe('scaleQualityOf / faceModeOf', () => {
+  it('maps scale ids to coarse qualities', () => {
+    expect(scaleQualityOf('major')).toBe('major');
+    expect(scaleQualityOf('minorHarmonic')).toBe('minor');
+    expect(scaleQualityOf('pentatonic')).toBe('pentatonicMajor');
+    expect(scaleQualityOf('minorPentatonic')).toBe('pentatonicMinor');
+  });
+  it('collapses face mappings to modes', () => {
+    expect(faceModeOf('none')).toBe('none');
+    expect(faceModeOf('timbre')).toBe('expression');
+    expect(faceModeOf('chord')).toBe('chord');
+    expect(faceModeOf('controls')).toBe('pose');
+  });
+});
+
+describe('summarizeInstrument (seed fixtures)', () => {
+  it('the gentle default: index-controlled pentatonic, no face, synced', () => {
+    const s = sumOf('Pentatonic');
+    expect(s.scaleQuality).toBe('pentatonicMajor');
+    expect(s.noteSource).toBe('index');
+    expect(s.faceMode).toBe('none');
+    expect(s.syncHands).toBe(true);
+    expect(s.fingerFx).toEqual([]);
+  });
+
+  it('Split Voices: unsynced, major right hand', () => {
+    const s = sumOf('Split Voices');
+    expect(s.syncHands).toBe(false);
+    expect(s.scaleQuality).toBe('major');
+  });
+
+  it('Finger FX: wrist-controlled with active finger routing', () => {
+    const s = sumOf('Finger FX');
+    expect(s.noteSource).toBe('wrist');
+    expect(s.fingerFx.length).toBeGreaterThan(0);
+  });
+
+  it('Glass Bells maps the face to a chord; Everything to expression/timbre', () => {
+    expect(sumOf('Glass Bells').faceMode).toBe('chord');
+    expect(sumOf('Everything').faceMode).toBe('expression');
+    expect(sumOf('Everything').fingerFx.length).toBeGreaterThan(0);
+  });
+
+  it('scaleLabel combines root name + scale name', () => {
+    const s = sumOf('Pentatonic');
+    expect(s.scaleLabel).toBe(`${s.rootName} ${s.scaleName}`);
+  });
+});
+
+describe('summaryLines', () => {
+  it('omits master rows at their defaults', () => {
+    const lines = summaryLines(sumOf('Pentatonic'));
+    const labels = lines.map((l) => l.label);
+    expect(labels).toContain('Scale');
+    expect(labels).toContain('Voices');
+    expect(labels).toContain('Notes');
+    expect(labels).not.toContain('Volume'); // default master volume
+    expect(labels).not.toContain('Octave shift');
+  });
+
+  it('shows a non-default master volume (Glass Bells lowers it)', () => {
+    const labels = summaryLines(sumOf('Glass Bells')).map((l) => l.label);
+    expect(labels).toContain('Volume');
+    expect(labels).toContain('Face'); // chord face mode surfaces a Face row
+  });
+
+  const voicesOf = (name: string): string =>
+    summaryLines(sumOf(name)).find((l) => l.label === 'Voices')?.value ?? '';
+
+  it('shows BOTH sounds when the hands differ, even while synced (no hidden left voice)', () => {
+    // Pentatonic: syncHands=true but right=Warm Pad, left=Glass — both must appear.
+    const voices = voicesOf('Pentatonic');
+    expect(voices).toContain('Warm Pad');
+    expect(voices).toContain('Glass');
+  });
+
+  it('collapses to one voice when both sounds match', () => {
+    // Wrist Theremin: right=left=Warm Pad, synced.
+    expect(voicesOf('Wrist Theremin')).toBe('Warm Pad (synced range)');
+  });
+});
+
+describe('fingerTargetLabel', () => {
+  it('humanizes camelCase targets', () => {
+    expect(fingerTargetLabel('pitchBend')).toBe('pitch bend');
+    expect(fingerTargetLabel('brightness')).toBe('brightness');
+  });
+});

--- a/test/library_systemtags.test.ts
+++ b/test/library_systemtags.test.ts
@@ -1,0 +1,63 @@
+/**
+ * System-tag derivation (issue #114), exercised against the real seed instruments. Every
+ * derived tag must be namespaced `sys:*` (so it can never be stored as a custom
+ * association), scale quality always leads, and the mode/split/finger-FX tags appear
+ * exactly when the instrument's parametrization calls for them.
+ */
+import { describe, it, expect } from 'vitest';
+import { SEED_INSTRUMENTS } from '@/app/dials/instruments';
+import { layerToSettings } from '@/settings/dials';
+import { systemTagsForSettings } from '@/app/library/systemTags';
+import { SYSTEM_TAG_PREFIX } from '@/app/library/model';
+
+const idsOf = (name: string): string[] => {
+  const seed = SEED_INSTRUMENTS.find((s) => s.name === name);
+  if (!seed) throw new Error(`seed not found: ${name}`);
+  return systemTagsForSettings(layerToSettings(seed.layer)).map((t) => t.id);
+};
+
+describe('deriveSystemTags (seed fixtures)', () => {
+  it('every derived id is namespaced and every tag carries an emoji + label', () => {
+    for (const seed of SEED_INSTRUMENTS) {
+      const tags = systemTagsForSettings(layerToSettings(seed.layer));
+      for (const t of tags) {
+        expect(t.id.startsWith(SYSTEM_TAG_PREFIX)).toBe(true);
+        expect(t.emoji.length).toBeGreaterThan(0);
+        expect(t.label.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('scale quality always leads the list', () => {
+    for (const seed of SEED_INSTRUMENTS) {
+      const tags = systemTagsForSettings(layerToSettings(seed.layer));
+      expect(tags[0]?.id.startsWith(`${SYSTEM_TAG_PREFIX}scale:`)).toBe(true);
+    }
+  });
+
+  it('the gentle default: pentatonic-major + index, nothing else', () => {
+    const ids = idsOf('Pentatonic');
+    expect(ids).toContain(`${SYSTEM_TAG_PREFIX}scale:pentatonicMajor`);
+    expect(ids).toContain(`${SYSTEM_TAG_PREFIX}note:index`);
+    expect(ids.some((i) => i.startsWith(`${SYSTEM_TAG_PREFIX}face:`))).toBe(false);
+    expect(ids).not.toContain(`${SYSTEM_TAG_PREFIX}voices:split`);
+    expect(ids).not.toContain(`${SYSTEM_TAG_PREFIX}fingerfx`);
+  });
+
+  it('Split Voices flags split + major', () => {
+    const ids = idsOf('Split Voices');
+    expect(ids).toContain(`${SYSTEM_TAG_PREFIX}voices:split`);
+    expect(ids).toContain(`${SYSTEM_TAG_PREFIX}scale:major`);
+  });
+
+  it('Finger FX flags wrist + finger FX', () => {
+    const ids = idsOf('Finger FX');
+    expect(ids).toContain(`${SYSTEM_TAG_PREFIX}note:wrist`);
+    expect(ids).toContain(`${SYSTEM_TAG_PREFIX}fingerfx`);
+  });
+
+  it('face modes: Glass Bells -> chord, Everything -> expression', () => {
+    expect(idsOf('Glass Bells')).toContain(`${SYSTEM_TAG_PREFIX}face:chord`);
+    expect(idsOf('Everything')).toContain(`${SYSTEM_TAG_PREFIX}face:expression`);
+  });
+});


### PR DESCRIPTION
## Instrument library UX — starring, default-in-settings, tags & emojis, tooltips

Builds the epic #116 in one branch (UI-only; does not touch `graph.ts`/nodes/overlay/the hot store version).
Closes #112, #113, #114, #115.

### What shipped

**#112 — Multi-star favorites + sort/filter; default moved into the editor**
- The ⭐ is now a **free multi-favorite** (any number of instruments). Default is chosen in the
  instrument's **editor** ("Set as default — opens on load"), with a `(default)` cue in the list.
- List header gains a **sort** control (default order / starred first / name A–Z) and the name filter.
- Default stays a single top-level pointer (`thoremin.instruments.default`); favorites/tags live in the
  new library metadata. **Migration is lossless**: a returning user's existing default is preserved (still
  opens on load, still shows `(default)`); favorites simply start empty.

**#113 — Tag system**
- Tags are `{ id (stable hidden slug), label (editable), emoji }`; instruments reference tags **by id**,
  so a rename never orphans an association.
- Editor **Tags section**: comma-separated input with **autosuggest** over existing tags; a typed label
  with no match creates a new tag (auto-assigned an emoji); applied tags render as removable chips.
- **Tag manager** (list header → tags icon): rename (id preserved), re-emoji via text search, delete with
  an **in-use guard** that strips the tag from every instrument.
- **Emoji is fully client-side, zero new deps**: a curated pool doubles as the auto-assign pool and the
  search corpus. See the sign-off note below.
- **Tags column** in the list: each glyph has a tooltip = the tag label.

**#114 — System tags (read-only, derived)**
- Derived from parametrization on read, namespaced `sys:*` (never editable, never stored as an
  association), rendered first in the column: scale quality, note source (index/wrist), face mode
  (expression/chord/pose), split voices, finger FX.

**#115 — Parametrization tooltip**
- Hovering a row shows a compact summary (scale, voices, range, controls, and only non-default master
  tweaks) via `summarizeInstrument()` — shared with #114.

### Architecture

New `src/app/library/` subsystem, framework-agnostic + unit-tested, React binding on top:
- `model.ts` (Zod SSOT: Tag, InstrumentMeta), `emoji.ts` (pool + search + auto-assign),
  `summarize.ts` (#115, shared), `systemTags.ts` (#114), `derive.ts` (saved-layer → summary/system-tags),
  `store.ts` (tags via `@zodal/store-localstorage` `DataProvider<Tag>`; per-instrument metadata as a
  Zod-validated blob), `useLibrary.ts` (React binding).
- UI: `InstrumentTags.tsx`, `EmojiPicker.tsx`, `TagsEditor.tsx`, `TagManager.tsx`, rewritten
  `InstrumentsPanel.tsx`.
- Storage is the **zodal way**: Zod schema first, a `DataProvider` for the browsable tags collection,
  localStorage default with an in-memory fallback for the Node test runtime.

### Verification
- `npm run typecheck` ✓ · `npx vitest run` ✓ (555, +50 new library tests against the real seed fixtures)
  · `npm run build` ✓ · `npm run catalog` ✓
- Adversarial multi-agent review run before opening.

### 🔖 Bikeshed — needs your sign-off (two emoji sets)

Per the handoff, these are proposals to settle, not silent guesses.

**1. Custom-tag auto-assign pool** (`src/app/library/emoji.ts`, ~112 glyphs): distinct animals / food /
objects & instruments / nature / shapes, deliberately biased for high mutual contrast at small size, and
**excluding every system-tag glyph** (a test locks that invariant). It doubles as the "type cat → 🐱"
search corpus. Easy to add/remove — it's one array.

**2. System-tag emoji set** (`src/app/library/systemTags.ts`):
| System tag | Emoji | Tooltip |
|---|---|---|
| Major | 🟢 | Major (M) |
| Minor (natural/harmonic) | 🔵 | Minor (m) |
| Pentatonic major | 🟡 | Pentatonic major (P) |
| Pentatonic minor | 🟣 | Pentatonic minor (p) |
| Blues | 🔴 | Blues |
| Chromatic | ⚪ | Chromatic |
| Face → expression/timbre | 😀 | Face expression → timbre |
| Face → emotion/chord | 🎭 | Face emotion → chord |
| Head/face pose | 🧭 | Head/face pose control |
| Index-controlled | 👆 | Index-controlled notes |
| Wrist-controlled | 🤚 | Wrist-controlled notes |
| Split voices | 🎚️ | Split voices (different sound per hand) |
| Finger FX | 🎛️ | Finger FX routing active |

I split the issue's single "face expression" into **expression / chord / pose** (three distinct face
mappings). If you'd rather collapse or re-glyph any of these, it's a one-line edit in the SSOT map.

**Deliberately deferred:** broad "search any emoji beyond the pool" (an `emojilib` lazy import) — kept the
feature dependency-free given the handoff's dependency-lock cautions; trivial to add later behind
`searchEmoji`.

https://claude.ai/code/session_01Ko5uFkbFb8oeZQa9NE8rPj
