### PR TITLE
Live tagging mode: time-aligned tags.jsonl for stream segmentation (#92)

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -21,7 +21,7 @@ This page catalogs the engine's building blocks — every node and how they conn
 - **Discrete triggers** — `hand-features → gesture-classifier → (events)`  
   Fist/open/pinch poses emit enter/exit events to trigger scale changes, stabs, mutes.
 
-## Nodes (28)
+## Nodes (30)
 
 ### Inputs (sources)
 _Where signals enter the graph._
@@ -55,7 +55,7 @@ Reads the live UI control store → scale + sound + overlay port values.
 
 - **roles:** source, control
 - **in:** —
-- **out:** scaleRight:number[], scaleLeft:number[], soundRight:sound, soundLeft:sound, octaveShift:number, magnetism:number, mute:boolean, overlay:overlay-config, rightSpec:scale-spec, faceMapping:face-mapping, chordConfig:chord-config, expressionSensitivity:expression-sensitivity, expressionDegrees:expression-degrees
+- **out:** scaleRight:number[], scaleLeft:number[], soundRight:sound, soundLeft:sound, octaveShift:number, magnetism:number, mute:boolean, overlay:overlay-config, rightSpec:scale-spec, chordSpec:scale-spec, chordScale:number[], faceMapping:face-mapping, chordConfig:chord-config, expressionSensitivity:expression-sensitivity, expressionDegrees:expression-degrees
 - **params:** —
 
 #### `synthetic-hands` — Synthetic Hands
@@ -116,6 +116,22 @@ Hand features → discrete poses (fist/open/pinch) + enter/exit edge events.
 - **in:** features:hand-features
 - **out:** poses:poses, events:gesture-events
 - **params:** pinchOn (number=0.6), pinchOff (number=0.45), fistBelow (number=0.25), openAbove (number=0.6), hysteresis (number=0.05)
+
+#### `face-feature-vector` — Face Feature Vector
+Face blendshapes + mesh + head pose -> a flat vector of enabled catalog features.
+
+- **roles:** feature
+- **in:** face:face-frame
+- **out:** vector:feature-vector
+- **params:** groups (array)
+
+#### `hand-feature-vector` — Hand Feature Vector
+Hand image + world landmarks -> a flat vector of enabled per-hand + two-hand catalog features.
+
+- **roles:** feature
+- **in:** hands:hands-frame
+- **out:** vector:feature-vector
+- **params:** mirrorX (boolean=true), mirrorHandedness (boolean=true), groups (array)
 
 ### Mapping (direct ↔ indirect)
 _Features → engine parameters, across the expression spectrum._
@@ -196,7 +212,7 @@ Roman-numeral progression in a key + position (0..1) → current chord symbol.
 - **params:** key (string="C"), romanNumerals (array=["I","IV","V","vi"])
 
 #### `expression-chord` — Expression Chord
-Facial expression → a voiced, rendered diatonic chord on the current seven-note scale (active only in face "chord" mode).
+Facial expression → a voiced, rendered diatonic chord on the chord-source scale (active only in face "chord" mode).
 
 - **roles:** music
 - **in:** expression:face-expression, spec:scale-spec, faceMapping:face-mapping, octaveShift:number, chordConfig:chord-config, degrees:expression-degrees
@@ -264,7 +280,7 @@ _Audio + the captured video with overlaid guides._
 Mirrored video + composable overlay elements (guides, landmarks, markers, cues).
 
 - **roles:** overlay
-- **in:** hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], chord:number[], faceFrame:face-frame, expression:face-expression, octaveShift:number, overlayConfig:overlay-config
+- **in:** hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], chordScale:number[], chord:number[], faceFrame:face-frame, expression:face-expression, octaveShift:number, overlayConfig:overlay-config, faceVector:feature-vector, handVector:feature-vector
 - **out:** —
-- **params:** video (object={}), scaleGuide (object={}), chordGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={}), fingerLines (object={}), faceLandmarks (object={}), timbreLevels (object={}), faceExpression (object={}), fingerBars (object={}), chordName (object={}), keyboardStrip (object={}), tagHud (object={})
+- **params:** video (object={}), scaleGuide (object={}), chordGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={}), fingerLines (object={}), faceLandmarks (object={}), timbreLevels (object={}), faceExpression (object={}), fingerBars (object={}), chordName (object={}), keyboardStrip (object={}), featureLab (object={}), tagHud (object={})
 

--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -21,7 +21,7 @@ This page catalogs the engine's building blocks — every node and how they conn
 - **Discrete triggers** — `hand-features → gesture-classifier → (events)`  
   Fist/open/pinch poses emit enter/exit events to trigger scale changes, stabs, mutes.
 
-## Nodes (30)
+## Nodes (28)
 
 ### Inputs (sources)
 _Where signals enter the graph._
@@ -55,7 +55,7 @@ Reads the live UI control store → scale + sound + overlay port values.
 
 - **roles:** source, control
 - **in:** —
-- **out:** scaleRight:number[], scaleLeft:number[], soundRight:sound, soundLeft:sound, octaveShift:number, magnetism:number, mute:boolean, overlay:overlay-config, rightSpec:scale-spec, chordSpec:scale-spec, chordScale:number[], faceMapping:face-mapping, chordConfig:chord-config, expressionSensitivity:expression-sensitivity, expressionDegrees:expression-degrees
+- **out:** scaleRight:number[], scaleLeft:number[], soundRight:sound, soundLeft:sound, octaveShift:number, magnetism:number, mute:boolean, overlay:overlay-config, rightSpec:scale-spec, faceMapping:face-mapping, chordConfig:chord-config, expressionSensitivity:expression-sensitivity, expressionDegrees:expression-degrees
 - **params:** —
 
 #### `synthetic-hands` — Synthetic Hands
@@ -116,22 +116,6 @@ Hand features → discrete poses (fist/open/pinch) + enter/exit edge events.
 - **in:** features:hand-features
 - **out:** poses:poses, events:gesture-events
 - **params:** pinchOn (number=0.6), pinchOff (number=0.45), fistBelow (number=0.25), openAbove (number=0.6), hysteresis (number=0.05)
-
-#### `face-feature-vector` — Face Feature Vector
-Face blendshapes + mesh + head pose -> a flat vector of enabled catalog features.
-
-- **roles:** feature
-- **in:** face:face-frame
-- **out:** vector:feature-vector
-- **params:** groups (array)
-
-#### `hand-feature-vector` — Hand Feature Vector
-Hand image + world landmarks -> a flat vector of enabled per-hand + two-hand catalog features.
-
-- **roles:** feature
-- **in:** hands:hands-frame
-- **out:** vector:feature-vector
-- **params:** mirrorX (boolean=true), mirrorHandedness (boolean=true), groups (array)
 
 ### Mapping (direct ↔ indirect)
 _Features → engine parameters, across the expression spectrum._
@@ -212,7 +196,7 @@ Roman-numeral progression in a key + position (0..1) → current chord symbol.
 - **params:** key (string="C"), romanNumerals (array=["I","IV","V","vi"])
 
 #### `expression-chord` — Expression Chord
-Facial expression → a voiced, rendered diatonic chord on the chord-source scale (active only in face "chord" mode).
+Facial expression → a voiced, rendered diatonic chord on the current seven-note scale (active only in face "chord" mode).
 
 - **roles:** music
 - **in:** expression:face-expression, spec:scale-spec, faceMapping:face-mapping, octaveShift:number, chordConfig:chord-config, degrees:expression-degrees
@@ -280,7 +264,7 @@ _Audio + the captured video with overlaid guides._
 Mirrored video + composable overlay elements (guides, landmarks, markers, cues).
 
 - **roles:** overlay
-- **in:** hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], chordScale:number[], chord:number[], faceFrame:face-frame, expression:face-expression, octaveShift:number, overlayConfig:overlay-config, faceVector:feature-vector, handVector:feature-vector
+- **in:** hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], chord:number[], faceFrame:face-frame, expression:face-expression, octaveShift:number, overlayConfig:overlay-config
 - **out:** —
-- **params:** video (object={}), scaleGuide (object={}), chordGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={}), fingerLines (object={}), faceLandmarks (object={}), timbreLevels (object={}), faceExpression (object={}), fingerBars (object={}), chordName (object={}), keyboardStrip (object={}), featureLab (object={})
+- **params:** video (object={}), scaleGuide (object={}), chordGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={}), fingerLines (object={}), faceLandmarks (object={}), timbreLevels (object={}), faceExpression (object={}), fingerBars (object={}), chordName (object={}), keyboardStrip (object={}), tagHud (object={})
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -91,12 +91,14 @@ Chord overlays sit outside both (self-contained), and are a good early win.
    scheme; a `manifest.json` for cross-stream time alignment; a three-tier local
    sink (dir handle / ZIP / per-file). Independent of the command-dispatch track.
 
-8. **[#92] Live tagging mode** — *L · depends on #88 · research in #81.*
-   Toggle tags during a recording → a time-aligned `tags.jsonl` that segments the
-   streams for ML/analysis. Interval+point tags, mutual-exclusivity groups,
-   1..9 keyboard toggles, per-tag lead-in + countdown, blinking open-tag buttons,
-   a burned-in corner overlay as the ground-truth clock. Built to **extract into
-   a reusable zodal tool** (`taglog`: affordances / provider / presentation).
+8. **[#92] Live tagging mode** — *✅ SHIPPED · L · was: depends on #88 · research in #81.*
+   Toggle tags during a recording → a time-aligned `tags.jsonl` (absolute engine
+   clock, shared with `features.jsonl` by construction) that segments the streams for
+   ML/analysis. Interval+point tags, mutual-exclusivity groups, 1..9 keyboard toggles,
+   per-tag lead-in + countdown, blinking open-tag buttons, a burned-in corner overlay
+   as the in-band ground truth. Built as a **reusable zodal tool** in `src/taglog/`
+   (affordances / adapters / provider / presentation) + thoremin glue in
+   `src/app/tagging/`; export adapters for Audacity / WebVTT / CSV / Praat TextGrid / OTIO.
 
 ### Stream Applier / alternative sources (active — 2026-07)
 

--- a/public/catalog.json
+++ b/public/catalog.json
@@ -28,10 +28,6 @@
         "kind": "number[]"
       },
       {
-        "name": "chordScale",
-        "kind": "number[]"
-      },
-      {
         "name": "chord",
         "kind": "number[]"
       },
@@ -51,14 +47,6 @@
       {
         "name": "overlayConfig",
         "kind": "overlay-config"
-      },
-      {
-        "name": "faceVector",
-        "kind": "feature-vector"
-      },
-      {
-        "name": "handVector",
-        "kind": "feature-vector"
       }
     ],
     "outputs": [],
@@ -129,7 +117,7 @@
         "default": {}
       },
       {
-        "name": "featureLab",
+        "name": "tagHud",
         "type": "object",
         "default": {}
       }
@@ -206,7 +194,7 @@
   {
     "type": "expression-chord",
     "title": "Expression Chord",
-    "description": "Facial expression → a voiced, rendered diatonic chord on the chord-source scale (active only in face \"chord\" mode).",
+    "description": "Facial expression → a voiced, rendered diatonic chord on the current seven-note scale (active only in face \"chord\" mode).",
     "roles": [
       "music"
     ],
@@ -420,32 +408,6 @@
     ]
   },
   {
-    "type": "face-feature-vector",
-    "title": "Face Feature Vector",
-    "description": "Face blendshapes + mesh + head pose -> a flat vector of enabled catalog features.",
-    "roles": [
-      "feature"
-    ],
-    "inputs": [
-      {
-        "name": "face",
-        "kind": "face-frame"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "vector",
-        "kind": "feature-vector"
-      }
-    ],
-    "params": [
-      {
-        "name": "groups",
-        "type": "array"
-      }
-    ]
-  },
-  {
     "type": "face-features",
     "title": "Face Features",
     "description": "Face blendshapes → normalized expression controls (smile, mouthOpen, brow, blink).",
@@ -525,42 +487,6 @@
         "name": "hysteresis",
         "type": "number",
         "default": 0.05
-      }
-    ]
-  },
-  {
-    "type": "hand-feature-vector",
-    "title": "Hand Feature Vector",
-    "description": "Hand image + world landmarks -> a flat vector of enabled per-hand + two-hand catalog features.",
-    "roles": [
-      "feature"
-    ],
-    "inputs": [
-      {
-        "name": "hands",
-        "kind": "hands-frame"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "vector",
-        "kind": "feature-vector"
-      }
-    ],
-    "params": [
-      {
-        "name": "mirrorX",
-        "type": "boolean",
-        "default": true
-      },
-      {
-        "name": "mirrorHandedness",
-        "type": "boolean",
-        "default": true
-      },
-      {
-        "name": "groups",
-        "type": "array"
       }
     ]
   },
@@ -1170,14 +1096,6 @@
       {
         "name": "rightSpec",
         "kind": "scale-spec"
-      },
-      {
-        "name": "chordSpec",
-        "kind": "scale-spec"
-      },
-      {
-        "name": "chordScale",
-        "kind": "number[]"
       },
       {
         "name": "faceMapping",

--- a/public/catalog.json
+++ b/public/catalog.json
@@ -28,6 +28,10 @@
         "kind": "number[]"
       },
       {
+        "name": "chordScale",
+        "kind": "number[]"
+      },
+      {
         "name": "chord",
         "kind": "number[]"
       },
@@ -47,6 +51,14 @@
       {
         "name": "overlayConfig",
         "kind": "overlay-config"
+      },
+      {
+        "name": "faceVector",
+        "kind": "feature-vector"
+      },
+      {
+        "name": "handVector",
+        "kind": "feature-vector"
       }
     ],
     "outputs": [],
@@ -113,6 +125,11 @@
       },
       {
         "name": "keyboardStrip",
+        "type": "object",
+        "default": {}
+      },
+      {
+        "name": "featureLab",
         "type": "object",
         "default": {}
       },
@@ -194,7 +211,7 @@
   {
     "type": "expression-chord",
     "title": "Expression Chord",
-    "description": "Facial expression → a voiced, rendered diatonic chord on the current seven-note scale (active only in face \"chord\" mode).",
+    "description": "Facial expression → a voiced, rendered diatonic chord on the chord-source scale (active only in face \"chord\" mode).",
     "roles": [
       "music"
     ],
@@ -408,6 +425,32 @@
     ]
   },
   {
+    "type": "face-feature-vector",
+    "title": "Face Feature Vector",
+    "description": "Face blendshapes + mesh + head pose -> a flat vector of enabled catalog features.",
+    "roles": [
+      "feature"
+    ],
+    "inputs": [
+      {
+        "name": "face",
+        "kind": "face-frame"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "vector",
+        "kind": "feature-vector"
+      }
+    ],
+    "params": [
+      {
+        "name": "groups",
+        "type": "array"
+      }
+    ]
+  },
+  {
     "type": "face-features",
     "title": "Face Features",
     "description": "Face blendshapes → normalized expression controls (smile, mouthOpen, brow, blink).",
@@ -487,6 +530,42 @@
         "name": "hysteresis",
         "type": "number",
         "default": 0.05
+      }
+    ]
+  },
+  {
+    "type": "hand-feature-vector",
+    "title": "Hand Feature Vector",
+    "description": "Hand image + world landmarks -> a flat vector of enabled per-hand + two-hand catalog features.",
+    "roles": [
+      "feature"
+    ],
+    "inputs": [
+      {
+        "name": "hands",
+        "kind": "hands-frame"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "vector",
+        "kind": "feature-vector"
+      }
+    ],
+    "params": [
+      {
+        "name": "mirrorX",
+        "type": "boolean",
+        "default": true
+      },
+      {
+        "name": "mirrorHandedness",
+        "type": "boolean",
+        "default": true
+      },
+      {
+        "name": "groups",
+        "type": "array"
       }
     ]
   },
@@ -1096,6 +1175,14 @@
       {
         "name": "rightSpec",
         "kind": "scale-spec"
+      },
+      {
+        "name": "chordSpec",
+        "kind": "scale-spec"
+      },
+      {
+        "name": "chordScale",
+        "kind": "number[]"
       },
       {
         "name": "faceMapping",

--- a/public/manual.html
+++ b/public/manual.html
@@ -23,7 +23,7 @@
   .examples code { color: #7dd3fc; } .note { color: #9aa; font-size: 13px; }
 </style></head><body><div class="wrap">
   <h1>θ Thoremin — Capabilities Manual</h1>
-  <p class="gen">Auto-generated from the node registry. 30 nodes.</p>
+  <p class="gen">Auto-generated from the node registry. 28 nodes.</p>
   <p>Thoremin turns live sensor streams (webcam hand gestures, facial expressions, computer keyboard, later MIDI) into a live audiovisual stream — musical audio plus the captured video with overlaid guides. You build sounds by wiring small, typed <b>nodes</b> into a dataflow graph (DAG): inputs → features → mapping → music-logic → synthesis/generation → output. Every edge can be recorded and replayed.</p><p>The mapping layer spans a spectrum: <b>direct</b> (a gesture *is* a note/parameter — e.g. hand position → scale-snapped pitch) through <b>indirect</b> (a gesture expresses a high-level idea — e.g. openness → musical density steering an AI model), including <b>conductor</b> mode (direct a fixed piece's tempo and dynamics).</p><p>This page catalogs the engine's building blocks — every node and how they connect. Some already run in the deployed app; wiring the full graph into the live sound is in progress.</p>
   <h3>Example pipelines</h3>
   <ul class="examples"><li><b>Theremin (direct)</b> — <code>webcam-hands → hand-features → voice-mapping → webaudio-synth ( + canvas-overlay)</code><br/><span class="note">Hand x → scale-snapped pitch, y → volume. Two hands = two voices.</span></li><li><b>Gesture → harmony</b> — <code>hand-features → pick('right.x') → progression → chord → webaudio-synth</code><br/><span class="note">Hand position walks an in-key chord progression.</span></li><li><b>Conductor</b> — <code>control → performance → transport → score → webaudio-synth</code><br/><span class="note">A control signal directs a fixed piece's tempo + dynamics (accelerando/crescendo…).</span></li><li><b>Indirect / AI (gesture or expression)</b> — <code>hand-features / face-features → indirect-map → lyria</code><br/><span class="note">Openness/smile/etc. steer weighted prompts + dials of Google Lyria RealTime.</span></li><li><b>Discrete triggers</b> — <code>hand-features → gesture-classifier → (events)</code><br/><span class="note">Fist/open/pinch poses emit enter/exit events to trigger scale changes, stabs, mutes.</span></li></ul>
@@ -64,7 +64,7 @@
       <dl>
         <dt>roles</dt><dd>source, control</dd>
         <dt>in</dt><dd>—</dd>
-        <dt>out</dt><dd>scaleRight:number[], scaleLeft:number[], soundRight:sound, soundLeft:sound, octaveShift:number, magnetism:number, mute:boolean, overlay:overlay-config, rightSpec:scale-spec, chordSpec:scale-spec, chordScale:number[], faceMapping:face-mapping, chordConfig:chord-config, expressionSensitivity:expression-sensitivity, expressionDegrees:expression-degrees</dd>
+        <dt>out</dt><dd>scaleRight:number[], scaleLeft:number[], soundRight:sound, soundLeft:sound, octaveShift:number, magnetism:number, mute:boolean, overlay:overlay-config, rightSpec:scale-spec, faceMapping:face-mapping, chordConfig:chord-config, expressionSensitivity:expression-sensitivity, expressionDegrees:expression-degrees</dd>
         <dt>params</dt><dd>—</dd>
       </dl>
     </div>
@@ -137,26 +137,6 @@
         <dt>in</dt><dd>features:hand-features</dd>
         <dt>out</dt><dd>poses:poses, events:gesture-events</dd>
         <dt>params</dt><dd>pinchOn (number=0.6), pinchOff (number=0.45), fistBelow (number=0.25), openAbove (number=0.6), hysteresis (number=0.05)</dd>
-      </dl>
-    </div>
-    <div class="node">
-      <h4><code>face-feature-vector</code> <span class="title">Face Feature Vector</span></h4>
-      <p>Face blendshapes + mesh + head pose -&gt; a flat vector of enabled catalog features.</p>
-      <dl>
-        <dt>roles</dt><dd>feature</dd>
-        <dt>in</dt><dd>face:face-frame</dd>
-        <dt>out</dt><dd>vector:feature-vector</dd>
-        <dt>params</dt><dd>groups (array)</dd>
-      </dl>
-    </div>
-    <div class="node">
-      <h4><code>hand-feature-vector</code> <span class="title">Hand Feature Vector</span></h4>
-      <p>Hand image + world landmarks -&gt; a flat vector of enabled per-hand + two-hand catalog features.</p>
-      <dl>
-        <dt>roles</dt><dd>feature</dd>
-        <dt>in</dt><dd>hands:hands-frame</dd>
-        <dt>out</dt><dd>vector:feature-vector</dd>
-        <dt>params</dt><dd>mirrorX (boolean=true), mirrorHandedness (boolean=true), groups (array)</dd>
       </dl>
     </div></div></section>
 <section><h3>Mapping (direct ↔ indirect)</h3><p class="blurb">Features → engine parameters, across the expression spectrum.</p><div class="grid">
@@ -253,7 +233,7 @@
     </div>
     <div class="node">
       <h4><code>expression-chord</code> <span class="title">Expression Chord</span></h4>
-      <p>Facial expression → a voiced, rendered diatonic chord on the chord-source scale (active only in face "chord" mode).</p>
+      <p>Facial expression → a voiced, rendered diatonic chord on the current seven-note scale (active only in face "chord" mode).</p>
       <dl>
         <dt>roles</dt><dd>music</dd>
         <dt>in</dt><dd>expression:face-expression, spec:scale-spec, faceMapping:face-mapping, octaveShift:number, chordConfig:chord-config, degrees:expression-degrees</dd>
@@ -329,9 +309,9 @@
       <p>Mirrored video + composable overlay elements (guides, landmarks, markers, cues).</p>
       <dl>
         <dt>roles</dt><dd>overlay</dd>
-        <dt>in</dt><dd>hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], chordScale:number[], chord:number[], faceFrame:face-frame, expression:face-expression, octaveShift:number, overlayConfig:overlay-config, faceVector:feature-vector, handVector:feature-vector</dd>
+        <dt>in</dt><dd>hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], chord:number[], faceFrame:face-frame, expression:face-expression, octaveShift:number, overlayConfig:overlay-config</dd>
         <dt>out</dt><dd>—</dd>
-        <dt>params</dt><dd>video (object={}), scaleGuide (object={}), chordGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={}), fingerLines (object={}), faceLandmarks (object={}), timbreLevels (object={}), faceExpression (object={}), fingerBars (object={}), chordName (object={}), keyboardStrip (object={}), featureLab (object={})</dd>
+        <dt>params</dt><dd>video (object={}), scaleGuide (object={}), chordGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={}), fingerLines (object={}), faceLandmarks (object={}), timbreLevels (object={}), faceExpression (object={}), fingerBars (object={}), chordName (object={}), keyboardStrip (object={}), tagHud (object={})</dd>
       </dl>
     </div></div></section>
 </div></body></html>

