### PR TITLE
feat(scale): decouple chord-source scale (#75) + double-thumb octave-range slider (#63)

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -55,7 +55,7 @@ Reads the live UI control store → scale + sound + overlay port values.
 
 - **roles:** source, control
 - **in:** —
-- **out:** scaleRight:number[], scaleLeft:number[], soundRight:sound, soundLeft:sound, octaveShift:number, magnetism:number, mute:boolean, overlay:overlay-config, rightSpec:scale-spec, faceMapping:face-mapping, chordConfig:chord-config, expressionSensitivity:expression-sensitivity, expressionDegrees:expression-degrees
+- **out:** scaleRight:number[], scaleLeft:number[], soundRight:sound, soundLeft:sound, octaveShift:number, magnetism:number, mute:boolean, overlay:overlay-config, rightSpec:scale-spec, chordSpec:scale-spec, chordScale:number[], faceMapping:face-mapping, chordConfig:chord-config, expressionSensitivity:expression-sensitivity, expressionDegrees:expression-degrees
 - **params:** —
 
 #### `synthetic-hands` — Synthetic Hands
@@ -196,7 +196,7 @@ Roman-numeral progression in a key + position (0..1) → current chord symbol.
 - **params:** key (string="C"), romanNumerals (array=["I","IV","V","vi"])
 
 #### `expression-chord` — Expression Chord
-Facial expression → a voiced, rendered diatonic chord on the current seven-note scale (active only in face "chord" mode).
+Facial expression → a voiced, rendered diatonic chord on the chord-source scale (active only in face "chord" mode).
 
 - **roles:** music
 - **in:** expression:face-expression, spec:scale-spec, faceMapping:face-mapping, octaveShift:number, chordConfig:chord-config, degrees:expression-degrees
@@ -264,7 +264,7 @@ _Audio + the captured video with overlaid guides._
 Mirrored video + composable overlay elements (guides, landmarks, markers, cues).
 
 - **roles:** overlay
-- **in:** hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], chord:number[], faceFrame:face-frame, expression:face-expression, octaveShift:number, overlayConfig:overlay-config
+- **in:** hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], chordScale:number[], chord:number[], faceFrame:face-frame, expression:face-expression, octaveShift:number, overlayConfig:overlay-config
 - **out:** —
 - **params:** video (object={}), scaleGuide (object={}), chordGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={}), fingerLines (object={}), faceLandmarks (object={}), timbreLevels (object={}), faceExpression (object={}), fingerBars (object={}), chordName (object={}), keyboardStrip (object={})
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -161,9 +161,12 @@ tags are a read-only *view* of the same parametrization #82 formalizes.
   instruments. Fed by both #90 (a keymap is a partial) and #87 (a materialized
   instrument is a replayable command sequence).
 