--- a/public/manual.html
+++ b/public/manual.html
@@ -23,7 +23,7 @@
   .examples code { color: #7dd3fc; } .note { color: #9aa; font-size: 13px; }
 </style></head><body><div class="wrap">
   <h1>θ Thoremin — Capabilities Manual</h1>
-  <p class="gen">Auto-generated from the node registry. 28 nodes.</p>
+  <p class="gen">Auto-generated from the node registry. 30 nodes.</p>
   <p>Thoremin turns live sensor streams (webcam hand gestures, facial expressions, computer keyboard, later MIDI) into a live audiovisual stream — musical audio plus the captured video with overlaid guides. You build sounds by wiring small, typed <b>nodes</b> into a dataflow graph (DAG): inputs → features → mapping → music-logic → synthesis/generation → output. Every edge can be recorded and replayed.</p><p>The mapping layer spans a spectrum: <b>direct</b> (a gesture *is* a note/parameter — e.g. hand position → scale-snapped pitch) through <b>indirect</b> (a gesture expresses a high-level idea — e.g. openness → musical density steering an AI model), including <b>conductor</b> mode (direct a fixed piece's tempo and dynamics).</p><p>This page catalogs the engine's building blocks — every node and how they connect. Some already run in the deployed app; wiring the full graph into the live sound is in progress.</p>
   <h3>Example pipelines</h3>
   <ul class="examples"><li><b>Theremin (direct)</b> — <code>webcam-hands → hand-features → voice-mapping → webaudio-synth ( + canvas-overlay)</code><br/><span class="note">Hand x → scale-snapped pitch, y → volume. Two hands = two voices.</span></li><li><b>Gesture → harmony</b> — <code>hand-features → pick('right.x') → progression → chord → webaudio-synth</code><br/><span class="note">Hand position walks an in-key chord progression.</span></li><li><b>Conductor</b> — <code>control → performance → transport → score → webaudio-synth</code><br/><span class="note">A control signal directs a fixed piece's tempo + dynamics (accelerando/crescendo…).</span></li><li><b>Indirect / AI (gesture or expression)</b> — <code>hand-features / face-features → indirect-map → lyria</code><br/><span class="note">Openness/smile/etc. steer weighted prompts + dials of Google Lyria RealTime.</span></li><li><b>Discrete triggers</b> — <code>hand-features → gesture-classifier → (events)</code><br/><span class="note">Fist/open/pinch poses emit enter/exit events to trigger scale changes, stabs, mutes.</span></li></ul>
@@ -64,7 +64,7 @@
       <dl>
         <dt>roles</dt><dd>source, control</dd>
         <dt>in</dt><dd>—</dd>
-        <dt>out</dt><dd>scaleRight:number[], scaleLeft:number[], soundRight:sound, soundLeft:sound, octaveShift:number, magnetism:number, mute:boolean, overlay:overlay-config, rightSpec:scale-spec, faceMapping:face-mapping, chordConfig:chord-config, expressionSensitivity:expression-sensitivity, expressionDegrees:expression-degrees</dd>
+        <dt>out</dt><dd>scaleRight:number[], scaleLeft:number[], soundRight:sound, soundLeft:sound, octaveShift:number, magnetism:number, mute:boolean, overlay:overlay-config, rightSpec:scale-spec, chordSpec:scale-spec, chordScale:number[], faceMapping:face-mapping, chordConfig:chord-config, expressionSensitivity:expression-sensitivity, expressionDegrees:expression-degrees</dd>
         <dt>params</dt><dd>—</dd>
       </dl>
     </div>
@@ -137,6 +137,26 @@
         <dt>in</dt><dd>features:hand-features</dd>
         <dt>out</dt><dd>poses:poses, events:gesture-events</dd>
         <dt>params</dt><dd>pinchOn (number=0.6), pinchOff (number=0.45), fistBelow (number=0.25), openAbove (number=0.6), hysteresis (number=0.05)</dd>
+      </dl>
+    </div>
+    <div class="node">
+      <h4><code>face-feature-vector</code> <span class="title">Face Feature Vector</span></h4>
+      <p>Face blendshapes + mesh + head pose -&gt; a flat vector of enabled catalog features.</p>
+      <dl>
+        <dt>roles</dt><dd>feature</dd>
+        <dt>in</dt><dd>face:face-frame</dd>
+        <dt>out</dt><dd>vector:feature-vector</dd>
+        <dt>params</dt><dd>groups (array)</dd>
+      </dl>
+    </div>
+    <div class="node">
+      <h4><code>hand-feature-vector</code> <span class="title">Hand Feature Vector</span></h4>
+      <p>Hand image + world landmarks -&gt; a flat vector of enabled per-hand + two-hand catalog features.</p>
+      <dl>
+        <dt>roles</dt><dd>feature</dd>
+        <dt>in</dt><dd>hands:hands-frame</dd>
+        <dt>out</dt><dd>vector:feature-vector</dd>
+        <dt>params</dt><dd>mirrorX (boolean=true), mirrorHandedness (boolean=true), groups (array)</dd>
       </dl>
     </div></div></section>
 <section><h3>Mapping (direct ↔ indirect)</h3><p class="blurb">Features → engine parameters, across the expression spectrum.</p><div class="grid">
@@ -233,7 +253,7 @@
     </div>
     <div class="node">
       <h4><code>expression-chord</code> <span class="title">Expression Chord</span></h4>
-      <p>Facial expression → a voiced, rendered diatonic chord on the current seven-note scale (active only in face "chord" mode).</p>
+      <p>Facial expression → a voiced, rendered diatonic chord on the chord-source scale (active only in face "chord" mode).</p>
       <dl>
         <dt>roles</dt><dd>music</dd>
         <dt>in</dt><dd>expression:face-expression, spec:scale-spec, faceMapping:face-mapping, octaveShift:number, chordConfig:chord-config, degrees:expression-degrees</dd>
@@ -309,9 +329,9 @@
       <p>Mirrored video + composable overlay elements (guides, landmarks, markers, cues).</p>
       <dl>
         <dt>roles</dt><dd>overlay</dd>
-        <dt>in</dt><dd>hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], chord:number[], faceFrame:face-frame, expression:face-expression, octaveShift:number, overlayConfig:overlay-config</dd>
+        <dt>in</dt><dd>hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], chordScale:number[], chord:number[], faceFrame:face-frame, expression:face-expression, octaveShift:number, overlayConfig:overlay-config, faceVector:feature-vector, handVector:feature-vector</dd>
         <dt>out</dt><dd>—</dd>
-        <dt>params</dt><dd>video (object={}), scaleGuide (object={}), chordGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={}), fingerLines (object={}), faceLandmarks (object={}), timbreLevels (object={}), faceExpression (object={}), fingerBars (object={}), chordName (object={}), keyboardStrip (object={}), tagHud (object={})</dd>
+        <dt>params</dt><dd>video (object={}), scaleGuide (object={}), chordGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={}), fingerLines (object={}), faceLandmarks (object={}), timbreLevels (object={}), faceExpression (object={}), fingerBars (object={}), chordName (object={}), keyboardStrip (object={}), featureLab (object={}), tagHud (object={})</dd>
       </dl>
     </div></div></section>
 </div></body></html>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -14,10 +14,12 @@ import { Play, BookOpen, VolumeX } from 'lucide-react';
 import { useThoreminEngine } from './useEngine';
 import { DEFAULT_SOURCE, type SourceSpec } from './sourceSpec';
 import { installKeyboardShortcuts } from './keyboardShortcuts';
+import { installTaggingKeymap } from './tagging/keymap';
 import { useControls } from './store';
 import { useFaceStatus } from './faceStatus';
 import InstrumentsPanel from './dials/InstrumentsPanel';
 import RecordButton from './RecordButton';
+import TaggingControls from './tagging/TaggingControls';
 import Toaster from './Toaster';
 import CommandPaletteOverlay from './CommandPaletteOverlay';
 import AssistantOverlay from '@/plugins/assistant/AssistantOverlay';