-- **[#75] Decouple the chord-source scale from the melody scale** — *S–M.*
-  Removes the 7-note-scale friction that the chord/`controls` face modes have;
-  also sharpens the #89 chord overlays. Do opportunistically.
+- **[#75] Decouple the chord-source scale from the melody scale** — *✅ SHIPPED 2026-07-10.*
+  Chords are drawn from a decoupled chord-source scale (auto-derived from the melody, or
+  custom), so a pentatonic melody still gets chords and the 7-note-scale friction on the
+  chord/`controls` face modes is gone. Shipped alongside **[#63] the double-thumb octave-RANGE
+  slider** (1–3 octaves, locked middle) in the same PR (`faceChord.chordSource/chordRoot/
+  chordType`; per-voice `rangeLow/rangeHigh`; store persist v6).
 
 - **[#76] Head-pose follow-ups** — per-axis live-tuning UI, per-user calibration
   (the `*ZeroDeg` seam exists), and Phase 4 (demote the emotion classifier to

--- a/public/catalog.json
+++ b/public/catalog.json
@@ -28,6 +28,10 @@
         "kind": "number[]"
       },
       {
+        "name": "chordScale",
+        "kind": "number[]"
+      },
+      {
         "name": "chord",
         "kind": "number[]"
       },
@@ -189,7 +193,7 @@
   {
     "type": "expression-chord",
     "title": "Expression Chord",
-    "description": "Facial expression → a voiced, rendered diatonic chord on the current seven-note scale (active only in face \"chord\" mode).",
+    "description": "Facial expression → a voiced, rendered diatonic chord on the chord-source scale (active only in face \"chord\" mode).",
     "roles": [
       "music"
     ],
@@ -1091,6 +1095,14 @@
       {
         "name": "rightSpec",
         "kind": "scale-spec"
+      },
+      {
+        "name": "chordSpec",
+        "kind": "scale-spec"
+      },
+      {
+        "name": "chordScale",
+        "kind": "number[]"
       },
       {
         "name": "faceMapping",

--- a/public/manual.html
+++ b/public/manual.html
@@ -64,7 +64,7 @@
       <dl>
         <dt>roles</dt><dd>source, control</dd>
         <dt>in</dt><dd>—</dd>
-        <dt>out</dt><dd>scaleRight:number[], scaleLeft:number[], soundRight:sound, soundLeft:sound, octaveShift:number, magnetism:number, mute:boolean, overlay:overlay-config, rightSpec:scale-spec, faceMapping:face-mapping, chordConfig:chord-config, expressionSensitivity:expression-sensitivity, expressionDegrees:expression-degrees</dd>
+        <dt>out</dt><dd>scaleRight:number[], scaleLeft:number[], soundRight:sound, soundLeft:sound, octaveShift:number, magnetism:number, mute:boolean, overlay:overlay-config, rightSpec:scale-spec, chordSpec:scale-spec, chordScale:number[], faceMapping:face-mapping, chordConfig:chord-config, expressionSensitivity:expression-sensitivity, expressionDegrees:expression-degrees</dd>
         <dt>params</dt><dd>—</dd>
       </dl>
     </div>
@@ -233,7 +233,7 @@
     </div>
     <div class="node">
       <h4><code>expression-chord</code> <span class="title">Expression Chord</span></h4>
-      <p>Facial expression → a voiced, rendered diatonic chord on the current seven-note scale (active only in face "chord" mode).</p>
+      <p>Facial expression → a voiced, rendered diatonic chord on the chord-source scale (active only in face "chord" mode).</p>
       <dl>
         <dt>roles</dt><dd>music</dd>
         <dt>in</dt><dd>expression:face-expression, spec:scale-spec, faceMapping:face-mapping, octaveShift:number, chordConfig:chord-config, degrees:expression-degrees</dd>
@@ -309,7 +309,7 @@
       <p>Mirrored video + composable overlay elements (guides, landmarks, markers, cues).</p>
       <dl>
         <dt>roles</dt><dd>overlay</dd>
-        <dt>in</dt><dd>hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], chord:number[], faceFrame:face-frame, expression:face-expression, octaveShift:number, overlayConfig:overlay-config</dd>
+        <dt>in</dt><dd>hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], chordScale:number[], chord:number[], faceFrame:face-frame, expression:face-expression, octaveShift:number, overlayConfig:overlay-config</dd>
         <dt>out</dt><dd>—</dd>
         <dt>params</dt><dd>video (object={}), scaleGuide (object={}), chordGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={}), fingerLines (object={}), faceLandmarks (object={}), timbreLevels (object={}), faceExpression (object={}), fingerBars (object={}), chordName (object={}), keyboardStrip (object={})</dd>
       </dl>

--- a/src/app/dials/DialsControlsPanel.tsx
+++ b/src/app/dials/DialsControlsPanel.tsx
@@ -135,26 +135,34 @@ function VoiceControls({ side }: { side: 'right' | 'left' }) {
     for (const [k, val] of voiceEditWrites(side, key, value, syncHands, v)) set(k, val);
   };
 
-  // #63 octave RANGE thumbs. Derive from `octaves` when the range is absent (a legacy
-  // preset / instrument), so the control always reads sensibly; the first drag writes it.
+  // #63 octave RANGE thumbs. When the range is absent (a legacy pre-#63 voice), DERIVE
+  // both thumbs from the `octaves` span — distributed across the two thumbs so an octaves=3
+  // voice seats at the representable 3.0 (not capped to 2.0) — and show the TRUE audible
+  // span in the readout (`octaves` itself), which for a legacy octaves=4 voice honestly
+  // exceeds the slider's 3-octave max. The first drag then adopts the range representation.
   const octaves = v[`${side}.octaves`] as number;
   const rawLow = v[`${side}.rangeLow`];
   const rawHigh = v[`${side}.rangeHigh`];
-  const rangeLow = typeof rawLow === 'number' ? rawLow : 0;
-  const rangeHigh = typeof rawHigh === 'number' ? rawHigh : Math.min(1, Math.max(0, octaves - 1));
-  const rangeSpan = 1 + rangeLow + rangeHigh;
+  const rangeAbsent = typeof rawLow !== 'number' || typeof rawHigh !== 'number';
+  const derivedHigh = Math.min(1, Math.max(0, octaves - 1));
+  const derivedLow = Math.min(1, Math.max(0, octaves - 1 - derivedHigh));
+  const rangeLow = rangeAbsent ? derivedLow : (rawLow as number);
+  const rangeHigh = rangeAbsent ? derivedHigh : (rawHigh as number);
+  const rangeSpan = rangeAbsent ? octaves : 1 + rangeLow + rangeHigh;
 
   const setRange = (nextLow: number, nextHigh: number) => {
-    // Atomic multi-field edit: write both range thumbs AND keep `octaves` a truthful
-    // integer shadow (round(1+low+high)) so no reader sees the two contradict. Mirror to
-    // both hands when synced (like voiceEditWrites does for single fields).
+    // Keep `octaves` a truthful integer shadow (round(1+low+high)) so no reader sees the
+    // two contradict. Re-snap the WHOLE non-sound voice across synced hands via the SSOT
+    // (voiceEditWrites) — so a range edit re-converges diverged hands like every other
+    // voice edit — then override the two range thumbs with the new values (applied last).
     const oct = Math.max(1, Math.min(4, Math.round(1 + nextLow + nextHigh)));
-    const targets = syncHands ? (['right', 'left'] as const) : ([side] as const);
-    for (const t of targets) {
-      set(`${t}.rangeLow`, nextLow);
-      set(`${t}.rangeHigh`, nextHigh);
-      set(`${t}.octaves`, oct);
+    const writes = voiceEditWrites(side, 'octaves', oct, syncHands, v);
+    writes.push([`${side}.rangeLow`, nextLow], [`${side}.rangeHigh`, nextHigh]);
+    if (syncHands) {
+      const other = side === 'right' ? 'left' : 'right';
+      writes.push([`${other}.rangeLow`, nextLow], [`${other}.rangeHigh`, nextHigh]);
     }
+    for (const [k, val] of writes) set(k, val);
   };
 
   return (
@@ -417,7 +425,18 @@ function ChordSourceControls() {
         <select
           className={selectCls}
           value={source}
-          onChange={(e) => set('faceChord.chordSource', e.target.value)}
+          onChange={(e) => {
+            const next = e.target.value as 'auto' | 'custom';
+            // On auto→custom, seed the custom root/type from the currently-sounding auto
+            // source, so switching to Custom is INAUDIBLE until the user deliberately edits
+            // it (otherwise chordRoot/chordType keep their C-major defaults and a non-C
+            // melody's chords would jump into the wrong key on the mere mode flip).
+            if (next === 'custom' && source !== 'custom') {
+              set('faceChord.chordRoot', auto.root);
+              set('faceChord.chordType', auto.type);
+            }
+            set('faceChord.chordSource', next);
+          }}
         >
           <option value="auto">Auto (follow melody)</option>
           <option value="custom">Custom</option>

--- a/src/app/dials/DialsControlsPanel.tsx
+++ b/src/app/dials/DialsControlsPanel.tsx
@@ -135,6 +135,28 @@ function VoiceControls({ side }: { side: 'right' | 'left' }) {
     for (const [k, val] of voiceEditWrites(side, key, value, syncHands, v)) set(k, val);
   };
 
+  // #63 octave RANGE thumbs. Derive from `octaves` when the range is absent (a legacy
+  // preset / instrument), so the control always reads sensibly; the first drag writes it.
+  const octaves = v[`${side}.octaves`] as number;
+  const rawLow = v[`${side}.rangeLow`];
+  const rawHigh = v[`${side}.rangeHigh`];
+  const rangeLow = typeof rawLow === 'number' ? rawLow : 0;
+  const rangeHigh = typeof rawHigh === 'number' ? rawHigh : Math.min(1, Math.max(0, octaves - 1));
+  const rangeSpan = 1 + rangeLow + rangeHigh;
+
+  const setRange = (nextLow: number, nextHigh: number) => {
+    // Atomic multi-field edit: write both range thumbs AND keep `octaves` a truthful
+    // integer shadow (round(1+low+high)) so no reader sees the two contradict. Mirror to
+    // both hands when synced (like voiceEditWrites does for single fields).
+    const oct = Math.max(1, Math.min(4, Math.round(1 + nextLow + nextHigh)));
+    const targets = syncHands ? (['right', 'left'] as const) : ([side] as const);
+    for (const t of targets) {
+      set(`${t}.rangeLow`, nextLow);
+      set(`${t}.rangeHigh`, nextHigh);
+      set(`${t}.octaves`, oct);
+    }
+  };
+
   return (
     <div className="space-y-2">
       <h3 className={`text-[11px] font-bold uppercase tracking-widest ${color}`}>{side} hand</h3>
@@ -174,13 +196,33 @@ function VoiceControls({ side }: { side: 'right' | 'left' }) {
           ))}
         </select>
       </label>
-      <label className="flex items-center justify-between gap-2 text-xs">
-        Octaves
-        <input
-          type="range" min={1} max={4} step={1} value={v[`${side}.octaves`] as number}
-          onChange={(e) => setField('octaves', Number(e.target.value))}
-        />
-      </label>
+      {/* #63 octave RANGE — a "double-thumb" span around an always-covered middle octave.
+          Two stacked native sliders (down/up extension) keep it touch-friendly and dependency-
+          free: the ↓ thumb extends up to a full octave below the middle, the ↑ thumb up to a
+          full octave above, so the span is a continuous 1..3 octaves that always includes the
+          middle. Overlay guides + the audible range update live from the regenerated scale. */}
+      <div className="space-y-1">
+        <div className="flex items-center justify-between text-xs">
+          <span>Range</span>
+          <span className="text-[10px] text-white/50">{rangeSpan.toFixed(1)} oct</span>
+        </div>
+        <label className="flex items-center gap-2 text-[10px] text-white/50" title="Extend the range below the middle octave">
+          <span className="w-4 shrink-0 text-center" aria-hidden>↓</span>
+          <input
+            type="range" min={0} max={1} step={0.01} value={rangeLow} className="flex-1"
+            aria-label={`${side} hand range below middle octave`}
+            onChange={(e) => setRange(Number(e.target.value), rangeHigh)}
+          />
+        </label>
+        <label className="flex items-center gap-2 text-[10px] text-white/50" title="Extend the range above the middle octave">
+          <span className="w-4 shrink-0 text-center" aria-hidden>↑</span>
+          <input
+            type="range" min={0} max={1} step={0.01} value={rangeHigh} className="flex-1"
+            aria-label={`${side} hand range above middle octave`}
+            onChange={(e) => setRange(rangeLow, Number(e.target.value))}
+          />
+        </label>
+      </div>
       <label className="flex items-center justify-between gap-2 text-xs">
         Base octave
         <input

--- a/src/app/dials/DialsControlsPanel.tsx
+++ b/src/app/dials/DialsControlsPanel.tsx
@@ -20,7 +20,14 @@
  * collapsible translucent overlay so the video stays the focus.
  */
 import { useState, type ReactNode } from 'react';
-import { NOTES, SCALE_TYPES, isSevenNoteScale, diatonicTriad, type ScaleTypeId } from '@/music/theory';
+import {
+  NOTES,
+  SCALE_TYPES,
+  diatonicTriad,
+  defaultChordSpecFor,
+  melodyNotesOutsideChord,
+  type ScaleTypeId,
+} from '@/music/theory';
 import { SOUNDS, SOUND_IDS } from '@/music/sounds';
 import { VOICINGS, RENDERINGS, isTempoRendering, voiceTriad, type VoicingId, type RenderingId } from '@/music/voicing';
 import { EXPRESSIONS, EMOTIONS, DEFAULT_EXPRESSION_TO_DEGREE, SILENCE_DEGREE } from '@/music/expression';
@@ -278,14 +285,10 @@ const FACE_MODE_OPTIONS: { value: FaceMapping; label: string }[] = [
 const FACE_MODE_HINT: Record<FaceMapping, string> = {
   none: 'No face detection. Pick a mode to map your expression to sound. Uses the same camera as hand tracking; loads a small face model on first use.',
   timbre: 'Smile → brighter tone, open mouth → vibrato — shaping the notes your hands play.',
-  chord: "Your expression plays a diatonic triad on the right hand's scale (needs a 7-note scale).",
+  chord: 'Your expression plays a chord from the chord-source scale (Chord sound → Chord scale). Works with any melody scale — pentatonic included.',
   controls:
-    "Deliberate head/face moves play chords — turn to pick the chord, open your mouth to sound it (needs a 7-note scale). The easy, controllable alternative to emotion mode.",
+    'Deliberate head/face moves play chords — turn to pick the chord, open your mouth to sound it. The easy, controllable alternative to emotion mode.',
 };
-
-/** Modes whose chord needs a seven-note scale (a diatonic triad is otherwise
- *  undefined): emotion `chord` and head-pose `controls`. */
-const needsSevenNote = (m: FaceMapping): boolean => m === 'chord' || m === 'controls';
 
 /** Live face-model status + detected expression, driven by the engine (#65). The
  *  classified emotion `label` is shown only when it actually drives the sound — in
@@ -345,6 +348,85 @@ const RENDERING_LABELS: Record<RenderingId, string> = {
   pulse: 'Pulse',
   alberti: 'Alberti',
 };
+
+/**
+ * The chord-source scale picker (#75): WHERE the face/pose chords are drawn from,
+ * decoupled from the right-hand melody scale. 'Auto' follows the melody (a smart
+ * default that makes pentatonic-melody + chords "just work" with zero config);
+ * 'Custom' pins any scale as the source, with a non-blocking warning naming the
+ * melody notes that fall outside the chosen source (they may clash — still allowed).
+ */
+function ChordSourceControls() {
+  const { state, set } = useDialsSettings();
+  const v = state.effective;
+  const melody = { root: v['right.root'] as number, type: v['right.type'] as ScaleTypeId };
+  const source = v['faceChord.chordSource'] as 'auto' | 'custom';
+  const chordRoot = v['faceChord.chordRoot'] as number;
+  const chordType = v['faceChord.chordType'] as ScaleTypeId;
+  const auto = defaultChordSpecFor(melody);
+  // The warning is authoritative on the subset test and only meaningful for a CUSTOM
+  // source — 'auto' is by construction the recommended embedding, so it never warns.
+  const outside = source === 'custom' ? melodyNotesOutsideChord(melody, { root: chordRoot, type: chordType }) : [];
+
+  return (
+    <div className="space-y-2 border-t border-white/10 pt-2">
+      <label className="flex items-center justify-between gap-2 text-xs">
+        Chord scale
+        <select
+          className={selectCls}
+          value={source}
+          onChange={(e) => set('faceChord.chordSource', e.target.value)}
+        >
+          <option value="auto">Auto (follow melody)</option>
+          <option value="custom">Custom</option>
+        </select>
+      </label>
+      {source === 'auto' ? (
+        <p className="text-[10px] leading-relaxed text-white/40">
+          Chords are drawn from{' '}
+          <span className="text-white/70">
+            {NOTES[auto.root]} {SCALE_TYPES[auto.type].name}
+          </span>
+          , matched to your melody scale.
+        </p>
+      ) : (
+        <>
+          <label className="flex items-center justify-between gap-2 text-xs">
+            Chord root
+            <select
+              className={selectCls}
+              value={chordRoot}
+              onChange={(e) => set('faceChord.chordRoot', Number(e.target.value))}
+            >
+              {NOTES.map((n, i) => (
+                <option key={n} value={i}>{n}</option>
+              ))}
+            </select>
+          </label>
+          <label className="flex items-center justify-between gap-2 text-xs">
+            Chord scale type
+            <select
+              className={selectCls}
+              value={chordType}
+              onChange={(e) => set('faceChord.chordType', e.target.value as ScaleTypeId)}
+            >
+              {Object.entries(SCALE_TYPES).map(([id, s]) => (
+                <option key={id} value={id}>{s.name}</option>
+              ))}
+            </select>
+          </label>
+          {outside.length > 0 && (
+            <p className="text-[10px] leading-relaxed text-amber-300/80">
+              Heads up: {outside.join(', ')} {outside.length === 1 ? 'is' : 'are'} in your melody but
+              not the chord scale — chords may clash with the melody. This is allowed; pick a chord
+              scale that contains your melody for a "safe" fit.
+            </p>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
 
 /** Sound settings for the face chord — shown when chord mapping is active. */
 function ChordControls() {
@@ -412,6 +494,7 @@ function ChordControls() {
           pad blurs fast arpeggios into a wash.
         </p>
       )}
+      <ChordSourceControls />
     </div>
   );
 }
@@ -439,12 +522,20 @@ function ExpressionMapping({ chordMode }: { chordMode: boolean }) {
     set('faceExpr.sensitivity', { ...sensitivity, [label]: value });
   const voicing = v['faceChord.voicing'] as VoicingId;
 
+  // Build the preview chords from the resolved CHORD-SOURCE scale (#75), so the notes
+  // shown match what actually sounds — not the melody scale.
+  const chordSource = v['faceChord.chordSource'] as 'auto' | 'custom';
+  const resolved =
+    chordSource === 'custom'
+      ? { root: v['faceChord.chordRoot'] as number, type: v['faceChord.chordType'] as ScaleTypeId }
+      : defaultChordSpecFor({ root: v['right.root'] as number, type: v['right.type'] as ScaleTypeId });
+
   const chordMidi = (degree: number): number[] => {
     if (degree < 0) return []; // SILENCE_DEGREE → no chord
     const triad = diatonicTriad(
       {
-        root: v['right.root'] as number,
-        type: v['right.type'] as ScaleTypeId,
+        root: resolved.root,
+        type: resolved.type,
         octaves: v['right.octaves'] as number,
         baseOctave: v['right.baseOctave'] as number,
       },
@@ -545,11 +636,7 @@ function ExpressionMapping({ chordMode }: { chordMode: boolean }) {
               </div>
               {chordMode && (
                 <div className="pl-16 font-mono text-[10px] text-white/40">
-                  {degree < 0
-                    ? 'silence (no chord)'
-                    : midi.length
-                      ? midi.join(' ')
-                      : '— (needs a 7-note scale)'}
+                  {degree < 0 ? 'silence (no chord)' : midi.length ? midi.join(' ') : '—'}
                 </div>
               )}
             </div>
@@ -561,10 +648,9 @@ function ExpressionMapping({ chordMode }: { chordMode: boolean }) {
 }
 
 function FaceControls() {
-  const { state, set } = useDialsSettings();
+  const { state } = useDialsSettings();
   const v = state.effective;
   const faceMapping = v['face.mapping'] as FaceMapping;
-  const sevenNote = isSevenNoteScale(v['right.type'] as ScaleTypeId);
 
   return (
     <div className="space-y-2">
@@ -575,11 +661,10 @@ function FaceControls() {
           value={faceMapping}
           onChange={(e) => dispatchDialSet('face.mapping', e.target.value as FaceMapping)}
         >
+          {/* Every mode is selectable on any melody scale (#75): chord/controls modes
+              draw from a decoupled chord-source scale, so no 7-note requirement remains. */}
           {FACE_MODE_OPTIONS.map((o) => (
-            <option key={o.value} value={o.value} disabled={needsSevenNote(o.value) && !sevenNote}>
-              {o.label}
-              {needsSevenNote(o.value) && !sevenNote ? ' (needs 7-note scale)' : ''}
-            </option>
+            <option key={o.value} value={o.value}>{o.label}</option>
           ))}
         </select>
       </label>
@@ -588,11 +673,6 @@ function FaceControls() {
         {/* Emotion how-to help is for the expression modes; pose mode has its own moves list. */}
         {faceMapping !== 'none' && faceMapping !== 'controls' && <ExpressionHelpButton />}
       </div>
-      {needsSevenNote(faceMapping) && !sevenNote && (
-        <p className="text-[10px] leading-relaxed text-amber-300/80">
-          This mode needs a 7-note scale (Major / Natural Minor / Harmonic Minor) on the right hand.
-        </p>
-      )}
       <p className="text-[10px] leading-relaxed text-white/40">{FACE_MODE_HINT[faceMapping]}</p>
       {faceMapping === 'controls' && <PoseMovesHelp />}
       {/* Both chord instruments (emotion + pose) share the same sound settings. */}

--- a/src/app/dials/settingsStore.ts
+++ b/src/app/dials/settingsStore.ts
@@ -63,11 +63,12 @@ export const setDial = (key: SettingKey, value: unknown): void => dialsStore.set
 export const resetDial = (key: SettingKey): void => dialsStore.reset(key);
 
 /** The voice fields mirrored between hands when synced. `sound` is never mirrored —
- *  each hand keeps its own timbre. */
-const MIRRORED_VOICE_FIELDS = ['root', 'type', 'octaves', 'baseOctave'] as const;
+ *  each hand keeps its own timbre. Includes the #63 octave-range fields, so the
+ *  double-thumb slider mirrors across hands like octaves/baseOctave do. */
+const MIRRORED_VOICE_FIELDS = ['root', 'type', 'octaves', 'baseOctave', 'rangeLow', 'rangeHigh'] as const;
 
 /** A field of one voice (the addressable keys under `right.` / `left.`). */
-export type VoiceField = 'root' | 'type' | 'octaves' | 'baseOctave' | 'sound';
+export type VoiceField = 'root' | 'type' | 'octaves' | 'baseOctave' | 'sound' | 'rangeLow' | 'rangeHigh';
 
 /**
  * The dials-layer writes for one voice edit, reproducing the hot store's `setVoice`

--- a/src/app/graph.ts
+++ b/src/app/graph.ts
@@ -152,7 +152,10 @@ export function defaultGraph(selection?: SlotSelection, registry?: NodeRegistry)
       // Live per-emotion sensitivities steer the classifier's thresholds.
       { from: { node: 'ui', port: 'expressionSensitivity' }, to: { node: 'faceExpr', port: 'sensitivity' } },
       { from: { node: 'faceExpr', port: 'expression' }, to: { node: 'exprChord', port: 'expression' } },
-      { from: { node: 'ui', port: 'rightSpec' }, to: { node: 'exprChord', port: 'spec' } },
+      // #75: the chord node reads the decoupled CHORD-SOURCE spec (auto-derived from
+      // the melody, or a custom scale), NOT the melody scale — so a pentatonic melody
+      // still gets chords from a sensible (seven-note) source by default.
+      { from: { node: 'ui', port: 'chordSpec' }, to: { node: 'exprChord', port: 'spec' } },
       // Live per-expression scale-degree map (which triad each expression plays).
       { from: { node: 'ui', port: 'expressionDegrees' }, to: { node: 'exprChord', port: 'degrees' } },
       { from: { node: 'ui', port: 'faceMapping' }, to: { node: 'exprChord', port: 'faceMapping' } },
@@ -165,7 +168,9 @@ export function defaultGraph(selection?: SlotSelection, registry?: NodeRegistry)
       // voices unless the mode is 'controls', so the merge is unaffected otherwise.
       { from: { node: 'camFace', port: 'face' }, to: { node: 'faceCtrl', port: 'face' } },
       { from: { node: 'faceCtrl', port: 'controls' }, to: { node: 'poseChord', port: 'controls' } },
-      { from: { node: 'ui', port: 'rightSpec' }, to: { node: 'poseChord', port: 'spec' } },
+      // #75: pose chords also read the decoupled chord-source spec (unblocks pose mode
+      // on a non-seven-note melody, exactly like the emotion chord).
+      { from: { node: 'ui', port: 'chordSpec' }, to: { node: 'poseChord', port: 'spec' } },
       { from: { node: 'ui', port: 'faceMapping' }, to: { node: 'poseChord', port: 'faceMapping' } },
       // Reuse the same live chord settings (sound / volume / voicing / rendering / tempo).
       { from: { node: 'ui', port: 'chordConfig' }, to: { node: 'poseChord', port: 'chordConfig' } },
@@ -200,6 +205,9 @@ export function defaultGraph(selection?: SlotSelection, registry?: NodeRegistry)
       { from: { node: 'ui', port: 'scaleRight' }, to: { node: 'overlay', port: 'scale' } },
       { from: { node: 'ui', port: 'scaleLeft' }, to: { node: 'overlay', port: 'scaleLeft' } },
       { from: { node: 'ui', port: 'octaveShift' }, to: { node: 'overlay', port: 'octaveShift' } },
+      // The chord-SOURCE scale (#75), so the overlay names/analyzes the sounding chord
+      // against the scale it was actually built from, not the melody scale.
+      { from: { node: 'ui', port: 'chordScale' }, to: { node: 'overlay', port: 'chordScale' } },
       // Whichever chord instrument is sounding (emotion triad OR pose chord), so the
       // overlay highlights the active chord's tones on the pitch guide in both modes.
       { from: { node: 'exprChord', port: 'triad' }, to: { node: 'chordSel', port: 'a' } },

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -342,12 +342,19 @@ export const useControls = create<ControlState>()(
     }),
     {
       name: 'thoremin-controls',
+      // Version 6: #75 (decoupled chord-source scale — faceChord.chordSource/chordRoot/
+      // chordType) + #63 (per-voice octave RANGE — right/left.rangeLow/rangeHigh). Both are
+      // ADDITIVE with defaults, so no data transform is needed: mergeControls re-parses
+      // faceChord through FaceChordSchema (filling chordSource='auto' etc. for returning
+      // users → identical sound on their seven-note melodies), and the range fields are
+      // optional (absent → the legacy `octaves` scale path, byte-identical). The bump is the
+      // version marker for the schema growth.
       // Version 5: the abstention retune — deliver the raised fearful/disgusted
       // sensitivity default (0.5 → 0.7) to a returning player who never customized it.
       // v4: added the `handMap`. v3: `instrument` → `sound` rename. v2: the face-mapping
       // chooser (#64). See migrateControls (field renames/bumps) and mergeControls (heals
       // stale nested `overlay`/`faceChord`/`faceExpr`/`handMap` + clamps `faceMapping`).
-      version: 5,
+      version: 6,
       migrate: migrateControls,
       merge: mergeControls,
       storage: createJSONStorage(controlsStorage),

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -48,6 +48,13 @@ export interface VoiceControl {
   octaves: number;
   baseOctave: number;
   sound: VoiceParams['sound'];
+  /** #63 octave RANGE — fractional octaves below/above the locked middle octave
+   *  (`baseOctave`), each 0..1, so the playable span is 1..3 octaves. Present on new/
+   *  edited voices (the double-thumb slider writes them, and keeps `octaves` synced as
+   *  their integer shadow); absent on a returning pre-#63 voice → the legacy `octaves`
+   *  scale path (identical sound). See {@link generateScale}. */
+  rangeLow?: number;
+  rangeHigh?: number;
 }
 
 export interface ControlState {
@@ -140,6 +147,10 @@ const defaultVoice = (sound: VoiceParams['sound']): VoiceControl => ({
   octaves: 2,
   baseOctave: 3,
   sound,
+  // #63: the middle octave plus a full octave above (== octaves: 2, today's default),
+  // so a fresh install sounds identical while using the range representation.
+  rangeLow: 0,
+  rangeHigh: 1,
 });
 
 /** The overlay element defaults (all on except the opt-in index-finger guide). */

--- a/src/music/theory.ts
+++ b/src/music/theory.ts
@@ -241,45 +241,125 @@ export function isSevenNoteScale(type: ScaleTypeId): boolean {
 }
 
 /**
- * The diatonic triad rooted on scale `degree` (0 = tonic .. 6 = leading tone) of
- * a seven-note scale, as three ascending MIDI notes. The triad is built by
- * stacking scale-thirds — degrees `degree`, `degree + 2`, `degree + 4` — within
- * the scale's own interval set, so it yields the correct chord quality for *any*
- * seven-note scale (major I/ii/iii…, harmonic-minor's augmented III and
- * diminished ii°, etc.) without naming the chord. Degrees that step past the
+ * The chord rooted on scale `degree` (0 = tonic) of a scale, as three ascending
+ * MIDI notes, built by stacking scale-thirds — degrees `degree`, `degree + 2`,
+ * `degree + 4` — within the scale's own interval set. On a seven-note scale this
+ * is the classic diatonic triad (major I/ii/iii…, harmonic-minor's augmented III
+ * and diminished ii°, etc.); on a non-seven-note scale it generalizes to that
+ * scale's own step-set (see {@link diatonicChord}) — e.g. a pentatonic source
+ * yields a musical, non-tertian stacked sonority. Degrees that step past the
  * octave wrap up by 12 semitones, keeping the triad ascending.
  *
- * Returns `[]` for non-seven-note scales (see {@link isSevenNoteScale}) so callers
- * degrade gracefully (no chord) rather than indexing out of range. A NEGATIVE
- * degree (the silence sentinel) also returns `[]`, so the sentinel is self-enforcing
- * — a caller that forgets to gate it gets silence, not a wrong (wrapped) chord.
+ * A NEGATIVE degree (the silence sentinel) returns `[]`, so the sentinel is
+ * self-enforcing — a caller that forgets to gate it gets silence, not a wrong
+ * (wrapped) chord.
  */
 export function diatonicTriad(spec: ScaleSpec, degree: number): number[] {
   return diatonicChord(spec, degree, 3);
 }
 
 /**
- * A diatonic chord rooted on scale `degree` of a seven-note scale, built by
- * stacking `size` scale-thirds — degrees `degree`, `degree+2`, … — within the
- * scale's own interval set, as ascending MIDI notes. `size = 3` is the triad
- * ({@link diatonicTriad}); `size = 4` adds the diatonic seventh (`[0,2,4,6]`),
- * used by the head-pose instrument's brow "add-7th" modifier (#76). Degrees that
- * step past the octave wrap up by 12 semitones, keeping the chord ascending.
+ * A chord rooted on scale `degree`, built by stacking `size` scale-thirds —
+ * degrees `degree`, `degree+2`, … — within the scale's own interval set, as
+ * ascending MIDI notes. `size = 3` is the triad ({@link diatonicTriad}); `size = 4`
+ * adds the diatonic seventh (`[0,2,4,6]`), used by the head-pose instrument's brow
+ * "add-7th" modifier (#76).
  *
- * Returns `[]` for non-seven-note scales (see {@link isSevenNoteScale}), a
- * negative degree (the silence sentinel), or a non-positive `size`, so callers
- * degrade gracefully to no chord rather than indexing out of range.
+ * Generalized over the scale's own length `L = intervals.length` (#75): a
+ * seven-note scale is byte-identical to the classic diatonic chord; a shorter
+ * scale (pentatonic L=5, blues L=6) stacks *its* thirds — the chord-source scale
+ * need no longer match the melody scale, so a pentatonic melody can still get
+ * chords (from a seven-note chord source by default) and arbitrary chord-source
+ * scales are allowed (yielding non-traditional but musical sonorities). Degrees
+ * are taken `mod L` and steps past the top octave wrap up by 12 semitones, keeping
+ * the chord ascending.
+ *
+ * Returns `[]` for a negative degree (the silence sentinel) or a non-positive
+ * `size`, so callers degrade gracefully to no chord rather than indexing out of
+ * range.
  */
 export function diatonicChord(spec: ScaleSpec, degree: number, size = 3): number[] {
   if (degree < 0 || size < 1) return [];
   const intervals = SCALE_TYPES[spec.type].intervals;
-  if (intervals.length !== 7) return [];
+  const L = intervals.length;
   const baseNote = (spec.baseOctave + 1) * 12 + spec.root;
-  const d = ((degree % 7) + 7) % 7;
+  const d = ((degree % L) + L) % L;
   return Array.from({ length: size }, (_, i) => {
     const idx = d + 2 * i;
-    return baseNote + intervals[idx % 7] + 12 * Math.floor(idx / 7);
+    return baseNote + intervals[idx % L] + 12 * Math.floor(idx / L);
   });
+}
+
+/**
+ * The default chord-source scale for a melody scale (#75): the melody scale is a
+ * smart *default* for where the face/pose chords are drawn from, decoupled from
+ * what the right hand plays. Seven-note melodies keep today's behaviour exactly
+ * (chord source = melody scale). Non-seven-note melodies map to the nearest
+ * diatonic embedding by root, so "pentatonic melody + chords" just works with zero
+ * configuration:
+ *  - Major Pentatonic @R → Major @R (C-maj-pent {C,D,E,G,A} ⊂ C major).
+ *  - Minor Pentatonic @R → Natural Minor @R (A-min-pent {A,C,D,E,G} ⊂ A minor;
+ *    same-root so the tonic/"home chord" matches the player's mental root).
+ *  - Blues @R → Natural Minor @R (blues is a minor-pentatonic + ♭5).
+ *  - Chromatic @R → Major @R (chromatic has no home; give plain tertian triads).
+ * The result is a subset-coherent embedding for the pentatonics; blues/chromatic
+ * carry expected blue-note/chromatic tension (so the "auto" default never triggers
+ * the custom-source clash warning). Pure — unit-tested next to {@link isSevenNoteScale}.
+ */
+export function defaultChordSpecFor(melody: Pick<ScaleSpec, 'root' | 'type'>): {
+  root: number;
+  type: ScaleTypeId;
+} {
+  const { root, type } = melody;
+  if (isSevenNoteScale(type)) return { root, type };
+  switch (type) {
+    case 'minorPentatonic':
+    case 'blues':
+      return { root, type: 'minor' };
+    case 'pentatonic':
+    case 'chromatic':
+    default:
+      return { root, type: 'major' };
+  }
+}
+
+/** The distinct pitch classes (0..11) a scale sounds — its root plus intervals, mod 12. */
+export function scalePitchClasses(root: number, type: ScaleTypeId): Set<number> {
+  return new Set(SCALE_TYPES[type].intervals.map((iv) => ((((root + iv) % 12) + 12) % 12)));
+}
+
+/**
+ * Whether a melody scale "lives inside" a chord-source scale — every melody pitch
+ * class is also a chord-scale pitch class (`pcset(melody) ⊆ pcset(chord)`). This is
+ * the musically-correct coherence condition (#75): when true, every note the hand
+ * can play is harmonized by the chord scale, so the two never clash. Drives the
+ * non-blocking custom-chord-source warning (the subset test is authoritative; the
+ * explanatory detail is {@link melodyNotesOutsideChord}, NOT a union-size count —
+ * the two heuristics disagree in both directions, so only subset is used).
+ */
+export function scaleIsSubset(
+  melody: Pick<ScaleSpec, 'root' | 'type'>,
+  chord: Pick<ScaleSpec, 'root' | 'type'>,
+): boolean {
+  const c = scalePitchClasses(chord.root, chord.type);
+  for (const pc of scalePitchClasses(melody.root, melody.type)) if (!c.has(pc)) return false;
+  return true;
+}
+
+/** The note names of the melody's pitch classes that fall OUTSIDE the chord-source
+ *  scale (ascending) — the concrete, always-subset-consistent explanation for the
+ *  custom-chord-source clash warning (e.g. `['F#']` → "F# is not in the chord scale").
+ *  Empty when {@link scaleIsSubset} holds. */
+export function melodyNotesOutsideChord(
+  melody: Pick<ScaleSpec, 'root' | 'type'>,
+  chord: Pick<ScaleSpec, 'root' | 'type'>,
+): string[] {
+  const c = scalePitchClasses(chord.root, chord.type);
+  const out: string[] = [];
+  for (const pc of [...scalePitchClasses(melody.root, melody.type)].sort((a, b) => a - b)) {
+    if (!c.has(pc)) out.push(NOTES[pc]);
+  }
+  return out;
 }
 
 /**

--- a/src/music/theory.ts
+++ b/src/music/theory.ts
@@ -203,10 +203,22 @@ export interface ScaleSpec {
   /** Pitch class of the root, 0 = C ... 11 = B. */
   root: number;
   type: ScaleTypeId;
-  /** Number of octaves the playable range spans. */
+  /** Number of octaves the playable range spans (the LEGACY span control; used by
+   *  {@link generateScale} only when the range fields below are absent). */
   octaves: number;
-  /** Octave of the lowest note (MIDI octave; 3 is a comfortable mid range). */
+  /** Octave of the lowest note (MIDI octave; 3 is a comfortable mid range). Also the
+   *  floor of the always-covered "middle octave" for the range model (#63). */
   baseOctave: number;
+  /**
+   * #63 octave RANGE (a "double-thumb" span around a locked middle octave). When BOTH
+   * `rangeLow` and `rangeHigh` are set, {@link generateScale} spans
+   * `[baseNote − rangeLow·12, (baseNote + 12) + rangeHigh·12]` — the middle octave
+   * `[baseNote, baseNote+12]` is always covered and the total span is 1..3 octaves.
+   * Each is a fractional octave in `[0,1]`. When EITHER is absent, generation falls
+   * back to the legacy `octaves` path (byte-identical), so pre-#63 specs are unchanged.
+   */
+  rangeLow?: number;
+  rangeHigh?: number;
 }
 
 export const DEFAULT_SCALE: ScaleSpec = {
@@ -220,11 +232,38 @@ export const DEFAULT_SCALE: ScaleSpec = {
  * Build the ascending list of MIDI notes for a scale spec, inclusive of the
  * octave-completing top note. e.g. C major, 2 octaves, base octave 3 ->
  * [48, 50, 52, 53, 55, 57, 59, 60, ... 72].
+ *
+ * Two spans (#63): when `rangeLow`/`rangeHigh` are set, the scale covers a locked
+ * MIDDLE octave `[baseNote, baseNote+12]` extended `rangeLow` octaves down and
+ * `rangeHigh` octaves up (each a fractional octave in `[0,1]` → a 1..3 octave span
+ * that always includes the middle). Otherwise it uses the legacy `octaves` span
+ * (byte-identical to before #63). A wider range simply lengthens the note array's
+ * span; the continuous pitch mapper ({@link magneticPitch}) glides across it.
  */
 export function generateScale(spec: ScaleSpec): number[] {
-  const { type, octaves, baseOctave, root } = spec;
+  const { type, baseOctave, root, rangeLow, rangeHigh } = spec;
   const intervals = SCALE_TYPES[type].intervals;
-  const baseNote = (baseOctave + 1) * 12 + root;
+  const baseNote = (baseOctave + 1) * 12 + root; // the root at the middle octave's floor
+
+  if (typeof rangeLow === 'number' && typeof rangeHigh === 'number') {
+    const EPS = 1e-9;
+    const lo = baseNote - Math.max(0, rangeLow) * 12;
+    const hi = baseNote + 12 + Math.max(0, rangeHigh) * 12;
+    const scale: number[] = [baseNote, baseNote + 12]; // the middle octave is always covered
+    const kMin = Math.floor((lo - baseNote) / 12) - 1;
+    const kMax = Math.ceil((hi - baseNote) / 12) + 1;
+    for (let k = kMin; k <= kMax; k++) {
+      for (const interval of intervals) {
+        const n = baseNote + k * 12 + interval;
+        if (n >= lo - EPS && n <= hi + EPS) scale.push(n);
+      }
+      const octaveTop = baseNote + (k + 1) * 12; // octave-completing root
+      if (octaveTop >= lo - EPS && octaveTop <= hi + EPS) scale.push(octaveTop);
+    }
+    return [...new Set(scale)].sort((a, b) => a - b);
+  }
+
+  const { octaves } = spec;
   const scale: number[] = [];
   for (let o = 0; o < octaves; o++) {
     for (const interval of intervals) scale.push(baseNote + o * 12 + interval);

--- a/src/music/voicing.ts
+++ b/src/music/voicing.ts
@@ -7,8 +7,9 @@
  *     into a tasteful chord with a clear low bass fundamental. The voicings are
  *     researched arranging idioms (close, bass+triad, open/spread, shell, power);
  *     they are *view-independent* (anchored an octave below the scale-degree root)
- *     and *quality-agnostic* (the third/fifth intervals are read from the triad,
- *     so the same recipe works for major / minor / diminished / augmented).
+ *     and *quality-agnostic* (the two upper intervals are read from the triad, so the
+ *     same recipe works for major / minor / diminished / augmented — and, since #75,
+ *     for the non-tertian sonorities a non-seven-note chord source produces).
  *
  *  2. {@link renderGains} — per-voice gain factors (0..1) for an articulation
  *     pattern at a given beat position: a sustained pad plus tempo-based arpeggios,
@@ -40,8 +41,12 @@ export function isTempoRendering(r: RenderingId): boolean {
 export function voiceTriad(triad: number[], voicing: VoicingId, octaveShift = 0): number[] {
   if (triad.length < 3) return [];
   const [r, third, fifth] = triad;
-  const T = third - r; // 3 (minor/dim) or 4 (major/aug) — read from the triad
-  const F = fifth - r; // 6 (dim) / 7 (perfect) / 8 (aug)
+  // T and F are the two upper intervals READ from the triad (root→2nd tone, root→3rd
+  // tone), not assumed. For a tertian triad T=3/4 and F=6/7/8; for a non-tertian
+  // chord-source sonority (e.g. C-maj-pent degree-0 {0,4,9} → F=9) they are whatever
+  // the source stacks — the voicing recipe stays valid ascending MIDI either way.
+  const T = third - r;
+  const F = fifth - r;
   const b = r - 12 + 12 * octaveShift; // low bass = the fundamental
   switch (voicing) {
     case 'close':

--- a/src/nodes/music/expression_chord.ts
+++ b/src/nodes/music/expression_chord.ts
@@ -2,16 +2,18 @@
  * `expression-chord` node — turns a classified facial expression into a played
  * chord (issue #64 + the voicing/rendering follow-up). The expression (from
  * `face-expression`) selects a scale degree via {@link DEFAULT_EXPRESSION_TO_DEGREE};
- * the diatonic triad on the active seven-note scale ({@link diatonicTriad}) is then
- * VOICED (a tasteful arrangement with a low bass fundamental — {@link voiceTriad})
- * and RENDERED over time (sustained pad or a tempo-based arpeggio/pulse/strum —
- * {@link renderGains}).
+ * the triad on the CHORD-SOURCE scale ({@link diatonicTriad}) — decoupled from the
+ * right-hand melody scale since #75 — is then VOICED (a tasteful arrangement with a
+ * low bass fundamental — {@link voiceTriad}) and RENDERED over time (sustained pad or
+ * a tempo-based arpeggio/pulse/strum — {@link renderGains}). The `spec` input is the
+ * chord source (auto-derived from the melody, or a custom scale), so a pentatonic
+ * melody still gets chords and any scale can be the chord source.
  *
  * It emits chord voices on ids ≥ {@link CHORD_VOICE_ID_BASE}, so they never collide
  * with the two hand voices (0, 1) and can be unioned into the synth alongside the
  * hand melody (see `synth-merge`). It is the live gate for chord mode: voices sound
- * ONLY when `faceMapping === 'chord'`, the expression is present, and the current
- * scale has seven notes — otherwise all voices are silent.
+ * ONLY when `faceMapping === 'chord'`, the expression is present, and a chord-source
+ * `spec` is wired — otherwise all voices are silent.
  *
  * It ALWAYS emits {@link MAX_CHORD_VOICES} voices on stable ids: the synth releases
  * voices it still sees in the array, so a vanishing voice would leave a chord stuck
@@ -73,7 +75,7 @@ export const expressionChordNode = defineNode<Params>({
   roles: ['music'],
   title: 'Expression Chord',
   description:
-    'Facial expression → a voiced, rendered diatonic chord on the current seven-note scale (active only in face "chord" mode).',
+    'Facial expression → a voiced, rendered diatonic chord on the chord-source scale (active only in face "chord" mode).',
   inputs: [
     { name: 'expression', kind: 'face-expression' },
     { name: 'spec', kind: 'scale-spec' },
@@ -128,7 +130,8 @@ export const expressionChordNode = defineNode<Params>({
           degrees?.[label] ?? DEFAULT_EXPRESSION_TO_DEGREE[label];
         const degree = active ? degreeFor(expr!.label) : SILENCE_DEGREE;
         // The un-voiced scale triad (3 tones) for the overlay highlight; [] when
-        // idle, off a seven-note scale, or when the expression maps to silence.
+        // idle or when the expression maps to silence (a non-seven-note chord source
+        // now yields a generalized chord rather than [], per #75).
         const triad = degree >= 0 ? diatonicTriad(spec!, degree) : [];
         // Voice the chord, then sort ascending by pitch so arpeggios traverse
         // low→high by actual pitch (some voicings stack out of pitch order). The

--- a/src/nodes/music/pose_chord.ts
+++ b/src/nodes/music/pose_chord.ts
@@ -4,8 +4,9 @@
  * control axes from `face-controls` into a voiced, rendered diatonic chord, using
  * the EASY default mapping the issue recommends as the first-run instrument:
  *
- *  - **head yaw → scale degree** — sweep the seven diatonic chords left→right, a
- *    horizontal "keyboard of chords";
+ *  - **head yaw → scale degree** — sweep the chord-source scale's chords left→right,
+ *    a horizontal "keyboard of chords" (one slice per degree, so a shorter source
+ *    sweeps monotonically over fewer chords — #75);
  *  - **head pitch → octave register** — nod up/down to shift the chord's octave;
  *  - **jaw-open → gate** — the chord sounds only while the mouth is open (jaw
  *    closed = rest), the most reliable channel as the play/rest control;
@@ -21,15 +22,16 @@
  * without id collisions. It ALWAYS emits {@link MAX_POSE_VOICES} voices on stable
  * ids (silent when idle), so a vanishing voice never leaves a chord stuck.
  *
- * Active ONLY when `faceMapping === 'controls'`, the controls are present, and the
- * scale is seven-note (a diatonic chord is otherwise undefined) — else silent.
+ * Active ONLY when `faceMapping === 'controls'`, the controls are present, and a
+ * chord-source `spec` is wired — else silent. Since #75 the chord source is decoupled
+ * from the melody (auto-derived or custom), so pose chords work on any melody scale.
  * Stateful (a beat clock + strum re-trigger) but deterministic given the tick
  * timing, so it replays exactly.
  */
 import { z } from 'zod';
 import { defineNode } from '@/dag';
 import type { NodeContext } from '@/dag';
-import { diatonicChord, midiToFreq, type ScaleSpec } from '@/music/theory';
+import { diatonicChord, midiToFreq, SCALE_TYPES, type ScaleSpec } from '@/music/theory';
 import { SoundSchema } from '@/music/sounds';
 import { VOICINGS, RENDERINGS, voiceTriad, renderGains, type VoicingId, type RenderingId } from '@/music/voicing';
 import type { FaceControls, VoiceParams } from '../domain';
@@ -42,7 +44,9 @@ export const POSE_VOICE_ID_BASE = 6;
 /** The largest chord is a voiced triad (up to 4 voices) plus the brow 7th. */
 export const MAX_POSE_VOICES = 5;
 
-/** The seven diatonic degrees the head-yaw sweep spans. */
+/** The default number of degrees the head-yaw sweep spans (a seven-note chord
+ *  source). Overridden per-tick by the chord-source scale's own length (#75), so the
+ *  sweep covers each of ITS degrees exactly once — see {@link yawToDegree}. */
 const DEGREE_COUNT = 7;
 
 const Params = z.object({
@@ -79,12 +83,17 @@ interface ChordConfig {
 const clamp01 = (v: number): number => (v < 0 ? 0 : v > 1 ? 1 : v);
 const clampSigned = (v: number): number => (v < -1 ? -1 : v > 1 ? 1 : v);
 
-/** Head-yaw [-1,1] → a scale degree 0..(DEGREE_COUNT-1): a left→right sweep of the
- *  seven diatonic chords, with each degree occupying an equal slice of the range. */
-export function yawToDegree(headYaw: number): number {
+/** Head-yaw [-1,1] → a scale degree 0..(count-1): a left→right sweep of the chord
+ *  source's degrees, each occupying an equal slice of the range. `count` is the
+ *  chord-source scale's length (#75): deriving it from the scale (not a hardcoded 7)
+ *  keeps the sweep MONOTONIC and complete for any source — a 5-note source sweeps
+ *  0..4 once (no mid-sweep wrap back to the tonic), a 12-note source reaches all 12
+ *  degrees (none unreachable). Defaults to {@link DEGREE_COUNT} when no scale is known. */
+export function yawToDegree(headYaw: number, count = DEGREE_COUNT): number {
+  const n = count > 0 ? count : DEGREE_COUNT;
   const t = (clampSigned(headYaw) + 1) / 2; // [-1,1] → [0,1]
-  const d = Math.floor(t * DEGREE_COUNT);
-  return d < 0 ? 0 : d >= DEGREE_COUNT ? DEGREE_COUNT - 1 : d;
+  const d = Math.floor(t * n);
+  return d < 0 ? 0 : d >= n ? n - 1 : d;
 }
 
 export const poseChordNode = defineNode<Params>({
@@ -151,7 +160,9 @@ export const poseChordNode = defineNode<Params>({
         }
 
         const c = controls as FaceControls;
-        const degree = yawToDegree(c.headYaw);
+        // Sweep across the chord-SOURCE scale's own degrees (#75), so a non-seven-note
+        // source stays monotonic and fully reachable.
+        const degree = yawToDegree(c.headYaw, SCALE_TYPES[spec!.type].intervals.length);
         // Head pitch sweeps the octave; brow raises add the diatonic 7th.
         const octaveShift = baseShift + Math.round(clampSigned(c.headPitch) * p.octaveRange);
         const withSeventh = c.browRaise >= p.browSeventhAt;

--- a/src/nodes/output/canvas_overlay.ts
+++ b/src/nodes/output/canvas_overlay.ts
@@ -159,6 +159,10 @@ export interface OverlayView {
     params?: SynthParams;
     scale?: number[];
     scaleLeft?: number[];
+    /** The chord-SOURCE scale note array (#75), decoupled from the melody `scale`. Used
+     *  to NAME/analyze the sounding chord (chord-name function line, expression chord
+     *  labels) against the scale it was actually built from. Falls back to `scale`. */
+    chordScale?: number[];
     octaveShift: number;
     chord?: number[];
     faceFrame?: FaceFrame;
@@ -614,9 +618,9 @@ function drawBarGraph(g: CanvasRenderingContext2D, x0: number, y0: number, bars:
 /**
  * Diatonic triad tones for a scale degree, by stacking thirds WITHIN the scale's own
  * octave and wrapping high degrees up an octave (so `vi`/`vii` don't run off a
- * single-octave array). `per` = notes per octave, detected from the scale. Only used
- * for chord-mode labels, where the app enforces a seven-note scale — the same shape
- * `diatonicTriad` plays, so the label agrees with the audio.
+ * single-octave array). `per` = notes per octave, detected from the scale — so it
+ * generalizes to a non-seven-note chord source (#75), matching {@link diatonicChord}.
+ * Fed the CHORD-SOURCE scale (not the melody), so the label agrees with the audio.
  */
 function triadForDegree(scale: number[] | undefined, degree: number): number[] {
   if (!Array.isArray(scale) || scale.length < 3 || degree < 0) return [];
@@ -659,7 +663,10 @@ const faceExpressionCue: OverlayElement = {
       if (p.exprLabels) labels.push(name ?? '');
       if (p.chordLabels && chordMode) {
         const deg = view.inputs.faceDegrees?.[name] ?? -1;
-        labels.push(deg >= 0 ? chordName(triadForDegree(view.inputs.scale, deg)) : '—');
+        // Name each expression's chord from the CHORD-SOURCE scale (#75), not the
+        // melody — so the printed name matches the audible chord for a pentatonic melody.
+        const chordScale = view.inputs.chordScale ?? view.inputs.scale;
+        labels.push(deg >= 0 ? chordName(triadForDegree(chordScale, deg)) : '—');
       }
       return {
         value: clamp01(score),
@@ -749,7 +756,9 @@ function chordFunctionLabel(view: OverlayView): string {
   const p = view.params.chordName;
   if (!p.roman) return '';
   const chord = view.inputs.chord;
-  const scale = view.inputs.scale;
+  // Analyze the chord's function against the CHORD-SOURCE scale (#75): the chord root
+  // is a degree of the scale it was built from, which need not be the melody scale.
+  const scale = view.inputs.chordScale ?? view.inputs.scale;
   if (!Array.isArray(chord) || !chord.length || !Array.isArray(scale) || scale.length < 2) return '';
   const info = classifyChord(chord);
   if (!info) return '';
@@ -1041,6 +1050,7 @@ export const canvasOverlayNode = defineNode<Params>({
     { name: 'params', kind: 'synth-params' },
     { name: 'scale', kind: 'number[]' },
     { name: 'scaleLeft', kind: 'number[]' },
+    { name: 'chordScale', kind: 'number[]' },
     { name: 'chord', kind: 'number[]' },
     { name: 'faceFrame', kind: 'face-frame' },
     { name: 'expression', kind: 'face-expression' },
@@ -1088,6 +1098,7 @@ export const canvasOverlayNode = defineNode<Params>({
             params: inputs.params as SynthParams | undefined,
             scale: inputs.scale as number[] | undefined,
             scaleLeft: inputs.scaleLeft as number[] | undefined,
+            chordScale: inputs.chordScale as number[] | undefined,
             octaveShift: typeof inputs.octaveShift === 'number' ? inputs.octaveShift : 0,
             chord: inputs.chord as number[] | undefined,
             faceFrame: inputs.faceFrame as FaceFrame | undefined,

--- a/src/nodes/sources/store_controls.ts
+++ b/src/nodes/sources/store_controls.ts
@@ -10,7 +10,7 @@
 import { z } from 'zod';
 import { defineNode } from '@/dag';
 import type { NodeContext } from '@/dag';
-import { generateScale, type ScaleSpec, type ScaleTypeId } from '@/music/theory';
+import { generateScale, defaultChordSpecFor, type ScaleSpec, type ScaleTypeId } from '@/music/theory';
 import type { SoundId } from '@/music/sounds';
 import { legacyFaceToMapping, type FaceMapping } from '@/nodes/domain';
 import type { FaceChord, FaceExpr } from '@/settings/schema';
@@ -73,8 +73,15 @@ export const storeControlsNode = defineNode<Record<string, never>>({
     { name: 'magnetism', kind: 'number' },
     { name: 'mute', kind: 'boolean' },
     { name: 'overlay', kind: 'overlay-config' },
-    // The right voice's scale spec + the face mode, for the expression→chord path.
+    // The right voice's melody scale spec (kept for reference/back-compat).
     { name: 'rightSpec', kind: 'scale-spec' },
+    // The CHORD-SOURCE scale spec (#75), decoupled from the melody: auto → derived
+    // from the melody via `defaultChordSpecFor`; custom → the faceChord chord scale.
+    // Both chord instruments (expression-chord, pose-chord) read this instead of
+    // rightSpec, so a pentatonic melody still gets (seven-note) chords. `chordScale`
+    // is its note array, for the overlay's chord-name/degree labels.
+    { name: 'chordSpec', kind: 'scale-spec' },
+    { name: 'chordScale', kind: 'number[]' },
     { name: 'faceMapping', kind: 'face-mapping' },
     // Live chord settings (sound / volume / voicing / rendering / tempo).
     { name: 'chordConfig', kind: 'chord-config' },
@@ -96,6 +103,20 @@ export const storeControlsNode = defineNode<Record<string, never>>({
           octaves: c.right.octaves,
           baseOctave: c.right.baseOctave,
         };
+        // Resolve the chord-source scale (#75): custom pins root/type, auto derives
+        // the smart default from the melody. Register (baseOctave/octaves) tracks the
+        // melody — diatonicChord builds its bass from baseOctave, so it is load-bearing.
+        const cs = c.faceChord;
+        const resolved =
+          cs && cs.chordSource === 'custom'
+            ? { root: cs.chordRoot, type: cs.chordType }
+            : defaultChordSpecFor(rightSpec);
+        const chordSpec: ScaleSpec = {
+          root: resolved.root,
+          type: resolved.type,
+          octaves: c.right.octaves,
+          baseOctave: c.right.baseOctave,
+        };
         const out: Record<string, unknown> = {
           scaleRight: generateScale(c.right),
           scaleLeft: generateScale(c.left),
@@ -105,6 +126,8 @@ export const storeControlsNode = defineNode<Record<string, never>>({
           magnetism: c.magnetism ?? 0.8,
           mute: c.muted ?? false,
           rightSpec,
+          chordSpec,
+          chordScale: generateScale(chordSpec),
           faceMapping: c.faceMapping ?? legacyFaceToMapping(c.faceEnabled),
         };
         if (c.faceChord) {

--- a/src/nodes/sources/store_controls.ts
+++ b/src/nodes/sources/store_controls.ts
@@ -22,6 +22,10 @@ export interface VoiceControlSnapshot {
   octaves: number;
   baseOctave: number;
   sound: SoundId;
+  /** #63 octave RANGE (fractional octaves below/above the middle octave). When present,
+   *  `generateScale` uses the range span; absent → the legacy `octaves` span. */
+  rangeLow?: number;
+  rangeHigh?: number;
 }
 export interface ControlSnapshot {
   right: VoiceControlSnapshot;

--- a/src/settings/dials.ts
+++ b/src/settings/dials.ts
@@ -35,6 +35,14 @@ const voice = (sound: SoundId, facet: string) => ({
   octaves: z.number().int().min(1).max(4).default(2).meta({ facets: [facet], title: 'Octaves' }),
   baseOctave: z.number().int().min(0).max(8).default(3).meta({ facets: [facet, 'advanced'], title: 'Base octave' }),
   sound: SoundEnum.default(sound).meta({ facets: [facet], title: 'Sound' }),
+  // #63 octave RANGE — fractional octaves below/above the locked middle octave. OPTIONAL
+  // (NOT `.default(...)`): a default would force a 2-octave range onto any preset/instrument
+  // loaded without range (via resolve → applySettings), silently shrinking an octaves≥3
+  // instrument. Absent → the hot store falls back to the legacy `octaves` span (exact); the
+  // fresh-install default (0/1) is seeded from the hot store, and the double-thumb slider
+  // derives its thumbs from `octaves` when the range is absent, writing it on first drag.
+  rangeLow: z.number().min(0).max(1).optional().meta({ facets: [facet, 'advanced'], title: 'Range below' }),
+  rangeHigh: z.number().min(0).max(1).optional().meta({ facets: [facet, 'advanced'], title: 'Range above' }),
 });
 const right = voice('warmPad', 'Right hand');
 const left = voice('glass', 'Left hand');
@@ -52,12 +60,16 @@ export const thoreminDials = defineDials(
     'right.octaves': right.octaves,
     'right.baseOctave': right.baseOctave,
     'right.sound': right.sound,
+    'right.rangeLow': right.rangeLow,
+    'right.rangeHigh': right.rangeHigh,
 
     'left.root': left.root,
     'left.type': left.type,
     'left.octaves': left.octaves,
     'left.baseOctave': left.baseOctave,
     'left.sound': left.sound,
+    'left.rangeLow': left.rangeLow,
+    'left.rangeHigh': left.rangeHigh,
 
     'face.mapping': FaceMappingEnum.default('none').meta({ facets: ['Face'], title: 'Mapping', description: 'What your facial expression controls' }),
     'faceChord.sound': SoundEnum.default(DEFAULT_FACE_CHORD.sound).meta({ facets: ['Face'], title: 'Chord sound' }),
@@ -103,11 +115,15 @@ export function settingsToLayer(s: Settings): Layer {
     'right.octaves': s.right.octaves,
     'right.baseOctave': s.right.baseOctave,
     'right.sound': s.right.sound,
+    'right.rangeLow': s.right.rangeLow,
+    'right.rangeHigh': s.right.rangeHigh,
     'left.root': s.left.root,
     'left.type': s.left.type,
     'left.octaves': s.left.octaves,
     'left.baseOctave': s.left.baseOctave,
     'left.sound': s.left.sound,
+    'left.rangeLow': s.left.rangeLow,
+    'left.rangeHigh': s.left.rangeHigh,
     'face.mapping': s.faceMapping,
     'faceChord.sound': s.faceChord.sound,
     'faceChord.volume': s.faceChord.volume,
@@ -131,8 +147,8 @@ export function layerToSettings(v: Record<string, unknown>): Settings {
     syncHands: v['master.syncHands'],
     octaveShift: v['master.octaveShift'],
     magnetism: v['master.magnetism'],
-    right: { root: v['right.root'], type: v['right.type'], octaves: v['right.octaves'], baseOctave: v['right.baseOctave'], sound: v['right.sound'] },
-    left: { root: v['left.root'], type: v['left.type'], octaves: v['left.octaves'], baseOctave: v['left.baseOctave'], sound: v['left.sound'] },
+    right: { root: v['right.root'], type: v['right.type'], octaves: v['right.octaves'], baseOctave: v['right.baseOctave'], sound: v['right.sound'], rangeLow: v['right.rangeLow'], rangeHigh: v['right.rangeHigh'] },
+    left: { root: v['left.root'], type: v['left.type'], octaves: v['left.octaves'], baseOctave: v['left.baseOctave'], sound: v['left.sound'], rangeLow: v['left.rangeLow'], rangeHigh: v['left.rangeHigh'] },
     faceMapping: v['face.mapping'],
     faceChord: {
       sound: v['faceChord.sound'],

--- a/src/settings/dials.ts
+++ b/src/settings/dials.ts
@@ -32,7 +32,12 @@ const FaceMappingEnum = z.enum(FACE_MAPPINGS as unknown as [FaceMapping, ...Face
 const voice = (sound: SoundId, facet: string) => ({
   root: z.number().int().min(0).max(11).default(0).meta({ facets: [facet], title: 'Root' }),
   type: ScaleEnum.default('pentatonic').meta({ facets: [facet], title: 'Scale' }),
-  octaves: z.number().int().min(1).max(4).default(2).meta({ facets: [facet], title: 'Octaves' }),
+  // #63: `octaves` is superseded by the range slider (rangeLow/rangeHigh) as the span
+  // control. It stays in the keyspace as the integer SHADOW that the slider keeps in sync
+  // (and the legacy generateScale fallback for pre-#63 voices), but is marked `hidden` so
+  // it generates no palette/AI `set` command — a direct "Set Octaves" would be a silent
+  // no-op whenever the range fields are present (generateScale ignores octaves then).
+  octaves: z.number().int().min(1).max(4).default(2).meta({ facets: [facet, 'advanced'], title: 'Octaves', hidden: true }),
   baseOctave: z.number().int().min(0).max(8).default(3).meta({ facets: [facet, 'advanced'], title: 'Base octave' }),
   sound: SoundEnum.default(sound).meta({ facets: [facet], title: 'Sound' }),
   // #63 octave RANGE — fractional octaves below/above the locked middle octave. OPTIONAL

--- a/src/settings/dials.ts
+++ b/src/settings/dials.ts
@@ -14,7 +14,7 @@
 import { z } from 'zod';
 import { defineDials } from '@zodal/dials-core';
 import type { Layer } from '@zodal/dials-core';
-import { SCALE_TYPES, isSevenNoteScale, type ScaleTypeId } from '@/music/theory';
+import { SCALE_TYPES, type ScaleTypeId } from '@/music/theory';
 import { SOUND_IDS, type SoundId } from '@/music/sounds';
 import { VOICINGS, RENDERINGS, type VoicingId, type RenderingId } from '@/music/voicing';
 import { FACE_MAPPINGS, type FaceMapping } from '@/nodes/domain';
@@ -65,6 +65,11 @@ export const thoreminDials = defineDials(
     'faceChord.voicing': VoicingEnum.default(DEFAULT_FACE_CHORD.voicing).meta({ facets: ['Face'], title: 'Voicing' }),
     'faceChord.rendering': RenderingEnum.default(DEFAULT_FACE_CHORD.rendering).meta({ facets: ['Face'], title: 'Rendering' }),
     'faceChord.bpm': z.number().int().min(40).max(200).default(DEFAULT_FACE_CHORD.bpm).meta({ facets: ['Face'], title: 'Tempo (BPM)' }),
+    // #75: the chord-source scale, decoupled from the right-hand melody scale.
+    // 'auto' follows the melody (smart default); 'custom' pins chordRoot/chordType.
+    'faceChord.chordSource': z.enum(['auto', 'custom']).default(DEFAULT_FACE_CHORD.chordSource).meta({ facets: ['Face'], title: 'Chord source' }),
+    'faceChord.chordRoot': z.number().int().min(0).max(11).default(DEFAULT_FACE_CHORD.chordRoot).meta({ facets: ['Face'], title: 'Chord root' }),
+    'faceChord.chordType': ScaleEnum.default(DEFAULT_FACE_CHORD.chordType).meta({ facets: ['Face'], title: 'Chord scale' }),
 
     // Complex/structured settings — rendered by bespoke widgets (the expression
     // table, the overlay accordion); carried as whole-object dial values.
@@ -81,21 +86,9 @@ export const thoreminDials = defineDials(
     // dial rendered by the bespoke Hand widget, like `overlay` / the expression maps.
     handMap: HandMapSchema.default(DEFAULT_HAND_MAP).meta({ facets: ['Hand'], title: 'Hand mapping' }),
   }),
-  {
-    constraints: {
-      assertions: [
-        {
-          message:
-            'Chord and head-pose face-mappings need a 7-note scale (Major / Natural Minor / Harmonic Minor) on the right hand.',
-          keys: ['face.mapping', 'right.type'],
-          check: (v) => {
-            const m = v['face.mapping'];
-            return (m !== 'chord' && m !== 'controls') || isSevenNoteScale(v['right.type'] as ScaleTypeId);
-          },
-        },
-      ],
-    },
-  },
+  // No cross-field constraints: since #75 the chord/head-pose modes no longer require
+  // a seven-note melody scale — the chord SOURCE (auto-derived or custom) is what a
+  // diatonic chord is built from, and a generalized chord is defined on any scale.
 );
 
 /** The nested {@link Settings} → the flat dials {@link Layer} (every key set). */
@@ -121,6 +114,9 @@ export function settingsToLayer(s: Settings): Layer {
     'faceChord.voicing': s.faceChord.voicing,
     'faceChord.rendering': s.faceChord.rendering,
     'faceChord.bpm': s.faceChord.bpm,
+    'faceChord.chordSource': s.faceChord.chordSource,
+    'faceChord.chordRoot': s.faceChord.chordRoot,
+    'faceChord.chordType': s.faceChord.chordType,
     'faceExpr.sensitivity': s.faceExpr.sensitivity,
     'faceExpr.degrees': s.faceExpr.degrees,
     overlay: s.overlay,
@@ -144,6 +140,9 @@ export function layerToSettings(v: Record<string, unknown>): Settings {
       voicing: v['faceChord.voicing'],
       rendering: v['faceChord.rendering'],
       bpm: v['faceChord.bpm'],
+      chordSource: v['faceChord.chordSource'],
+      chordRoot: v['faceChord.chordRoot'],
+      chordType: v['faceChord.chordType'],
     },
     faceExpr: { sensitivity: v['faceExpr.sensitivity'], degrees: v['faceExpr.degrees'] },
     overlay: v.overlay,

--- a/src/settings/schema.ts
+++ b/src/settings/schema.ts
@@ -66,7 +66,14 @@ export const FaceMappingSchema = z.enum(
   FACE_MAPPINGS as unknown as [FaceMapping, ...FaceMapping[]],
 );
 
-/** How the face chord sounds: sound, volume, voicing, rendering, tempo. */
+/** How the face chord sounds: sound, volume, voicing, rendering, tempo, and — since
+ *  #75 — WHERE its chords are drawn from (the chord-source scale, decoupled from the
+ *  right-hand melody scale). `chordSource: 'auto'` (the default) recomputes the source
+ *  from the melody scale each tick via `defaultChordSpecFor` (so a pentatonic melody
+ *  still gets chords, and a seven-note melody sounds exactly as before); `'custom'`
+ *  pins it to `chordRoot`/`chordType` (any scale, even non-traditional). The
+ *  `.default(...)` on the three new fields keeps presets saved before #75 valid — they
+ *  resolve to auto → identical sound on the seven-note melodies they were saved with. */
 export const FaceChordSchema = z.object({
   sound: InstrumentEnum,
   volume: z.number().min(0).max(1),
@@ -74,16 +81,26 @@ export const FaceChordSchema = z.object({
   rendering: z.enum(RENDERINGS as unknown as [RenderingId, ...RenderingId[]]),
   // 40..200 matches the Tempo slider (one source of truth for the bounds).
   bpm: z.number().min(40).max(200),
+  // #75: chord-source scale (decoupled from the melody). auto = follow the melody
+  // (smart default); custom = the chordRoot/chordType below. `.default(...)` keeps
+  // pre-#75 presets valid (filled on parse) → auto → identical sound.
+  chordSource: z.enum(['auto', 'custom']).default('auto'),
+  chordRoot: z.number().int().min(0).max(11).default(0),
+  chordType: ScaleTypeEnum.default('major'),
 });
 export type FaceChord = z.infer<typeof FaceChordSchema>;
 
-/** The shipped defaults for the face chord (open voicing, sustained pad, 100 BPM). */
+/** The shipped defaults for the face chord (open voicing, sustained pad, 100 BPM,
+ *  chord source following the melody). */
 export const DEFAULT_FACE_CHORD: FaceChord = {
   sound: 'warmPad',
   volume: 0.22,
   voicing: 'spread',
   rendering: 'sustained',
   bpm: 100,
+  chordSource: 'auto',
+  chordRoot: 0,
+  chordType: 'major',
 };
 
 /**

--- a/src/settings/schema.ts
+++ b/src/settings/schema.ts
@@ -140,6 +140,12 @@ export const VoiceSettingsSchema = z.object({
   octaves: z.number().int().min(1).max(4),
   baseOctave: z.number().int().min(0).max(8),
   sound: InstrumentEnum,
+  // #63 octave RANGE (fractional octaves below/above the locked middle octave). OPTIONAL
+  // (NOT `.default(...)`): a pre-#63 preset parses WITHOUT them → the legacy `octaves`
+  // scale path → byte-identical sound (even for octaves ≥ 3, which the 1..3 range can't
+  // represent). New/edited voices carry them (set in the store + dials defaults).
+  rangeLow: z.number().min(0).max(1).optional(),
+  rangeHigh: z.number().min(0).max(1).optional(),
 });
 export type VoiceSettings = z.infer<typeof VoiceSettingsSchema>;
 

--- a/test/app_store.test.ts
+++ b/test/app_store.test.ts
@@ -347,6 +347,34 @@ describe('store-controls node reads the store', () => {
     expect(out.chordSpec).toMatchObject({ root: 7, type: 'minor', baseOctave: 3 });
   });
 
+  it('a wider octave range widens scaleRight through store-controls (#63 replay)', () => {
+    useControls.getState().setSync(false);
+    const node = storeControlsNode.make(storeControlsNode.params.parse({}));
+    const scaleFor = () => node.process({}, ctxWith({ controls: () => useControls.getState() })).scaleRight as number[];
+    useControls.getState().setVoice('right', { rangeLow: 0, rangeHigh: 0 }); // one octave (middle only)
+    const narrow = scaleFor();
+    useControls.getState().setVoice('right', { rangeLow: 1, rangeHigh: 1 }); // three octaves
+    const wide = scaleFor();
+    const span = (a: number[]) => a[a.length - 1] - a[0];
+    expect(span(wide)).toBeGreaterThan(span(narrow));
+    expect(wide.length).toBeGreaterThan(narrow.length);
+    // The middle octave stays covered at the minimum span (the locked middle).
+    expect(narrow[narrow.length - 1] - narrow[0]).toBe(12);
+  });
+
+  it('a legacy voice without a range still generates its octaves span (dual-path, #63)', () => {
+    useControls.getState().setSync(false);
+    // Simulate a returning voice: octaves set, range absent (delete the initializer defaults).
+    useControls.setState({
+      right: { root: 0, type: 'major', octaves: 3, baseOctave: 3, sound: 'warmPad' } as never,
+    });
+    const node = storeControlsNode.make(storeControlsNode.params.parse({}));
+    const scale = node.process({}, ctxWith({ controls: () => useControls.getState() })).scaleRight as number[];
+    // Legacy octaves:3 path — an upward-growing three-octave span (unchanged by #63).
+    expect(scale[0]).toBe(48);
+    expect(scale[scale.length - 1]).toBe(48 + 3 * 12);
+  });
+
   it('emits the keyboard-driven globals (octaveShift / magnetism / mute) from the store (#90)', () => {
     useControls.setState({ octaveShift: 2, magnetism: 0.3, muted: true });
     const node = storeControlsNode.make(storeControlsNode.params.parse({}));

--- a/test/app_store.test.ts
+++ b/test/app_store.test.ts
@@ -313,12 +313,38 @@ describe('store-controls node reads the store', () => {
     // The chord-path ports: the right voice's scale spec + the face mode + config.
     expect(out.faceMapping).toBe('chord');
     expect(out.rightSpec).toMatchObject({ root: 2, type: 'minor' });
+    // #75: the CHORD-SOURCE spec is emitted alongside rightSpec. Right is a 7-note
+    // minor melody here, so auto → the same scale (identical chord behaviour).
+    expect(out.chordSpec).toMatchObject({ root: 2, type: 'minor', baseOctave: 3 });
     // chordConfig maps the store's faceChord (volume → gain) for expression-chord.
     expect(out.chordConfig).toMatchObject({ voicing: 'spread', gain: 0.22, bpm: 100 });
     // The expression-mapping ports: per-emotion sensitivity + per-expression degrees.
     expect(out.expressionSensitivity).toMatchObject({ happy: 0.5, angry: 0.45 });
     expect((out.expressionDegrees as Record<string, number>).neutral).toBe(-1); // silence default
     expect((out.expressionDegrees as Record<string, number>).happy).toBe(0);
+  });
+
+  it('emits a decoupled chord source: auto derives a 7-note scale from a pentatonic melody (#75)', () => {
+    useControls.getState().setSync(false);
+    useControls.getState().setVoice('right', { root: 0, type: 'pentatonic', baseOctave: 3, octaves: 2 });
+    useControls.getState().setFaceMapping('chord');
+    const node = storeControlsNode.make(storeControlsNode.params.parse({}));
+    const out = node.process({}, ctxWith({ controls: () => useControls.getState() }));
+    // Pentatonic melody + auto (default) → C major chord source, with the melody's register.
+    expect(out.chordSpec).toMatchObject({ root: 0, type: 'major', baseOctave: 3 });
+    // chordScale is that source's note array (a seven-note C major, two octaves).
+    expect(out.chordScale).toEqual(generateScale({ root: 0, type: 'major', octaves: 2, baseOctave: 3 }));
+    // rightSpec still reflects the (pentatonic) melody — kept for reference.
+    expect(out.rightSpec).toMatchObject({ root: 0, type: 'pentatonic' });
+  });
+
+  it('emits a CUSTOM chord source when faceChord.chordSource=custom (#75)', () => {
+    useControls.getState().setVoice('right', { root: 0, type: 'pentatonic', baseOctave: 3 });
+    useControls.getState().setFaceChord({ chordSource: 'custom', chordRoot: 7, chordType: 'minor' });
+    const node = storeControlsNode.make(storeControlsNode.params.parse({}));
+    const out = node.process({}, ctxWith({ controls: () => useControls.getState() }));
+    // custom pins the source to G minor; register (baseOctave) still tracks the melody.
+    expect(out.chordSpec).toMatchObject({ root: 7, type: 'minor', baseOctave: 3 });
   });
 
   it('emits the keyboard-driven globals (octaveShift / magnetism / mute) from the store (#90)', () => {

--- a/test/commands_perdial.test.ts
+++ b/test/commands_perdial.test.ts
@@ -20,6 +20,27 @@ describe('per-dial command generation (#87)', () => {
     expect(registry.has('dial.master.syncHands.set')).toBe(true); // boolean
   });
 
+  it('does NOT generate a Set Octaves command; the octave span is set via the range dials (#63)', () => {
+    // #63 replaced the octaves control with the double-thumb range slider. `octaves` stays
+    // in the keyspace as the integer shadow (+ legacy generateScale fallback) but is hidden,
+    // so no "Set Octaves" command is generated — a direct write would be a silent no-op
+    // whenever the range fields are present (generateScale ignores octaves then). The span
+    // is instead settable (palette + AI) via the range dials.
+    expect(registry.has('dial.right.octaves.set')).toBe(false);
+    expect(registry.has('dial.left.octaves.set')).toBe(false);
+    expect(registry.has('dial.right.rangeLow.set')).toBe(true);
+    expect(registry.has('dial.right.rangeHigh.set')).toBe(true);
+  });
+
+  it('a range dial command actually writes the voice span (not a no-op like octaves) (#63)', async () => {
+    // Guards the SSOT the #63 fix rests on: the range dial IS the live span control and its
+    // write lands in the hot store (which generateScale reads), unlike the hidden octaves dial.
+    await registry.dispatch('dial.right.rangeHigh.set', { value: 0 }); // middle octave only
+    expect(useControls.getState().right.rangeHigh).toBe(0);
+    await registry.dispatch('dial.right.rangeHigh.set', { value: 1 }); // + a full octave up
+    expect(useControls.getState().right.rangeHigh).toBe(1);
+  });
+
   it('skips ALL structured dials (objects/records are not a single settable scalar)', () => {
     // All four structured dials in thoreminDials — incl. the dotted faceExpr.* ones
     // most likely to be mis-classified as scalars by a regression.

--- a/test/dials.test.ts
+++ b/test/dials.test.ts
@@ -73,9 +73,12 @@ describe('thoreminDials', () => {
     expect(layerToSettings(settingsToLayer(custom)).handMap).toEqual(custom.handMap);
   });
 
-  it('enforces the chord-needs-a-7-note-scale constraint', () => {
+  it('allows chord/controls face modes on ANY melody scale (#75 decouple)', () => {
+    // The old chord-needs-a-7-note-scale assertion is removed: chords are drawn from a
+    // decoupled chord-source scale, so chord & pose modes are valid on a pentatonic melody.
     const base = thoreminDials.defaults as Record<string, unknown>;
-    expect(thoreminDials.validate({ ...base, 'face.mapping': 'chord', 'right.type': 'pentatonic' }).ok).toBe(false);
+    expect(thoreminDials.validate({ ...base, 'face.mapping': 'chord', 'right.type': 'pentatonic' }).ok).toBe(true);
+    expect(thoreminDials.validate({ ...base, 'face.mapping': 'controls', 'right.type': 'pentatonic' }).ok).toBe(true);
     expect(thoreminDials.validate({ ...base, 'face.mapping': 'chord', 'right.type': 'major' }).ok).toBe(true);
     expect(thoreminDials.validate({ ...base, 'face.mapping': 'timbre', 'right.type': 'pentatonic' }).ok).toBe(true);
   });

--- a/test/dials_sync.test.ts
+++ b/test/dials_sync.test.ts
@@ -71,8 +71,8 @@ describe('voiceEditWrites (the panel sync-hands mirror, reproducing setVoice)', 
   // A snapshot where the two hands have DIVERGED (the reachable un-sync / edit-left
   // / re-sync state). The mirror must re-converge them on the next edit, like setVoice.
   const eff = {
-    'right.root': 0, 'right.type': 'major', 'right.octaves': 2, 'right.baseOctave': 3, 'right.sound': 'warmPad',
-    'left.root': 5, 'left.type': 'blues', 'left.octaves': 4, 'left.baseOctave': 2, 'left.sound': 'glass',
+    'right.root': 0, 'right.type': 'major', 'right.octaves': 2, 'right.baseOctave': 3, 'right.sound': 'warmPad', 'right.rangeLow': 0, 'right.rangeHigh': 1,
+    'left.root': 5, 'left.type': 'blues', 'left.octaves': 4, 'left.baseOctave': 2, 'left.sound': 'glass', 'left.rangeLow': 0.5, 'left.rangeHigh': 0.5,
   };
 
   it('unsynced edit writes only the addressed field', () => {
@@ -81,13 +81,15 @@ describe('voiceEditWrites (the panel sync-hands mirror, reproducing setVoice)', 
 
   it('synced non-sound edit re-snaps the whole non-sound voice onto the other hand', () => {
     // Editing right.octaves while synced: left re-converges to right (root/type/
-    // baseOctave) and takes the new octaves — healing the prior divergence.
+    // baseOctave/range) and takes the new octaves — healing the prior divergence.
     expect(voiceEditWrites('right', 'octaves', 3, true, eff)).toEqual([
       ['right.octaves', 3],
       ['left.root', 0],
       ['left.type', 'major'],
       ['left.octaves', 3],
       ['left.baseOctave', 3],
+      ['left.rangeLow', 0],
+      ['left.rangeHigh', 1],
     ]);
   });
 
@@ -99,17 +101,21 @@ describe('voiceEditWrites (the panel sync-hands mirror, reproducing setVoice)', 
       ['left.type', 'major'],
       ['left.octaves', 2],
       ['left.baseOctave', 3],
+      ['left.rangeLow', 0],
+      ['left.rangeHigh', 1],
     ]);
     expect(writes.some(([k]) => k === 'left.sound')).toBe(false);
   });
 
-  it('mirrors left into right symmetrically', () => {
+  it('mirrors left into right symmetrically (incl. the octave range)', () => {
     expect(voiceEditWrites('left', 'root', 9, true, eff)).toEqual([
       ['left.root', 9],
       ['right.root', 9],
       ['right.type', 'blues'],
       ['right.octaves', 4],
       ['right.baseOctave', 2],
+      ['right.rangeLow', 0.5],
+      ['right.rangeHigh', 0.5],
     ]);
   });
 });

--- a/test/expression_map.test.ts
+++ b/test/expression_map.test.ts
@@ -56,10 +56,19 @@ describe('diatonicTriad', () => {
     expect(triad.map((m) => ((m % 12) + 12) % 12).sort((a, b) => a - b)).toEqual([0, 4, 8]);
   });
 
-  it('returns [] for non-seven-note scales', () => {
+  it('generalizes to non-seven-note scales (#75): stacks the scale\'s OWN thirds', () => {
+    // Pre-#75 this returned []; now a non-seven-note chord source yields a musical,
+    // (non-tertian) chord by stacking that scale's own thirds — so a pentatonic chord
+    // source is allowed and a pentatonic MELODY can still get chords (via its default).
     expect(isSevenNoteScale('pentatonic')).toBe(false);
-    expect(diatonicTriad({ ...cMajor, type: 'pentatonic' }, 0)).toEqual([]);
-    expect(diatonicTriad({ ...cMajor, type: 'blues' }, 0)).toEqual([]);
+    // C major pentatonic {C,D,E,G,A}, L=5: degree 0 stacks idx 0,2,4 → C,E,A (48,52,57).
+    expect(diatonicTriad({ ...cMajor, type: 'pentatonic' }, 0)).toEqual([48, 52, 57]);
+    // Blues {0,3,5,6,7,10}, L=6: degree 0 → idx 0,2,4 → 0,5,7 → C,F,G (48,53,55).
+    expect(diatonicTriad({ ...cMajor, type: 'blues' }, 0)).toEqual([48, 53, 55]);
+    // Seven-note scales are byte-identical to before (still tertian thirds).
+    expect(diatonicTriad(cMajor, 0)).toEqual([48, 52, 55]);
+    // The negative-degree silence sentinel still returns [].
+    expect(diatonicTriad({ ...cMajor, type: 'pentatonic' }, -1)).toEqual([]);
   });
 });
 

--- a/test/face_chord_nodes.test.ts
+++ b/test/face_chord_nodes.test.ts
@@ -216,10 +216,16 @@ describe('expression-chord node', () => {
     expect(DEFAULT_EXPRESSION_TO_DEGREE.neutral).toBe(-1); // pin the silence default
   });
 
-  it('stays silent on a non-seven-note scale even in chord mode', async () => {
-    const out = await chordVoices(happyExpr, 'chord', { ...cMajor, type: 'pentatonic' });
-    expect(out.triad).toEqual([]);
-    expect((out.params as SynthParams).voices.every((v) => !v.present)).toBe(true);
+  it('plays a generalized chord on a non-seven-note chord source (#75)', async () => {
+    // Pre-#75 a non-seven-note spec silenced the chord; now the spec is the (possibly
+    // non-seven-note) CHORD SOURCE and yields a generalized chord. Feeding a pentatonic
+    // spec directly produces its stacked-thirds triad, voiced and sounding.
+    const pentSpec = { ...cMajor, type: 'pentatonic' as const };
+    const out = await chordVoices(happyExpr, 'chord', pentSpec);
+    const triad = out.triad as number[];
+    expect(triad).toEqual(diatonicTriad(pentSpec, DEFAULT_EXPRESSION_TO_DEGREE.happy));
+    expect(triad.length).toBeGreaterThan(0);
+    expect((out.params as SynthParams).voices.some((v) => v.present)).toBe(true);
   });
 
   it('stays silent when the face is absent', async () => {

--- a/test/music_theory.test.ts
+++ b/test/music_theory.test.ts
@@ -13,6 +13,10 @@ import {
   romanNumeral,
   nashvilleNumber,
   scaleGuide,
+  defaultChordSpecFor,
+  scalePitchClasses,
+  scaleIsSubset,
+  melodyNotesOutsideChord,
   DEFAULT_SCALE,
 } from '@/music/theory';
 
@@ -173,6 +177,44 @@ describe('magneticPitch (tonal guidance)', () => {
   it('clamps x outside [0,1]', () => {
     expect(magneticPitch(-1, scale, 0.5)).toBeCloseTo(scale[0], 6);
     expect(magneticPitch(2, scale, 0.5)).toBeCloseTo(scale[scale.length - 1], 6);
+  });
+});
+
+describe('defaultChordSpecFor (smart chord source — #75)', () => {
+  it('seven-note melodies use themselves (byte-identical to pre-#75 chord behaviour)', () => {
+    expect(defaultChordSpecFor({ root: 0, type: 'major' })).toEqual({ root: 0, type: 'major' });
+    expect(defaultChordSpecFor({ root: 9, type: 'minor' })).toEqual({ root: 9, type: 'minor' });
+    expect(defaultChordSpecFor({ root: 9, type: 'minorHarmonic' })).toEqual({ root: 9, type: 'minorHarmonic' });
+  });
+  it('pentatonics map to same-root major/minor, and the melody is a true subset of it', () => {
+    expect(defaultChordSpecFor({ root: 0, type: 'pentatonic' })).toEqual({ root: 0, type: 'major' });
+    expect(defaultChordSpecFor({ root: 9, type: 'minorPentatonic' })).toEqual({ root: 9, type: 'minor' });
+    // C major pentatonic ⊂ C major; A minor pentatonic ⊂ A natural minor (so auto never warns).
+    expect(scaleIsSubset({ root: 0, type: 'pentatonic' }, { root: 0, type: 'major' })).toBe(true);
+    expect(scaleIsSubset({ root: 9, type: 'minorPentatonic' }, { root: 9, type: 'minor' })).toBe(true);
+  });
+  it('blues → same-root minor; chromatic → same-root major (defaults with expected tension)', () => {
+    expect(defaultChordSpecFor({ root: 0, type: 'blues' })).toEqual({ root: 0, type: 'minor' });
+    expect(defaultChordSpecFor({ root: 5, type: 'chromatic' })).toEqual({ root: 5, type: 'major' });
+  });
+});
+
+describe('scale pitch-class helpers (#75 compatibility warning)', () => {
+  it('scalePitchClasses lists the mod-12 notes of a scale', () => {
+    expect([...scalePitchClasses(0, 'pentatonic')].sort((a, b) => a - b)).toEqual([0, 2, 4, 7, 9]);
+    expect([...scalePitchClasses(9, 'minorPentatonic')].sort((a, b) => a - b)).toEqual([0, 2, 4, 7, 9]); // A C D E G
+  });
+  it('scaleIsSubset is the authoritative coherence test (melody ⊆ chord source)', () => {
+    expect(scaleIsSubset({ root: 0, type: 'pentatonic' }, { root: 0, type: 'major' })).toBe(true);
+    // C major is NOT inside D major (C/F vs C#/F#).
+    expect(scaleIsSubset({ root: 0, type: 'major' }, { root: 2, type: 'major' })).toBe(false);
+    // Anything is inside the chromatic scale.
+    expect(scaleIsSubset({ root: 0, type: 'major' }, { root: 0, type: 'chromatic' })).toBe(true);
+  });
+  it('melodyNotesOutsideChord names the clashing melody notes, consistent with the subset test', () => {
+    expect(melodyNotesOutsideChord({ root: 0, type: 'pentatonic' }, { root: 0, type: 'major' })).toEqual([]);
+    // C major melody vs D major chord source: C and F fall outside D major.
+    expect(melodyNotesOutsideChord({ root: 0, type: 'major' }, { root: 2, type: 'major' })).toEqual(['C', 'F']);
   });
 });
 

--- a/test/music_theory.test.ts
+++ b/test/music_theory.test.ts
@@ -18,6 +18,7 @@ import {
   scaleIsSubset,
   melodyNotesOutsideChord,
   DEFAULT_SCALE,
+  type ScaleSpec,
 } from '@/music/theory';
 
 describe('chordName', () => {
@@ -141,6 +142,55 @@ describe('scale generation', () => {
   it('pentatonic has 5 notes per octave', () => {
     const s = generateScale({ root: 0, type: 'pentatonic', octaves: 1, baseOctave: 4 });
     expect(s.length).toBe(6); // 5 + completing octave
+  });
+});
+
+describe('scale generation — octave RANGE (#63)', () => {
+  const spec = (over: Partial<ScaleSpec>): ScaleSpec => ({ root: 0, type: 'major', octaves: 2, baseOctave: 3, ...over });
+
+  it('the default range (0 below, 1 above) equals the legacy octaves:2 span', () => {
+    const ranged = generateScale(spec({ rangeLow: 0, rangeHigh: 1 }));
+    const legacy = generateScale({ root: 0, type: 'major', octaves: 2, baseOctave: 3 });
+    expect(ranged).toEqual(legacy);
+  });
+
+  it('always covers the locked middle octave; the minimum span is one octave (0 below, 0 above)', () => {
+    const s = generateScale(spec({ rangeLow: 0, rangeHigh: 0 }));
+    expect(s[0]).toBe(48); // middle floor (baseNote = the root at baseOctave 3)
+    expect(s[s.length - 1]).toBe(60); // middle ceiling, one octave up
+    expect(s).toContain(48);
+    expect(s).toContain(60);
+  });
+
+  it('extends down and up around the locked middle (1 below, 1 above = 3 octaves)', () => {
+    const s = generateScale(spec({ rangeLow: 1, rangeHigh: 1 }));
+    expect(s[0]).toBe(36); // a full octave below the middle floor (48-12)
+    expect(s[s.length - 1]).toBe(72); // a full octave above the middle ceiling (60+12)
+  });
+
+  it('a wider range produces a strictly wider pitch span (the #63 acceptance property)', () => {
+    const narrow = generateScale(spec({ rangeLow: 0, rangeHigh: 0 }));
+    const wide = generateScale(spec({ rangeLow: 1, rangeHigh: 1 }));
+    const span = (a: number[]) => a[a.length - 1] - a[0];
+    expect(span(wide)).toBeGreaterThan(span(narrow));
+    expect(wide.length).toBeGreaterThan(narrow.length);
+  });
+
+  it('a fractional range lengthens the span (adds notes as the boundary crosses them)', () => {
+    const half = generateScale(spec({ rangeLow: 0, rangeHigh: 0.5 }));
+    const full = generateScale(spec({ rangeLow: 0, rangeHigh: 1 }));
+    expect(half[half.length - 1]).toBeGreaterThan(60); // past the middle ceiling
+    expect(half[half.length - 1]).toBeLessThanOrEqual(66); // but within half an octave (baseNote+18)
+    expect(full[full.length - 1]).toBe(72);
+    expect(full.length).toBeGreaterThan(half.length);
+  });
+
+  it('falls back to the legacy octaves path when the range fields are absent (byte-identical)', () => {
+    for (const octaves of [1, 2, 3, 4]) {
+      const s = generateScale({ root: 0, type: 'major', octaves, baseOctave: 3 });
+      expect(s[0]).toBe(48);
+      expect(s[s.length - 1]).toBe(48 + octaves * 12); // legacy upward-growing span, unchanged
+    }
   });
 });
 

--- a/test/pose_chord.test.ts
+++ b/test/pose_chord.test.ts
@@ -77,8 +77,10 @@ describe('diatonicChord', () => {
     expect(diatonicChord(cMajor, 4, 3)).toEqual(diatonicTriad(cMajor, 4));
   });
 
-  it('returns [] for a non-seven-note scale or negative degree', () => {
-    expect(diatonicChord(pentatonic, 0, 3)).toEqual([]);
+  it('generalizes to a non-seven-note scale; negative degree stays silent (#75)', () => {
+    // C major pentatonic {C,D,E,G,A}, L=5: degree 0 stacks its own thirds → C,E,A.
+    expect(diatonicChord(pentatonic, 0, 3)).toEqual([48, 52, 57]);
+    // The negative-degree silence sentinel still returns [].
     expect(diatonicChord(cMajor, -1, 3)).toEqual([]);
   });
 });
@@ -154,10 +156,29 @@ describe('pose-chord node', () => {
     expect(sounding(neutral.voices)[0].brightness).toBeCloseTo(0.5, 5);
   });
 
-  it('needs a seven-note scale (a pentatonic scale stays silent)', async () => {
+  it('plays a generalized chord on a non-seven-note chord source (#75)', async () => {
+    // Pre-#75 a pentatonic scale silenced the pose chord; now the spec is the CHORD
+    // SOURCE and a pentatonic source sounds a generalized chord. The yaw at the low end
+    // lands on degree 0 for any slice count (the sweep is derived from the source length).
     const { voices, chord } = await play(ctrl({ headYaw: yawForDegree(0), mouthOpen: 1 }), { spec: pentatonic });
-    expect(sounding(voices)).toHaveLength(0);
-    expect(chord).toEqual([]);
+    expect(sounding(voices).length).toBeGreaterThan(0);
+    expect(chord).toEqual(diatonicChord(pentatonic, 0, 3));
+  });
+
+  it('sweeps monotonically over a non-seven-note source (no mid-sweep wrap) (#75)', async () => {
+    // A 5-note source must sweep 0..4 once as the head turns left→right — the slice
+    // count comes from L=5, so it never wraps back to the tonic mid-sweep.
+    const degrees: number[] = [];
+    for (const yaw of [-1, -0.5, 0, 0.5, 1]) {
+      const { chord } = await play(ctrl({ headYaw: yaw, mouthOpen: 1 }), { spec: pentatonic });
+      // Recover the degree from the sounding tones (compare against each candidate).
+      const match = [0, 1, 2, 3, 4].find((d) => JSON.stringify(diatonicChord(pentatonic, d, 3)) === JSON.stringify(chord));
+      degrees.push(match ?? -1);
+    }
+    // Non-decreasing across the sweep (monotonic), covering low→high degrees.
+    for (let i = 1; i < degrees.length; i++) expect(degrees[i]).toBeGreaterThanOrEqual(degrees[i - 1]);
+    expect(degrees[0]).toBe(0);
+    expect(degrees[degrees.length - 1]).toBe(4);
   });
 
   it('honors a live chordConfig (volume + voicing) over the static params', async () => {

--- a/test/settings_presets.test.ts
+++ b/test/settings_presets.test.ts
@@ -59,6 +59,19 @@ describe('preset persistence', () => {
     expect(loaded?.settings.overlay.video.alpha).toBeCloseTo(0.1);
   });
 
+  it('round-trips a per-voice fractional octave range (#63)', async () => {
+    const s = store();
+    const settings = sampleSettings({
+      right: { root: 0, type: 'pentatonic', octaves: 3, baseOctave: 3, sound: 'warmPad', rangeLow: 0.5, rangeHigh: 1 },
+    });
+    await s.save('Wide Range', settings, 1000);
+    const loaded = await s.load('wide-range');
+    expect(loaded?.settings.right.rangeLow).toBe(0.5);
+    expect(loaded?.settings.right.rangeHigh).toBe(1);
+    // A voice without range is preserved as absent (the legacy octaves span → identical sound).
+    expect(loaded?.settings.left.rangeLow).toBeUndefined();
+  });
+
   it('saving the same name overwrites instead of duplicating', async () => {
     const s = store();
     await s.save('My Setup', sampleSettings({ masterVolume: 0.2 }), 1000);


### PR DESCRIPTION
Two coupled scale/range improvements, both client-side, no backend.

## #75 — decouple the chord-source scale from the melody scale
The face/pose chord modes no longer require a 7-note right-hand melody scale. Chords are drawn from a **chord-source scale**, decoupled from what the right hand plays — so a **pentatonic melody still gets chords** (the friendliest gesture scale), and any scale can be a chord source.

- `diatonicChord`/`diatonicTriad` generalized to the scale's own length `L` (byte-identical for 7-note scales; stacks a scale's own thirds otherwise).
- `defaultChordSpecFor` smart default (pentatonic→major, minorPentatonic/blues→minor, chromatic→major, 7-note→itself) makes "pentatonic + chords" work with zero config.
- New `chordSpec` (a full ScaleSpec — `baseOctave` is load-bearing) + `chordScale` outputs from `store-controls`; **both** `expression-chord` and `pose-chord` re-pointed from the melody spec to the chord source, unblocking chord AND head-pose modes on any melody.
- Chord-source picker in the panel (auto/custom + root + type) with a **non-blocking** subset warning that names the melody notes outside a custom source (auto never warns — it's the recommended embedding). Overlay chord-name/function labels + the expression-map preview now read the chord source, so on-screen names match the audible chord.
- pose `yawToDegree` slice count derived from the chord source's length (monotonic sweep, fully reachable for non-7 sources).
- Removed the dials 7-note assertion; removed the chord/controls option-disabling.

Closes #75.

## #63 — double-thumb octave-RANGE slider (1–3 octaves, locked middle)
Replaces the discrete Octaves (1–4) control with a **double-thumb** range around an always-covered middle octave: the ↓ thumb extends up to a full octave below, the ↑ thumb up to a full octave above → a continuous **1–3 octave** span that always includes the middle. Overlay guides + the audible range update live.

- `generateScale` gains a **range path** (`[baseNote − rangeLow·12, (baseNote+12) + rangeHigh·12]`, fractional octaves); absent → the legacy `octaves` path, **byte-identical**.
- Per-voice `rangeLow`/`rangeHigh` are **optional** (no schema/dials default), so a pre-#63 preset/instrument keeps its exact `octaves` span (no silent shrink). New/edited voices carry them; the slider derives thumbs from `octaves` when absent and keeps `octaves` a truthful integer shadow on write. Range mirrors across synced hands.

Closes #63.

## Persistence
Store persist **v5 → v6** (additive; the `faceChord` chord-source fields self-heal via `mergeControls`, and the range fields are optional). A returning user's instruments sound identical.

## Landed shapes (for the Instrument-library-UX epic, #114/#115)
- Chord source: `faceChord.chordSource: 'auto' | 'custom'`, `faceChord.chordRoot: 0..11`, `faceChord.chordType: ScaleTypeId`.
- Octave range: per-voice `rangeLow?`, `rangeHigh?` (fractional octaves 0..1 below/above the middle octave). `octaves` is kept as a truthful integer shadow, so a summary that reads `octaves` stays correct.

## Verification
`npm run typecheck` · `npx vitest run` (525 tests) · `npm run build` · `npm run catalog` — all green. Design + adversarial multi-agent reviews were run at the design and pre-PR junctures; the review surfaced four real defects in the range surface (a silent-no-op "Set Octaves" command exposed to the AI/palette, a range-readout lie for returning octaves≥3 voices, a synced-hands non-convergence on range drag, and an Auto→Custom chord-source key jump), all fixed in `6691ca9` before this PR.

https://claude.ai/code/session_01EB8d2F3kkQQL3PW2mWQS8x