@@ -77,6 +79,9 @@ export default function App({ source = DEFAULT_SOURCE }: { source?: SourceSpec }
   // #90: install the keyboard shortcuts (octave / magnetism / mute) — an app-level
   // tinykeys keymap dispatching dial commands, replacing the retired in-DAG switch.
   useEffect(() => installKeyboardShortcuts(), []);
+  // #92: install the MODAL tag-toggle keymap (1..9 / 0) — inert unless tagging mode
+  // is on, so it never shadows other digit bindings.
+  useEffect(() => installTaggingKeymap(), []);
 
   return (
     <div className="relative h-dvh w-screen overflow-hidden bg-black font-mono text-white">
@@ -118,6 +123,11 @@ export default function App({ source = DEFAULT_SOURCE }: { source?: SourceSpec }
           a settings sheet (out-of-instrument config) then a compact HUD. Available
           once audio is running. */}
       {audioOn && <RecordButton recording={recording} />}
+
+      {/* Live tagging (#92): the launcher + setup sheet, the in-take button stack
+          (left edge), and the centered lead-in countdown. Available once the engine
+          is ready; toggling a tag during a recording writes a time-aligned tags.jsonl. */}
+      {status === 'ready' && <TaggingControls />}
 
       {/* Top-right: the instruments surface (the list + the per-instrument editor). */}
       <InstrumentsPanel />

--- a/src/app/overlayControls.ts
+++ b/src/app/overlayControls.ts
@@ -90,4 +90,7 @@ export const OVERLAY_CONTROLS: OverlayControlDesc[] = [
   { name: 'scaleGuide', label: 'Scale guide', toggles: [{ key: 'showLabels', label: 'Note labels' }] },
   { name: 'indexGuide', label: 'Index-finger guide', toggles: [{ key: 'dashed', label: 'Dashed' }] },
   { name: 'video', label: 'Video backdrop', slider: { key: 'alpha', label: 'Opacity' } },
+  // Live tagging (#92): the burned-in corner HUD (open tags + timecode) that composits
+  // into the recorded video. Shown only while a take records; toggle to hide the burn-in.
+  { name: 'tagHud', label: 'Tagging HUD (recorded)' },
 ];

--- a/src/app/recording/plan.ts
+++ b/src/app/recording/plan.ts
@@ -50,6 +50,9 @@ export interface PlanInput {
   videoMime: string;
   /** Alpha (overlay-only) MIME — Chromium VP9; defaults to `video/webm;codecs=vp9`. */
   alphaMime?: string;
+  /** Whether live tagging (#92) is active for this take — adds a `.tags.jsonl` stream
+   *  to the folder (and forces folder mode, since a tag log needs the manifest). */
+  includeTags?: boolean;
 }
 
 /** Selected audio output formats, filtered to ids the registry knows (an unknown
@@ -103,9 +106,11 @@ export function planRecording(input: PlanInput): RecordingPlan {
   const s = session.streams;
   const fps = session.fps;
   const videoExt = videoExtForMime(videoMime);
+  const includeTags = input.includeTags === true;
 
   // --- single-file escape hatch: one bare media file, no folder, no manifest ---
-  if (singleFileEligible(session)) {
+  // A tag log needs the folder + manifest, so it disqualifies the escape hatch.
+  if (!includeTags && singleFileEligible(session)) {
     let file: PlannedFile;
     if (s.audio) {
       file = audioFiles(session, stem, audioMime)[0];
@@ -132,6 +137,10 @@ export function planRecording(input: PlanInput): RecordingPlan {
   if (s.audio) files.push(...audioFiles(session, stem, audioMime));
   if (s.features)
     files.push({ name: fileName(stem, { role: 'features', ext: 'jsonl' }), kind: 'features', role: 'features', ext: 'jsonl' });
+  // The live-tagging stream (#92) drops in like features.jsonl: same folder, same
+  // stem, same t0/JSONL convention, listed in the manifest as `kind: 'tags'`.
+  if (includeTags)
+    files.push({ name: fileName(stem, { role: 'tags', ext: 'jsonl' }), kind: 'tags', role: 'tags', ext: 'jsonl' });
 
   // The manifest is always present (provenance + alignment SSOT), so a folder has
   // ≥ 2 files even for an audio-only take.

--- a/src/app/recording/session.ts
+++ b/src/app/recording/session.ts
@@ -21,6 +21,7 @@ import { createRecordingSink, type RecordingSink, type SinkResult } from './sink
 import { FeatureJsonlTap } from './featureTap';
 import { saveBlob } from './save';
 import { hasAnyStream, type RecordingSession } from './schema';
+import type { TagStreamSource } from './tagStream';
 
 /** Chunk media into ~2s slices so long takes stay constant-memory (#88 §1). */
 const TIMESLICE_MS = 2000;
@@ -41,6 +42,9 @@ export interface SessionRecorderDeps {
   resources: Record<string, unknown>;
   /** Active instrument/sound id, for the manifest. */
   instrument?: string;
+  /** Live-tagging source (#92): when active, writes a `.tags.jsonl` stream into the
+   *  folder on the shared `t0`. Absent = no tagging. */
+  tagSource?: TagStreamSource;
 }
 
 interface Rec {
@@ -129,6 +133,9 @@ export class SessionRecorder {
   private t0 = 0;
   private startPerf = 0;
   private running = false;
+  /** Whether this take is writing a `.tags.jsonl` (#92) — set at start from the tag
+   *  source's `active()`, so plan/stop stay in agreement. */
+  private tagsActive = false;
 
   constructor(deps: SessionRecorderDeps, session: RecordingSession) {
     this.deps = deps;
@@ -154,6 +161,10 @@ export class SessionRecorder {
    */
   async start(): Promise<void> {
     if (this.running) return;
+    // Tagging is a COMPANION stream: its tags.jsonl segments the OTHER streams on the
+    // shared t0, so a take needs at least one capturable media/feature stream to tag
+    // (a tags-only take would reference streams that don't exist). Hence the guard is
+    // on hasAnyStream, deliberately not counting tags.
     if (!hasAnyStream(this.session.streams)) throw new Error('No streams selected to record');
     const { audioContext, masterGain, canvas, video, cameraStream, engine, resources } = this.deps;
     const s = this.session.streams;
@@ -167,12 +178,17 @@ export class SessionRecorder {
       : prefillName({ instrument: this.deps.instrument ?? 'thoremin', date: new Date() });
     this.stem = name;
 
+    // Live tagging (#92): if the tag source is active, this take writes a
+    // `.tags.jsonl` (which also forces folder mode — a tag log needs the manifest).
+    this.tagsActive = this.deps.tagSource?.active() === true;
+
     this.plan = planRecording({
       session: this.session,
       stem: this.stem,
       audioMime: this.audioMime,
       videoMime: this.videoMime,
       alphaMime: this.alphaMime ?? undefined,
+      includeTags: this.tagsActive,
     });
 
     // A folder take goes through a sink (dir/zip); the single-file escape hatch
@@ -243,6 +259,14 @@ export class SessionRecorder {
       throw new Error('None of the selected streams can be captured in this browser');
     }
 
+    // Begin the tag take on the SAME t0 the media/feature streams share, so the
+    // `.tags.jsonl` events share the absolute engine clock and line up frame-accurately (#92 §5).
+    // Done last, once capture is committed, so a fail-fast above never leaves the
+    // tagging runtime with a dangling take.
+    if (this.tagsActive) {
+      this.deps.tagSource!.beginTake({ t0: this.t0, startedAt: this.startedAt, session: this.stem });
+    }
+
     this.running = true;
   }
 
@@ -255,9 +279,18 @@ export class SessionRecorder {
     if (!this.running) throw new Error('Not recording');
     this.running = false;
 
-    // Detach the tap first so no more feature lines arrive after t-stop.
+    // The take's end on the ABSOLUTE engine clock (the same frame tag/feature events
+    // are stamped in), captured now at stop-request so still-open tags close at the
+    // true take end (#92).
+    const endEngineT = performance.now() / 1000;
+
+    // Detach the feature tap AND freeze the tag log at the SAME instant, so neither
+    // stream keeps recording input during the (possibly seconds-long) async
+    // stop/convert window below. endTake closes still-open tags at endEngineT and
+    // returns the anchored JSONL; the file loop just writes it.
     this.detachTap?.();
     this.detachTap = null;
+    const tagsJsonl = this.tagsActive ? (this.deps.tagSource?.endTake(endEngineT) ?? '') : '';
 
     const [audioBlob, overlayBlob, pureBlob, alphaBlob] = await Promise.all([
       this.audioRec ? stopRec(this.audioRec) : Promise.resolve(null),
@@ -310,6 +343,10 @@ export class SessionRecorder {
           break;
         case 'features':
           await putFile(file, this.tap?.drain() ?? '');
+          break;
+        case 'tags':
+          // The tag log was already closed + drained above (symmetric with the tap).
+          await putFile(file, tagsJsonl);
           break;
         case 'manifest': {
           const manifest = buildManifest({
@@ -406,6 +443,16 @@ export class SessionRecorder {
   dispose(): void {
     this.detachTap?.();
     this.detachTap = null;
+    // Release the tagging runtime's take context so a dropped/aborted recording
+    // doesn't leave it stuck "recording" (endTake is a no-op if already ended).
+    if (this.tagsActive) {
+      try {
+        this.deps.tagSource?.endTake(performance.now() / 1000);
+      } catch {
+        /* runtime already reset */
+      }
+      this.tagsActive = false;
+    }
     for (const rec of [this.audioRec, this.overlayRec, this.pureRec, this.alphaRec]) {
       try {
         if (rec && rec.recorder.state !== 'inactive') rec.recorder.stop();

--- a/src/app/recording/tagStream.ts
+++ b/src/app/recording/tagStream.ts
@@ -1,0 +1,34 @@
+/**
+ * TagStreamSource (#92) — the seam between the multi-stream recorder and the live-
+ * tagging runtime. `tags.jsonl` is "just another stream" in the recording folder
+ * (recording-v2 doc), sharing the take's `t0` and JSONL convention, so the
+ * {@link SessionRecorder} treats tagging as an injected source it asks three things:
+ *
+ *  - is tagging active for this take? (`active`)
+ *  - here is the shared `t0` — begin the take (write the anchor, reset the log)
+ *  - the take ended at this media-time — hand back the `tags.jsonl` text
+ *
+ * The recorder never imports the tagging store; the runtime implements this contract
+ * over it. Keeping the interface here (not in `session.ts`) lets both sides depend on
+ * it without a cycle.
+ */
+
+export interface TagTakeMeta {
+  /** The recording anchor `t0` (engine-clock seconds) shared by every stream. */
+  t0: number;
+  /** Wall-clock ISO of record start (for the anchor record's human field). */
+  startedAt: string;
+  /** The take/session id (= recording stem), for cross-file correlation. */
+  session: string;
+}
+
+export interface TagStreamSource {
+  /** True if tagging mode is on with tags defined — this take should write a
+   *  `tags.jsonl`. Read once at record start. */
+  active(): boolean;
+  /** Begin a take on the shared clock: write the anchor, start a fresh event log. */
+  beginTake(meta: TagTakeMeta): void;
+  /** End the take at `endT` media-seconds: close still-open tags, return the JSONL
+   *  (already including the anchor). '' if nothing was captured. */
+  endTake(endT: number): string;
+}

--- a/src/app/tagging/Countdown.tsx
+++ b/src/app/tagging/Countdown.tsx
@@ -1,0 +1,50 @@
+/**
+ * Countdown (#92, design §6) — the centered lead-in countdown. When a tag with a
+ * lead-in opens, the performer needs `leadIn` seconds to physically start the action;
+ * this tells them when the tagged action officially begins (at `tCorrected`).
+ *
+ * It is PURELY presentational: the stored event time is the click instant; the
+ * countdown never gates logging. A subscriber to the tagging store's `countdown`
+ * state; it ticks itself off `performance.now()` and clears when the lead-in elapses
+ * (showing a brief "GO"). Part of the build-checked React layer.
+ */
+import { useEffect, useState } from 'react';
+import { useTagging } from './store';
+
+export default function Countdown() {
+  const countdown = useTagging((s) => s.countdown);
+  const clear = useTagging((s) => s.clearCountdown);
+  const [remaining, setRemaining] = useState(0);
+
+  useEffect(() => {
+    if (!countdown) return;
+    let raf = 0;
+    const tick = () => {
+      const rem = countdown.leadIn - (performance.now() / 1000 - countdown.startPerf);
+      setRemaining(rem);
+      // Hold "GO" for ~0.4s past zero, then dismiss.
+      if (rem <= -0.4) {
+        clear();
+        return;
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [countdown, clear]);
+
+  if (!countdown) return null;
+  const label = remaining > 0 ? String(Math.ceil(remaining)) : 'GO';
+  return (
+    <div className="pointer-events-none absolute inset-0 z-40 flex items-center justify-center">
+      <div className="flex flex-col items-center gap-2">
+        <div className="text-[120px] font-black leading-none text-white drop-shadow-[0_0_30px_rgba(0,0,0,0.9)]">
+          {label}
+        </div>
+        <div className="rounded-full bg-black/60 px-4 py-1 text-xs uppercase tracking-widest text-white/80 backdrop-blur">
+          {countdown.label} starting
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/tagging/TagButtonStack.tsx
+++ b/src/app/tagging/TagButtonStack.tsx
@@ -1,0 +1,83 @@
+/**
+ * TagButtonStack (#92, design §10) — the in-recording button stack: one button per
+ * tag, shown on the left edge while tagging mode is on. Each button carries its
+ * number badge (1..9), a kind glyph (a bar for an interval, a dot for a point — a
+ * SHAPE difference, not just colour, for accessibility), and the tag label.
+ *
+ * Status is shown by MOTION: an open interval tag BLINKS (a REC light, so "something
+ * is being recorded" reads peripherally); a point tag flashes once on fire. Clicking
+ * pushes the same `TagAction` the keyboard digit does (`src` records which), so the
+ * two paths are indistinguishable downstream. Purely presentational — a subscriber to
+ * the tagging store, part of the build-checked React layer.
+ */
+import { useEffect, useRef, useState } from 'react';
+import type { TagDef } from '@/taglog/affordances';
+import { useTagging } from './store';
+
+/** One tag button. A point button flashes briefly when IT fires (via the store, so a
+ *  KEYBOARD-triggered point flashes too, not just a click); an interval blinks while open. */
+function TagButton({ def, isOpen }: { def: TagDef; isOpen: boolean }) {
+  const toggle = useTagging((s) => s.toggle);
+  const pulse = useTagging((s) => s.pulse);
+  const lastPoint = useTagging((s) => s.lastPoint);
+  const [flash, setFlash] = useState(false);
+  const prevPulse = useRef(pulse);
+
+  // Flash when this point tag is the just-fired one. Keyed on `pulse` so a repeat
+  // fire of the same tag re-triggers; the ref skips the initial mount.
+  useEffect(() => {
+    if (pulse === prevPulse.current) return;
+    prevPulse.current = pulse;
+    if (def.kind !== 'point' || lastPoint !== def.id) return;
+    setFlash(true);
+    const id = setTimeout(() => setFlash(false), 180);
+    return () => clearTimeout(id);
+  }, [pulse]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const onClick = () => toggle(def.id, 'click');
+  const active = isOpen || flash;
+  return (
+    <button
+      onClick={onClick}
+      title={`${def.label} (${def.kind}${def.number ? `, key ${def.number}` : ''})`}
+      style={{
+        borderColor: def.color,
+        backgroundColor: active ? def.color : 'rgba(0,0,0,0.45)',
+        color: active ? '#000' : def.color,
+      }}
+      className={`pointer-events-auto flex w-40 items-center gap-2 rounded-lg border-2 px-2.5 py-1.5 text-left text-xs font-bold uppercase tracking-wide backdrop-blur transition ${
+        isOpen ? 'animate-pulse shadow-lg' : ''
+      }`}
+    >
+      <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded bg-black/40 text-[10px] text-white/90">
+        {def.number ?? '·'}
+      </span>
+      {/* Kind glyph: a bar = interval, a dot = point (distinct shapes). */}
+      <span aria-hidden className="w-3 text-center text-sm leading-none">
+        {def.kind === 'interval' ? '▬' : '●'}
+      </span>
+      <span className="truncate">{def.label}</span>
+    </button>
+  );
+}
+
+export default function TagButtonStack() {
+  const mode = useTagging((s) => s.mode);
+  const defs = useTagging((s) => s.defs);
+  const open = useTagging((s) => s.state.open);
+  const recording = useTagging((s) => s.take !== null);
+
+  if (!mode || defs.length === 0) return null;
+  return (
+    <div className="absolute left-3 top-1/2 z-20 flex -translate-y-1/2 flex-col gap-1.5">
+      <div className="mb-0.5 flex items-center gap-1.5 px-1 text-[9px] uppercase tracking-widest text-white/50">
+        <span className={`inline-block h-1.5 w-1.5 rounded-full ${recording ? 'animate-pulse bg-red-500' : 'bg-white/30'}`} />
+        {recording ? 'tagging · rec' : 'tagging'}
+      </div>
+      {defs.map((def) => (
+        <TagButton key={def.id} def={def} isOpen={open[def.id] !== undefined} />
+      ))}
+      <div className="mt-0.5 px-1 text-[9px] uppercase tracking-widest text-white/35">1–9 toggle · 0 clears</div>
+    </div>
+  );
+}

--- a/src/app/tagging/TaggingControls.tsx
+++ b/src/app/tagging/TaggingControls.tsx
@@ -1,0 +1,45 @@
+/**
+ * TaggingControls (#92) — the single entry point mounted by `App` for live tagging.
+ * It renders the launcher pill (bottom-center) that opens the {@link TaggingSheet}
+ * setup surface, plus the always-on subscribers: the {@link TagButtonStack} (shown
+ * while tagging mode is on) and the centered {@link Countdown}.
+ *
+ * Keeping these together behind one component keeps `App` changes minimal. Purely
+ * presentational; the tagging store is the single source of truth.
+ */
+import { useState } from 'react';
+import { Tags } from 'lucide-react';
+import { useTagging } from './store';
+import TagButtonStack from './TagButtonStack';
+import Countdown from './Countdown';
+import TaggingSheet from './TaggingSheet';
+
+export default function TaggingControls() {
+  const [open, setOpen] = useState(false);
+  const mode = useTagging((s) => s.mode);
+  const tagCount = useTagging((s) => s.defs.length);
+
+  return (
+    <>
+      <TagButtonStack />
+      <Countdown />
+      <div className="absolute bottom-3 left-1/2 z-30 flex -translate-x-1/2 flex-col items-center gap-2">
+        {open && <TaggingSheet onClose={() => setOpen(false)} />}
+        <button
+          onClick={() => setOpen((o) => !o)}
+          aria-label="Tagging mode"
+          aria-expanded={open}
+          className={`flex items-center gap-2 rounded-full px-4 py-2 text-[10px] font-bold uppercase tracking-widest backdrop-blur transition ${
+            mode ? 'bg-emerald-500 text-black' : 'bg-black/50 text-white/80 hover:text-white'
+          }`}
+        >
+          <Tags className="h-3.5 w-3.5" />
+          Tags
+          {mode && tagCount > 0 && (
+            <span className="rounded-full bg-black/30 px-1.5 text-[9px] tabular-nums">{tagCount}</span>
+          )}
+        </button>
+      </div>
+    </>
+  );
+}

--- a/src/app/tagging/TaggingSheet.tsx
+++ b/src/app/tagging/TaggingSheet.tsx
@@ -1,0 +1,218 @@
+/**
+ * TaggingSheet (#92) — the tagging-mode setup surface. Pick + order the tag set
+ * (pre-seeded with the last-used set), choose exclusivity, and per tag set its kind
+ * (interval/point), lead-in (pre-roll seconds), colour and label. It is a SETTINGS
+ * surface, not a form to submit: every edit flows straight into the tagging store
+ * (which debounce-persists via the taglog provider), so closing never loses anything.
+ *
+ * Purely presentational — a subscriber to the tagging store. Part of the build-checked
+ * React layer (no @types/react). Styling mirrors the recording SettingsSheet.
+ */
+import { ChevronDown, ChevronUp, Plus, Trash2, X } from 'lucide-react';
+import type { ExclusivityMode, TagDef, TagKind } from '@/taglog/affordances';
+import { CODECS } from '@/taglog/affordances';
+import { useTagging } from './store';
+
+const selectCls = 'rounded bg-white/10 px-2 py-1 text-xs outline-none focus:bg-white/20';
+
+const EXCLUSIVITY_OPTIONS: { value: ExclusivityMode; label: string }[] = [
+  { value: 'off', label: 'Multiple at once' },
+  { value: 'single', label: 'One at a time' },
+  { value: 'group', label: 'By group' },
+];
+
+/** One editable tag row: number badge, colour, label, kind, lead-in, reorder, delete. */
+function TagRow({ def, index, count }: { def: TagDef; index: number; count: number }) {
+  const updateTag = useTagging((s) => s.updateTag);
+  const removeTag = useTagging((s) => s.removeTag);
+  const moveTag = useTagging((s) => s.moveTag);
+  const exclusivity = useTagging((s) => s.config.exclusivity);
+
+  return (
+    <div className="rounded-lg bg-white/5 p-2">
+      <div className="flex items-center gap-1.5">
+        <span
+          className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-[10px] font-bold text-black"
+          style={{ backgroundColor: def.color }}
+        >
+          {def.number ?? '·'}
+        </span>
+        <input
+          type="color"
+          value={def.color}
+          onChange={(e) => updateTag(def.id, { color: e.target.value })}
+          className="h-5 w-5 shrink-0 cursor-pointer rounded border-0 bg-transparent p-0"
+          title="Tag colour"
+        />
+        <input
+          type="text"
+          value={def.label}
+          spellCheck={false}
+          onChange={(e) => updateTag(def.id, { label: e.target.value })}
+          className="min-w-0 flex-1 rounded bg-white/10 px-2 py-1 text-xs outline-none focus:bg-white/20"
+        />
+        <div className="flex shrink-0 flex-col">
+          <button
+            onClick={() => moveTag(def.id, -1)}
+            disabled={index === 0}
+            aria-label="Move up"
+            className="text-white/50 transition hover:text-white disabled:opacity-20"
+          >
+            <ChevronUp className="h-3 w-3" />
+          </button>
+          <button
+            onClick={() => moveTag(def.id, 1)}
+            disabled={index === count - 1}
+            aria-label="Move down"
+            className="text-white/50 transition hover:text-white disabled:opacity-20"
+          >
+            <ChevronDown className="h-3 w-3" />
+          </button>
+        </div>
+        <button
+          onClick={() => removeTag(def.id)}
+          aria-label="Delete tag"
+          className="shrink-0 rounded p-1 text-white/40 transition hover:bg-white/10 hover:text-rose-400"
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </button>
+      </div>
+      <div className="mt-1.5 flex items-center gap-2 pl-6 text-[11px] text-white/70">
+        <label className="flex items-center gap-1" title="Interval (open→close) or an instantaneous point">
+          Kind
+          <select
+            className={selectCls}
+            value={def.kind}
+            onChange={(e) => updateTag(def.id, { kind: e.target.value as TagKind })}
+          >
+            <option value="interval">interval ▬</option>
+            <option value="point">point ●</option>
+          </select>
+        </label>
+        {def.kind === 'interval' && (
+          <label className="flex items-center gap-1" title="Lead-in seconds: open shifts later, close earlier — trims the reach-in/out.">
+            Lead-in
+            <input
+              type="number"
+              min={0}
+              max={9}
+              value={def.leadIn}
+              onChange={(e) => updateTag(def.id, { leadIn: Math.max(0, Math.min(9, Number(e.target.value) || 0)) })}
+              className="w-12 rounded bg-white/10 px-1.5 py-1 text-xs outline-none focus:bg-white/20"
+            />
+            s
+          </label>
+        )}
+        {exclusivity === 'group' && def.kind === 'interval' && (
+          <label className="flex items-center gap-1" title="Tags sharing a group auto-close each other.">
+            Group
+            <input
+              type="text"
+              value={def.group ?? ''}
+              spellCheck={false}
+              onChange={(e) => updateTag(def.id, { group: e.target.value.trim() || null })}
+              className="w-16 rounded bg-white/10 px-1.5 py-1 text-xs outline-none focus:bg-white/20"
+            />
+          </label>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function TaggingSheet({ onClose }: { onClose: () => void }) {
+  const mode = useTagging((s) => s.mode);
+  const setMode = useTagging((s) => s.setMode);
+  const defs = useTagging((s) => s.defs);
+  const config = useTagging((s) => s.config);
+  const setConfig = useTagging((s) => s.setConfig);
+  const addTag = useTagging((s) => s.addTag);
+  const recording = useTagging((s) => s.take !== null);
+
+  return (
+    <div className="max-h-[80vh] w-80 overflow-y-auto rounded-2xl bg-black/70 p-3 text-white/90 shadow-2xl backdrop-blur">
+      <div className="mb-2 flex items-center justify-between">
+        <span className="text-[10px] font-bold uppercase tracking-widest text-white/60">Tagging mode</span>
+        <button
+          onClick={onClose}
+          aria-label="Close tagging settings"
+          className="rounded p-1 text-white/60 transition hover:bg-white/10 hover:text-white"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      </div>
+
+      {/* Master on/off — arms the button stack + the 1..9 keys. Disabled mid-take so
+          an active recording keeps its tag log. */}
+      <label
+        className={`mb-3 flex items-center justify-between rounded-lg bg-white/5 px-3 py-2 ${recording ? 'opacity-60' : ''}`}
+        title={recording ? 'Stop the recording to change this' : undefined}
+      >
+        <span className="text-xs font-bold uppercase tracking-wide">{mode ? 'On' : 'Off'}</span>
+        <input type="checkbox" checked={mode} disabled={recording} onChange={(e) => setMode(e.target.checked)} />
+      </label>
+
+      <div className="mb-3 flex items-center justify-between">
+        <span className="text-[10px] uppercase tracking-widest text-white/50">Exclusivity</span>
+        <select
+          className={selectCls}
+          value={config.exclusivity}
+          onChange={(e) => setConfig({ exclusivity: e.target.value as ExclusivityMode })}
+        >
+          {EXCLUSIVITY_OPTIONS.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="mb-2 flex items-center justify-between">
+        <span className="text-[10px] uppercase tracking-widest text-white/50">Tags</span>
+        <button
+          onClick={() => addTag()}
+          className="flex items-center gap-1 rounded-full bg-white/10 px-2.5 py-1 text-[10px] font-bold uppercase tracking-widest transition hover:bg-white/20"
+        >
+          <Plus className="h-3 w-3" /> Add
+        </button>
+      </div>
+      <div className="space-y-1.5">
+        {defs.length === 0 && (
+          <p className="rounded-lg bg-white/5 p-3 text-center text-[11px] text-white/50">
+            No tags yet — add one to start.
+          </p>
+        )}
+        {defs.map((def, i) => (
+          <TagRow key={def.id} def={def} index={i} count={defs.length} />
+        ))}
+      </div>
+
+      {/* Advanced: the wire representation (extraction-ready config). statusEnum is
+          the smallest, self-describing default; pointPair/kindField are for interop. */}
+      <details className="mt-3">
+        <summary className="cursor-pointer text-[10px] uppercase tracking-widest text-white/40">Advanced</summary>
+        <div className="mt-2 flex items-center justify-between">
+          <span className="text-[10px] uppercase tracking-widest text-white/50" title="How each event is written to tags.jsonl">
+            Event format
+          </span>
+          <select
+            className={selectCls}
+            value={config.codec}
+            onChange={(e) => setConfig({ codec: e.target.value })}
+          >
+            {Object.keys(CODECS).map((name) => (
+              <option key={name} value={name}>
+                {name}
+              </option>
+            ))}
+          </select>
+        </div>
+      </details>
+
+      <p className="mt-3 text-[10px] leading-relaxed text-white/40">
+        Toggling a tag while recording writes a time-aligned <code>.tags.jsonl</code> into the take
+        folder. Keys 1–9 toggle; 0 clears all.
+      </p>
+    </div>
+  );
+}

--- a/src/app/tagging/keymap.ts
+++ b/src/app/tagging/keymap.ts
@@ -1,0 +1,36 @@
+/**
+ * Modal tag-toggle keymap (#92, design §8) — digits 1..9 toggle the positional tag,
+ * `0` closes all open tags (panic / clean-stop). It is deliberately **modal**: the
+ * handler no-ops unless tagging mode is on, so it never shadows any other digit
+ * binding (e.g. a future instrument-load keymap) and the keys are inert until the
+ * performer opts into tagging.
+ *
+ * Guarded by the shared {@link isEditableTarget} (typing a tag label must never fire
+ * a tag) and by the modifier check (Cmd/Ctrl/Alt combos pass through to the palette
+ * etc.). Auto-repeat is ignored so a held key is one toggle, not a stream. The
+ * handler only pushes a `TagAction` into the store — the same path a button click
+ * takes — so keyboard and mouse are indistinguishable downstream (`src` records which).
+ */
+import { isEditableTarget } from '@/nodes/sources/keyboard';
+import { useTagging } from './store';
+
+/** Install the modal keymap on `target` (default window); returns the unsubscribe. */
+export function installTaggingKeymap(target: Window = window): () => void {
+  const onKey = (e: KeyboardEvent) => {
+    const st = useTagging.getState();
+    if (!st.mode) return; // modal: only while tagging mode is on
+    if (isEditableTarget(e.target)) return; // don't steal keys from a focused input
+    if (e.metaKey || e.ctrlKey || e.altKey) return; // leave modifier combos alone
+    if (e.repeat) return; // one toggle per physical press, not per auto-repeat
+    const k = e.key;
+    if (k === '0') {
+      e.preventDefault();
+      st.closeAllTags('key');
+    } else if (k >= '1' && k <= '9') {
+      e.preventDefault();
+      st.toggleByNumber(Number(k), 'key');
+    }
+  };
+  target.addEventListener('keydown', onKey);
+  return () => target.removeEventListener('keydown', onKey);
+}

--- a/src/app/tagging/runtime.ts
+++ b/src/app/tagging/runtime.ts
@@ -1,0 +1,28 @@
+/**
+ * Tagging runtime bindings (#92) — thin adapters that expose the tagging store to
+ * the two host subsystems that must reach it without importing zustand directly:
+ *
+ *  - the {@link SessionRecorder}, via the {@link TagStreamSource} contract, so
+ *    `tags.jsonl` rides in the recording folder on the shared `t0`;
+ *  - the DAG overlay node, via a `ctx.resources.tagOverlay` function it reads each
+ *    tick to burn the open tags + timecode into the recorded frames.
+ *
+ * Both are one-liners over `useTagging.getState()` — the store is the single source
+ * of truth; these just present it behind the stable seams the recorder / overlay expect.
+ */
+import { useTagging } from './store';
+import type { TagStreamSource, TagTakeMeta } from '../recording/tagStream';
+import type { TagOverlaySnapshot } from '@/taglog/presentation';
+
+/** A TagStreamSource backed by the live tagging store, handed to the SessionRecorder. */
+export const tagStreamSource: TagStreamSource = {
+  active: () => useTagging.getState().active(),
+  beginTake: (meta: TagTakeMeta) => useTagging.getState().beginTake(meta),
+  endTake: (endT: number) => useTagging.getState().endTake(endT),
+};
+
+/** The overlay resource the burned-in corner HUD reads each tick (null unless a take
+ *  is recording). Installed as `ctx.resources.tagOverlay` in `useEngine`. */
+export function tagOverlayResource(): TagOverlaySnapshot | null {
+  return useTagging.getState().overlaySnapshot();
+}

--- a/src/app/tagging/store.ts
+++ b/src/app/tagging/store.ts
@@ -1,0 +1,305 @@
+/**
+ * Tagging runtime store (#92) — the thoremin glue that binds the pure `taglog` core
+ * to the live app. This is a DEDICATED zustand store, deliberately SEPARATE from
+ * `src/app/store.ts`: it owns nothing the instrument persists and never bumps that
+ * store's persist version. Tag DEFINITIONS + config persist through the `taglog`
+ * provider (localStorage, the zodal way); only live per-tick runtime state lives here
+ * (read synchronously by the overlay + button stack, same discipline as `useControls`).
+ *
+ * What lives here: the active tag set (`defs`), session `config`, tagging `mode`
+ * on/off, the live open/seq `state`, the active recording `take` (with its JSONL
+ * sink), and the presentation `countdown`. The take lifecycle (`beginTake`/`endTake`)
+ * is driven by the recorder via the {@link TagStreamSource} adapter (`runtime.ts`).
+ *
+ * The tick/audio loop is never awaited here — persistence is debounced and the
+ * provider is only touched on setup/edits, never on a toggle.
+ */
+import { create } from 'zustand';
+import type { DataProvider } from '@zodal/store';
+import {
+  applyToggle,
+  closeAll,
+  emptyTagState,
+  TagDefSchema,
+  DEFAULT_TAGGING_CONFIG,
+  TAGS_SCHEMA_ID,
+  type TagDef,
+  type TaggingConfig,
+  type TagState,
+  type TagSrc,
+} from '@/taglog/affordances';
+import { TagEventSink } from '@/taglog/provider/sink';
+import {
+  createTagSetProvider,
+  loadLastUsed,
+  saveTagSet,
+  TagSetDocSchema,
+  type TagSetDoc,
+} from '@/taglog/provider/defsStore';
+import type { TagOverlaySnapshot } from '@/taglog/presentation';
+
+/** The active take's runtime context (present only while recording). */
+interface TakeContext {
+  t0: number;
+  session: string;
+  sink: TagEventSink;
+}
+
+/** The presentation countdown for a just-opened tag with a lead-in (§6). */
+export interface CountdownState {
+  tagId: string;
+  label: string;
+  leadIn: number;
+  /** perf-seconds when the open fired; the component derives remaining from this. */
+  startPerf: number;
+}
+
+interface TaggingState {
+  /** Tagging mode on/off — shows the button stack + arms the 1..9 keys. */
+  mode: boolean;
+  /** The active, ordered tag set. */
+  defs: TagDef[];
+  /** Session-level config (exclusivity, codec, clock, offset). */
+  config: TaggingConfig;
+  /** Live open/seq state (the toggle state machine's data). */
+  state: TagState;
+  /** The active recording take, or null when not recording. */
+  take: TakeContext | null;
+  /** The active lead-in countdown, or null. */
+  countdown: CountdownState | null;
+  /** Bumped whenever a point fires — a cheap signal for one-shot flash animations. */
+  pulse: number;
+  /** The tag id of the most recent point fire (paired with `pulse`), so a button can
+   *  flash on a keyboard-triggered point, not just a click. */
+  lastPoint: string | null;
+  /** Engine-clock source in seconds (performance.now()/1000). Injectable for tests. */
+  clock: () => number;
+
+  // ---- selectors ----
+  isOpen(tagId: string): boolean;
+  /** True if this take should write a tags.jsonl (mode on + tags defined). */
+  active(): boolean;
+  /** The burned-in-overlay snapshot (null unless recording). */
+  overlaySnapshot(): TagOverlaySnapshot | null;
+
+  // ---- mode + setup ----
+  setMode(on: boolean): void;
+  setDefs(defs: TagDef[]): void;
+  setConfig(patch: Partial<TaggingConfig>): void;
+  addTag(partial?: Partial<TagDef>): void;
+  updateTag(id: string, patch: Partial<TagDef>): void;
+  removeTag(id: string): void;
+  moveTag(id: string, dir: -1 | 1): void;
+
+  // ---- live actions (the hot path — never awaits) ----
+  toggle(tagId: string, src: TagSrc): void;
+  toggleByNumber(n: number, src: TagSrc): void;
+  closeAllTags(src: TagSrc): void;
+  clearCountdown(): void;
+
+  // ---- take lifecycle (called by the recorder) ----
+  beginTake(input: { t0: number; startedAt: string; session: string }): void;
+  endTake(endT: number): string;
+
+  // ---- persistence ----
+  hydrate(): Promise<void>;
+
+  /** Test hook: override the clock. */
+  _setClock(fn: () => number): void;
+}
+
+/** Assign positional numbers (1..9 by order; null past the ninth) + display order. */
+export function renumber(defs: TagDef[]): TagDef[] {
+  return defs.map((d, i) => ({ ...d, order: i, number: i < 9 ? i + 1 : null }));
+}
+
+/** A small starter set so the button stack is usable on first open (pre-seed is
+ *  overwritten by the last-used set once one has been saved). */
+export function defaultTagSet(): TagDef[] {
+  return renumber([
+    TagDefSchema.parse({ id: 'tag_a', label: 'A', kind: 'interval', color: '#34d399' }),
+    TagDefSchema.parse({ id: 'tag_b', label: 'B', kind: 'interval', color: '#60a5fa' }),
+    TagDefSchema.parse({ id: 'tag_c', label: 'C', kind: 'point', color: '#f59e0b' }),
+  ]);
+}
+
+/** A fresh unique tag id (app glue — Math.random is fine here, never in pure code). */
+function newTagId(): string {
+  return 'tag_' + Math.random().toString(36).slice(2, 8);
+}
+
+// --- persistence: a lazily-created provider + a debounced "last-used" save ---------
+let _provider: DataProvider<TagSetDoc> | null = null;
+function provider(): DataProvider<TagSetDoc> {
+  return (_provider ??= createTagSetProvider());
+}
+let _saveTimer: ReturnType<typeof setTimeout> | null = null;
+/** Debounced persist of the current defs+config as the "last-used" tag set. Best
+ *  effort — a storage failure never disrupts tagging. */
+function persist(get: () => TaggingState): void {
+  if (_saveTimer) clearTimeout(_saveTimer);
+  _saveTimer = setTimeout(() => {
+    const s = get();
+    const doc = TagSetDocSchema.parse({
+      id: 'last',
+      name: 'Last used',
+      tags: s.defs,
+      config: s.config,
+      updatedAt: Date.now(),
+    });
+    void saveTagSet(provider(), doc).catch(() => {});
+  }, 400);
+}
+
+export const useTagging = create<TaggingState>((set, get) => ({
+  mode: false,
+  defs: [],
+  config: DEFAULT_TAGGING_CONFIG,
+  state: emptyTagState(),
+  take: null,
+  countdown: null,
+  pulse: 0,
+  lastPoint: null,
+  clock: () => performance.now() / 1000,
+
+  isOpen: (tagId) => get().state.open[tagId] !== undefined,
+  active: () => {
+    const s = get();
+    return s.mode && s.defs.length > 0;
+  },
+  overlaySnapshot: () => {
+    const s = get();
+    if (!s.take) return null;
+    const open = Object.keys(s.state.open).map((id) => {
+      const d = s.defs.find((x) => x.id === id);
+      return { tag: id, label: d?.label ?? id, color: d?.color ?? '#34d399' };
+    });
+    return { t0: s.take.t0, open };
+  },
+
+  setMode: (on) => {
+    if (on) {
+      void get().hydrate();
+      set({ mode: true });
+    } else {
+      // Leaving tagging mode clears the live open state so buttons stop blinking; a
+      // take in progress keeps its own log (its `sink` is captured in `take`).
+      set({ mode: false, state: emptyTagState(), countdown: null });
+    }
+  },
+
+  setDefs: (defs) => {
+    set({ defs: renumber(defs) });
+    persist(get);
+  },
+  setConfig: (patch) => {
+    set((s) => ({ config: { ...s.config, ...patch } }));
+    persist(get);
+  },
+  addTag: (partial) => {
+    const def = TagDefSchema.parse({ id: newTagId(), label: 'Tag', kind: 'interval', ...partial });
+    set((s) => ({ defs: renumber([...s.defs, def]) }));
+    persist(get);
+  },
+  updateTag: (id, patch) => {
+    set((s) => ({ defs: renumber(s.defs.map((d) => (d.id === id ? TagDefSchema.parse({ ...d, ...patch, id }) : d))) }));
+    persist(get);
+  },
+  removeTag: (id) => {
+    set((s) => ({ defs: renumber(s.defs.filter((d) => d.id !== id)) }));
+    persist(get);
+  },
+  moveTag: (id, dir) => {
+    set((s) => {
+      const i = s.defs.findIndex((d) => d.id === id);
+      const j = i + dir;
+      if (i < 0 || j < 0 || j >= s.defs.length) return s;
+      const next = [...s.defs];
+      [next[i], next[j]] = [next[j], next[i]];
+      return { defs: renumber(next) };
+    });
+    persist(get);
+  },
+
+  toggle: (tagId, src) => {
+    const s = get();
+    const def = s.defs.find((d) => d.id === tagId);
+    if (!def) return;
+    const perf = s.clock();
+    // ABSOLUTE engine-clock seconds (= ctx.time = performance.now()/1000) — the SAME
+    // stamp features.jsonl uses, so the two label streams share one frame by
+    // construction. The take offset is `t - t0` per the manifest SSOT; NEVER subtract
+    // t0 here or a consumer following the manifest would double-subtract it. During
+    // rehearsal (no take) t is unused (nothing is logged).
+    const t = perf;
+    const { state, edges } = applyToggle(s.state, s.defs, { tagId, t, src }, s.config);
+    if (s.take && edges.length) s.take.sink.append(edges);
+    const opened = edges.find((e) => e.tag === tagId && e.status === 'open');
+    const firedPoint = edges.some((e) => e.status === 'point');
+    set({
+      state,
+      countdown: opened && def.leadIn > 0 ? { tagId, label: def.label, leadIn: def.leadIn, startPerf: perf } : s.countdown,
+      pulse: firedPoint ? s.pulse + 1 : s.pulse,
+      // The just-fired point tag id (with the bumped pulse) drives its button's flash
+      // for BOTH click and keyboard, since both toggles route through here.
+      lastPoint: firedPoint ? tagId : s.lastPoint,
+    });
+  },
+  toggleByNumber: (n, src) => {
+    const def = get().defs.find((d) => d.number === n);
+    if (def) get().toggle(def.id, src);
+  },
+  closeAllTags: (src) => {
+    const s = get();
+    // Absolute engine clock, same as toggle() (see the note there).
+    const t = s.clock();
+    const { state, edges } = closeAll(s.state, s.defs, t, s.config, src);
+    if (s.take && edges.length) s.take.sink.append(edges);
+    set({ state, countdown: null });
+  },
+  clearCountdown: () => set({ countdown: null }),
+
+  beginTake: ({ t0, startedAt, session }) => {
+    const s = get();
+    const sink = new TagEventSink(s.config.codec);
+    // The anchor documents the origin so the file is self-describing: `t` is the
+    // absolute engine-clock t0 (== manifest.t0). Every event `t` minus this is its
+    // offset into the take — the same rule the manifest applies to every stream.
+    sink.writeAnchor({
+      anchor: true,
+      t: t0,
+      clock: s.config.clock,
+      wallClockISO: startedAt,
+      recStartPerf: t0 * 1000,
+      session,
+      schema: TAGS_SCHEMA_ID,
+    });
+    // Fresh log per take: seq starts at 0, no carried-over open tags (the recorded
+    // intervals are exactly what is toggled during the take).
+    set({ take: { t0, session, sink }, state: emptyTagState(), countdown: null });
+  },
+  endTake: (endT) => {
+    const s = get();
+    if (!s.take) return '';
+    const { edges } = closeAll(s.state, s.defs, endT, s.config, 'auto');
+    if (edges.length) s.take.sink.append(edges);
+    const jsonl = s.take.sink.drain();
+    set({ take: null, state: emptyTagState(), countdown: null });
+    return jsonl;
+  },
+
+  hydrate: async () => {
+    try {
+      const last = await loadLastUsed(provider());
+      if (last && last.tags.length) {
+        set({ defs: renumber(last.tags), config: last.config });
+        return;
+      }
+    } catch {
+      /* no storage — fall through to the in-memory default */
+    }
+    if (!get().defs.length) set({ defs: defaultTagSet() });
+  },
+
+  _setClock: (fn) => set({ clock: fn }),
+}));

--- a/src/app/tagging/store.ts
+++ b/src/app/tagging/store.ts
@@ -72,7 +72,12 @@ interface TaggingState {
   /** The tag id of the most recent point fire (paired with `pulse`), so a button can
    *  flash on a keyboard-triggered point, not just a click. */
   lastPoint: string | null;
-  /** Engine-clock source in seconds (performance.now()/1000). Injectable for tests. */
+  /** Engine-clock source in seconds (performance.now()/1000 = the DAG `ctx.time` on
+   *  the live rAF path). Injectable for tests. NOTE: this reads the wall clock
+   *  directly, so it equals `ctx.time` only while the engine runs in real time. If
+   *  batch/speed-scaled recording (the Clock abstraction) is ever wired into a live
+   *  take, tags.jsonl (this clock) and features.jsonl (`ctx.time`) would diverge —
+   *  route both through one clock source then. */
   clock: () => number;
 
   // ---- selectors ----

--- a/src/app/useEngine.ts
+++ b/src/app/useEngine.ts
@@ -21,6 +21,7 @@ import {
   type RecordingSession,
 } from './recording/schema';
 import { prefillName } from './recording/naming';
+import { tagStreamSource, tagOverlayResource } from './tagging/runtime';
 import { useFaceStatus } from './faceStatus';
 import type { FaceStatus } from '@/nodes';
 import type { ExpressionScores } from '@/music/expression';
@@ -177,6 +178,9 @@ export function useThoreminEngine(source: SourceSpec = DEFAULT_SOURCE) {
         resources.canvas = canvasRef.current;
         resources.window = window;
         resources.controls = () => useControls.getState();
+        // Live tagging (#92): the burned-in corner HUD reads this each tick (null
+        // unless a take is recording). Same synchronous-read pattern as `controls`.
+        resources.tagOverlay = tagOverlayResource;
 
         const engine = new Engine(defaultGraph(), createAppRegistry(), { resources });
         await engine.init(); // loads the MediaPipe model
@@ -372,6 +376,8 @@ export function useThoreminEngine(source: SourceSpec = DEFAULT_SOURCE) {
         engine,
         resources: resourcesRef.current,
         instrument: recInstrumentRef.current,
+        // If tagging mode is on, tags.jsonl rides in the folder on the shared t0 (#92).
+        tagSource: tagStreamSource,
       },
       recSession,
     );

--- a/src/nodes/output/canvas_overlay.ts
+++ b/src/nodes/output/canvas_overlay.ts
@@ -49,6 +49,7 @@ import {
   safeName,
   type FeatureVector,
 } from '@/features/catalog';
+import { computeTagOverlay, type TagOverlayFrame, type TagOverlaySnapshot } from '@/taglog/presentation';
 import { EFFECT_SHORT, type HandMap } from '../mapping/hand_map';
 import {
   FINGER_NAMES,
@@ -176,6 +177,20 @@ const Params = z.object({
       resetNonce: z.number().default(0),
     })
     .prefault({}),
+  /**
+   * Live-tagging burned-in corner HUD (#92): while a take is recording with tagging
+   * on, paints the open tags + a media timecode + a ~1 Hz REC blink into the
+   * composited (and alpha) frames — the in-band "second opinion" that makes stream
+   * alignment verifiable in the very pixels a model trains on. A no-op (draws
+   * nothing) whenever no take is recording, so it costs nothing the rest of the time.
+   */
+  tagHud: z
+    .object({
+      show: z.boolean().default(true),
+      /** Which top corner the chip stack anchors to. */
+      position: z.enum(['left', 'right']).default('right'),
+    })
+    .prefault({}),
 });
 type Params = z.infer<typeof Params>;
 
@@ -231,6 +246,9 @@ export interface OverlayView {
     faceDegrees?: Record<string, number>;
     /** Live face mapping mode ('chord'/'timbre'/…); chord labels show only in 'chord'. */
     faceMapping?: string;
+    /** Burned-in tag HUD frame (#92): open tags + timecode + blink; null unless a
+     *  take is recording. Computed in `process` from `ctx.resources.tagOverlay`. */
+    tagOverlay?: TagOverlayFrame | null;
   };
   params: Params;
   /** Computed top-left origin per cue element name (set by the layout pass). */
@@ -1206,6 +1224,62 @@ const featureLabElement: OverlayElement = {
   },
 };
 
+// ---- Live-tagging burned-in corner HUD (#92) ------------------------------------
+// A self-contained additive block (first mover; keep it isolated so a concurrent
+// OVERLAY_ELEMENTS addition merges cleanly). Draws only when a take is recording.
+const TAG_HUD_CHAR_W = 7.6; // approx width of a 13px monospace glyph (no measureText,
+//                              so the headless recording-canvas test needs no extra API)
+const TAG_HUD_PAD = 8;
+const TAG_HUD_ROW = 18;
+const TAG_HUD_DOT = 7;
+
+/** Paint the burned-in tag HUD: a REC-dot + timecode header, then one blinking chip
+ *  per open tag, anchored to a top corner. Uses only fillRect/arc/fill/fillText so it
+ *  matches the elements the settings panel + tests already exercise. */
+function drawTagHud(g: CanvasRenderingContext2D, view: OverlayView, frame: TagOverlayFrame): void {
+  const rows: { text: string; color: string }[] = [
+    { text: `REC ${frame.timecode}`, color: '#ef4444' },
+    ...frame.chips.map((c) => ({ text: c.label, color: c.color })),
+  ];
+  const textW = Math.max(...rows.map((r) => r.text.length)) * TAG_HUD_CHAR_W;
+  const boxW = TAG_HUD_PAD + TAG_HUD_DOT + 6 + textW + TAG_HUD_PAD;
+  const boxH = TAG_HUD_PAD * 2 + TAG_HUD_ROW * rows.length;
+  const x0 = view.params.tagHud.position === 'left' ? 12 : view.W - boxW - 12;
+  const y0 = 12;
+
+  g.save();
+  g.globalAlpha = 1;
+  g.fillStyle = 'rgba(0, 0, 0, 0.55)';
+  g.fillRect(x0, y0, boxW, boxH);
+  g.font = '600 13px ui-monospace, SFMono-Regular, Menlo, monospace';
+  g.textBaseline = 'middle';
+  g.textAlign = 'left';
+  rows.forEach((row, i) => {
+    const cy = y0 + TAG_HUD_PAD + TAG_HUD_ROW * i + TAG_HUD_ROW / 2;
+    const dx = x0 + TAG_HUD_PAD;
+    // The dot pulses with the blink phase (a REC light), so a dropped frame shows.
+    g.globalAlpha = frame.blinkOn ? 1 : 0.35;
+    g.beginPath();
+    g.arc(dx + TAG_HUD_DOT / 2, cy, TAG_HUD_DOT / 2, 0, Math.PI * 2);
+    g.fillStyle = row.color;
+    g.fill();
+    g.globalAlpha = 1;
+    g.fillStyle = '#ffffff';
+    g.fillText(row.text, dx + TAG_HUD_DOT + 6, cy);
+  });
+  g.restore();
+}
+
+const tagHud: OverlayElement = {
+  name: 'tagHud',
+  category: 'output',
+  draw(g, view) {
+    const frame = view.inputs.tagOverlay;
+    if (!frame || !view.params.tagHud.show) return;
+    drawTagHud(g, view, frame);
+  },
+};
+
 /**
  * The overlay elements, in draw (z) order. In-scene first, HUD cues last (on top).
  * Each has a `category` and a `<name>` sub-object in `Params`. Append here to add one.
@@ -1230,6 +1304,9 @@ export const OVERLAY_ELEMENTS: readonly OverlayElement[] = [
   // stays the topmost cue; cues on different edges don't overlap regardless.
   chordNameCue,
   faceExpressionCue,
+  // The burned-in tag HUD sits above the cues (its own top corner); fingerBars stays
+  // the array's last element so the z-order invariant + concurrent additions hold.
+  tagHud,
   fingerBarsCue,
 ];
 
@@ -1422,6 +1499,12 @@ export const canvasOverlayNode = defineNode<Params>({
             | undefined
         )?.();
 
+        // Burned-in tag HUD (#92): read the runtime snapshot (null unless a take is
+        // recording) and derive this tick's frame from the engine clock. A no-op
+        // resource means frame === null and the tagHud element draws nothing.
+        const tagOverlayFn = ctx.resources.tagOverlay as (() => TagOverlaySnapshot | null) | undefined;
+        const tagOverlay = computeTagOverlay(tagOverlayFn?.() ?? null, ctx.time);
+
         const liveConfig = inputs.overlayConfig as OverlayParams | undefined;
         const view: OverlayView = {
           W,
@@ -1443,6 +1526,7 @@ export const canvasOverlayNode = defineNode<Params>({
             handMap: controls?.handMap,
             faceDegrees: controls?.faceExpr?.degrees,
             faceMapping: controls?.faceMapping,
+            tagOverlay,
           },
         };
 

--- a/src/taglog/README.md
+++ b/src/taglog/README.md
@@ -1,0 +1,77 @@
+# taglog
+
+A live event-tagging tool: toggle a small set of **tags** on/off while recording,
+and each toggle appends a `(t, tag, status)` row to a `tags.jsonl` that later
+**segments** the recorded streams (video / audio / features) for analysis or ML
+training.
+
+This folder is written to **lift out of thoremin into a standalone package**
+(working name `taglog`). It has no thoremin imports and no React; the thoremin-
+specific glue lives outside it (`src/app/tagging/*`, the overlay element in
+`src/nodes/output/canvas_overlay.ts`) and imports *from* here, never the reverse.
+
+Design research + prior art (BORIS, Praat, ELAN, OTIO, Allen's interval algebra) and
+references are in thoremin **issue #92** and **discussion #81**.
+
+## The three layers (strict dependency direction)
+
+```
+presentation  ->  affordances  <-  provider
+   (host)          (pure core)      (storage)
+```
+
+That one rule — everything depends on the affordance core, the core depends on
+nothing — is what makes extraction mechanical.
+
+### `affordances/` — the pure heart (Zod schemas + logic; no React/storage/timers)
+
+| File | What |
+|------|------|
+| `schema.ts` | `TagDef` (kind lives here), `TagEvent` (status lives here), `TaggingConfig`, `AnchorRecord`, and the neutral in-memory types (`TagAction`, `EdgeEvent`, `TagState`, `ResolvedInterval`). |
+| `toggle.ts` | `applyToggle` / `closeAll` — the state machine: interval open↔close, point emit, BORIS-style mutual-exclusivity auto-close, `seq` ordering. |
+| `leadIn.ts` | Lead-in / pre-roll correction: open shifts later, close earlier (shrink to the clean middle), degeneracy guard. |
+| `resolve.ts` | `resolveIntervals` — pair edges into intervals/points for a segmentation consumer. |
+| `codec.ts` | The pluggable `EventCodec` (representation strategy): `statusEnum` (default), `pointPair`, `kindField`. |
+
+### `adapters/` — pure exporters (`ResolvedInterval[] -> string`)
+
+Audacity labels · WebVTT · CSV · Praat TextGrid · OTIO. Add a format by adding one
+entry to `ADAPTERS`.
+
+### `provider/` — persistence + the event sink
+
+- `defsStore.ts` — persist named **tag sets** (last-used pre-seed) via a zodal
+  `DataProvider<T>` (localStorage default via `@zodal/store-localstorage`). Swap the
+  provider to retarget storage; call sites never change.
+- `sink.ts` — `TagEventSink`: buffer the anchor + codec-serialized rows, `drain()`
+  to JSONL (mirrors thoremin's `FeatureJsonlTap`).
+
+## Time alignment (the highest-stakes part, design §5)
+
+One recording anchor `t0`; event times stamped from the recorder's **absolute engine
+clock** (`performance.now()/1000` = the DAG `ctx.time`) — the SAME clock
+`features.jsonl` uses, so both streams share one frame by construction and the take
+offset is a uniform `t - t0` for every stream (the manifest SSOT rule). A
+self-describing **anchor record** (`t` = the origin t0) as the file's first line; an
+optional **segmentation-time offset** never baked into stored `t`; and a **burned-in
+corner overlay** as the in-band ground truth. File-creation dates are rejected as a clock.
+
+## Quick use
+
+```ts
+import { emptyTagState, applyToggle, closeAll, resolveIntervals, TagEventSink } from 'taglog';
+
+let state = emptyTagState();
+const sink = new TagEventSink('statusEnum');
+sink.writeAnchor({ anchor: true, t: t0, clock: 'media', /* … */ });   // t = origin (== manifest.t0)
+
+// on each click / keypress (t = absolute engine seconds = performance.now()/1000):
+const { state: next, edges } = applyToggle(state, defs, { tagId: 'pluck', t, src: 'key' }, config);
+state = next;
+sink.append(edges);
+
+// on stop:
+sink.append(closeAll(state, defs, tEnd, config, 'auto').edges);
+const jsonl = sink.drain();                          // -> {stem}.tags.jsonl
+const intervals = resolveIntervals(/* parsed edges */, { endT: tEnd });
+```

--- a/src/taglog/adapters/index.ts
+++ b/src/taglog/adapters/index.ts
@@ -1,0 +1,228 @@
+/**
+ * taglog — export adapters (the survey's non-negotiable I/O pattern, design §2/§4).
+ *
+ * The native log is `tags.jsonl` (raw events, written by the provider sink). These
+ * adapters take the RESOLVED view (`ResolvedInterval[]` from `resolveIntervals`) and
+ * emit standard interchange formats so a tag log opens in the tools researchers
+ * already use — Audacity, Praat, a `<track>` preview, a spreadsheet, an NLE:
+ *
+ *  - **Audacity** label track (TSV `start\tend\tlabel`)
+ *  - **WebVTT** cues (preview segments in an HTML `<track>`)
+ *  - **CSV** (spreadsheet / pandas)
+ *  - **Praat TextGrid** (IntervalTier per interval tag, PointTier per point tag)
+ *  - **OTIO** (OpenTimelineIO JSON — RationalTime discipline, §2)
+ *
+ * Pure `ResolvedInterval[] -> string`. Adding a format is one entry in {@link ADAPTERS},
+ * so the representation stays open/closed. By default each uses the lead-in-CORRECTED
+ * times (the clean middle of the action); pass `time:'raw'` for the click instants.
+ */
+import type { ResolvedInterval, TagDef } from '../affordances/schema';
+import { formatTimecode } from '../affordances/time';
+
+// formatTimecode lives in the affordance layer (shared with presentation); re-exported
+// here for convenience so existing `@/taglog/adapters` importers keep working.
+export { formatTimecode };
+
+/** Whether an adapter emits the corrected (default) or raw event times. */
+export type TimeChoice = 'corrected' | 'raw';
+
+/** Strip TAB/CR/LF from a label so it can't break a TSV column, a WebVTT cue, or a
+ *  Praat mark (line/column-structured formats). JSON formats need no such guard. */
+function sanitizeInline(s: string): string {
+  return s.replace(/[\t\r\n]+/g, ' ');
+}
+
+export interface AdapterOptions {
+  /** Human labels per tag id (falls back to the tag id). */
+  defs?: readonly TagDef[];
+  /** corrected (clean middle, default) | raw (click instants). */
+  time?: TimeChoice;
+  /** Timeline duration (seconds) — the tier/timeline extent. Defaults to max end. */
+  duration?: number;
+  /** Frame rate for OTIO RationalTime (default 30). */
+  rate?: number;
+}
+
+/** The human label for a tag id, from the defs (else the id itself). */
+function labelOf(tag: string, defs?: readonly TagDef[]): string {
+  return defs?.find((d) => d.id === tag)?.label ?? tag;
+}
+
+/** The [start, end] an adapter should use for an interval, per the time choice. */
+function span(iv: ResolvedInterval, time: TimeChoice): [number, number] {
+  return time === 'raw' ? [iv.start, iv.end] : [iv.startCorrected, iv.endCorrected];
+}
+
+/** The timeline extent: the caller-supplied duration or the max end across intervals. */
+function extent(intervals: readonly ResolvedInterval[], time: TimeChoice, duration?: number): number {
+  if (typeof duration === 'number') return duration;
+  return intervals.reduce((m, iv) => Math.max(m, span(iv, time)[1]), 0);
+}
+
+/** Audacity label track: `start<TAB>end<TAB>label` per line (points have start==end). */
+export function toAudacityLabels(intervals: readonly ResolvedInterval[], opts: AdapterOptions = {}): string {
+  const time = opts.time ?? 'corrected';
+  return (
+    intervals
+      .map((iv) => {
+        const [a, b] = span(iv, time);
+        return `${a.toFixed(6)}\t${b.toFixed(6)}\t${sanitizeInline(labelOf(iv.tag, opts.defs))}`;
+      })
+      .join('\n') + (intervals.length ? '\n' : '')
+  );
+}
+
+/** WebVTT: a cue per interval; a point becomes a 1ms cue so players still show it. */
+export function toWebVTT(intervals: readonly ResolvedInterval[], opts: AdapterOptions = {}): string {
+  const time = opts.time ?? 'corrected';
+  const cues = intervals.map((iv, i) => {
+    let [a, b] = span(iv, time);
+    if (b <= a) b = a + 0.001; // WebVTT needs end > start
+    return `${i + 1}\n${formatTimecode(a)} --> ${formatTimecode(b)}\n${sanitizeInline(labelOf(iv.tag, opts.defs))}`;
+  });
+  return `WEBVTT\n\n${cues.join('\n\n')}${cues.length ? '\n' : ''}`;
+}
+
+/** CSV: one row per resolved interval/point, with both raw and corrected times. */
+export function toCSV(intervals: readonly ResolvedInterval[], opts: AdapterOptions = {}): string {
+  const head = 'tag,label,kind,start,end,startCorrected,endCorrected,degenerate,openEnded';
+  // Quote on any CR/LF/quote/comma so a lone \r can't corrupt a CRLF-strict parser.
+  const esc = (s: string) => (/[",\r\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s);
+  const rows = intervals.map((iv) =>
+    [
+      esc(iv.tag),
+      esc(labelOf(iv.tag, opts.defs)),
+      iv.kind,
+      iv.start,
+      iv.end,
+      iv.startCorrected,
+      iv.endCorrected,
+      iv.degenerate,
+      iv.openEnded,
+    ].join(','),
+  );
+  return `${head}\n${rows.join('\n')}${rows.length ? '\n' : ''}`;
+}
+
+/** Praat TextGrid: an IntervalTier per interval tag (gaps filled with empty intervals,
+ *  as Praat requires adjacency-completeness) and a PointTier per point tag. */
+export function toTextGrid(intervals: readonly ResolvedInterval[], opts: AdapterOptions = {}): string {
+  const time = opts.time ?? 'corrected';
+  // The timeline must cover ALL content: never let an explicit `duration` shrink xmax
+  // below an interval's end (Praat rejects a tier/interval xmax that exceeds the file
+  // xmax). So take the larger of the content extent and the requested duration.
+  const xmax = Math.max(extent(intervals, time), opts.duration ?? 0);
+  const byTag = new Map<string, ResolvedInterval[]>();
+  for (const iv of intervals) {
+    const arr = byTag.get(iv.tag) ?? [];
+    arr.push(iv);
+    byTag.set(iv.tag, arr);
+  }
+  const quote = (s: string) => `"${s.replace(/"/g, '""')}"`;
+  const tiers: string[] = [];
+  for (const [tag, ivs] of byTag) {
+    const isPoint = ivs.every((i) => i.kind === 'point');
+    const name = sanitizeInline(labelOf(tag, opts.defs));
+    if (isPoint) {
+      // Praat requires point times strictly increasing — sort even if the input
+      // ResolvedInterval[] wasn't time-ordered.
+      const sortedPts = [...ivs].sort((p, q) => span(p, time)[0] - span(q, time)[0]);
+      const pts = sortedPts
+        .map((iv, i) => `        points [${i + 1}]:\n            number = ${span(iv, time)[0]}\n            mark = ${quote(name)}`)
+        .join('\n');
+      tiers.push(
+        `    item [${tiers.length + 1}]:\n        class = "TextTier"\n        name = ${quote(name)}\n` +
+          `        xmin = 0\n        xmax = ${xmax}\n        points: size = ${ivs.length}\n${pts}`,
+      );
+      continue;
+    }
+    // Interval tier: fill [0, xmax] with labelled + empty intervals, clamping overlaps.
+    const sorted = ivs
+      .map((iv) => span(iv, time))
+      .filter(([a, b]) => b > a)
+      .sort((p, q) => p[0] - q[0]);
+    const cells: { a: number; b: number; text: string }[] = [];
+    let cursor = 0;
+    for (const [a0, b] of sorted) {
+      const a = Math.max(a0, cursor);
+      if (a >= b) continue; // fully overlapped by a previous interval
+      if (a > cursor) cells.push({ a: cursor, b: a, text: '' });
+      cells.push({ a, b, text: name });
+      cursor = b;
+    }
+    if (cursor < xmax) cells.push({ a: cursor, b: xmax, text: '' });
+    if (!cells.length) cells.push({ a: 0, b: xmax, text: '' });
+    const body = cells
+      .map((c, i) => `        intervals [${i + 1}]:\n            xmin = ${c.a}\n            xmax = ${c.b}\n            text = ${quote(c.text)}`)
+      .join('\n');
+    tiers.push(
+      `    item [${tiers.length + 1}]:\n        class = "IntervalTier"\n        name = ${quote(name)}\n` +
+        `        xmin = 0\n        xmax = ${xmax}\n        intervals: size = ${cells.length}\n${body}`,
+    );
+  }
+  return (
+    `File type = "ooTextFile"\nObject class = "TextGrid"\n\n` +
+    `xmin = 0\nxmax = ${xmax}\ntiers? <exists>\nsize = ${tiers.length}\nitem []:\n${tiers.join('\n')}\n`
+  );
+}
+
+/** OpenTimelineIO JSON: a timeline with one marker per interval/point (RationalTime,
+ *  §2). A minimal, schema-valid OTIO document — enough for `otiotool` / an NLE import. */
+export function toOTIO(intervals: readonly ResolvedInterval[], opts: AdapterOptions = {}): string {
+  const time = opts.time ?? 'corrected';
+  const rate = opts.rate ?? 30;
+  const rt = (sec: number) => ({ OTIO_SCHEMA: 'RationalTime.1', rate, value: Math.round(sec * rate) });
+  const markers = intervals.map((iv) => {
+    const [a, b] = span(iv, time);
+    return {
+      OTIO_SCHEMA: 'Marker.2',
+      name: labelOf(iv.tag, opts.defs),
+      color: 'RED',
+      marked_range: {
+        OTIO_SCHEMA: 'TimeRange.1',
+        start_time: rt(a),
+        duration: rt(Math.max(0, b - a)),
+      },
+      metadata: { taglog: { tag: iv.tag, kind: iv.kind, openEnded: iv.openEnded, degenerate: iv.degenerate } },
+    };
+  });
+  const doc = {
+    OTIO_SCHEMA: 'Timeline.1',
+    name: 'taglog',
+    tracks: {
+      OTIO_SCHEMA: 'Stack.1',
+      children: [
+        {
+          OTIO_SCHEMA: 'Track.1',
+          name: 'tags',
+          kind: 'Video',
+          markers,
+          children: [],
+        },
+      ],
+    },
+  };
+  return JSON.stringify(doc, null, 2) + '\n';
+}
+
+/** One export format: how to name/mime the file and how to render it. */
+export interface Adapter {
+  name: string;
+  ext: string;
+  mime: string;
+  render(intervals: readonly ResolvedInterval[], opts?: AdapterOptions): string;
+}
+
+/** The shipped adapter registry (open for extension). Keyed by format name. */
+export const ADAPTERS: Record<string, Adapter> = {
+  audacity: { name: 'audacity', ext: 'txt', mime: 'text/plain', render: toAudacityLabels },
+  webvtt: { name: 'webvtt', ext: 'vtt', mime: 'text/vtt', render: toWebVTT },
+  csv: { name: 'csv', ext: 'csv', mime: 'text/csv', render: toCSV },
+  textgrid: { name: 'textgrid', ext: 'TextGrid', mime: 'text/plain', render: toTextGrid },
+  otio: { name: 'otio', ext: 'otio', mime: 'application/json', render: toOTIO },
+};
+
+/** Look up an adapter by name (undefined for an unknown format). */
+export function getAdapter(name: string): Adapter | undefined {
+  return ADAPTERS[name];
+}

--- a/src/taglog/affordances/codec.ts
+++ b/src/taglog/affordances/codec.ts
@@ -1,0 +1,139 @@
+/**
+ * taglog — the pluggable event codec (design §4c).
+ *
+ * The user asked for the point/interval *representation* to be a user-selectable
+ * strategy. An {@link EventCodec} governs ONLY serialization: it maps the neutral
+ * semantic {@link EdgeEvent} (produced by the state machine) to 0..2 wire rows and
+ * back. The store always holds neutral edges; swapping the codec never touches the
+ * state machine or the UI — this is the seam that makes the tool extractable.
+ *
+ * Three codecs ship:
+ *  - **statusEnum** (default): one row per edge, `status in {open,close,point}` —
+ *    smallest, self-describing, direct BORIS/Praat parity. Full round-trip.
+ *  - **pointPair**: a `point` becomes TWO rows (open+close at the same `t`), so every
+ *    tag is uniformly an interval downstream (a zero-length interval IS a point).
+ *  - **kindField**: statusEnum plus a redundant `kind` field, for interop with tools
+ *    that key off a per-row kind column.
+ *
+ * Pure — no I/O. The provider's JSONL sink stringifies whatever rows a codec emits.
+ */
+import {
+  TagEventSchema,
+  type EdgeEvent,
+  type TagKind,
+} from './schema';
+
+/** A wire row is a plain JSON object (the codec decides its exact shape). */
+export type WireRow = Record<string, unknown>;
+
+/**
+ * A representation strategy: `encode` one semantic edge -> 1..2 wire rows; `decode`
+ * a full stream of rows -> semantic edges (the inverse over a stream). Stateless.
+ */
+export interface EventCodec {
+  name: string;
+  encode(edge: EdgeEvent): WireRow[];
+  decode(rows: readonly WireRow[]): EdgeEvent[];
+}
+
+/** The canonical statusEnum row (also the `TagEvent` wire schema). Drops `kind`
+ *  (redundant with the def) and omits `degenerate` unless set. */
+function statusRow(edge: EdgeEvent): WireRow {
+  const row: WireRow = {
+    t: edge.t,
+    tCorrected: edge.tCorrected,
+    tag: edge.tag,
+    status: edge.status,
+    seq: edge.seq,
+    clock: edge.clock,
+    src: edge.src,
+  };
+  if (edge.degenerate) row.degenerate = true;
+  return row;
+}
+
+/** Parse a statusEnum-shaped row back to a semantic edge (kind inferred from status:
+ *  a `point` status is a point; open/close are intervals). Validates via Zod, so a
+ *  malformed row throws with a clear message rather than corrupting the stream. */
+function statusEdge(row: WireRow): EdgeEvent {
+  const e = TagEventSchema.parse(row);
+  const kind: TagKind = e.status === 'point' ? 'point' : 'interval';
+  return {
+    tag: e.tag,
+    kind,
+    status: e.status,
+    t: e.t,
+    tCorrected: e.tCorrected,
+    seq: e.seq,
+    clock: e.clock,
+    src: e.src,
+    ...(e.degenerate ? { degenerate: true } : {}),
+  };
+}
+
+/** statusEnum (default): 1:1 edge <-> row. */
+export const statusEnumCodec: EventCodec = {
+  name: 'statusEnum',
+  encode: (edge) => [statusRow(edge)],
+  decode: (rows) => rows.map(statusEdge),
+};
+
+/**
+ * pointPair: a `point` edge is written as an open+close pair at the same `t` (the
+ * close carries `seq + 0.5`-style ordering via a paired suffix is avoided — instead
+ * both rows share the point's seq and the close is emitted immediately after). On
+ * decode the pair is recognised (same tag, same t, open then close) and folded back
+ * into a single `point` edge, so the round-trip is faithful.
+ */
+export const pointPairCodec: EventCodec = {
+  name: 'pointPair',
+  encode: (edge) => {
+    if (edge.status !== 'point') return [statusRow(edge)];
+    const open: WireRow = { t: edge.t, tCorrected: edge.t, tag: edge.tag, status: 'open', seq: edge.seq, clock: edge.clock, src: edge.src };
+    const close: WireRow = { t: edge.t, tCorrected: edge.t, tag: edge.tag, status: 'close', seq: edge.seq, clock: edge.clock, src: edge.src };
+    return [open, close];
+  },
+  decode: (rows) => {
+    const edges: EdgeEvent[] = [];
+    for (let i = 0; i < rows.length; i++) {
+      const e = statusEdge(rows[i]);
+      const nextRow = rows[i + 1];
+      // Fold a same-t, same-tag, same-seq open+close pair back into a point.
+      if (e.status === 'open' && nextRow) {
+        const n = statusEdge(nextRow);
+        if (n.status === 'close' && n.tag === e.tag && n.t === e.t && n.seq === e.seq) {
+          edges.push({ ...e, kind: 'point', status: 'point' });
+          i++; // consume the close
+          continue;
+        }
+      }
+      edges.push(e);
+    }
+    return edges;
+  },
+};
+
+/** kindField: statusEnum plus a redundant `kind` column (interop). */
+export const kindFieldCodec: EventCodec = {
+  name: 'kindField',
+  encode: (edge) => [{ ...statusRow(edge), kind: edge.kind }],
+  decode: (rows) =>
+    rows.map((row) => {
+      const e = statusEdge(row);
+      const kind = row.kind === 'point' || row.kind === 'interval' ? (row.kind as TagKind) : e.kind;
+      return { ...e, kind };
+    }),
+};
+
+/** The shipped codec registry (open for extension — register more strategies here). */
+export const CODECS: Record<string, EventCodec> = {
+  [statusEnumCodec.name]: statusEnumCodec,
+  [pointPairCodec.name]: pointPairCodec,
+  [kindFieldCodec.name]: kindFieldCodec,
+};
+
+/** Look up a codec by name, falling back to the statusEnum default for an unknown
+ *  id (a stale saved config never breaks logging). */
+export function getCodec(name: string | undefined): EventCodec {
+  return (name && CODECS[name]) || statusEnumCodec;
+}

--- a/src/taglog/affordances/index.ts
+++ b/src/taglog/affordances/index.ts
@@ -1,0 +1,14 @@
+/**
+ * taglog affordances — the pure, framework-free core (Zod schemas + logic).
+ *
+ * Re-exports the schemas, the toggle state machine, interval resolution, lead-in
+ * correction, and the event codecs. Import from here (or from `@/taglog`) rather
+ * than reaching into individual files, so the extraction boundary stays clean:
+ * nothing in this layer imports React, storage, or timers.
+ */
+export * from './schema';
+export * from './leadIn';
+export * from './time';
+export * from './codec';
+export * from './toggle';
+export * from './resolve';

--- a/src/taglog/affordances/leadIn.ts
+++ b/src/taglog/affordances/leadIn.ts
@@ -1,0 +1,38 @@
+/**
+ * taglog — lead-in (pre-roll) correction (design §6).
+ *
+ * A busy performer clicks *before* acting, so the intended action time is offset
+ * from the click. The correction is **asymmetric and signed** so both moves shrink
+ * the tagged interval toward the clean middle of the action (excluding the reach-in
+ * and reach-out — exactly what training data wants):
+ *
+ *   - **open**  -> `t + leadIn`  (the action begins *after* the click; the countdown
+ *                                 covers this gap)
+ *   - **close** -> `t - leadIn`  (trims the trailing ramp-down before the hands leave)
+ *   - **point** -> `t`           (a point is the instant itself)
+ *
+ * Pure functions — no state, no timers. The countdown UI is a separate presentation
+ * concern; here we only compute times.
+ */
+import type { TagStatus } from './schema';
+
+/** The lead-in-corrected time for one event, given its status and the tag's lead-in. */
+export function correctedTime(status: TagStatus, t: number, leadIn: number): number {
+  switch (status) {
+    case 'open':
+      return t + leadIn;
+    case 'close':
+      return t - leadIn;
+    case 'point':
+      return t;
+  }
+}
+
+/**
+ * True if applying lead-in to an interval inverted it (`openCorrected >= closeCorrected`)
+ * — e.g. a lead-in larger than the interval itself. The consumer should fall back to
+ * raw times (or a zero-length point) rather than emit a negative interval (§6 guard).
+ */
+export function isDegenerate(openCorrected: number, closeCorrected: number): boolean {
+  return openCorrected >= closeCorrected;
+}

--- a/src/taglog/affordances/resolve.ts
+++ b/src/taglog/affordances/resolve.ts
@@ -1,0 +1,107 @@
+/**
+ * taglog — resolve a stream of {@link EdgeEvent}s into {@link ResolvedInterval}s
+ * (the shape a segmentation / ML-training consumer cuts on).
+ *
+ * Pairs each `open` with the next `close` of the same tag (by `seq` order), turns a
+ * `point` into a zero-length interval, and reports lead-in degeneracy and still-open
+ * ("open-ended") intervals. This is the offline / read-side counterpart to the live
+ * {@link applyToggle}; Allen's interval algebra belongs in the *consumer* on top of
+ * this, not here (design §2). Pure — no state, no I/O.
+ */
+import { isDegenerate } from './leadIn';
+import type { EdgeEvent, ResolvedInterval } from './schema';
+
+export interface ResolveOptions {
+  /** Media time the recording ended, used to close still-open intervals. When
+   *  absent, an open-ended interval ends at its own start (flagged `openEnded`). */
+  endT?: number;
+}
+
+/** Build one resolved interval from a matched open/close (or a point). Applies the
+ *  lead-in-degeneracy fallback: if corrected times invert, fall back to raw. */
+function resolveClosed(open: EdgeEvent, close: EdgeEvent): ResolvedInterval {
+  const degenerate = isDegenerate(open.tCorrected, close.tCorrected) || close.degenerate === true;
+  return {
+    tag: open.tag,
+    kind: 'interval',
+    start: open.t,
+    end: close.t,
+    startCorrected: degenerate ? open.t : open.tCorrected,
+    endCorrected: degenerate ? close.t : close.tCorrected,
+    degenerate,
+    openEnded: false,
+    openSeq: open.seq,
+    closeSeq: close.seq,
+  };
+}
+
+/**
+ * Resolve edges to intervals. Edges may arrive unsorted; we sort by `seq` (the
+ * monotonic counter) so an auto-close always precedes its triggering open. Unmatched
+ * opens at the end are returned `openEnded`.
+ */
+export function resolveIntervals(
+  edges: readonly EdgeEvent[],
+  options: ResolveOptions = {},
+): ResolvedInterval[] {
+  const sorted = [...edges].sort((a, b) => a.seq - b.seq);
+  const out: ResolvedInterval[] = [];
+  // Multiple opens of the same tag can stack only in non-exclusive overlapping use;
+  // we match close -> the most recent still-open of that tag (LIFO), which is the
+  // intuitive pairing for nested/overlapping toggles.
+  const openStacks = new Map<string, EdgeEvent[]>();
+
+  for (const e of sorted) {
+    if (e.status === 'point') {
+      out.push({
+        tag: e.tag,
+        kind: 'point',
+        start: e.t,
+        end: e.t,
+        startCorrected: e.tCorrected,
+        endCorrected: e.tCorrected,
+        degenerate: false,
+        openEnded: false,
+        openSeq: e.seq,
+      });
+      continue;
+    }
+    if (e.status === 'open') {
+      const stack = openStacks.get(e.tag) ?? [];
+      stack.push(e);
+      openStacks.set(e.tag, stack);
+      continue;
+    }
+    // close: pair with the most recent open of this tag, if any (else a stray close
+    // — a log that opened before the window; ignored rather than throwing).
+    const stack = openStacks.get(e.tag);
+    const open = stack?.pop();
+    if (open) out.push(resolveClosed(open, e));
+  }
+
+  // Any opens never closed -> open-ended intervals (open at recording end). The
+  // take end is an uncorrected boundary (there is no close event to shift), so it
+  // can fall INSIDE the open's lead-in window — apply the same §6 degeneracy guard
+  // as the closed path (fall back to raw rather than emit an inverted interval).
+  for (const stack of openStacks.values()) {
+    for (const open of stack) {
+      const end = options.endT ?? open.t;
+      const endCorrected = options.endT ?? open.tCorrected;
+      const degenerate = options.endT !== undefined && isDegenerate(open.tCorrected, options.endT);
+      out.push({
+        tag: open.tag,
+        kind: 'interval',
+        start: open.t,
+        end,
+        startCorrected: degenerate ? open.t : open.tCorrected,
+        endCorrected: degenerate ? end : endCorrected,
+        degenerate,
+        openEnded: true,
+        openSeq: open.seq,
+      });
+    }
+  }
+
+  // Deterministic output order: by start time, then open seq.
+  return out.sort((a, b) => a.start - b.start || a.openSeq - b.openSeq);
+}

--- a/src/taglog/affordances/schema.ts
+++ b/src/taglog/affordances/schema.ts
@@ -1,0 +1,219 @@
+/**
+ * taglog — affordance schemas (the SSOT of what tagging data *is*).
+ *
+ * This is the reusable heart of the live-tagging tool (thoremin issue #92,
+ * design research in discussion #81). It defines, with Zod, the two schemas the
+ * whole system pivots on — the **TagDef** (a tag's definition, chosen before
+ * recording) and the **TagEvent** (one wire row in `tags.jsonl`) — plus the
+ * neutral in-memory types (`TagAction`, `EdgeEvent`, `TagState`, `ResolvedInterval`)
+ * the pure logic passes around.
+ *
+ * Design crux (BORIS / Praat precedent): **`kind` lives on the definition, `status`
+ * lives on the event.** A tag is declared `interval` or `point`; an event carries
+ * `open` / `close` / `point`. That keeps the event log self-describing and small.
+ *
+ * Nothing here imports React, storage, or timers — it is the extraction-ready core
+ * (`taglog`). Dependency direction is strictly presentation -> affordances <- provider.
+ */
+import { z } from 'zod';
+
+/** The schema id written into a `tags.jsonl` anchor record (version from day one,
+ * per the annotation-systems survey). Overridable for a non-thoremin host. */
+export const TAGS_SCHEMA_ID = 'thoremin.tags/1' as const;
+
+/** A tag is either a labelled interval (open then close) or an instantaneous point. */
+export const TagKindSchema = z.enum(['interval', 'point']);
+export type TagKind = z.infer<typeof TagKindSchema>;
+
+/** The event edge discriminator — the point/interval representation the user chose
+ * as the recommended default (§4c strategy b): one row per action. */
+export const TagStatusSchema = z.enum(['open', 'close', 'point']);
+export type TagStatus = z.infer<typeof TagStatusSchema>;
+
+/** Which clock an event `t` is on. `media` = the engine/recorder clock
+ * (performance.now()/1000 = the DAG `ctx.time`), the SAME absolute clock
+ * features.jsonl uses — so the take offset is `t - t0` for BOTH streams. `perf` =
+ * raw performance.now (a non-recording fallback). */
+export const TagClockSchema = z.enum(['media', 'perf']);
+export type TagClock = z.infer<typeof TagClockSchema>;
+
+/** Provenance of an event: a keyboard digit, a button click, or an auto-close
+ * triggered by mutual exclusivity. */
+export const TagSrcSchema = z.enum(['key', 'click', 'auto']);
+export type TagSrc = z.infer<typeof TagSrcSchema>;
+
+/**
+ * A single tag's definition — chosen and ordered before recording, persisted as
+ * part of a tag set (the provider layer). `id` is the stable slug that survives
+ * renames/reorders; `number` (1..9) is the positional keyboard shortcut assigned
+ * by display order (null past the ninth tag → click-only).
+ */
+export const TagDefSchema = z.object({
+  /** Stable slug (survives label edits / reordering). */
+  id: z.string().min(1),
+  /** Human label shown on the button. */
+  label: z.string(),
+  /** Positional keyboard shortcut 1..9 (UI-assigned by order); null = no shortcut. */
+  number: z.number().int().min(1).max(9).nullable().default(null),
+  /** interval (default) | point — the BORIS/Praat "behavior type". */
+  kind: TagKindSchema.default('interval'),
+  /** Pre-roll seconds (single digit, §6): open shifts later, close earlier. 0 = none. */
+  leadIn: z.number().min(0).max(9).default(0),
+  /** Mutual-exclusivity group id (§7); null = ungrouped. */
+  group: z.string().nullable().default(null),
+  /** Presentation colour (kept here for convenience — the survey allows a UI hint). */
+  color: z.string().default('#34d399'),
+  /** Display / z order in the button stack. */
+  order: z.number().int().default(0),
+});
+export type TagDef = z.infer<typeof TagDefSchema>;
+
+/**
+ * One JSONL row (the `statusEnum` wire representation, the thoremin default). `t`
+ * is the RAW event time on the absolute engine clock (offset into the take = `t - t0`,
+ * §5); `tCorrected` is `t` adjusted by the tag's lead-in (§6) and is a derived
+ * convenience — `t` remains the source of truth.
+ */
+export const TagEventSchema = z.object({
+  /** Raw event time, seconds, on the absolute engine clock (offset = t - t0). */
+  t: z.number(),
+  /** Lead-in-corrected time (derived; open = t+leadIn, close = t-leadIn, point = t). */
+  tCorrected: z.number(),
+  /** TagDef.id. */
+  tag: z.string(),
+  /** open | close | point. */
+  status: TagStatusSchema,
+  /** Monotonic event counter — tiebreak/order/gap-detection; auto-closes sort before
+   * their triggering open by carrying a lower seq (so times stay clean, no epsilon). */
+  seq: z.number().int(),
+  /** Which clock `t` is relative to. */
+  clock: TagClockSchema.default('media'),
+  /** Provenance. */
+  src: TagSrcSchema.default('click'),
+  /** Set on a close whose lead-in inverted the interval (§6) — consumer falls back
+   * to raw times rather than producing a negative interval. */
+  degenerate: z.boolean().optional(),
+});
+export type TagEvent = z.infer<typeof TagEventSchema>;
+
+/** Exclusivity mode (§7). `off` = overlapping tags; `single` = one implicit group
+ * ("only one tag at a time"); `group` = per-tag `group` ids form exclusion sets. */
+export const ExclusivityModeSchema = z.enum(['off', 'single', 'group']);
+export type ExclusivityMode = z.infer<typeof ExclusivityModeSchema>;
+
+/** The implicit group all interval tags share in `single` exclusivity mode. */
+export const DEFAULT_EXCLUSIVITY_GROUP = '__default__' as const;
+
+/**
+ * Session-level tagging configuration (chosen at mode setup, persisted with the
+ * tag set). The event `codec` name selects the wire representation strategy; the
+ * `offset` is applied by a downstream segmentation tool, never baked into stored `t`.
+ */
+export const TaggingConfigSchema = z.object({
+  exclusivity: ExclusivityModeSchema.default('off'),
+  /** Registered EventCodec name (`statusEnum` default | `pointPair` | `kindField`). */
+  codec: z.string().default('statusEnum'),
+  /** Clock the events are stamped from. */
+  clock: TagClockSchema.default('media'),
+  /** Segmentation-time offset (seconds): `t_effective = t + offset`. Lossless. */
+  offset: z.number().default(0),
+});
+export type TaggingConfig = z.infer<typeof TaggingConfigSchema>;
+
+/** The all-defaults tagging config (materialized once for a `.default(...)`). */
+export const DEFAULT_TAGGING_CONFIG: TaggingConfig = TaggingConfigSchema.parse({});
+
+/**
+ * The self-describing first line of a `tags.jsonl`: it records the anchor origin so
+ * a consumer can interpret the file without trusting file-creation dates (§5). `t` is
+ * the absolute engine-clock **origin** (== manifest.t0); every event `t` minus this
+ * is its offset into the take — the same rule the manifest applies to every stream.
+ */
+export const AnchorRecordSchema = z.object({
+  anchor: z.literal(true),
+  /** The absolute engine-clock origin t0 (seconds); == manifest.t0. */
+  t: z.number(),
+  clock: TagClockSchema,
+  /** For humans / debugging only — never the segmentation clock. */
+  wallClockISO: z.string(),
+  /** performance.now() at record start (cross-check for the media clock). */
+  recStartPerf: z.number(),
+  /** Session/take id, for cross-file correlation. */
+  session: z.string(),
+  /** Schema id + version (e.g. "thoremin.tags/1"). */
+  schema: z.string(),
+});
+export type AnchorRecord = z.infer<typeof AnchorRecordSchema>;
+
+/**
+ * The neutral in-memory action produced by a click or a keyboard digit — the ONE
+ * shape the store pushes, so keyboard and mouse are indistinguishable downstream
+ * (`src` records which). The timestamp is captured synchronously at the input event.
+ */
+export interface TagAction {
+  /** TagDef.id being toggled. */
+  tagId: string;
+  /** Raw event time (seconds, absolute engine clock), captured at the input event. */
+  t: number;
+  /** How the action was triggered. */
+  src: TagSrc;
+}
+
+/**
+ * The neutral semantic event the state machine emits (representation-independent).
+ * A codec serializes this to 1..2 wire rows; `resolveIntervals` reads a stream of
+ * these. Carries `kind` (from the def) so codecs that want it are self-sufficient.
+ */
+export interface EdgeEvent {
+  tag: string;
+  kind: TagKind;
+  status: TagStatus;
+  /** Raw event time. */
+  t: number;
+  /** Lead-in-corrected time. */
+  tCorrected: number;
+  seq: number;
+  clock: TagClock;
+  src: TagSrc;
+  /** Set on a close whose lead-in inverted the interval. */
+  degenerate?: boolean;
+}
+
+/**
+ * Live open-state for the toggle state machine. `open[tagId]` exists iff that
+ * interval tag is currently open. `seq` is the running event counter. Pure data —
+ * the store holds one of these and passes it through `applyToggle`.
+ */
+export interface TagState {
+  open: Record<string, { openT: number; openCorrected: number; seq: number; leadIn: number }>;
+  seq: number;
+}
+
+/** A fresh, empty tag state. */
+export function emptyTagState(): TagState {
+  return { open: {}, seq: 0 };
+}
+
+/**
+ * A resolved interval/point, the output of `resolveIntervals` — what a segmentation
+ * consumer cuts on. A point has `start === end`; `openEnded` marks an interval that
+ * was still open at the end of the log; `degenerate` marks a lead-in inversion that
+ * fell back to raw times.
+ */
+export interface ResolvedInterval {
+  tag: string;
+  kind: TagKind;
+  /** Raw start (== end for a point). */
+  start: number;
+  /** Raw end. */
+  end: number;
+  /** Lead-in-corrected start / end (equal raw for a point). */
+  startCorrected: number;
+  endCorrected: number;
+  /** The lead-in inverted the interval → corrected times fell back to raw. */
+  degenerate: boolean;
+  /** Never closed in the log (open at recording end). */
+  openEnded: boolean;
+  openSeq: number;
+  closeSeq?: number;
+}

--- a/src/taglog/affordances/time.ts
+++ b/src/taglog/affordances/time.ts
@@ -1,0 +1,23 @@
+/**
+ * taglog — shared time formatting (a pure affordance util).
+ *
+ * Lives in the affordance layer so BOTH the adapters (export formats) and the
+ * presentation layer depend on it downward (presentation -> affordances,
+ * adapters -> affordances) rather than presentation reaching sideways into adapters.
+ */
+
+/**
+ * Format seconds as `HH:MM:SS.mmm`. Rounds to whole milliseconds UP FRONT so a
+ * fractional part >= 0.9995s carries into the next second instead of producing an
+ * out-of-range 4-digit millisecond field (which would be an invalid WebVTT/timecode).
+ */
+export function formatTimecode(seconds: number): string {
+  const total = Math.max(0, Math.round(seconds * 1000)); // whole ms, carry-safe
+  const ms = total % 1000;
+  const totalSec = (total - ms) / 1000;
+  const ss = totalSec % 60;
+  const mm = Math.floor(totalSec / 60) % 60;
+  const hh = Math.floor(totalSec / 3600);
+  const pad = (n: number, w = 2) => String(n).padStart(w, '0');
+  return `${pad(hh)}:${pad(mm)}:${pad(ss)}.${pad(ms, 3)}`;
+}

--- a/src/taglog/affordances/toggle.ts
+++ b/src/taglog/affordances/toggle.ts
@@ -1,0 +1,163 @@
+/**
+ * taglog — the toggle state machine (design §7, §8).
+ *
+ * `applyToggle` turns one neutral {@link TagAction} into the next {@link TagState}
+ * plus the semantic {@link EdgeEvent}s it produced. It is the single, pure heart of
+ * live tagging: interval open <-> close, point emit, BORIS-style mutual-exclusivity
+ * auto-close of open siblings, lead-in correction, and monotonic `seq` assignment.
+ *
+ * Ordering rule (§7, §11.2): an auto-close carries a LOWER `seq` than the triggering
+ * open (it is emitted first), so `resolveIntervals` sees the sibling close before the
+ * new open with NO epsilon time-nudge — stored times stay clean. Keyboard and mouse
+ * are indistinguishable here; only `src` differs.
+ *
+ * Pure: no React, no storage, no timers. `state` in -> `{state, edges}` out.
+ */
+import { correctedTime, isDegenerate } from './leadIn';
+import {
+  DEFAULT_EXCLUSIVITY_GROUP,
+  type EdgeEvent,
+  type TagAction,
+  type TagDef,
+  type TaggingConfig,
+  type TagSrc,
+  type TagState,
+} from './schema';
+
+/** The result of applying an action: the new (immutably-derived) state + edges. */
+export interface ToggleResult {
+  state: TagState;
+  edges: EdgeEvent[];
+}
+
+/** The exclusion group a tag belongs to under the active mode, or null if none.
+ *  `single` collapses every interval tag into one implicit group; `group` uses the
+ *  tag's declared `group`; `off` means no exclusivity. */
+function exclusionGroup(def: TagDef, config: TaggingConfig): string | null {
+  if (def.kind !== 'interval') return null; // a point can't be "open" (§7)
+  switch (config.exclusivity) {
+    case 'off':
+      return null;
+    case 'single':
+      return DEFAULT_EXCLUSIVITY_GROUP;
+    case 'group':
+      return def.group;
+  }
+}
+
+/** Shallow-clone a state so callers never mutate the input (React/store friendly). */
+function cloneState(state: TagState): TagState {
+  return { open: { ...state.open }, seq: state.seq };
+}
+
+/** Emit a close edge for an open interval tag and remove it from `open`. Mutates the
+ *  (already-cloned) `state` and pushes to `edges`. Used by both a manual close and an
+ *  auto-close. `degenerate` is computed against the stored open's corrected time. */
+function closeOpenTag(
+  state: TagState,
+  edges: EdgeEvent[],
+  def: TagDef,
+  t: number,
+  src: TagSrc,
+  clock: TaggingConfig['clock'],
+): void {
+  const open = state.open[def.id];
+  if (!open) return;
+  const tCorrected = correctedTime('close', t, def.leadIn);
+  const degenerate = isDegenerate(open.openCorrected, tCorrected);
+  edges.push({
+    tag: def.id,
+    kind: def.kind,
+    status: 'close',
+    t,
+    tCorrected,
+    seq: state.seq++,
+    clock,
+    src,
+    ...(degenerate ? { degenerate: true } : {}),
+  });
+  delete state.open[def.id];
+}
+
+/**
+ * Apply one toggle/point action. Returns the next state and the edges produced
+ * (0..N — a point is 1, an interval open in exclusive mode may be several: the
+ * auto-closes of open siblings, then the open). A no-op (unknown tag) returns the
+ * input state unchanged and no edges.
+ */
+export function applyToggle(
+  state: TagState,
+  defs: readonly TagDef[],
+  action: TagAction,
+  config: TaggingConfig,
+): ToggleResult {
+  const def = defs.find((d) => d.id === action.tagId);
+  if (!def) return { state, edges: [] };
+
+  const next = cloneState(state);
+  const edges: EdgeEvent[] = [];
+  const { t, src } = action;
+  const clock = config.clock;
+
+  // A point is instantaneous — one edge, no open-state, unaffected by exclusivity.
+  if (def.kind === 'point') {
+    edges.push({
+      tag: def.id,
+      kind: 'point',
+      status: 'point',
+      t,
+      tCorrected: correctedTime('point', t, def.leadIn),
+      seq: next.seq++,
+      clock,
+      src,
+    });
+    return { state: next, edges };
+  }
+
+  // Interval: open tag -> close it; else open it (auto-closing exclusion siblings).
+  if (next.open[def.id]) {
+    closeOpenTag(next, edges, def, t, src, clock);
+    return { state: next, edges };
+  }
+
+  const group = exclusionGroup(def, config);
+  if (group !== null) {
+    // Auto-close every OTHER open interval tag in the same group first (lower seq).
+    for (const openId of Object.keys(next.open)) {
+      if (openId === def.id) continue;
+      const openDef = defs.find((d) => d.id === openId);
+      if (openDef && exclusionGroup(openDef, config) === group) {
+        closeOpenTag(next, edges, openDef, t, 'auto', clock);
+      }
+    }
+  }
+
+  const openCorrected = correctedTime('open', t, def.leadIn);
+  const seq = next.seq++;
+  edges.push({ tag: def.id, kind: 'interval', status: 'open', t, tCorrected: openCorrected, seq, clock, src });
+  next.open[def.id] = { openT: t, openCorrected, seq, leadIn: def.leadIn };
+  return { state: next, edges };
+}
+
+/**
+ * Close every currently-open interval tag (the `0` "panic / clean-stop" key, and the
+ * take-end sweep). Emits close edges in a stable order (by open seq) so the log is
+ * deterministic. `src` records the trigger (`key` for the 0 key, `auto` for take-end).
+ */
+export function closeAll(
+  state: TagState,
+  defs: readonly TagDef[],
+  t: number,
+  config: TaggingConfig,
+  src: TagSrc = 'key',
+): ToggleResult {
+  const next = cloneState(state);
+  const edges: EdgeEvent[] = [];
+  const openIds = Object.keys(next.open).sort((a, b) => next.open[a].seq - next.open[b].seq);
+  for (const id of openIds) {
+    const def = defs.find((d) => d.id === id);
+    if (def) closeOpenTag(next, edges, def, t, src, config.clock);
+    else delete next.open[id]; // orphaned open (def removed) — drop it
+  }
+  return { state: next, edges };
+}

--- a/src/taglog/index.ts
+++ b/src/taglog/index.ts
@@ -1,0 +1,28 @@
+/**
+ * taglog — a live event-tagging tool, structured to lift out of thoremin into a
+ * standalone reusable package (working name `taglog`). Toggle a small set of tags
+ * on/off while recording; each toggle appends a `(t, tag, status)` row to a
+ * `tags.jsonl` that later segments the recorded streams for analysis / ML training.
+ *
+ * Three layers, strict dependency direction **presentation -> affordances <- provider**
+ * (that one rule is what makes extraction mechanical):
+ *
+ *  - {@link module:affordances} — Zod schemas + pure logic (toggle state machine,
+ *    interval resolution, lead-in correction, the pluggable event codecs). No React,
+ *    no storage, no timers.
+ *  - {@link module:adapters} — pure exporters to Audacity / WebVTT / CSV / Praat
+ *    TextGrid / OTIO from the resolved interval view.
+ *  - {@link module:provider} — the `DataProvider<T>` tag-set persistence
+ *    (localStorage default) + the append-only JSONL event sink.
+ *
+ * The thoremin-specific glue (a zustand runtime store, the recording integration,
+ * the React button stack / overlay) lives OUTSIDE this folder (`src/app/tagging/*`,
+ * `src/nodes/output/canvas_overlay.ts`) and only imports from here — never the reverse.
+ *
+ * Design research + prior art (BORIS, Praat, ELAN, OTIO, Allen's interval algebra):
+ * discussion #81; issue #92.
+ */
+export * from './affordances';
+export * as adapters from './adapters';
+export * from './provider';
+export * from './presentation';

--- a/src/taglog/presentation/index.ts
+++ b/src/taglog/presentation/index.ts
@@ -1,0 +1,9 @@
+/**
+ * taglog presentation layer — subscriber-only render helpers (design §9.3).
+ *
+ * Pure "what to draw" computation the host UI subscribes to. It imports the
+ * affordance/adapter types but nothing imports it back — so the same core can drive
+ * a different UI or headless capture. Today it ships the burned-in corner overlay's
+ * frame computation; the React button stack / countdown live in the host.
+ */
+export * from './overlay';

--- a/src/taglog/presentation/overlay.ts
+++ b/src/taglog/presentation/overlay.ts
@@ -1,0 +1,63 @@
+/**
+ * taglog presentation — the burned-in corner overlay's pure compute (design §5/§10).
+ *
+ * The overlay is the in-band "second opinion" composited into the recorded video:
+ * the currently-open tags + a media timecode + a blink phase, so alignment is
+ * *verifiable in the pixels a model trains on*, not just trusted metadata. The canvas
+ * DRAWING is host-specific (thoremin's `canvas_overlay.ts`), but WHAT to draw is this
+ * pure function — so it is reusable and unit-testable, and the host stays dumb.
+ *
+ * A host supplies a {@link TagOverlaySnapshot} (from the runtime store; null when not
+ * recording) plus the engine's current time; this returns the frame to draw, or null
+ * to draw nothing.
+ */
+import { formatTimecode } from '../affordances/time';
+
+/** One open-tag chip to render in the corner (label + colour). */
+export interface OpenTagChip {
+  tag: string;
+  label: string;
+  color: string;
+}
+
+/** The runtime snapshot the host installs as a resource: the take anchor + open tags.
+ *  Null means "not recording" — the overlay draws nothing. */
+export interface TagOverlaySnapshot {
+  /** The take's t0 (engine-clock seconds), so mediaTime = engineTime - t0. */
+  t0: number;
+  open: OpenTagChip[];
+}
+
+/** The computed corner-overlay frame: what to actually paint this tick. */
+export interface TagOverlayFrame {
+  /** mm:ss.mmm since record start (the burned-in timecode). */
+  timecode: string;
+  /** Media-relative seconds since t0. */
+  mediaTime: number;
+  /** ~1 Hz blink phase — a REC-light so a dropped frame is detectable. */
+  blinkOn: boolean;
+  chips: OpenTagChip[];
+}
+
+/** Blink rate for the REC dot / open-tag pulse (Hz). */
+const BLINK_HZ = 1;
+
+/**
+ * Compute the corner-overlay frame from the runtime snapshot and the engine clock.
+ * `engineTime` is `ctx.time` (performance.now()/1000, the same clock t0 is on), so
+ * `mediaTime = engineTime - t0` is the recording-relative timecode. Returns null when
+ * there is nothing to draw (not recording).
+ */
+export function computeTagOverlay(
+  snapshot: TagOverlaySnapshot | null,
+  engineTime: number,
+): TagOverlayFrame | null {
+  if (!snapshot) return null;
+  const mediaTime = Math.max(0, engineTime - snapshot.t0);
+  return {
+    timecode: formatTimecode(mediaTime),
+    mediaTime,
+    blinkOn: Math.floor(mediaTime * BLINK_HZ * 2) % 2 === 0,
+    chips: snapshot.open,
+  };
+}

--- a/src/taglog/provider/defsStore.ts
+++ b/src/taglog/provider/defsStore.ts
@@ -1,0 +1,69 @@
+/**
+ * taglog — tag-set persistence via the zodal DataProvider contract (design §9.2a).
+ *
+ * A **tag set** is a named, ordered list of {@link TagDef}s plus its
+ * {@link TaggingConfig} — the thing the user picks and reorders before recording,
+ * and the thing pre-seeded "last-used" at mode setup. It is persisted the zodal way:
+ * a Zod schema (SSOT) behind a `DataProvider<T>` whose default target is
+ * localStorage (`@zodal/store-localstorage`). Swapping to files/cloud later is a
+ * provider swap, never a call-site change.
+ *
+ * The provider is async (persistence, never the hot path); the live store hydrates
+ * from it on mode open and debounces writes back. The helpers here (`loadLastUsed`,
+ * `saveTagSet`) take a `DataProvider<TagSetDoc>` by injection, so they work over the
+ * localStorage default or any other backend (and are unit-testable in isolation).
+ */
+import { z } from 'zod';
+import type { DataProvider } from '@zodal/store';
+import { createLocalStorageProvider } from '@zodal/store-localstorage';
+import { TagDefSchema, TaggingConfigSchema } from '../affordances/schema';
+
+/** localStorage key the default tag-set collection lives under. */
+export const TAGSETS_STORAGE_KEY = 'taglog.tagsets';
+
+/** A persisted tag set: an ordered tag list + its config, named and timestamped so
+ *  the most-recently-used one can be pre-seeded. */
+export const TagSetDocSchema = z.object({
+  /** Stable id (the collection key). */
+  id: z.string().min(1),
+  /** Human name ("hands drill", "session 3"…). */
+  name: z.string().default('Tag set'),
+  /** The ordered tag definitions. */
+  tags: z.array(TagDefSchema).default([]),
+  /** Session-level tagging config (exclusivity, codec, clock, offset). */
+  config: TaggingConfigSchema.default(() => TaggingConfigSchema.parse({})),
+  /** ms-epoch of the last save — the "last used" sort key (stamped by the host,
+   *  never `Date.now()` inside pure code). */
+  updatedAt: z.number().default(0),
+});
+export type TagSetDoc = z.infer<typeof TagSetDocSchema>;
+
+/** Validate a raw persisted blob into a TagSetDoc, healing missing fields (never
+ *  throws) — the same forward-compat discipline the recording schema uses. */
+export function parseTagSet(raw: unknown): TagSetDoc {
+  const parsed = TagSetDocSchema.safeParse(raw ?? {});
+  return parsed.success ? parsed.data : TagSetDocSchema.parse({ id: 'default' });
+}
+
+/** The default localStorage-backed tag-set provider (the zodal way). Swap this call
+ *  for a different `createXProvider(...)` to retarget storage — nothing else changes. */
+export function createTagSetProvider(storageKey: string = TAGSETS_STORAGE_KEY): DataProvider<TagSetDoc> {
+  return createLocalStorageProvider<TagSetDoc>({ storageKey, idField: 'id', searchFields: ['name'] });
+}
+
+/** The most-recently-updated tag set (pre-seed at mode setup), or null if none saved. */
+export async function loadLastUsed(provider: DataProvider<TagSetDoc>): Promise<TagSetDoc | null> {
+  const { data } = await provider.getList({ sort: [{ id: 'updatedAt', desc: true }] });
+  return data[0] ?? null;
+}
+
+/** Upsert a tag set (create if new by id, else update) and return the stored doc. */
+export async function saveTagSet(provider: DataProvider<TagSetDoc>, doc: TagSetDoc): Promise<TagSetDoc> {
+  if (provider.upsert) return provider.upsert(doc);
+  try {
+    await provider.getOne(doc.id);
+    return await provider.update(doc.id, doc);
+  } catch {
+    return provider.create(doc);
+  }
+}

--- a/src/taglog/provider/index.ts
+++ b/src/taglog/provider/index.ts
@@ -1,0 +1,10 @@
+/**
+ * taglog provider layer — persistence (tag sets) + the append-only event sink.
+ *
+ * Two responsibilities, one boundary: persist the last-used tag set + config via a
+ * zodal `DataProvider<T>` (localStorage default), and drain live events to JSONL via
+ * {@link TagEventSink}. Both sit behind stable contracts so storage is swappable
+ * without touching the affordance core or the UI.
+ */
+export * from './sink';
+export * from './defsStore';

--- a/src/taglog/provider/sink.ts
+++ b/src/taglog/provider/sink.ts
@@ -1,0 +1,55 @@
+/**
+ * taglog — the event sink (the provider layer's append-only writer, design §9.2).
+ *
+ * A {@link TagEventSink} buffers the self-describing anchor record plus every
+ * semantic {@link EdgeEvent} (serialized through the active {@link EventCodec}) as
+ * JSONL lines, then hands them back with {@link TagEventSink.drain}. It mirrors the
+ * recording subsystem's `FeatureJsonlTap`: serialize on receipt so value objects are
+ * freed immediately, `drain()` is the seam a future appendable file sink flushes on
+ * a timer. Swapping storage (a POST endpoint, IndexedDB, File System Access) never
+ * touches the state machine — the sink only ever sees rows.
+ *
+ * Pure of DOM/filesystem — it produces strings; the host writes them.
+ */
+import { getCodec, type EventCodec } from '../affordances/codec';
+import type { AnchorRecord, EdgeEvent } from '../affordances/schema';
+
+export class TagEventSink {
+  private lines: string[] = [];
+  private readonly codec: EventCodec;
+
+  /** @param codecName registered codec id; unknown/absent falls back to statusEnum. */
+  constructor(codecName?: string) {
+    this.codec = getCodec(codecName);
+  }
+
+  /** Write the self-describing anchor as the first line (§5). Call once at take start. */
+  writeAnchor(anchor: AnchorRecord): void {
+    this.lines.push(JSON.stringify(anchor));
+  }
+
+  /** Append semantic edges, serialized to 1..2 wire rows each via the codec. */
+  append(edges: readonly EdgeEvent[]): void {
+    for (const e of edges) {
+      for (const row of this.codec.encode(e)) this.lines.push(JSON.stringify(row));
+    }
+  }
+
+  /** Number of buffered lines (anchor + rows) so far. */
+  get count(): number {
+    return this.lines.length;
+  }
+
+  /** True until any line (even the anchor) has been buffered. */
+  get isEmpty(): boolean {
+    return this.lines.length === 0;
+  }
+
+  /** Take the buffered JSONL chunk and clear the buffer. '' when nothing is buffered. */
+  drain(): string {
+    if (!this.lines.length) return '';
+    const chunk = this.lines.join('\n') + '\n';
+    this.lines = [];
+    return chunk;
+  }
+}

--- a/test/recording_plan.test.ts
+++ b/test/recording_plan.test.ts
@@ -116,3 +116,29 @@ describe('planRecording — single-file escape hatch', () => {
     expect(p.useFolder).toBe(true);
   });
 });
+
+describe('planRecording — live-tagging stream (#92)', () => {
+  const planT = (s: RecordingSession, includeTags: boolean) =>
+    planRecording({ session: s, stem: STEM, audioMime: AUDIO_MIME, videoMime: VIDEO_MIME, includeTags });
+
+  it('adds a `.tags.jsonl` stream (before the manifest) when tagging is active', () => {
+    const p = planT(session(), true);
+    const tags = p.files.find((f) => f.kind === 'tags');
+    expect(tags?.name).toBe(`${STEM}.tags.jsonl`);
+    expect(tags).toMatchObject({ role: 'tags', ext: 'jsonl' });
+    // ordering: tags sits right before the always-last manifest
+    const kinds = p.files.map((f) => f.kind);
+    expect(kinds.indexOf('tags')).toBe(kinds.indexOf('manifest') - 1);
+  });
+
+  it('omits the tags stream when tagging is inactive', () => {
+    expect(planT(session(), false).files.some((f) => f.kind === 'tags')).toBe(false);
+  });
+
+  it('forces folder mode even for an otherwise single-file-eligible take', () => {
+    const p = planT(session({ singleFileWhenAlone: true, streams: { audio: true } }), true);
+    expect(p.useFolder).toBe(true);
+    expect(p.files.some((f) => f.kind === 'tags')).toBe(true);
+    expect(p.files.some((f) => f.kind === 'manifest')).toBe(true);
+  });
+});

--- a/test/tag_hud_overlay.test.ts
+++ b/test/tag_hud_overlay.test.ts
@@ -1,0 +1,83 @@
+/**
+ * The burned-in tag HUD overlay element (#92) — drives the `canvas-overlay` node with
+ * a fake recording 2D context and asserts it paints the open tags + timecode ONLY
+ * while a take is recording (the `tagOverlay` resource returns a snapshot), and is a
+ * silent no-op otherwise (the common case, so it must cost nothing).
+ */
+import { describe, it, expect } from 'vitest';
+import type { NodeContext } from '@/dag';
+import { canvasOverlayNode, OVERLAY_ELEMENTS } from '@/nodes/output/canvas_overlay';
+import type { TagOverlaySnapshot } from '@/taglog/presentation';
+
+interface Call {
+  m: string;
+  args: unknown[];
+}
+function makeCanvas(width = 1280, height = 720) {
+  const calls: Call[] = [];
+  const ctx: Record<string, unknown> = { globalAlpha: 1, fillStyle: '', font: '', textBaseline: '', textAlign: '' };
+  const rec = (m: string) => (...args: unknown[]) => void calls.push({ m, args });
+  for (const m of ['clearRect', 'save', 'restore', 'beginPath', 'arc', 'fill', 'stroke', 'moveTo', 'lineTo', 'drawImage', 'fillText', 'setLineDash', 'scale', 'translate', 'rotate', 'fillRect']) {
+    ctx[m] = rec(m);
+  }
+  const canvas = { width, height, getContext: () => ctx } as unknown as HTMLCanvasElement;
+  return { canvas, calls, texts: () => calls.filter((c) => c.m === 'fillText').map((c) => c.args[0] as string) };
+}
+
+/** Every element off except tagHud, so only its draws show up. */
+const onlyTagHud = Object.fromEntries(OVERLAY_ELEMENTS.map((e) => [e.name, { show: e.name === 'tagHud' }]));
+
+function run(snapshot: TagOverlaySnapshot | null, time: number, position?: 'left' | 'right') {
+  const rc = makeCanvas();
+  const params = { ...onlyTagHud, tagHud: { show: true, ...(position ? { position } : {}) } };
+  const handlers = canvasOverlayNode.make(canvasOverlayNode.params.parse(params));
+  const ctx: NodeContext = {
+    tick: 0,
+    time,
+    dt: 0,
+    resources: { canvas: rc.canvas, tagOverlay: () => snapshot },
+  };
+  handlers.process({}, ctx);
+  return rc;
+}
+
+const snap: TagOverlaySnapshot = { t0: 0, open: [{ tag: 'a', label: 'Pluck', color: '#34d399' }] };
+
+describe('tagHud burned-in overlay (#92)', () => {
+  it('draws a box + REC timecode header + a chip per open tag while recording', () => {
+    const rc = run(snap, 3.5);
+    expect(rc.calls.filter((c) => c.m === 'fillRect').length).toBeGreaterThanOrEqual(1); // box
+    const texts = rc.texts();
+    expect(texts).toContain('REC 00:00:03.500'); // media timecode from ctx.time - t0
+    expect(texts).toContain('Pluck'); // the open tag's label
+    expect(rc.calls.some((c) => c.m === 'arc')).toBe(true); // the blink dots
+  });
+
+  it('draws nothing when not recording (tagOverlay resource returns null)', () => {
+    const rc = run(null, 10);
+    expect(rc.calls.some((c) => c.m === 'fillRect')).toBe(false);
+    expect(rc.texts()).toHaveLength(0);
+  });
+
+  it('draws nothing when toggled off even while recording', () => {
+    const rc = makeCanvas();
+    const handlers = canvasOverlayNode.make(
+      canvasOverlayNode.params.parse({ ...onlyTagHud, tagHud: { show: false } }),
+    );
+    const ctx: NodeContext = { tick: 0, time: 2, dt: 0, resources: { canvas: rc.canvas, tagOverlay: () => snap } };
+    handlers.process({}, ctx);
+    expect(rc.texts()).toHaveLength(0);
+  });
+
+  it('still shows the timecode header when no tags are open', () => {
+    const rc = run({ t0: 0, open: [] }, 61);
+    expect(rc.texts()).toEqual(['REC 00:01:01.000']);
+  });
+
+  it('anchors left vs right (x differs)', () => {
+    const leftX = run(snap, 1, 'left').calls.find((c) => c.m === 'fillRect')!.args[0] as number;
+    const rightX = run(snap, 1, 'right').calls.find((c) => c.m === 'fillRect')!.args[0] as number;
+    expect(leftX).toBe(12);
+    expect(rightX).toBeGreaterThan(12);
+  });
+});

--- a/test/tagging_store.test.ts
+++ b/test/tagging_store.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Tagging runtime store (#92) — the thoremin glue over the pure `taglog` core.
+ * Drives the take lifecycle with an injected clock (deterministic media times) and
+ * asserts the emitted `tags.jsonl`, exclusivity, the overlay snapshot, and that
+ * rehearsal toggles (no take) are NOT logged.
+ */
+// localStorage shim for the node test env (persistence is best-effort/debounced).
+if (typeof (globalThis as { localStorage?: unknown }).localStorage === 'undefined') {
+  const store = new Map<string, string>();
+  (globalThis as { localStorage?: unknown }).localStorage = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => void store.set(k, String(v)),
+    removeItem: (k: string) => void store.delete(k),
+    clear: () => store.clear(),
+  };
+}
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useTagging, renumber, defaultTagSet } from '@/app/tagging/store';
+import { emptyTagState, DEFAULT_TAGGING_CONFIG, TagDefSchema } from '@/taglog/affordances';
+
+const A = TagDefSchema.parse({ id: 'a', label: 'A', kind: 'interval', group: 'g' });
+const B = TagDefSchema.parse({ id: 'b', label: 'B', kind: 'interval', group: 'g' });
+const P = TagDefSchema.parse({ id: 'p', label: 'P', kind: 'point' });
+
+let now = 0;
+function setNow(sec: number) {
+  now = sec;
+}
+
+beforeEach(() => {
+  useTagging.setState({
+    mode: false,
+    defs: [],
+    config: DEFAULT_TAGGING_CONFIG,
+    state: emptyTagState(),
+    take: null,
+    countdown: null,
+    pulse: 0,
+    clock: () => now,
+  });
+});
+
+describe('renumber', () => {
+  it('assigns 1..9 by order, null past the ninth, and sets order', () => {
+    const many = renumber(Array.from({ length: 11 }, (_, i) => TagDefSchema.parse({ id: `t${i}`, label: `${i}` })));
+    expect(many[0].number).toBe(1);
+    expect(many[8].number).toBe(9);
+    expect(many[9].number).toBeNull();
+    expect(many[10].order).toBe(10);
+  });
+});
+
+describe('take lifecycle → tags.jsonl', () => {
+  it('logs absolute engine-clock events with an origin anchor, closing still-open at endTake', () => {
+    const st = useTagging.getState();
+    st.setDefs([A, B, P]);
+    st.setConfig({ exclusivity: 'single' });
+    // t0 = 0 here so the clock() values ARE the take offsets (keeps the assertions
+    // readable); in production t0 is the page-load->record gap and the offset is t - t0.
+    st.beginTake({ t0: 0, startedAt: '2026-07-10T00:00:00.000Z', session: 'sess_1' });
+
+    setNow(1);
+    st.toggle('a', 'click');
+    setNow(3);
+    st.toggle('b', 'key'); // exclusivity: auto-closes A, opens B
+    setNow(4);
+    st.toggle('p', 'key'); // a point
+    const jsonl = useTagging.getState().endTake(6); // closes B at t=6
+
+    const lines = jsonl.trim().split('\n').map((l) => JSON.parse(l));
+    // The anchor's `t` is the origin (== t0), matching the manifest t0.
+    expect(lines[0]).toMatchObject({ anchor: true, t: 0, session: 'sess_1', schema: 'thoremin.tags/1', recStartPerf: 0 });
+    const events = lines.slice(1);
+    // open A @1, auto-close A @3, open B @3, point p @4, close B @6 (all absolute engine time)
+    expect(events.map((e) => [e.tag, e.status, e.t])).toEqual([
+      ['a', 'open', 1],
+      ['a', 'close', 3],
+      ['b', 'open', 3],
+      ['p', 'point', 4],
+      ['b', 'close', 6],
+    ]);
+    expect(events.find((e) => e.tag === 'a' && e.status === 'close').src).toBe('auto');
+    expect(useTagging.getState().take).toBeNull();
+  });
+
+  it('stamps t on the ABSOLUTE clock (offset t - t0), matching features.jsonl', () => {
+    const st = useTagging.getState();
+    st.setDefs([A]);
+    st.beginTake({ t0: 180, startedAt: 'x', session: 's' }); // record 180s after page load
+    setNow(182); // engine clock now 182 -> take offset 2s
+    st.toggle('a', 'key');
+    const jsonl = useTagging.getState().endTake(185);
+    const events = jsonl.trim().split('\n').slice(1).map((l) => JSON.parse(l));
+    // Absolute t (182), NOT the relative 2 — so a consumer doing (t - manifest.t0)
+    // recovers the correct 2s offset instead of double-subtracting to -178.
+    expect(events[0]).toMatchObject({ tag: 'a', status: 'open', t: 182 });
+  });
+
+  it('does not log toggles while not recording (rehearsal), but still tracks open state', () => {
+    const st = useTagging.getState();
+    st.setDefs([A, B]);
+    setNow(5);
+    st.toggle('a', 'key');
+    expect(useTagging.getState().isOpen('a')).toBe(true); // live UI reflects it
+    // Nothing was logged: a subsequent take starts with a clean, empty log.
+    st.beginTake({ t0: 0, startedAt: 'x', session: 's' });
+    expect(useTagging.getState().isOpen('a')).toBe(false); // fresh slate per take
+    expect(useTagging.getState().endTake(1).trim().split('\n')).toHaveLength(1); // anchor only
+  });
+});
+
+describe('overlay snapshot', () => {
+  it('is null unless recording, then lists open tags with labels/colors', () => {
+    const st = useTagging.getState();
+    st.setDefs([A]);
+    expect(useTagging.getState().overlaySnapshot()).toBeNull();
+    st.beginTake({ t0: 50, startedAt: 'x', session: 's' });
+    setNow(52);
+    st.toggle('a', 'key');
+    const snap = useTagging.getState().overlaySnapshot()!;
+    expect(snap.t0).toBe(50);
+    expect(snap.open).toEqual([{ tag: 'a', label: 'A', color: A.color }]);
+  });
+});
+
+describe('keyboard-facing actions', () => {
+  it('toggleByNumber maps the digit to the positional tag; closeAllTags clears', () => {
+    const st = useTagging.getState();
+    st.setDefs([A, B]); // A→1, B→2
+    st.beginTake({ t0: 0, startedAt: 'x', session: 's' });
+    setNow(1);
+    st.toggleByNumber(1, 'key');
+    st.toggleByNumber(2, 'key');
+    expect(Object.keys(useTagging.getState().state.open).sort()).toEqual(['a', 'b']);
+    setNow(2);
+    st.closeAllTags('key');
+    expect(Object.keys(useTagging.getState().state.open)).toHaveLength(0);
+  });
+});
+
+describe('active() gate', () => {
+  it('is false without tags or when mode is off', () => {
+    const st = useTagging.getState();
+    expect(useTagging.getState().active()).toBe(false);
+    st.setDefs([A]);
+    useTagging.setState({ mode: true });
+    expect(useTagging.getState().active()).toBe(true);
+    useTagging.setState({ mode: false });
+    expect(useTagging.getState().active()).toBe(false);
+  });
+});
+
+describe('defaultTagSet', () => {
+  it('is a small, numbered, usable starter set', () => {
+    const set = defaultTagSet();
+    expect(set.length).toBeGreaterThanOrEqual(2);
+    expect(set[0].number).toBe(1);
+  });
+});

--- a/test/taglog_adapters.test.ts
+++ b/test/taglog_adapters.test.ts
@@ -1,0 +1,148 @@
+/**
+ * taglog export adapters — the interchange seam (design §2/§4). Proves the resolved
+ * interval view round-trips to the standard formats researchers already use, so a
+ * tag log opens in Audacity / Praat / a `<track>` / a spreadsheet / an NLE.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  toAudacityLabels,
+  toWebVTT,
+  toCSV,
+  toTextGrid,
+  toOTIO,
+  formatTimecode,
+  getAdapter,
+  ADAPTERS,
+} from '@/taglog/adapters';
+import { TagDefSchema, type ResolvedInterval, type TagDef } from '@/taglog/affordances';
+
+const defs: TagDef[] = [
+  TagDefSchema.parse({ id: 'pluck', label: 'Pluck', kind: 'interval' }),
+  TagDefSchema.parse({ id: 'boom', label: 'Boom', kind: 'point' }),
+];
+
+const intervals: ResolvedInterval[] = [
+  {
+    tag: 'pluck',
+    kind: 'interval',
+    start: 5,
+    end: 12,
+    startCorrected: 7,
+    endCorrected: 10,
+    degenerate: false,
+    openEnded: false,
+    openSeq: 0,
+    closeSeq: 1,
+  },
+  {
+    tag: 'boom',
+    kind: 'point',
+    start: 8,
+    end: 8,
+    startCorrected: 8,
+    endCorrected: 8,
+    degenerate: false,
+    openEnded: false,
+    openSeq: 2,
+  },
+];
+
+describe('formatTimecode', () => {
+  it('formats HH:MM:SS.mmm and clamps negatives', () => {
+    expect(formatTimecode(0)).toBe('00:00:00.000');
+    expect(formatTimecode(3661.5)).toBe('01:01:01.500');
+    expect(formatTimecode(-3)).toBe('00:00:00.000');
+  });
+  it('carries a sub-ms rounding into the next second (never a 4-digit ms field)', () => {
+    // 8.9996 rounds to 9.000s, not 08.1000 (an invalid WebVTT timestamp).
+    expect(formatTimecode(8.9996)).toBe('00:00:09.000');
+    expect(formatTimecode(59.9999)).toBe('00:01:00.000');
+  });
+});
+
+describe('Audacity labels', () => {
+  it('emits start<TAB>end<TAB>label with corrected times by default', () => {
+    const out = toAudacityLabels(intervals, { defs });
+    const lines = out.trim().split('\n');
+    expect(lines[0]).toBe('7.000000\t10.000000\tPluck');
+    expect(lines[1]).toBe('8.000000\t8.000000\tBoom'); // point: start==end
+  });
+  it('uses raw times when asked', () => {
+    expect(toAudacityLabels(intervals, { defs, time: 'raw' }).split('\n')[0]).toBe('5.000000\t12.000000\tPluck');
+  });
+});
+
+describe('WebVTT', () => {
+  it('opens with WEBVTT and gives a point a nonzero cue', () => {
+    const out = toWebVTT(intervals, { defs });
+    expect(out.startsWith('WEBVTT')).toBe(true);
+    expect(out).toContain('00:00:07.000 --> 00:00:10.000');
+    expect(out).toContain('Pluck');
+    // point: 8.000 --> 8.001 (end nudged so a player renders it)
+    expect(out).toContain('00:00:08.000 --> 00:00:08.001');
+  });
+});
+
+describe('CSV', () => {
+  it('has a header and one row per interval with raw + corrected times', () => {
+    const rows = toCSV(intervals, { defs }).trim().split('\n');
+    expect(rows[0]).toBe('tag,label,kind,start,end,startCorrected,endCorrected,degenerate,openEnded');
+    expect(rows[1]).toBe('pluck,Pluck,interval,5,12,7,10,false,false');
+    expect(rows[2]).toBe('boom,Boom,point,8,8,8,8,false,false');
+  });
+});
+
+describe('Praat TextGrid', () => {
+  it('makes an IntervalTier (gap-filled) for the interval and a TextTier for the point', () => {
+    const out = toTextGrid(intervals, { defs, duration: 15 });
+    expect(out).toContain('Object class = "TextGrid"');
+    expect(out).toContain('class = "IntervalTier"');
+    expect(out).toContain('name = "Pluck"');
+    expect(out).toContain('class = "TextTier"'); // point tier
+    expect(out).toContain('mark = "Boom"');
+    // adjacency-complete: an empty lead interval 0..7, the label 7..10, empty 10..15
+    expect(out).toContain('text = "Pluck"');
+    expect(out).toMatch(/xmax = 15/);
+  });
+  it('never lets an explicit duration shrink xmax below an interval end (Praat would reject)', () => {
+    // Interval ends at corrected 10; a smaller duration:5 must NOT clip xmax to 5.
+    const out = toTextGrid(intervals, { defs, duration: 5 });
+    const fileXmax = Number(out.match(/^xmax = (\d+)/m)![1]);
+    expect(fileXmax).toBeGreaterThanOrEqual(10);
+    expect(out).not.toMatch(/xmax = 5\b/); // no tier/file xmax below the content
+  });
+});
+
+describe('OTIO', () => {
+  it('is valid JSON with a marker per interval carrying taglog metadata', () => {
+    const doc = JSON.parse(toOTIO(intervals, { defs, rate: 30 }));
+    expect(doc.OTIO_SCHEMA).toBe('Timeline.1');
+    const markers = doc.tracks.children[0].markers;
+    expect(markers).toHaveLength(2);
+    expect(markers[0].name).toBe('Pluck');
+    expect(markers[0].marked_range.start_time.value).toBe(210); // 7s * 30fps
+    expect(markers[0].metadata.taglog.tag).toBe('pluck');
+  });
+});
+
+describe('label sanitization (structured formats)', () => {
+  const dirtyDefs: TagDef[] = [TagDefSchema.parse({ id: 'pluck', label: 'a\tb\nc', kind: 'interval' })];
+  const iv: ResolvedInterval[] = [
+    { tag: 'pluck', kind: 'interval', start: 1, end: 2, startCorrected: 1, endCorrected: 2, degenerate: false, openEnded: false, openSeq: 0, closeSeq: 1 },
+  ];
+  it('strips TAB/newline from Audacity + WebVTT labels so they cannot break the row/cue', () => {
+    const audacity = toAudacityLabels(iv, { defs: dirtyDefs });
+    expect(audacity.split('\n')[0].split('\t')).toHaveLength(3); // start, end, label — label has no stray TAB
+    expect(audacity).toContain('a b c');
+    expect(toWebVTT(iv, { defs: dirtyDefs })).toContain('a b c');
+  });
+});
+
+describe('adapter registry', () => {
+  it('exposes each format with an ext/mime and a render fn', () => {
+    expect(Object.keys(ADAPTERS).sort()).toEqual(['audacity', 'csv', 'otio', 'textgrid', 'webvtt']);
+    expect(getAdapter('csv')?.ext).toBe('csv');
+    expect(getAdapter('nope')).toBeUndefined();
+    expect(getAdapter('webvtt')!.render(intervals, { defs }).startsWith('WEBVTT')).toBe(true);
+  });
+});

--- a/test/taglog_affordances.test.ts
+++ b/test/taglog_affordances.test.ts
@@ -1,0 +1,223 @@
+/**
+ * taglog affordance core — the pure heart of live tagging (#92, design #81).
+ * Tested hard because it is the reusable, extraction-ready layer and the one place
+ * mislabeled training data would originate.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  applyToggle,
+  closeAll,
+  correctedTime,
+  isDegenerate,
+  resolveIntervals,
+  emptyTagState,
+  getCodec,
+  statusEnumCodec,
+  pointPairCodec,
+  kindFieldCodec,
+  TagDefSchema,
+  TaggingConfigSchema,
+  type TagDef,
+  type TaggingConfig,
+  type EdgeEvent,
+  type TagState,
+} from '@/taglog/affordances';
+
+/** A tag def from a partial (schema fills defaults). */
+function def(over: Partial<TagDef> & { id: string }): TagDef {
+  return TagDefSchema.parse({ label: over.id, ...over });
+}
+const cfg = (over: Partial<TaggingConfig> = {}): TaggingConfig => TaggingConfigSchema.parse(over);
+
+const PLUCK = def({ id: 'pluck', number: 1, kind: 'interval', group: 'hands' });
+const STRUM = def({ id: 'strum', number: 2, kind: 'interval', group: 'hands' });
+const BOOM = def({ id: 'boom', number: 3, kind: 'point' });
+
+describe('lead-in correction (§6)', () => {
+  it('open shifts later, close shifts earlier, point is the instant', () => {
+    expect(correctedTime('open', 10, 2)).toBe(12);
+    expect(correctedTime('close', 10, 2)).toBe(8);
+    expect(correctedTime('point', 10, 2)).toBe(10);
+  });
+  it('flags a degenerate (inverted) interval', () => {
+    expect(isDegenerate(12, 8)).toBe(true);
+    expect(isDegenerate(8, 12)).toBe(false);
+  });
+});
+
+describe('applyToggle — intervals & points', () => {
+  const defs = [PLUCK, STRUM, BOOM];
+
+  it('opens then closes an interval, stamping raw + corrected times', () => {
+    const p2 = def({ id: 'pluck', number: 1, kind: 'interval', leadIn: 2 });
+    let s = emptyTagState();
+    const r1 = applyToggle(s, [p2], { tagId: 'pluck', t: 5, src: 'key' }, cfg());
+    expect(r1.edges).toHaveLength(1);
+    expect(r1.edges[0]).toMatchObject({ status: 'open', t: 5, tCorrected: 7, seq: 0, src: 'key' });
+    s = r1.state;
+    const r2 = applyToggle(s, [p2], { tagId: 'pluck', t: 20, src: 'click' }, cfg());
+    expect(r2.edges[0]).toMatchObject({ status: 'close', t: 20, tCorrected: 18, seq: 1 });
+    expect(r2.state.open.pluck).toBeUndefined();
+  });
+
+  it('emits a single point edge, unaffected by open-state', () => {
+    const r = applyToggle(emptyTagState(), defs, { tagId: 'boom', t: 3, src: 'click' }, cfg());
+    expect(r.edges).toEqual([
+      expect.objectContaining({ status: 'point', kind: 'point', t: 3, tCorrected: 3, seq: 0 }),
+    ]);
+    expect(Object.keys(r.state.open)).toHaveLength(0);
+  });
+
+  it('is a no-op for an unknown tag (returns the same state, no edges)', () => {
+    const s = emptyTagState();
+    const r = applyToggle(s, defs, { tagId: 'nope', t: 1, src: 'key' }, cfg());
+    expect(r.edges).toEqual([]);
+    expect(r.state).toBe(s);
+  });
+
+  it('does not mutate the input state', () => {
+    const s = emptyTagState();
+    applyToggle(s, defs, { tagId: 'pluck', t: 1, src: 'key' }, cfg());
+    expect(s.open).toEqual({});
+    expect(s.seq).toBe(0);
+  });
+});
+
+describe('mutual exclusivity (§7)', () => {
+  it('single mode: opening a tag auto-closes the open sibling with a LOWER seq', () => {
+    const defs = [PLUCK, STRUM];
+    let s = emptyTagState();
+    s = applyToggle(s, defs, { tagId: 'pluck', t: 5, src: 'key' }, cfg({ exclusivity: 'single' })).state;
+    const r = applyToggle(s, defs, { tagId: 'strum', t: 10, src: 'key' }, cfg({ exclusivity: 'single' }));
+    // Two edges: the auto-close of pluck (seq 1) BEFORE the open of strum (seq 2).
+    const autoClose = r.edges.find((e) => e.tag === 'pluck');
+    const open = r.edges.find((e) => e.tag === 'strum');
+    expect(autoClose).toMatchObject({ status: 'close', src: 'auto', t: 10 });
+    expect(open).toMatchObject({ status: 'open', src: 'key', t: 10 });
+    expect(autoClose!.seq).toBeLessThan(open!.seq);
+    expect(Object.keys(r.state.open)).toEqual(['strum']);
+  });
+
+  it('group mode: only same-group tags exclude each other', () => {
+    const hands1 = def({ id: 'h1', kind: 'interval', group: 'hands' });
+    const hands2 = def({ id: 'h2', kind: 'interval', group: 'hands' });
+    const feet = def({ id: 'f1', kind: 'interval', group: 'feet' });
+    const defs = [hands1, hands2, feet];
+    let s = emptyTagState();
+    s = applyToggle(s, defs, { tagId: 'h1', t: 1, src: 'key' }, cfg({ exclusivity: 'group' })).state;
+    s = applyToggle(s, defs, { tagId: 'f1', t: 2, src: 'key' }, cfg({ exclusivity: 'group' })).state;
+    expect(Object.keys(s.open).sort()).toEqual(['f1', 'h1']); // different groups coexist
+    const r = applyToggle(s, defs, { tagId: 'h2', t: 3, src: 'key' }, cfg({ exclusivity: 'group' }));
+    expect(r.edges.some((e) => e.tag === 'h1' && e.status === 'close' && e.src === 'auto')).toBe(true);
+    expect(Object.keys(r.state.open).sort()).toEqual(['f1', 'h2']); // feet untouched
+  });
+
+  it('off mode: multiple tags stay open at once', () => {
+    const defs = [PLUCK, STRUM];
+    let s = emptyTagState();
+    s = applyToggle(s, defs, { tagId: 'pluck', t: 1, src: 'key' }, cfg()).state;
+    s = applyToggle(s, defs, { tagId: 'strum', t: 2, src: 'key' }, cfg()).state;
+    expect(Object.keys(s.open).sort()).toEqual(['pluck', 'strum']);
+  });
+});
+
+describe('closeAll (0 key / take-end sweep)', () => {
+  it('closes every open interval in open-seq order', () => {
+    const defs = [PLUCK, STRUM];
+    let s = emptyTagState();
+    s = applyToggle(s, defs, { tagId: 'pluck', t: 1, src: 'key' }, cfg()).state;
+    s = applyToggle(s, defs, { tagId: 'strum', t: 2, src: 'key' }, cfg()).state;
+    const r = closeAll(s, defs, 9, cfg(), 'key');
+    expect(r.edges.map((e) => e.tag)).toEqual(['pluck', 'strum']);
+    expect(r.edges.every((e) => e.status === 'close' && e.t === 9)).toBe(true);
+    expect(Object.keys(r.state.open)).toHaveLength(0);
+  });
+});
+
+describe('resolveIntervals', () => {
+  const defs = [PLUCK, STRUM, BOOM];
+  function log(actions: [string, number][], config = cfg()): EdgeEvent[] {
+    let s: TagState = emptyTagState();
+    const edges: EdgeEvent[] = [];
+    for (const [tagId, t] of actions) {
+      const r = applyToggle(s, defs, { tagId, t, src: 'key' }, config);
+      s = r.state;
+      edges.push(...r.edges);
+    }
+    return edges;
+  }
+
+  it('pairs open/close into an interval and resolves a point', () => {
+    const edges = log([['pluck', 5], ['pluck', 12], ['boom', 8]]);
+    const out = resolveIntervals(edges);
+    expect(out).toHaveLength(2);
+    const iv = out.find((i) => i.tag === 'pluck')!;
+    expect(iv).toMatchObject({ kind: 'interval', start: 5, end: 12, openEnded: false });
+    const pt = out.find((i) => i.tag === 'boom')!;
+    expect(pt).toMatchObject({ kind: 'point', start: 8, end: 8 });
+  });
+
+  it('reports still-open intervals as open-ended, closing at endT when given', () => {
+    const edges = log([['pluck', 5]]);
+    expect(resolveIntervals(edges)[0]).toMatchObject({ openEnded: true, start: 5, end: 5 });
+    expect(resolveIntervals(edges, { endT: 30 })[0]).toMatchObject({ openEnded: true, end: 30, endCorrected: 30 });
+  });
+
+  it('applies the lead-in degeneracy guard to an open-ended interval whose take end falls inside the lead-in', () => {
+    const p = def({ id: 'pluck', kind: 'interval', leadIn: 5 });
+    const e = applyToggle(emptyTagState(), [p], { tagId: 'pluck', t: 10, src: 'key' }, cfg()); // open, tCorrected 15
+    // Take stopped at t=12, INSIDE the 5s lead-in (corrected open 15 > end 12).
+    const iv = resolveIntervals(e.edges, { endT: 12 })[0];
+    expect(iv.openEnded).toBe(true);
+    expect(iv.degenerate).toBe(true);
+    expect(iv.startCorrected).toBe(10); // fell back to raw, NOT 15
+    expect(iv.endCorrected).toBe(12); //  ... not an inverted [15,12]
+  });
+
+  it('falls back to raw times on a degenerate (lead-in-inverted) interval', () => {
+    const p = def({ id: 'pluck', kind: 'interval', leadIn: 5 });
+    let s = emptyTagState();
+    const e1 = applyToggle(s, [p], { tagId: 'pluck', t: 10, src: 'key' }, cfg());
+    s = e1.state;
+    const e2 = applyToggle(s, [p], { tagId: 'pluck', t: 12, src: 'key' }, cfg()); // interval 10..12, leadIn 5
+    const out = resolveIntervals([...e1.edges, ...e2.edges]);
+    expect(out[0].degenerate).toBe(true);
+    expect(out[0].startCorrected).toBe(10); // fell back to raw, not 15
+    expect(out[0].endCorrected).toBe(12); //  ... not 7
+  });
+
+  it('ignores a stray close with no matching open', () => {
+    const close: EdgeEvent = { tag: 'pluck', kind: 'interval', status: 'close', t: 5, tCorrected: 5, seq: 0, clock: 'media', src: 'key' };
+    expect(resolveIntervals([close])).toEqual([]);
+  });
+});
+
+describe('event codecs (§4c)', () => {
+  const edge: EdgeEvent = { tag: 'pluck', kind: 'interval', status: 'open', t: 5, tCorrected: 7, seq: 0, clock: 'media', src: 'key' };
+  const point: EdgeEvent = { tag: 'boom', kind: 'point', status: 'point', t: 3, tCorrected: 3, seq: 1, clock: 'media', src: 'click' };
+
+  it('statusEnum: 1:1 row round-trip', () => {
+    const rows = statusEnumCodec.encode(edge);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ status: 'open', t: 5, tCorrected: 7, tag: 'pluck' });
+    expect(statusEnumCodec.decode(rows)[0]).toMatchObject({ status: 'open', kind: 'interval', t: 5 });
+  });
+
+  it('pointPair: a point becomes open+close rows and folds back to a point', () => {
+    const rows = pointPairCodec.encode(point);
+    expect(rows.map((r) => r.status)).toEqual(['open', 'close']);
+    const back = pointPairCodec.decode(rows);
+    expect(back).toHaveLength(1);
+    expect(back[0]).toMatchObject({ status: 'point', kind: 'point', t: 3 });
+  });
+
+  it('kindField: carries a redundant kind column', () => {
+    expect(kindFieldCodec.encode(edge)[0].kind).toBe('interval');
+    expect(kindFieldCodec.decode(kindFieldCodec.encode(point))[0].kind).toBe('point');
+  });
+
+  it('getCodec falls back to statusEnum for an unknown name', () => {
+    expect(getCodec('nope')).toBe(statusEnumCodec);
+    expect(getCodec('pointPair')).toBe(pointPairCodec);
+  });
+});

--- a/test/taglog_presentation.test.ts
+++ b/test/taglog_presentation.test.ts
@@ -1,0 +1,34 @@
+/**
+ * taglog presentation — the burned-in corner overlay's pure frame computation.
+ * The canvas drawing is host-specific; WHAT to draw (timecode, blink phase, chips)
+ * is this pure function and is unit-tested here.
+ */
+import { describe, it, expect } from 'vitest';
+import { computeTagOverlay, type TagOverlaySnapshot } from '@/taglog/presentation';
+
+const snap: TagOverlaySnapshot = {
+  t0: 100,
+  open: [{ tag: 'a', label: 'A', color: '#34d399' }],
+};
+
+describe('computeTagOverlay', () => {
+  it('returns null when not recording', () => {
+    expect(computeTagOverlay(null, 123)).toBeNull();
+  });
+
+  it('derives the media timecode from engineTime - t0 and passes chips through', () => {
+    const frame = computeTagOverlay(snap, 100 + 65.5)!; // 65.5s into the take
+    expect(frame.mediaTime).toBeCloseTo(65.5);
+    expect(frame.timecode).toBe('00:01:05.500');
+    expect(frame.chips).toEqual(snap.open);
+  });
+
+  it('blinks ~1 Hz (on for the first half-second, off for the next)', () => {
+    expect(computeTagOverlay(snap, 100.0)!.blinkOn).toBe(true);
+    expect(computeTagOverlay(snap, 100.75)!.blinkOn).toBe(false);
+  });
+
+  it('clamps a pre-t0 engineTime to zero', () => {
+    expect(computeTagOverlay(snap, 99)!.mediaTime).toBe(0);
+  });
+});

--- a/test/taglog_provider.test.ts
+++ b/test/taglog_provider.test.ts
@@ -1,0 +1,101 @@
+/**
+ * taglog provider layer — the JSONL event sink + the zodal tag-set persistence.
+ * The sink is pure (strings in/out); the tag-set provider is exercised over the real
+ * `@zodal/store-localstorage` adapter with a Node localStorage shim, proving the
+ * zodal-way persistence actually works end-to-end.
+ */
+// localStorage shim for the node test env (matches the repo's other browser-code tests).
+if (typeof (globalThis as { localStorage?: unknown }).localStorage === 'undefined') {
+  const store = new Map<string, string>();
+  (globalThis as { localStorage?: unknown }).localStorage = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => void store.set(k, String(v)),
+    removeItem: (k: string) => void store.delete(k),
+    clear: () => store.clear(),
+  };
+}
+
+import { describe, it, expect } from 'vitest';
+import { TagEventSink } from '@/taglog/provider/sink';
+import {
+  createTagSetProvider,
+  loadLastUsed,
+  saveTagSet,
+  parseTagSet,
+  TagSetDocSchema,
+} from '@/taglog/provider/defsStore';
+import type { AnchorRecord, EdgeEvent } from '@/taglog/affordances';
+
+describe('TagEventSink', () => {
+  const anchor: AnchorRecord = {
+    anchor: true,
+    t: 0,
+    clock: 'media',
+    wallClockISO: '2026-07-10T00:00:00.000Z',
+    recStartPerf: 1234.5,
+    session: 'sess_1',
+    schema: 'thoremin.tags/1',
+  };
+  const open: EdgeEvent = { tag: 'pluck', kind: 'interval', status: 'open', t: 5, tCorrected: 7, seq: 0, clock: 'media', src: 'key' };
+  const point: EdgeEvent = { tag: 'boom', kind: 'point', status: 'point', t: 8, tCorrected: 8, seq: 1, clock: 'media', src: 'click' };
+
+  it('writes the anchor first, then codec-serialized rows, and drains to JSONL', () => {
+    const sink = new TagEventSink('statusEnum');
+    expect(sink.isEmpty).toBe(true);
+    sink.writeAnchor(anchor);
+    sink.append([open, point]);
+    expect(sink.count).toBe(3); // anchor + 2 rows
+    const out = sink.drain();
+    const lines = out.trim().split('\n').map((l) => JSON.parse(l));
+    expect(lines[0]).toMatchObject({ anchor: true, schema: 'thoremin.tags/1' });
+    expect(lines[1]).toMatchObject({ status: 'open', tag: 'pluck', t: 5 });
+    expect(lines[2]).toMatchObject({ status: 'point', tag: 'boom' });
+    expect(sink.drain()).toBe(''); // cleared
+  });
+
+  it('honors the pointPair codec (a point becomes two rows)', () => {
+    const sink = new TagEventSink('pointPair');
+    sink.append([point]);
+    expect(sink.count).toBe(2);
+    const rows = sink.drain().trim().split('\n').map((l) => JSON.parse(l));
+    expect(rows.map((r) => r.status)).toEqual(['open', 'close']);
+  });
+});
+
+describe('parseTagSet', () => {
+  it('heals a partial blob to a valid doc', () => {
+    const doc = parseTagSet({ id: 'x', tags: [{ id: 'a', label: 'A' }] });
+    expect(doc.tags[0]).toMatchObject({ id: 'a', kind: 'interval', number: null });
+    expect(doc.config.exclusivity).toBe('off');
+  });
+});
+
+describe('tag-set provider (zodal localStorage)', () => {
+  const KEY = 'taglog.test.tagsets';
+  const mk = (id: string, updatedAt: number) =>
+    TagSetDocSchema.parse({ id, name: id, tags: [{ id: 't1', label: 'T1' }], updatedAt });
+
+  it('persists tag sets and pre-seeds the most-recently-updated one', async () => {
+    localStorage.removeItem(KEY);
+    const provider = createTagSetProvider(KEY);
+    await saveTagSet(provider, mk('old', 100));
+    await saveTagSet(provider, mk('new', 200));
+    const last = await loadLastUsed(provider);
+    expect(last?.id).toBe('new');
+  });
+
+  it('saveTagSet upserts (update in place, no duplicate)', async () => {
+    localStorage.removeItem(KEY);
+    const provider = createTagSetProvider(KEY);
+    await saveTagSet(provider, mk('s', 100));
+    await saveTagSet(provider, { ...mk('s', 300), name: 'renamed' });
+    const { data, total } = await provider.getList({});
+    expect(total).toBe(1);
+    expect(data[0].name).toBe('renamed');
+  });
+
+  it('loadLastUsed returns null when nothing is saved', async () => {
+    localStorage.removeItem(KEY);
+    expect(await loadLastUsed(createTagSetProvider(KEY))).toBeNull();
+  });
+});

--- a/tsconfig.dag.json
+++ b/tsconfig.dag.json
@@ -7,5 +7,5 @@
     "noUnusedParameters": true,
     "types": ["node", "vitest/globals"]
   },
-  "include": ["src/dag", "src/nodes", "src/music", "src/features", "src/settings", "src/app/graph.ts", "src/app/lab", "test", "scripts"]
+  "include": ["src/dag", "src/nodes", "src/music", "src/features", "src/settings", "src/taglog", "src/app/graph.ts", "src/app/lab", "test", "scripts"]
 }


### PR DESCRIPTION
Closes #92. Full design: discussion #81.

## What this adds

A **tagging mode**: toggle a small set of tags on/off during a recording; each toggle appends a `(t, tag, status)` row to a `{stem}.tags.jsonl` written into the take folder on the **shared t0**, so it segments the recorded streams (video / audio / features) for analysis or ML training. `tags.jsonl` is "just another stream" per the recording-v2 doc (manifest `kind: "tags"`).

Acceptance (issue #92), all met:
- Tagging mode: pick + order tags (pre-seeded with last-used), choose exclusivity, per-tag kind + lead-in.
- Toggling writes `{stem}.tags.jsonl` into the active recording folder, time-aligned to features/audio/video.
- Interval + point tags; mutual-exclusivity; **1..9** keyboard toggles (`0` clears); lead-in + countdown; blinking open-tag buttons; **burned-in corner overlay**.
- Core logic is React/storage-free (extraction-ready).

## Structured to extract into a reusable zodal `taglog`

Strict dependency direction **presentation → affordances ← provider** (the one rule that makes extraction mechanical):

| Layer | Path | What |
|---|---|---|
| affordances (pure) | `src/taglog/affordances/` | Zod schemas (kind-on-def / status-on-event), toggle state machine (interval/point, BORIS-style mutual-exclusivity auto-close via `seq` ordering, lead-in), interval resolution, pluggable `EventCodec` (`statusEnum` default / `pointPair` / `kindField`) |
| adapters (pure) | `src/taglog/adapters/` | exporters to Audacity / WebVTT / CSV / Praat TextGrid / OTIO |
| provider | `src/taglog/provider/` | JSONL event sink + zodal localStorage tag-set persistence (last-used pre-seed) |
| presentation | `src/taglog/presentation/` | pure burned-in-overlay frame computation |

thoremin glue lives outside `src/taglog/` in `src/app/tagging/` (a dedicated zustand runtime store — **not** `src/app/store.ts`, no persist-version bump — the `TagStreamSource` recorder seam, a **modal** 1..9/0 keymap that is inert unless tagging mode is on, and the React button stack / countdown / setup sheet).

## Time alignment (the highest-stakes part, #81 §5)

One recording anchor `t0`; events stamped from the **absolute engine clock** (`performance.now()/1000` = `ctx.time`) — the SAME clock `features.jsonl` uses, so both streams share one frame by construction and the take offset is a uniform `t - t0` (the manifest SSOT rule). Self-describing anchor record (`t` = the origin), segmentation-time offset never baked into stored `t`, and the burned-in corner HUD (open tags + timecode + REC blink) as the in-band ground truth.

## Coordination with parallel tracks

- `canvas_overlay.ts`: the burned-in HUD is a purely-additive `tagHud` element in its own block; `fingerBars` stays the array's last element (z-order invariant intact) so a concurrent `OVERLAY_ELEMENTS` addition (#119 / #63) merges cleanly.
- `src/app/store.ts` untouched (Track D owns the persist bump).
- The 1..9 keys are modal (guarded by `isEditableTarget` + tagging-mode) so they can't shadow any future digit binding.

## Review + verification

Adversarially reviewed via a 6-dimension multi-agent workflow (core correctness, time-alignment, recording integration, hot-path/React, extraction architecture, adapters/provider); each finding was verified by two independent skeptics. 12 confirmed findings fixed, including: a **critical clock-frame mismatch** (tags were media-relative while features are absolute — now unified on the absolute clock), the lead-in degeneracy guard on open-ended intervals, a `formatTimecode` millisecond-carry bug, TextGrid `xmax` coverage, and label sanitization. The alignment fix was independently re-verified end-to-end (5 invariants confirmed).

Verify gate green: `npm run typecheck` · **561** vitest · `npm run build` · `npm run catalog`. New tests: `taglog_affordances`, `taglog_adapters`, `taglog_provider`, `taglog_presentation`, `tagging_store`, `tag_hud_overlay`, plus tags coverage in `recording_plan`.

https://claude.ai/code/session_013hVfBJBCVNo1zXQnXmA4aj