### PR TITLE
feat(annotations): export the recorded intervals, and stop calling two things "tags" (#92)

### DIFF
--- a/docs/design/recording-v2.md
+++ b/docs/design/recording-v2.md
@@ -66,7 +66,7 @@ with a **secondary ext = the role** when streams share a primary ext:
 ```
 demo-theremin-2026-07-05T14-30-12/
   ….overlay.webm  ….camera.webm  ….alpha.webm
-  ….webm  ….wav  ….features.jsonl  ….tags.jsonl  ….manifest.json
+  ….webm  ….wav  ….features.jsonl  ….annotations.jsonl  ….manifest.json
 ```
 
 `recordingStem()` + `fileName(stem,{role,ext})` are pure and unit-tested; every
@@ -104,14 +104,14 @@ is never lost.
 }
 ```
 
-Every stream's timestamps (`t` in the feature/tags JSONL) are relative to `t0`.
+Every stream's timestamps (`t` in the feature/annotation JSONL) are relative to `t0`.
 
-## Forward-compat: the live-tagging `.tags.jsonl`
+## The live-annotation `.annotations.jsonl`
 
-The live-tagging stream (separate issue) is **just another stream** written into
+The live-annotation stream (#92, shipped) is **just another stream** written into
 the same folder: same `{stem}`, the same `t0`/`ctx.time` clock, the same JSONL
-line-per-event convention (`kind: "tags"` in the manifest). No restructuring is
-needed — it drops in.
+line-per-event convention (`kind: "annotations"` in the manifest). No restructuring
+was needed — it dropped in.
 
 ## What is verified vs. browser-only
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -124,9 +124,10 @@ export default function App({ source = DEFAULT_SOURCE }: { source?: SourceSpec }
           once audio is running. */}
       {audioOn && <RecordButton recording={recording} />}
 
-      {/* Live tagging (#92): the launcher + setup sheet, the in-take button stack
+      {/* Live annotations (#92): the launcher + setup sheet, the in-take button stack
           (left edge), and the centered lead-in countdown. Available once the engine
-          is ready; toggling a tag during a recording writes a time-aligned tags.jsonl. */}
+          is ready; tapping an annotation during a recording writes a time-aligned
+          annotations.jsonl into the take folder. */}
       {status === 'ready' && <TaggingControls />}
 
       {/* Top-right: the instruments surface (the list + the per-instrument editor). */}

--- a/src/app/overlayControls.ts
+++ b/src/app/overlayControls.ts
@@ -92,5 +92,5 @@ export const OVERLAY_CONTROLS: OverlayControlDesc[] = [
   { name: 'video', label: 'Video backdrop', slider: { key: 'alpha', label: 'Opacity' } },
   // Live tagging (#92): the burned-in corner HUD (open tags + timecode) that composits
   // into the recorded video. Shown only while a take records; toggle to hide the burn-in.
-  { name: 'tagHud', label: 'Tagging HUD (recorded)' },
+  { name: 'tagHud', label: 'Annotation HUD (recorded)' },
 ];

--- a/src/app/recording/manifest.ts
+++ b/src/app/recording/manifest.ts
@@ -17,7 +17,7 @@ export type RecordingStreamKind =
   | 'pureVideo'
   | 'overlayAlpha'
   | 'features'
-  | 'tags';
+  | 'annotations';
 
 /** One stream's entry in the manifest. `file` is the name within the folder. */
 export interface RecordingStreamEntry {

--- a/src/app/recording/manifest.ts
+++ b/src/app/recording/manifest.ts
@@ -2,8 +2,8 @@
  * Recording manifest (#88) — the per-folder alignment SSOT. Every recording is a
  * folder containing a `{stem}.manifest.json` that records the shared clock origin
  * (`startedAt`, `t0`), the instrument, and one entry per captured stream
- * (`{file, kind, mime?, fps?}`). A future importer/aligner (and the live-tagging
- * `.tags.jsonl`, which drops into the same folder on the same clock) reads this
+ * (`{file, kind, mime?, fps?}`). A future importer/aligner (and the live-annotation
+ * `.annotations.jsonl`, which drops into the same folder on the same clock) reads this
  * to line the streams up frame-accurately. Pure and unit-testable — no DOM, no
  * filesystem.
  */

--- a/src/app/recording/plan.ts
+++ b/src/app/recording/plan.ts
@@ -51,7 +51,7 @@ export interface PlanInput {
   /** Alpha (overlay-only) MIME — Chromium VP9; defaults to `video/webm;codecs=vp9`. */
   alphaMime?: string;
   /** Whether live annotations (#92) are active for this take — adds a `.annotations.jsonl`
-   *  stream to the folder (and forces folder mode, since a annotation log needs the
+   *  stream to the folder (and forces folder mode, since an annotation log needs the
    *  manifest to say what it segments). */
   includeAnnotations?: boolean;
 }

--- a/src/app/recording/plan.ts
+++ b/src/app/recording/plan.ts
@@ -50,9 +50,10 @@ export interface PlanInput {
   videoMime: string;
   /** Alpha (overlay-only) MIME — Chromium VP9; defaults to `video/webm;codecs=vp9`. */
   alphaMime?: string;
-  /** Whether live tagging (#92) is active for this take — adds a `.tags.jsonl` stream
-   *  to the folder (and forces folder mode, since a tag log needs the manifest). */
-  includeTags?: boolean;
+  /** Whether live annotations (#92) are active for this take — adds a `.annotations.jsonl`
+   *  stream to the folder (and forces folder mode, since a annotation log needs the
+   *  manifest to say what it segments). */
+  includeAnnotations?: boolean;
 }
 
 /** Selected audio output formats, filtered to ids the registry knows (an unknown
@@ -106,11 +107,11 @@ export function planRecording(input: PlanInput): RecordingPlan {
   const s = session.streams;
   const fps = session.fps;
   const videoExt = videoExtForMime(videoMime);
-  const includeTags = input.includeTags === true;
+  const includeAnnotations = input.includeAnnotations === true;
 
   // --- single-file escape hatch: one bare media file, no folder, no manifest ---
-  // A tag log needs the folder + manifest, so it disqualifies the escape hatch.
-  if (!includeTags && singleFileEligible(session)) {
+  // A annotation log needs the folder + manifest, so it disqualifies the escape hatch.
+  if (!includeAnnotations && singleFileEligible(session)) {
     let file: PlannedFile;
     if (s.audio) {
       file = audioFiles(session, stem, audioMime)[0];
@@ -137,10 +138,10 @@ export function planRecording(input: PlanInput): RecordingPlan {
   if (s.audio) files.push(...audioFiles(session, stem, audioMime));
   if (s.features)
     files.push({ name: fileName(stem, { role: 'features', ext: 'jsonl' }), kind: 'features', role: 'features', ext: 'jsonl' });
-  // The live-tagging stream (#92) drops in like features.jsonl: same folder, same
-  // stem, same t0/JSONL convention, listed in the manifest as `kind: 'tags'`.
-  if (includeTags)
-    files.push({ name: fileName(stem, { role: 'tags', ext: 'jsonl' }), kind: 'tags', role: 'tags', ext: 'jsonl' });
+  // The live-annotation stream (#92) drops in like features.jsonl: same folder, same
+  // stem, same t0/JSONL convention, listed in the manifest as `kind: 'annotations'`.
+  if (includeAnnotations)
+    files.push({ name: fileName(stem, { role: 'annotations', ext: 'jsonl' }), kind: 'annotations', role: 'annotations', ext: 'jsonl' });
 
   // The manifest is always present (provenance + alignment SSOT), so a folder has
   // ≥ 2 files even for an audio-only take.

--- a/src/app/recording/session.ts
+++ b/src/app/recording/session.ts
@@ -163,7 +163,7 @@ export class SessionRecorder {
     if (this.running) return;
     // Annotations are a COMPANION stream: annotations.jsonl segments the OTHER streams on the
     // shared t0, so a take needs at least one capturable media/feature stream to tag
-    // (a annotations-only take would reference streams that don't exist). Hence the guard is
+    // (an annotations-only take would reference streams that don't exist). Hence the guard is
     // on hasAnyStream, deliberately not counting annotations.
     if (!hasAnyStream(this.session.streams)) throw new Error('No streams selected to record');
     const { audioContext, masterGain, canvas, video, cameraStream, engine, resources } = this.deps;
@@ -179,7 +179,7 @@ export class SessionRecorder {
     this.stem = name;
 
     // Live tagging (#92): if the tag source is active, this take writes a
-    // `.annotations.jsonl` (which also forces folder mode — a annotation log needs the manifest).
+    // `.annotations.jsonl` (which also forces folder mode — an annotation log needs the manifest).
     this.annotationsActive = this.deps.tagSource?.active() === true;
 
     this.plan = planRecording({
@@ -445,9 +445,11 @@ export class SessionRecorder {
     this.detachTap = null;
     // Release the tagging runtime's take context so a dropped/aborted recording
     // doesn't leave it stuck "recording" (endTake is a no-op if already ended).
+    // `abandoned`: this take wrote NO media files, so it must not displace the last
+    // cleanly-stopped take's export unless it actually captured annotations itself.
     if (this.annotationsActive) {
       try {
-        this.deps.tagSource?.endTake(performance.now() / 1000);
+        this.deps.tagSource?.endTake(performance.now() / 1000, { abandoned: true });
       } catch {
         /* runtime already reset */
       }

--- a/src/app/recording/session.ts
+++ b/src/app/recording/session.ts
@@ -42,7 +42,7 @@ export interface SessionRecorderDeps {
   resources: Record<string, unknown>;
   /** Active instrument/sound id, for the manifest. */
   instrument?: string;
-  /** Live-tagging source (#92): when active, writes a `.tags.jsonl` stream into the
+  /** Live-annotation source (#92): when active, writes a `.annotations.jsonl` stream into the
    *  folder on the shared `t0`. Absent = no tagging. */
   tagSource?: TagStreamSource;
 }
@@ -133,9 +133,9 @@ export class SessionRecorder {
   private t0 = 0;
   private startPerf = 0;
   private running = false;
-  /** Whether this take is writing a `.tags.jsonl` (#92) — set at start from the tag
+  /** Whether this take is writing a `.annotations.jsonl` (#92) — set at start from the annotation
    *  source's `active()`, so plan/stop stay in agreement. */
-  private tagsActive = false;
+  private annotationsActive = false;
 
   constructor(deps: SessionRecorderDeps, session: RecordingSession) {
     this.deps = deps;
@@ -161,10 +161,10 @@ export class SessionRecorder {
    */
   async start(): Promise<void> {
     if (this.running) return;
-    // Tagging is a COMPANION stream: its tags.jsonl segments the OTHER streams on the
+    // Annotations are a COMPANION stream: annotations.jsonl segments the OTHER streams on the
     // shared t0, so a take needs at least one capturable media/feature stream to tag
-    // (a tags-only take would reference streams that don't exist). Hence the guard is
-    // on hasAnyStream, deliberately not counting tags.
+    // (a annotations-only take would reference streams that don't exist). Hence the guard is
+    // on hasAnyStream, deliberately not counting annotations.
     if (!hasAnyStream(this.session.streams)) throw new Error('No streams selected to record');
     const { audioContext, masterGain, canvas, video, cameraStream, engine, resources } = this.deps;
     const s = this.session.streams;
@@ -179,8 +179,8 @@ export class SessionRecorder {
     this.stem = name;
 
     // Live tagging (#92): if the tag source is active, this take writes a
-    // `.tags.jsonl` (which also forces folder mode — a tag log needs the manifest).
-    this.tagsActive = this.deps.tagSource?.active() === true;
+    // `.annotations.jsonl` (which also forces folder mode — a annotation log needs the manifest).
+    this.annotationsActive = this.deps.tagSource?.active() === true;
 
     this.plan = planRecording({
       session: this.session,
@@ -188,7 +188,7 @@ export class SessionRecorder {
       audioMime: this.audioMime,
       videoMime: this.videoMime,
       alphaMime: this.alphaMime ?? undefined,
-      includeTags: this.tagsActive,
+      includeAnnotations: this.annotationsActive,
     });
 
     // A folder take goes through a sink (dir/zip); the single-file escape hatch
@@ -260,10 +260,10 @@ export class SessionRecorder {
     }
 
     // Begin the tag take on the SAME t0 the media/feature streams share, so the
-    // `.tags.jsonl` events share the absolute engine clock and line up frame-accurately (#92 §5).
+    // `.annotations.jsonl` events share the absolute engine clock and line up frame-accurately (#92 §5).
     // Done last, once capture is committed, so a fail-fast above never leaves the
     // tagging runtime with a dangling take.
-    if (this.tagsActive) {
+    if (this.annotationsActive) {
       this.deps.tagSource!.beginTake({ t0: this.t0, startedAt: this.startedAt, session: this.stem });
     }
 
@@ -280,17 +280,17 @@ export class SessionRecorder {
     this.running = false;
 
     // The take's end on the ABSOLUTE engine clock (the same frame tag/feature events
-    // are stamped in), captured now at stop-request so still-open tags close at the
+    // are stamped in), captured now at stop-request so still-open annotations close at the
     // true take end (#92).
     const endEngineT = performance.now() / 1000;
 
     // Detach the feature tap AND freeze the tag log at the SAME instant, so neither
     // stream keeps recording input during the (possibly seconds-long) async
-    // stop/convert window below. endTake closes still-open tags at endEngineT and
+    // stop/convert window below. endTake closes still-open annotations at endEngineT and
     // returns the anchored JSONL; the file loop just writes it.
     this.detachTap?.();
     this.detachTap = null;
-    const tagsJsonl = this.tagsActive ? (this.deps.tagSource?.endTake(endEngineT) ?? '') : '';
+    const annotationsJsonl = this.annotationsActive ? (this.deps.tagSource?.endTake(endEngineT) ?? '') : '';
 
     const [audioBlob, overlayBlob, pureBlob, alphaBlob] = await Promise.all([
       this.audioRec ? stopRec(this.audioRec) : Promise.resolve(null),
@@ -344,9 +344,9 @@ export class SessionRecorder {
         case 'features':
           await putFile(file, this.tap?.drain() ?? '');
           break;
-        case 'tags':
+        case 'annotations':
           // The tag log was already closed + drained above (symmetric with the tap).
-          await putFile(file, tagsJsonl);
+          await putFile(file, annotationsJsonl);
           break;
         case 'manifest': {
           const manifest = buildManifest({
@@ -445,13 +445,13 @@ export class SessionRecorder {
     this.detachTap = null;
     // Release the tagging runtime's take context so a dropped/aborted recording
     // doesn't leave it stuck "recording" (endTake is a no-op if already ended).
-    if (this.tagsActive) {
+    if (this.annotationsActive) {
       try {
         this.deps.tagSource?.endTake(performance.now() / 1000);
       } catch {
         /* runtime already reset */
       }
-      this.tagsActive = false;
+      this.annotationsActive = false;
     }
     for (const rec of [this.audioRec, this.overlayRec, this.pureRec, this.alphaRec]) {
       try {

--- a/src/app/recording/tagStream.ts
+++ b/src/app/recording/tagStream.ts
@@ -1,12 +1,12 @@
 /**
  * TagStreamSource (#92) — the seam between the multi-stream recorder and the live-
- * tagging runtime. `tags.jsonl` is "just another stream" in the recording folder
+ * annotation runtime. `annotations.jsonl` is "just another stream" in the recording folder
  * (recording-v2 doc), sharing the take's `t0` and JSONL convention, so the
- * {@link SessionRecorder} treats tagging as an injected source it asks three things:
+ * {@link SessionRecorder} treats annotating as an injected source it asks three things:
  *
- *  - is tagging active for this take? (`active`)
+ *  - is annotating active for this take? (`active`)
  *  - here is the shared `t0` — begin the take (write the anchor, reset the log)
- *  - the take ended at this media-time — hand back the `tags.jsonl` text
+ *  - the take ended at this media-time — hand back the `annotations.jsonl` text
  *
  * The recorder never imports the tagging store; the runtime implements this contract
  * over it. Keeping the interface here (not in `session.ts`) lets both sides depend on
@@ -22,13 +22,22 @@ export interface TagTakeMeta {
   session: string;
 }
 
+/** How the take ended — see {@link TagStreamSource.endTake}. */
+export interface TagTakeEnd {
+  /** True when the recorder was torn down WITHOUT a clean stop (`dispose`), so no media
+   *  files were written. The runtime uses this to decide whether the take is worth
+   *  keeping as the exportable "last take" — an aborted, empty one must not displace the
+   *  previous, cleanly-finished take. */
+  abandoned?: boolean;
+}
+
 export interface TagStreamSource {
-  /** True if tagging mode is on with tags defined — this take should write a
-   *  `tags.jsonl`. Read once at record start. */
+  /** True if annotation mode is on with annotations defined — this take should write an
+   *  `annotations.jsonl`. Read once at record start. */
   active(): boolean;
   /** Begin a take on the shared clock: write the anchor, start a fresh event log. */
   beginTake(meta: TagTakeMeta): void;
-  /** End the take at `endT` media-seconds: close still-open tags, return the JSONL
+  /** End the take at `endT` media-seconds: close still-open annotations, return the JSONL
    *  (already including the anchor). '' if nothing was captured. */
-  endTake(endT: number): string;
+  endTake(endT: number, end?: TagTakeEnd): string;
 }

--- a/src/app/tagging/TagButtonStack.tsx
+++ b/src/app/tagging/TagButtonStack.tsx
@@ -72,7 +72,7 @@ export default function TagButtonStack() {
     <div className="absolute left-3 top-1/2 z-20 flex -translate-y-1/2 flex-col gap-1.5">
       <div className="mb-0.5 flex items-center gap-1.5 px-1 text-[9px] uppercase tracking-widest text-white/50">
         <span className={`inline-block h-1.5 w-1.5 rounded-full ${recording ? 'animate-pulse bg-red-500' : 'bg-white/30'}`} />
-        {recording ? 'tagging · rec' : 'tagging'}
+        {recording ? 'annotations · rec' : 'annotations'}
       </div>
       {defs.map((def) => (
         <TagButton key={def.id} def={def} isOpen={open[def.id] !== undefined} />

--- a/src/app/tagging/TaggingControls.tsx
+++ b/src/app/tagging/TaggingControls.tsx
@@ -1,14 +1,31 @@
 /**
- * TaggingControls (#92) — the single entry point mounted by `App` for live tagging.
+ * AnnotationControls (#92) — the single entry point mounted by `App` for live annotations.
  * It renders the launcher pill (bottom-center) that opens the {@link TaggingSheet}
  * setup surface, plus the always-on subscribers: the {@link TagButtonStack} (shown
- * while tagging mode is on) and the centered {@link Countdown}.
+ * while annotation mode is on) and the centered {@link Countdown}.
  *
  * Keeping these together behind one component keeps `App` changes minimal. Purely
  * presentational; the tagging store is the single source of truth.
+ *
+ * VOCABULARY — three nearby nouns, kept deliberately distinct:
+ *
+ *   - **Annotation** (`Highlighter`, this feature) — a time-anchored point or interval
+ *     over a recording, tapped live to segment it. Written to `<take>.annotations.jsonl`.
+ *   - **Tag** (`Tags`, `src/app/library/`) — a keyword on a saved instrument preset.
+ *   - **Marker** (no icon, `canvas_overlay`) — the "Control markers" overlay element,
+ *     i.e. the note-position guides drawn on the video.
+ *
+ * Annotations and tags used to share BOTH the word "Tags" and the `Tags` icon, which was
+ * genuinely confusing. "Marker" was the obvious replacement and is wrong: it is already
+ * taken by the overlay element above, so it would have moved the collision rather than
+ * removed it. Hence "annotation" — free, and it says exactly what the feature does.
+ *
+ * Code under `src/taglog/` and this folder keeps the generic `tag` vocabulary of the
+ * extraction-ready library; every user-facing string, and every artifact written to
+ * disk, says "annotation".
  */
 import { useState } from 'react';
-import { Tags } from 'lucide-react';
+import { Highlighter } from 'lucide-react';
 import { useTagging } from './store';
 import TagButtonStack from './TagButtonStack';
 import Countdown from './Countdown';
@@ -27,14 +44,14 @@ export default function TaggingControls() {
         {open && <TaggingSheet onClose={() => setOpen(false)} />}
         <button
           onClick={() => setOpen((o) => !o)}
-          aria-label="Tagging mode"
+          aria-label="Annotation mode"
           aria-expanded={open}
           className={`flex items-center gap-2 rounded-full px-4 py-2 text-[10px] font-bold uppercase tracking-widest backdrop-blur transition ${
             mode ? 'bg-emerald-500 text-black' : 'bg-black/50 text-white/80 hover:text-white'
           }`}
         >
-          <Tags className="h-3.5 w-3.5" />
-          Tags
+          <Highlighter className="h-3.5 w-3.5" />
+          Annotations
           {mode && tagCount > 0 && (
             <span className="rounded-full bg-black/30 px-1.5 text-[9px] tabular-nums">{tagCount}</span>
           )}

--- a/src/app/tagging/TaggingSheet.tsx
+++ b/src/app/tagging/TaggingSheet.tsx
@@ -9,12 +9,13 @@
  * Purely presentational — a subscriber to the tagging store. Part of the build-checked
  * React layer (no @types/react). Styling mirrors the recording SettingsSheet.
  */
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { ChevronDown, ChevronUp, Download, Plus, Trash2, X } from 'lucide-react';
 import type { ExclusivityMode, TagDef, TagKind } from '@/taglog/affordances';
 import { CODECS } from '@/taglog/affordances';
+import type { TimeChoice } from '@/taglog/adapters';
 import { useTagging } from './store';
-import { EXPORT_FORMATS, downloadTake, summarizeTake } from './export';
+import { EXPORT_FORMATS, RAW_FORMAT, TIME_CHOICES, downloadTake, summarizeTake } from './export';
 
 const selectCls = 'rounded bg-white/10 px-2 py-1 text-xs outline-none focus:bg-white/20';
 
@@ -30,6 +31,7 @@ function TagRow({ def, index, count }: { def: TagDef; index: number; count: numb
   const removeTag = useTagging((s) => s.removeTag);
   const moveTag = useTagging((s) => s.moveTag);
   const exclusivity = useTagging((s) => s.config.exclusivity);
+  const recording = useTagging((s) => s.take !== null);
 
   return (
     <div className="rounded-lg bg-white/5 p-2">
@@ -72,10 +74,15 @@ function TagRow({ def, index, count }: { def: TagDef; index: number; count: numb
             <ChevronDown className="h-3 w-3" />
           </button>
         </div>
+        {/* Deleting mid-take is disabled: the take's export labels come from the set it
+            STARTED with, and pulling a definition out from under an open interval is
+            confusing rather than useful. Stop first. */}
         <button
           onClick={() => removeTag(def.id)}
+          disabled={recording}
           aria-label="Delete annotation"
-          className="shrink-0 rounded p-1 text-white/40 transition hover:bg-white/10 hover:text-rose-400"
+          title={recording ? 'Stop the recording to delete an annotation' : undefined}
+          className="shrink-0 rounded p-1 text-white/40 transition hover:bg-white/10 hover:text-rose-400 disabled:cursor-not-allowed disabled:opacity-20 disabled:hover:bg-transparent disabled:hover:text-white/40"
         >
           <Trash2 className="h-3.5 w-3.5" />
         </button>
@@ -237,10 +244,21 @@ function ExportPanel() {
   const lastTake = useTagging((s) => s.lastTake);
   const recording = useTagging((s) => s.take !== null);
   const [format, setFormat] = useState<string>(EXPORT_FORMATS[0].id);
+  // Corrected vs raw is a real fork, not a detail: a lead-in shifts an annotation's
+  // times (open later, close earlier), so an export that silently picked one would
+  // hand the user numbers they never tapped. Default corrected (that is what a lead-in
+  // is for); one click gets the raw instants.
+  const [time, setTime] = useState<TimeChoice>('corrected');
 
-  const summary = lastTake ? summarizeTake(lastTake) : null;
+  // summarizeTake re-resolves the take (copy + sort + map); the take only changes when a
+  // recording ends, so don't redo it on every keystroke elsewhere in the sheet.
+  const summary = useMemo(() => (lastTake ? summarizeTake(lastTake) : null), [lastTake]);
   const total = summary ? summary.intervals + summary.points : 0;
   const chosen = EXPORT_FORMATS.find((f) => f.id === format) ?? EXPORT_FORMATS[0];
+  const chosenTime = TIME_CHOICES.find((t) => t.value === time) ?? TIME_CHOICES[0];
+  // The raw JSONL is the log itself — absolute-clock edges, uncorrected by construction —
+  // so the time basis simply does not apply to it.
+  const timeApplies = chosen.id !== RAW_FORMAT;
 
   return (
     <div className="mt-3 border-t border-white/10 pt-3">
@@ -284,7 +302,7 @@ function ExportPanel() {
               ))}
             </select>
             <button
-              onClick={() => downloadTake(lastTake, format)}
+              onClick={() => downloadTake(lastTake, format, time)}
               disabled={total === 0}
               className="flex items-center gap-1 rounded-full bg-emerald-500 px-3 py-1 text-[10px] font-bold uppercase tracking-widest text-black transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:bg-white/10 disabled:text-white/40"
             >
@@ -292,10 +310,32 @@ function ExportPanel() {
               Download
             </button>
           </div>
+          {/* The time basis, surfaced rather than silently applied (see export.ts). */}
+          <label className="mt-1.5 flex items-center justify-between gap-2">
+            <span className="text-[10px] uppercase tracking-widest text-white/50">Times</span>
+            <select
+              className={selectCls}
+              value={time}
+              disabled={!timeApplies}
+              onChange={(e) => setTime(e.target.value as TimeChoice)}
+              aria-label="Annotation export times"
+              title={timeApplies ? chosenTime.note : 'The raw log always carries the untouched event times.'}
+            >
+              {TIME_CHOICES.map((t) => (
+                <option key={t.value} value={t.value} title={t.note}>
+                  {t.label}
+                </option>
+              ))}
+            </select>
+          </label>
           <p className="mt-1.5 text-[10px] leading-snug text-white/35">
             {total === 0
               ? 'That take recorded no annotations — nothing to export.'
-              : chosen.note}
+              : `${chosen.note}${timeApplies ? ` ${chosenTime.note}` : ''}`}
+          </p>
+          <p className="mt-1 text-[10px] leading-snug text-white/25">
+            Kept in memory until you reload — the archival copy is the{' '}
+            <code>.annotations.jsonl</code> in the take folder.
           </p>
         </>
       )}

--- a/src/app/tagging/TaggingSheet.tsx
+++ b/src/app/tagging/TaggingSheet.tsx
@@ -1,17 +1,20 @@
 /**
- * TaggingSheet (#92) — the tagging-mode setup surface. Pick + order the tag set
- * (pre-seeded with the last-used set), choose exclusivity, and per tag set its kind
- * (interval/point), lead-in (pre-roll seconds), colour and label. It is a SETTINGS
+ * TaggingSheet (#92) — the annotation-mode setup surface. Pick + order the annotation set
+ * (pre-seeded with the last-used set), choose exclusivity, and per annotation set its kind
+ * (interval/point), lead-in (pre-roll seconds), colour and label. It also hosts the
+ * EXPORT panel for the last finished take. It is a SETTINGS
  * surface, not a form to submit: every edit flows straight into the tagging store
  * (which debounce-persists via the taglog provider), so closing never loses anything.
  *
  * Purely presentational — a subscriber to the tagging store. Part of the build-checked
  * React layer (no @types/react). Styling mirrors the recording SettingsSheet.
  */
-import { ChevronDown, ChevronUp, Plus, Trash2, X } from 'lucide-react';
+import { useState } from 'react';
+import { ChevronDown, ChevronUp, Download, Plus, Trash2, X } from 'lucide-react';
 import type { ExclusivityMode, TagDef, TagKind } from '@/taglog/affordances';
 import { CODECS } from '@/taglog/affordances';
 import { useTagging } from './store';
+import { EXPORT_FORMATS, downloadTake, summarizeTake } from './export';
 
 const selectCls = 'rounded bg-white/10 px-2 py-1 text-xs outline-none focus:bg-white/20';
 
@@ -42,7 +45,7 @@ function TagRow({ def, index, count }: { def: TagDef; index: number; count: numb
           value={def.color}
           onChange={(e) => updateTag(def.id, { color: e.target.value })}
           className="h-5 w-5 shrink-0 cursor-pointer rounded border-0 bg-transparent p-0"
-          title="Tag colour"
+          title="Annotation colour"
         />
         <input
           type="text"
@@ -71,7 +74,7 @@ function TagRow({ def, index, count }: { def: TagDef; index: number; count: numb
         </div>
         <button
           onClick={() => removeTag(def.id)}
-          aria-label="Delete tag"
+          aria-label="Delete annotation"
           className="shrink-0 rounded p-1 text-white/40 transition hover:bg-white/10 hover:text-rose-400"
         >
           <Trash2 className="h-3.5 w-3.5" />
@@ -104,7 +107,7 @@ function TagRow({ def, index, count }: { def: TagDef; index: number; count: numb
           </label>
         )}
         {exclusivity === 'group' && def.kind === 'interval' && (
-          <label className="flex items-center gap-1" title="Tags sharing a group auto-close each other.">
+          <label className="flex items-center gap-1" title="Annotations sharing a group auto-close each other.">
             Group
             <input
               type="text"
@@ -132,10 +135,10 @@ export default function TaggingSheet({ onClose }: { onClose: () => void }) {
   return (
     <div className="max-h-[80vh] w-80 overflow-y-auto rounded-2xl bg-black/70 p-3 text-white/90 shadow-2xl backdrop-blur">
       <div className="mb-2 flex items-center justify-between">
-        <span className="text-[10px] font-bold uppercase tracking-widest text-white/60">Tagging mode</span>
+        <span className="text-[10px] font-bold uppercase tracking-widest text-white/60">Annotation mode</span>
         <button
           onClick={onClose}
-          aria-label="Close tagging settings"
+          aria-label="Close annotation settings"
           className="rounded p-1 text-white/60 transition hover:bg-white/10 hover:text-white"
         >
           <X className="h-3.5 w-3.5" />
@@ -143,7 +146,7 @@ export default function TaggingSheet({ onClose }: { onClose: () => void }) {
       </div>
 
       {/* Master on/off — arms the button stack + the 1..9 keys. Disabled mid-take so
-          an active recording keeps its tag log. */}
+          an active recording keeps its annotation log. */}
       <label
         className={`mb-3 flex items-center justify-between rounded-lg bg-white/5 px-3 py-2 ${recording ? 'opacity-60' : ''}`}
         title={recording ? 'Stop the recording to change this' : undefined}
@@ -168,7 +171,7 @@ export default function TaggingSheet({ onClose }: { onClose: () => void }) {
       </div>
 
       <div className="mb-2 flex items-center justify-between">
-        <span className="text-[10px] uppercase tracking-widest text-white/50">Tags</span>
+        <span className="text-[10px] uppercase tracking-widest text-white/50">Annotations</span>
         <button
           onClick={() => addTag()}
           className="flex items-center gap-1 rounded-full bg-white/10 px-2.5 py-1 text-[10px] font-bold uppercase tracking-widest transition hover:bg-white/20"
@@ -179,7 +182,7 @@ export default function TaggingSheet({ onClose }: { onClose: () => void }) {
       <div className="space-y-1.5">
         {defs.length === 0 && (
           <p className="rounded-lg bg-white/5 p-3 text-center text-[11px] text-white/50">
-            No tags yet — add one to start.
+            No annotations yet — add one to start.
           </p>
         )}
         {defs.map((def, i) => (
@@ -192,7 +195,7 @@ export default function TaggingSheet({ onClose }: { onClose: () => void }) {
       <details className="mt-3">
         <summary className="cursor-pointer text-[10px] uppercase tracking-widest text-white/40">Advanced</summary>
         <div className="mt-2 flex items-center justify-between">
-          <span className="text-[10px] uppercase tracking-widest text-white/50" title="How each event is written to tags.jsonl">
+          <span className="text-[10px] uppercase tracking-widest text-white/50" title="How each event is written to annotations.jsonl">
             Event format
           </span>
           <select
@@ -209,10 +212,93 @@ export default function TaggingSheet({ onClose }: { onClose: () => void }) {
         </div>
       </details>
 
+      <ExportPanel />
+
       <p className="mt-3 text-[10px] leading-relaxed text-white/40">
-        Toggling a tag while recording writes a time-aligned <code>.tags.jsonl</code> into the take
-        folder. Keys 1–9 toggle; 0 clears all.
+        Annotations are recorded <strong className="text-white/60">only while the Record button is
+        running</strong> — tapping them otherwise is rehearsal and is not saved. During a take they
+        are written to <code>&lt;take&gt;.annotations.jsonl</code> in the take folder, on the same
+        clock as the audio and video. Keys 1–9 toggle; 0 clears all.
       </p>
+    </div>
+  );
+}
+
+/**
+ * Export the last finished take.
+ *
+ * This panel exists because the feature was previously write-only from the user's point of
+ * view: you could tap annotations all day and there was nowhere in the app to see or fetch
+ * them. The take folder did receive a `.annotations.jsonl`, but nothing said so, and JSONL of
+ * absolute-clock edges is not what anyone wants to open anyway. So: state plainly what
+ * happened (or why nothing did), and hand over a file in a format a real tool can read.
+ */
+function ExportPanel() {
+  const lastTake = useTagging((s) => s.lastTake);
+  const recording = useTagging((s) => s.take !== null);
+  const [format, setFormat] = useState<string>(EXPORT_FORMATS[0].id);
+
+  const summary = lastTake ? summarizeTake(lastTake) : null;
+  const total = summary ? summary.intervals + summary.points : 0;
+  const chosen = EXPORT_FORMATS.find((f) => f.id === format) ?? EXPORT_FORMATS[0];
+
+  return (
+    <div className="mt-3 border-t border-white/10 pt-3">
+      <div className="mb-2 flex items-center justify-between">
+        <span className="text-[10px] uppercase tracking-widest text-white/50">Export</span>
+        {recording && (
+          <span className="text-[9px] uppercase tracking-widest text-emerald-400">recording…</span>
+        )}
+      </div>
+
+      {!lastTake ? (
+        <p className="rounded-lg bg-white/5 p-3 text-[11px] leading-relaxed text-white/50">
+          {recording
+            ? 'Recording — your annotations will be exportable here as soon as you stop.'
+            : 'Nothing to export yet. Start a recording, tap some annotations, then stop: the take shows up here.'}
+        </p>
+      ) : (
+        <>
+          <p className="mb-2 text-[11px] text-white/60">
+            Last take:{' '}
+            <span className="tabular-nums text-white/90">
+              {summary!.intervals} interval{summary!.intervals === 1 ? '' : 's'}
+            </span>
+            {', '}
+            <span className="tabular-nums text-white/90">
+              {summary!.points} point{summary!.points === 1 ? '' : 's'}
+            </span>{' '}
+            over <span className="tabular-nums text-white/90">{summary!.seconds.toFixed(1)}s</span>.
+          </p>
+          <div className="flex items-center gap-2">
+            <select
+              className={`${selectCls} flex-1`}
+              value={format}
+              onChange={(e) => setFormat(e.target.value)}
+              aria-label="Annotation export format"
+            >
+              {EXPORT_FORMATS.map((f) => (
+                <option key={f.id} value={f.id} title={f.note}>
+                  {f.label}
+                </option>
+              ))}
+            </select>
+            <button
+              onClick={() => downloadTake(lastTake, format)}
+              disabled={total === 0}
+              className="flex items-center gap-1 rounded-full bg-emerald-500 px-3 py-1 text-[10px] font-bold uppercase tracking-widest text-black transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:bg-white/10 disabled:text-white/40"
+            >
+              <Download className="h-3 w-3" />
+              Download
+            </button>
+          </div>
+          <p className="mt-1.5 text-[10px] leading-snug text-white/35">
+            {total === 0
+              ? 'That take recorded no annotations — nothing to export.'
+              : chosen.note}
+          </p>
+        </>
+      )}
     </div>
   );
 }

--- a/src/app/tagging/TaggingSheet.tsx
+++ b/src/app/tagging/TaggingSheet.tsx
@@ -15,7 +15,7 @@ import type { ExclusivityMode, TagDef, TagKind } from '@/taglog/affordances';
 import { CODECS } from '@/taglog/affordances';
 import type { TimeChoice } from '@/taglog/adapters';
 import { useTagging } from './store';
-import { EXPORT_FORMATS, RAW_FORMAT, TIME_CHOICES, downloadTake, summarizeTake } from './export';
+import { DEFAULT_EXPORT_FORMAT, EXPORT_FORMATS, TIME_CHOICES, downloadTake, summarizeTake } from './export';
 
 const selectCls = 'rounded bg-white/10 px-2 py-1 text-xs outline-none focus:bg-white/20';
 
@@ -246,11 +246,15 @@ export default function TaggingSheet({ onClose }: { onClose: () => void }) {
  * them. The take folder did receive a `.annotations.jsonl`, but nothing said so, and JSONL of
  * absolute-clock edges is not what anyone wants to open anyway. So: state plainly what
  * happened (or why nothing did), and hand over a file in a format a real tool can read.
+ *
+ * It shows the last FINISHED take, and during a take there is none — `beginTake` clears the
+ * slot (store.ts), so a recording user sees the recording state, not the previous take's
+ * counts under a live Download button.
  */
 function ExportPanel() {
   const lastTake = useTagging((s) => s.lastTake);
   const recording = useTagging((s) => s.take !== null);
-  const [format, setFormat] = useState<string>(EXPORT_FORMATS[0].id);
+  const [format, setFormat] = useState<string>(DEFAULT_EXPORT_FORMAT);
   // Corrected vs raw is a real fork, not a detail: a lead-in shifts an annotation's
   // times (open later, close earlier), so an export that silently picked one would
   // hand the user numbers they never tapped. Default corrected (that is what a lead-in
@@ -263,9 +267,11 @@ function ExportPanel() {
   const total = summary ? summary.intervals + summary.points : 0;
   const chosen = EXPORT_FORMATS.find((f) => f.id === format) ?? EXPORT_FORMATS[0];
   const chosenTime = TIME_CHOICES.find((t) => t.value === time) ?? TIME_CHOICES[0];
-  // The raw JSONL is the log itself — absolute-clock edges, uncorrected by construction —
-  // so the time basis simply does not apply to it.
-  const timeApplies = chosen.id !== RAW_FORMAT;
+  // Whether the time basis changes the FILE — an adapter fact, read off the format, never
+  // assumed. CSV emits both time columns and the raw JSONL is the uncorrected log itself,
+  // so for those the picker is replaced by the one line that says so: a control that
+  // cannot change the download must not be offered as though it could.
+  const timeApplies = chosen.honorsTime;
 
   return (
     <div className="mt-3 border-t border-white/10 pt-3">
@@ -317,24 +323,32 @@ function ExportPanel() {
               Download
             </button>
           </div>
-          {/* The time basis, surfaced rather than silently applied (see export.ts). */}
-          <label className="mt-1.5 flex items-center justify-between gap-2">
-            <span className="text-[10px] uppercase tracking-widest text-white/50">Times</span>
-            <select
-              className={selectCls}
-              value={time}
-              disabled={!timeApplies}
-              onChange={(e) => setTime(e.target.value as TimeChoice)}
-              aria-label="Annotation export times"
-              title={timeApplies ? chosenTime.note : 'The raw log always carries the untouched event times.'}
-            >
-              {TIME_CHOICES.map((t) => (
-                <option key={t.value} value={t.value} title={t.note}>
-                  {t.label}
-                </option>
-              ))}
-            </select>
-          </label>
+          {/* The time basis, surfaced rather than silently applied (see export.ts) — and
+              only where it is real. For a format that carries both times (CSV) or none
+              (the raw log), the picker is replaced by the line that explains why: an
+              enabled control that cannot change the file is a lie about the file. */}
+          {timeApplies ? (
+            <label className="mt-1.5 flex items-center justify-between gap-2">
+              <span className="text-[10px] uppercase tracking-widest text-white/50">Times</span>
+              <select
+                className={selectCls}
+                value={time}
+                onChange={(e) => setTime(e.target.value as TimeChoice)}
+                aria-label="Annotation export times"
+                title={chosenTime.note}
+              >
+                {TIME_CHOICES.map((t) => (
+                  <option key={t.value} value={t.value} title={t.note}>
+                    {t.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+          ) : (
+            <p className="mt-1.5 text-[10px] leading-snug text-white/40">
+              <span className="uppercase tracking-widest text-white/50">Times</span> — {chosen.timeNote}
+            </p>
+          )}
           <p className="mt-1.5 text-[10px] leading-snug text-white/35">
             {total === 0
               ? 'That take recorded no annotations — nothing to export.'

--- a/src/app/tagging/TaggingSheet.tsx
+++ b/src/app/tagging/TaggingSheet.tsx
@@ -179,8 +179,15 @@ export default function TaggingSheet({ onClose }: { onClose: () => void }) {
 
       <div className="mb-2 flex items-center justify-between">
         <span className="text-[10px] uppercase tracking-widest text-white/50">Annotations</span>
+        {/* Adding mid-take is DELIBERATELY allowed (unlike deleting — see TagRow): you are
+            playing, you realise you want to mark "Bridge", you add it and tap it. The store
+            supports it end to end — `toggle` opens against the live set, and `endTake` closes
+            and labels against the take snapshot UNIONED with the live set (store.ts
+            `takeDefs`), so a mid-take annotation gets a real close edge in the archival JSONL
+            and its own label in the export. Deleting is the confusing one, not adding. */}
         <button
           onClick={() => addTag()}
+          title={recording ? 'You can add an annotation mid-take — it records from the moment you tap it' : undefined}
           className="flex items-center gap-1 rounded-full bg-white/10 px-2.5 py-1 text-[10px] font-bold uppercase tracking-widest transition hover:bg-white/20"
         >
           <Plus className="h-3 w-3" /> Add

--- a/src/app/tagging/export.ts
+++ b/src/app/tagging/export.ts
@@ -41,31 +41,77 @@ export interface ExportFormat {
   label: string;
   /** What the format is good for — shown next to the picker. */
   note: string;
+  /** Does the Times choice ({@link TIME_CHOICES}) actually change this file? Taken from
+   *  the adapter itself (`Adapter.honorsTime`), never guessed here. False for CSV (both
+   *  time columns) and for the raw log (absolute, uncorrected by construction) — for
+   *  those the UI must NOT offer a picker, or it would claim an effect it cannot deliver. */
+  honorsTime: boolean;
+  /** When `honorsTime` is false: the one line that says why, shown where the picker would be. */
+  timeNote?: string;
 }
 
 /**
  * The human copy for each adapter — the ONLY thing the picker adds to the registry.
  *
- * The picker is DERIVED from {@link ADAPTERS} below rather than listed by hand, so the
- * two cannot drift: a new adapter shows up in the UI by construction (with its id as a
- * fallback label), and a picker entry with no adapter behind it is unrepresentable.
+ * Format METADATA is derived from {@link ADAPTERS} (below) rather than listed by hand, so
+ * the two cannot drift: a new adapter shows up in the UI by construction (with its id as
+ * a fallback label), and a picker entry with no adapter behind it is unrepresentable.
+ * `honorsTime` likewise comes from the adapter, which is the only thing that knows.
  */
-const FORMAT_COPY: Record<string, { label: string; note: string }> = {
+const FORMAT_COPY: Record<string, { label: string; note: string; timeNote?: string }> = {
   audacity: { label: 'Audacity labels', note: 'Import as a label track (File → Import → Labels).' },
-  csv: { label: 'CSV', note: 'One row per annotation — spreadsheets, pandas, anything.' },
+  csv: {
+    label: 'CSV',
+    note: 'One row per annotation — spreadsheets, pandas, anything.',
+    timeNote: 'CSV carries both — raw and lead-in-corrected times are separate columns.',
+  },
   webvtt: { label: 'WebVTT', note: 'Subtitle/cue track for a <video> element or a player.' },
   textgrid: { label: 'Praat TextGrid', note: 'A tier per annotation — phonetics/speech tooling.' },
   otio: { label: 'OTIO', note: 'OpenTimelineIO — NLE round-trip (Resolve, Premiere…).' },
 };
 
+/**
+ * The picker's ORDER — declared here, in the app, not inherited from `Object.keys(ADAPTERS)`.
+ *
+ * `src/taglog/` is a library built to be lifted out into a standalone package: it has no
+ * knowledge of this UI, and the declaration order of its registry is an implementation
+ * detail. Deriving the order (and therefore the DEFAULT, which is just "the first one")
+ * from that key order would let a harmless reshuffle inside taglog silently change which
+ * file thoremin hands a user who never touched the picker. So ordering and default are
+ * thoremin's decisions, stated as such — while the metadata stays derived, so a NEW
+ * adapter still cannot go missing: unlisted ids are appended (alphabetically) rather than
+ * dropped.
+ */
+const FORMAT_ORDER: readonly string[] = ['audacity', 'csv', 'webvtt', 'textgrid', 'otio'];
+
+/** The format selected when the panel opens. Pinned by a test — changing it is a product
+ *  decision, and must not be a side effect of editing a library file. */
+export const DEFAULT_EXPORT_FORMAT = 'audacity';
+
+/** Adapter ids in the picker's order: the ones we ranked, then anything shipped since. */
+function orderedAdapterIds(): string[] {
+  const ids = Object.keys(ADAPTERS);
+  const ranked = FORMAT_ORDER.filter((id) => ids.includes(id));
+  const rest = ids.filter((id) => !FORMAT_ORDER.includes(id)).sort();
+  return [...ranked, ...rest];
+}
+
 /** The formats offered in the UI: every shipped adapter, plus the archival raw log. */
 export const EXPORT_FORMATS: ExportFormat[] = [
-  ...Object.keys(ADAPTERS).map((id) => ({
+  ...orderedAdapterIds().map((id) => ({
     id,
     label: FORMAT_COPY[id]?.label ?? id,
     note: FORMAT_COPY[id]?.note ?? `Rendered by the ${id} adapter.`,
+    honorsTime: ADAPTERS[id].honorsTime,
+    timeNote: FORMAT_COPY[id]?.timeNote,
   })),
-  { id: RAW_FORMAT, label: 'Raw JSONL', note: 'The exact archival file written into the take folder.' },
+  {
+    id: RAW_FORMAT,
+    label: 'Raw JSONL',
+    note: 'The exact archival file written into the take folder.',
+    honorsTime: false,
+    timeNote: 'The raw log always carries the untouched event times.',
+  },
 ];
 
 /** The two time bases an export can carry — surfaced, never silently chosen (see the

--- a/src/app/tagging/export.ts
+++ b/src/app/tagging/export.ts
@@ -1,0 +1,105 @@
+/**
+ * Annotation export (#92) — turn the last finished take into a file the user can
+ * actually open, in the tool they actually use.
+ *
+ * This is the missing half of live annotating. Until now the ONLY egress was the raw
+ * `<take>.annotations.jsonl` the recorder drops in the take folder: absolute-clock edge
+ * events, one JSON object per line. That is the right *archival* format (self-describing,
+ * losslessly re-resolvable, aligned to the manifest), but it is not something you can
+ * drag into Audacity — and if you never found the folder, it may as well not exist.
+ *
+ * `src/taglog/adapters/` already knew how to render Audacity label tracks, WebVTT cues,
+ * CSV, Praat TextGrids, and OTIO; nothing had ever called it. This module is the wiring.
+ *
+ * THE ONE SUBTLETY — the clock. Edge events are stamped on the ABSOLUTE engine clock
+ * (`performance.now()/1000`), the same clock `features.jsonl` uses, and the manifest's
+ * rule is that a stream's offset into the take is `t - t0`. Every consumer here wants
+ * take-relative seconds (an Audacity label at 0.0 = the first frame of the recording),
+ * so we shift by `t0` exactly once, right here, before resolving. Shifting the EDGES
+ * rather than the resolved intervals keeps it a single subtraction on one field, instead
+ * of four (start/end/startCorrected/endCorrected) — fewer places to forget one.
+ */
+import { resolveIntervals } from '@/taglog/affordances';
+import type { EdgeEvent, ResolvedInterval } from '@/taglog/affordances';
+import { ADAPTERS, getAdapter } from '@/taglog/adapters';
+import { downloadBlob } from '@/app/recorder';
+import type { LastTake } from './store';
+
+/** The raw recorded JSONL, offered alongside the rendered formats. It is the archival
+ *  artifact (identical to the file in the take folder), so it is a first-class choice —
+ *  not an adapter, because nothing needs to be rendered. */
+export const RAW_FORMAT = 'jsonl' as const;
+
+export interface ExportFormat {
+  id: string;
+  label: string;
+  /** What the format is good for — shown next to the picker. */
+  note: string;
+}
+
+/** The formats offered in the UI, in the order a user is likely to want them. */
+export const EXPORT_FORMATS: ExportFormat[] = [
+  { id: 'audacity', label: 'Audacity labels', note: 'Import as a label track (File → Import → Labels).' },
+  { id: 'csv', label: 'CSV', note: 'One row per annotation — spreadsheets, pandas, anything.' },
+  { id: 'webvtt', label: 'WebVTT', note: 'Subtitle/cue track for a <video> element or a player.' },
+  { id: 'textgrid', label: 'Praat TextGrid', note: 'A tier per annotation — phonetics/speech tooling.' },
+  { id: 'otio', label: 'OTIO', note: 'OpenTimelineIO — NLE round-trip (Resolve, Premiere…).' },
+  { id: RAW_FORMAT, label: 'Raw JSONL', note: 'The exact archival file written into the take folder.' },
+];
+
+/**
+ * Resolve a finished take into intervals on the TAKE clock (0 = start of recording).
+ *
+ * Still-open annotations are closed at the take's end (`endT`) rather than being dropped,
+ * so holding a button until you hit Stop yields an interval running to the end of the
+ * recording — which is what the gesture plainly means.
+ */
+export function resolveTake(take: LastTake): ResolvedInterval[] {
+  const shifted: EdgeEvent[] = take.edges.map((e) => ({
+    ...e,
+    t: e.t - take.t0,
+    tCorrected: e.tCorrected - take.t0,
+  }));
+  return resolveIntervals(shifted, { endT: take.endT - take.t0 });
+}
+
+/** Take duration in seconds — the timeline extent an adapter should span. */
+export const takeDuration = (take: LastTake): number => Math.max(0, take.endT - take.t0);
+
+/** Render a finished take in `format`. Returns the file body + the name to save it as. */
+export function renderTake(take: LastTake, format: string): { body: string; filename: string; mime: string } {
+  // `startedAt` is an ISO stamp; `:` is illegal in filenames on Windows and awkward
+  // everywhere, so flatten it the same way the recorder's stem does.
+  const stamp = take.startedAt.replace(/[:.]/g, '-').replace(/Z$/, '');
+  if (format === RAW_FORMAT) {
+    return { body: take.jsonl, filename: `${stamp}.annotations.jsonl`, mime: 'application/x-ndjson' };
+  }
+  const adapter = getAdapter(format);
+  if (!adapter) throw new Error(`Unknown annotation export format: ${format}`);
+  const body = adapter.render(resolveTake(take), {
+    defs: take.defs,
+    duration: takeDuration(take),
+  });
+  return { body, filename: `${stamp}.annotations.${adapter.ext}`, mime: adapter.mime };
+}
+
+/** Render + download a finished take. The one call the UI makes. */
+export function downloadTake(take: LastTake, format: string): void {
+  const { body, filename, mime } = renderTake(take, format);
+  downloadBlob(new Blob([body], { type: mime }), filename);
+}
+
+/** A one-line summary of what a take actually captured, for the sheet's export panel. */
+export function summarizeTake(take: LastTake): { intervals: number; points: number; seconds: number } {
+  const resolved = resolveTake(take);
+  return {
+    intervals: resolved.filter((iv) => iv.kind === 'interval').length,
+    points: resolved.filter((iv) => iv.kind === 'point').length,
+    seconds: takeDuration(take),
+  };
+}
+
+/** Guard: every id in {@link EXPORT_FORMATS} must be renderable (raw, or a known
+ *  adapter). Exported for the test that pins the two registries together, so adding a
+ *  format to the picker without an adapter fails in CI rather than at the user's click. */
+export const isRenderableFormat = (id: string): boolean => id === RAW_FORMAT || id in ADAPTERS;

--- a/src/app/tagging/export.ts
+++ b/src/app/tagging/export.ts
@@ -18,10 +18,16 @@
  * so we shift by `t0` exactly once, right here, before resolving. Shifting the EDGES
  * rather than the resolved intervals keeps it a single subtraction on one field, instead
  * of four (start/end/startCorrected/endCorrected) — fewer places to forget one.
+ *
+ * THE OTHER ONE — lead-in correction. An annotation with a lead-in is trimmed
+ * asymmetrically (open -> t+leadIn, close -> t-leadIn) to cut the reach-in/reach-out.
+ * That is the useful default, but it is NOT what the user tapped, so the choice is
+ * surfaced ({@link TIME_CHOICES}) and threaded to the adapters rather than silently
+ * defaulted.
  */
 import { resolveIntervals } from '@/taglog/affordances';
 import type { EdgeEvent, ResolvedInterval } from '@/taglog/affordances';
-import { ADAPTERS, getAdapter } from '@/taglog/adapters';
+import { ADAPTERS, getAdapter, type TimeChoice } from '@/taglog/adapters';
 import { downloadBlob } from '@/app/recorder';
 import type { LastTake } from './store';
 
@@ -37,14 +43,44 @@ export interface ExportFormat {
   note: string;
 }
 
-/** The formats offered in the UI, in the order a user is likely to want them. */
+/**
+ * The human copy for each adapter — the ONLY thing the picker adds to the registry.
+ *
+ * The picker is DERIVED from {@link ADAPTERS} below rather than listed by hand, so the
+ * two cannot drift: a new adapter shows up in the UI by construction (with its id as a
+ * fallback label), and a picker entry with no adapter behind it is unrepresentable.
+ */
+const FORMAT_COPY: Record<string, { label: string; note: string }> = {
+  audacity: { label: 'Audacity labels', note: 'Import as a label track (File → Import → Labels).' },
+  csv: { label: 'CSV', note: 'One row per annotation — spreadsheets, pandas, anything.' },
+  webvtt: { label: 'WebVTT', note: 'Subtitle/cue track for a <video> element or a player.' },
+  textgrid: { label: 'Praat TextGrid', note: 'A tier per annotation — phonetics/speech tooling.' },
+  otio: { label: 'OTIO', note: 'OpenTimelineIO — NLE round-trip (Resolve, Premiere…).' },
+};
+
+/** The formats offered in the UI: every shipped adapter, plus the archival raw log. */
 export const EXPORT_FORMATS: ExportFormat[] = [
-  { id: 'audacity', label: 'Audacity labels', note: 'Import as a label track (File → Import → Labels).' },
-  { id: 'csv', label: 'CSV', note: 'One row per annotation — spreadsheets, pandas, anything.' },
-  { id: 'webvtt', label: 'WebVTT', note: 'Subtitle/cue track for a <video> element or a player.' },
-  { id: 'textgrid', label: 'Praat TextGrid', note: 'A tier per annotation — phonetics/speech tooling.' },
-  { id: 'otio', label: 'OTIO', note: 'OpenTimelineIO — NLE round-trip (Resolve, Premiere…).' },
+  ...Object.keys(ADAPTERS).map((id) => ({
+    id,
+    label: FORMAT_COPY[id]?.label ?? id,
+    note: FORMAT_COPY[id]?.note ?? `Rendered by the ${id} adapter.`,
+  })),
   { id: RAW_FORMAT, label: 'Raw JSONL', note: 'The exact archival file written into the take folder.' },
+];
+
+/** The two time bases an export can carry — surfaced, never silently chosen (see the
+ *  module docstring). `corrected` is the default because it is what a lead-in is FOR. */
+export const TIME_CHOICES: { value: TimeChoice; label: string; note: string }[] = [
+  {
+    value: 'corrected',
+    label: 'Lead-in corrected',
+    note: 'Times are trimmed by each annotation’s lead-in (opens later, closes earlier).',
+  },
+  {
+    value: 'raw',
+    label: 'Raw taps',
+    note: 'Times are the exact instants you tapped, with no lead-in correction.',
+  },
 ];
 
 /**
@@ -66,26 +102,38 @@ export function resolveTake(take: LastTake): ResolvedInterval[] {
 /** Take duration in seconds — the timeline extent an adapter should span. */
 export const takeDuration = (take: LastTake): number => Math.max(0, take.endT - take.t0);
 
-/** Render a finished take in `format`. Returns the file body + the name to save it as. */
-export function renderTake(take: LastTake, format: string): { body: string; filename: string; mime: string } {
-  // `startedAt` is an ISO stamp; `:` is illegal in filenames on Windows and awkward
-  // everywhere, so flatten it the same way the recorder's stem does.
-  const stamp = take.startedAt.replace(/[:.]/g, '-').replace(/Z$/, '');
+/**
+ * Render a finished take in `format`, on the chosen `time` basis. Returns the file body
+ * + the name to save it as.
+ *
+ * The file stem is the take's `session` — which IS the take's folder name and file stem
+ * (the recorder's `stem`, already sanitized to be filesystem-safe). So a downloaded
+ * export can be matched back to the recording it came from by name alone, including when
+ * the user NAMED the take in the recording sheet (in which case the stem carries no
+ * timestamp at all, and anything derived from the clock would share nothing with it).
+ */
+export function renderTake(
+  take: LastTake,
+  format: string,
+  time: TimeChoice = 'corrected',
+): { body: string; filename: string; mime: string } {
+  const stem = take.session;
   if (format === RAW_FORMAT) {
-    return { body: take.jsonl, filename: `${stamp}.annotations.jsonl`, mime: 'application/x-ndjson' };
+    return { body: take.jsonl, filename: `${stem}.annotations.${RAW_FORMAT}`, mime: 'application/x-ndjson' };
   }
   const adapter = getAdapter(format);
   if (!adapter) throw new Error(`Unknown annotation export format: ${format}`);
   const body = adapter.render(resolveTake(take), {
     defs: take.defs,
     duration: takeDuration(take),
+    time,
   });
-  return { body, filename: `${stamp}.annotations.${adapter.ext}`, mime: adapter.mime };
+  return { body, filename: `${stem}.annotations.${adapter.ext}`, mime: adapter.mime };
 }
 
 /** Render + download a finished take. The one call the UI makes. */
-export function downloadTake(take: LastTake, format: string): void {
-  const { body, filename, mime } = renderTake(take, format);
+export function downloadTake(take: LastTake, format: string, time: TimeChoice = 'corrected'): void {
+  const { body, filename, mime } = renderTake(take, format, time);
   downloadBlob(new Blob([body], { type: mime }), filename);
 }
 
@@ -98,8 +146,3 @@ export function summarizeTake(take: LastTake): { intervals: number; points: numb
     seconds: takeDuration(take),
   };
 }
-
-/** Guard: every id in {@link EXPORT_FORMATS} must be renderable (raw, or a known
- *  adapter). Exported for the test that pins the two registries together, so adding a
- *  format to the picker without an adapter fails in CI rather than at the user's click. */
-export const isRenderableFormat = (id: string): boolean => id === RAW_FORMAT || id in ADAPTERS;

--- a/src/app/tagging/runtime.ts
+++ b/src/app/tagging/runtime.ts
@@ -3,7 +3,7 @@
  * the two host subsystems that must reach it without importing zustand directly:
  *
  *  - the {@link SessionRecorder}, via the {@link TagStreamSource} contract, so
- *    `tags.jsonl` rides in the recording folder on the shared `t0`;
+ *    `annotations.jsonl` rides in the recording folder on the shared `t0`;
  *  - the DAG overlay node, via a `ctx.resources.tagOverlay` function it reads each
  *    tick to burn the open tags + timecode into the recorded frames.
  *
@@ -11,14 +11,14 @@
  * of truth; these just present it behind the stable seams the recorder / overlay expect.
  */
 import { useTagging } from './store';
-import type { TagStreamSource, TagTakeMeta } from '../recording/tagStream';
+import type { TagStreamSource, TagTakeEnd, TagTakeMeta } from '../recording/tagStream';
 import type { TagOverlaySnapshot } from '@/taglog/presentation';
 
 /** A TagStreamSource backed by the live tagging store, handed to the SessionRecorder. */
 export const tagStreamSource: TagStreamSource = {
   active: () => useTagging.getState().active(),
   beginTake: (meta: TagTakeMeta) => useTagging.getState().beginTake(meta),
-  endTake: (endT: number) => useTagging.getState().endTake(endT),
+  endTake: (endT: number, end?: TagTakeEnd) => useTagging.getState().endTake(endT, end),
 };
 
 /** The overlay resource the burned-in corner HUD reads each tick (null unless a take

--- a/src/app/tagging/store.ts
+++ b/src/app/tagging/store.ts
@@ -56,6 +56,16 @@ interface TakeContext {
    *  It is the BASE of the set the end-of-take closeAll and the export label from — see
    *  {@link takeDefs} for why that set is the snapshot UNIONED with the live defs. */
   defs: TagDef[];
+  /** The take that held the export slot when THIS take began.
+   *
+   *  `beginTake` clears `lastTake` (a take in progress must never leave a *previous*
+   *  take's summary sitting in the export panel with a live Download button — record
+   *  take B, glance at the panel, and you would be looking at, and able to download,
+   *  take A). But an ABANDONED take that captured nothing is not a take at all — it
+   *  wrote no media files — and must not cost the user the export of the last real one.
+   *  So the displaced take is parked here for the duration and put back by `endTake` in
+   *  exactly that case. */
+  prev: LastTake | null;
 }
 
 /**
@@ -88,8 +98,9 @@ function takeDefs(snapshot: readonly TagDef[], live: readonly TagDef[]): TagDef[
  *  clean stop (source switch, engine restart, unmount) — see `SessionRecorder.dispose`. */
 export interface EndTakeOptions {
   /** True from `dispose()`. Such a take wrote NO media files, so it only earns the
-   *  {@link LastTake} slot if it actually captured annotations of its own — otherwise it
-   *  would clobber the previous, cleanly-finished take's export with an empty one. */
+   *  {@link LastTake} slot if it actually captured annotations of its own — otherwise the
+   *  take it displaced at `beginTake` ({@link TakeContext.prev}) gets the slot back,
+   *  rather than the user losing a real take's export to a phantom one. */
   abandoned?: boolean;
 }
 
@@ -147,8 +158,10 @@ interface TaggingState {
   state: TagState;
   /** The active recording take, or null when not recording. */
   take: TakeContext | null;
-  /** The take that just finished, kept so its annotations can still be exported. Null
-   *  until the first take of the session ends. See {@link LastTake}. */
+  /** The take that just FINISHED, kept so its annotations can still be exported. Null
+   *  until the first take of the session ends — and null again for the duration of every
+   *  take, because "the last finished take" is not a thing while one is in progress (see
+   *  {@link TakeContext.prev}). See {@link LastTake}. */
   lastTake: LastTake | null;
   /** The active lead-in countdown, or null. */
   countdown: CountdownState | null;
@@ -374,8 +387,14 @@ export const useTagging = create<TaggingState>((set, get) => ({
     // Fresh log per take: seq starts at 0, no carried-over open tags (the recorded
     // intervals are exactly what is toggled during the take). `defs` is snapshotted HERE
     // (see TakeContext) so a mid-take edit can't rewrite what was already recorded.
+    //
+    // `lastTake` is CLEARED (parked in `take.prev`): the export panel shows "the last
+    // finished take", and while a take is running there isn't one. Leaving the previous
+    // take in the slot showed a recording user the PRIOR take's interval counts under a
+    // live Download button — take A's file, offered while take B was being recorded.
     set({
-      take: { t0, session, sink, edges: [], defs: [...s.defs] },
+      take: { t0, session, sink, edges: [], defs: [...s.defs], prev: s.lastTake },
+      lastTake: null,
       state: emptyTagState(),
       countdown: null,
     });
@@ -409,13 +428,14 @@ export const useTagging = create<TaggingState>((set, get) => ({
       jsonl,
     };
     // An abandoned take (no clean stop => no media files on disk) publishes only if it
-    // captured something; otherwise the previous, exportable take keeps the slot.
+    // captured something; otherwise the take it displaced at beginTake gets the slot back
+    // (beginTake cleared it, so "keep the previous one" now means restoring it).
     const publish = !opts?.abandoned || s.take.edges.length > 0;
     set({
       take: null,
       state: emptyTagState(),
       countdown: null,
-      ...(publish ? { lastTake } : {}),
+      lastTake: publish ? lastTake : s.take.prev,
     });
     return jsonl;
   },

--- a/src/app/tagging/store.ts
+++ b/src/app/tagging/store.ts
@@ -42,14 +42,28 @@ import type { TagOverlaySnapshot } from '@/taglog/presentation';
 /** The active take's runtime context (present only while recording). */
 interface TakeContext {
   t0: number;
+  /** The take id == the recording stem == the take's folder + file-stem name. */
   session: string;
-  /** ISO wall-clock of the take start — carried into {@link LastTake} for file naming. */
-  startedAt: string;
   sink: TagEventSink;
   /** Every edge emitted during this take, kept alongside the sink's serialized lines.
    *  The sink only holds JSONL strings; resolving intervals for an export needs the
    *  structured edges, so we retain them here rather than re-parsing our own output. */
   edges: EdgeEvent[];
+  /** The annotation set the take STARTED with. Snapshotted here — not read live at
+   *  endTake — because the sheet stays openable mid-take: renaming "Verse" to "Chorus"
+   *  while recording must not retroactively relabel what was already recorded (and
+   *  deleting a def must not silently drop the auto-close of an interval it left open).
+   *  This is the set both the end-of-take closeAll and the export label from. */
+  defs: TagDef[];
+}
+
+/** How a take ended. An ABANDONED take is one whose recorder was torn down without a
+ *  clean stop (source switch, engine restart, unmount) — see `SessionRecorder.dispose`. */
+export interface EndTakeOptions {
+  /** True from `dispose()`. Such a take wrote NO media files, so it only earns the
+   *  {@link LastTake} slot if it actually captured annotations of its own — otherwise it
+   *  would clobber the previous, cleanly-finished take's export with an empty one. */
+  abandoned?: boolean;
 }
 
 /**
@@ -63,18 +77,22 @@ interface TakeContext {
  * for "their data" finds nothing anywhere in the app. Keeping the last take lets the
  * Annotations sheet offer a real export (Audacity / WebVTT / CSV / TextGrid / OTIO).
  *
- * `defs` is snapshotted at endTake so an export still carries the labels the annotations
- * were recorded WITH, even if the user edits the set afterwards.
+ * This is MEMORY-ONLY (no persist middleware, deliberately): it is an egress convenience,
+ * not state the instrument owns. The archival copy is the `.annotations.jsonl` in the take
+ * folder, and the panel says so.
+ *
+ * `defs` comes from the take's own snapshot ({@link TakeContext}), so an export always
+ * carries the labels the annotations were recorded WITH.
  */
 export interface LastTake {
+  /** The take id == the recording stem == the take's folder + file-stem name, so an
+   *  exported file can be named after — and matched back to — its recording. */
   session: string;
   /** Absolute engine-clock origin of the take (== manifest.t0). Export times are
    *  `t - t0`, i.e. offsets into the recording — the same rule the manifest states. */
   t0: number;
   /** Absolute engine-clock time the take ended (used to close open intervals). */
   endT: number;
-  /** ISO wall-clock of the take start — for naming the exported file. */
-  startedAt: string;
   edges: EdgeEvent[];
   defs: TagDef[];
   /** The exact JSONL written into the take folder (offered as a raw export too). */
@@ -115,13 +133,13 @@ interface TaggingState {
    *  the live rAF path). Injectable for tests. NOTE: this reads the wall clock
    *  directly, so it equals `ctx.time` only while the engine runs in real time. If
    *  batch/speed-scaled recording (the Clock abstraction) is ever wired into a live
-   *  take, tags.jsonl (this clock) and features.jsonl (`ctx.time`) would diverge —
+   *  take, annotations.jsonl (this clock) and features.jsonl (`ctx.time`) would diverge —
    *  route both through one clock source then. */
   clock: () => number;
 
   // ---- selectors ----
   isOpen(tagId: string): boolean;
-  /** True if this take should write a tags.jsonl (mode on + tags defined). */
+  /** True if this take should write an annotations.jsonl (mode on + tags defined). */
   active(): boolean;
   /** The burned-in-overlay snapshot (null unless recording). */
   overlaySnapshot(): TagOverlaySnapshot | null;
@@ -143,7 +161,7 @@ interface TaggingState {
 
   // ---- take lifecycle (called by the recorder) ----
   beginTake(input: { t0: number; startedAt: string; session: string }): void;
-  endTake(endT: number): string;
+  endTake(endT: number, opts?: EndTakeOptions): string;
 
   // ---- persistence ----
   hydrate(): Promise<void>;
@@ -326,17 +344,20 @@ export const useTagging = create<TaggingState>((set, get) => ({
       schema: ANNOTATIONS_SCHEMA_ID,
     });
     // Fresh log per take: seq starts at 0, no carried-over open tags (the recorded
-    // intervals are exactly what is toggled during the take).
+    // intervals are exactly what is toggled during the take). `defs` is snapshotted HERE
+    // (see TakeContext) so a mid-take edit can't rewrite what was already recorded.
     set({
-      take: { t0, session, sink, edges: [], startedAt },
+      take: { t0, session, sink, edges: [], defs: [...s.defs] },
       state: emptyTagState(),
       countdown: null,
     });
   },
-  endTake: (endT) => {
+  endTake: (endT, opts) => {
     const s = get();
     if (!s.take) return '';
-    const { edges } = closeAll(s.state, s.defs, endT, s.config, 'auto');
+    // Close against the take's OWN defs, not the current ones: an annotation deleted
+    // mid-take still has an open interval in `state` and must still be closed.
+    const { edges } = closeAll(s.state, s.take.defs, endT, s.config, 'auto');
     if (edges.length) {
       s.take.sink.append(edges);
       s.take.edges.push(...edges);
@@ -349,12 +370,19 @@ export const useTagging = create<TaggingState>((set, get) => ({
       session: s.take.session,
       t0: s.take.t0,
       endT,
-      startedAt: s.take.startedAt,
       edges: [...s.take.edges],
-      defs: [...s.defs],
+      defs: [...s.take.defs],
       jsonl,
     };
-    set({ take: null, lastTake, state: emptyTagState(), countdown: null });
+    // An abandoned take (no clean stop => no media files on disk) publishes only if it
+    // captured something; otherwise the previous, exportable take keeps the slot.
+    const publish = !opts?.abandoned || s.take.edges.length > 0;
+    set({
+      take: null,
+      state: emptyTagState(),
+      countdown: null,
+      ...(publish ? { lastTake } : {}),
+    });
     return jsonl;
   },
 

--- a/src/app/tagging/store.ts
+++ b/src/app/tagging/store.ts
@@ -53,8 +53,35 @@ interface TakeContext {
    *  endTake — because the sheet stays openable mid-take: renaming "Verse" to "Chorus"
    *  while recording must not retroactively relabel what was already recorded (and
    *  deleting a def must not silently drop the auto-close of an interval it left open).
-   *  This is the set both the end-of-take closeAll and the export label from. */
+   *  It is the BASE of the set the end-of-take closeAll and the export label from — see
+   *  {@link takeDefs} for why that set is the snapshot UNIONED with the live defs. */
   defs: TagDef[];
+}
+
+/**
+ * The annotation set a finished take is CLOSED and LABELLED against: the take's own
+ * snapshot, extended with any definition that only exists in the LIVE set (i.e. was
+ * added during the take). Snapshot wins on every id it has.
+ *
+ * Both mid-take edits pull the other way, and both must work:
+ *
+ *  - EDIT/DELETE of a def the take started with — the SNAPSHOT must win. Renaming
+ *    "Verse" to "Chorus" while recording must not retroactively relabel what was
+ *    already recorded, and deleting a def must not silently drop the auto-close of an
+ *    interval it left open (`closeAll` drops opens whose def it cannot find).
+ *  - ADD of a def during the take — the LIVE set must be consulted. `toggle` opens
+ *    against the live defs, so an annotation created mid-take is immediately tappable;
+ *    it therefore has to be closable and nameable too. Closing against the snapshot
+ *    alone orphans its open: NO `close` edge in the archival `.annotations.jsonl` (an
+ *    unpaired open, with nothing telling a consumer where the interval ended), no label
+ *    in the export, and an `openEnded` resolve.
+ *
+ * Union, snapshot-first: everything the take could have opened is closable, and nothing
+ * the take recorded is rewritten.
+ */
+function takeDefs(snapshot: readonly TagDef[], live: readonly TagDef[]): TagDef[] {
+  const recorded = new Set(snapshot.map((d) => d.id));
+  return [...snapshot, ...live.filter((d) => !recorded.has(d.id))];
 }
 
 /** How a take ended. An ABANDONED take is one whose recorder was torn down without a
@@ -81,8 +108,9 @@ export interface EndTakeOptions {
  * not state the instrument owns. The archival copy is the `.annotations.jsonl` in the take
  * folder, and the panel says so.
  *
- * `defs` comes from the take's own snapshot ({@link TakeContext}), so an export always
- * carries the labels the annotations were recorded WITH.
+ * `defs` is the take's own snapshot ({@link TakeContext}) unioned with anything added to
+ * the live set mid-take ({@link takeDefs}), so an export carries the labels the
+ * annotations were recorded WITH — and every annotation the take could tap has one.
  */
 export interface LastTake {
   /** The take id == the recording stem == the take's folder + file-stem name, so an
@@ -355,9 +383,13 @@ export const useTagging = create<TaggingState>((set, get) => ({
   endTake: (endT, opts) => {
     const s = get();
     if (!s.take) return '';
-    // Close against the take's OWN defs, not the current ones: an annotation deleted
-    // mid-take still has an open interval in `state` and must still be closed.
-    const { edges } = closeAll(s.state, s.take.defs, endT, s.config, 'auto');
+    // Neither the take's snapshot NOR the live set is the right thing to close against
+    // on its own — it is their union (see takeDefs). Closing against the live set alone
+    // drops an interval whose def was DELETED mid-take; closing against the snapshot
+    // alone drops the close of an interval whose def was ADDED mid-take (`toggle` opens
+    // against the live defs, so such an annotation is tappable and must be closable).
+    const defs = takeDefs(s.take.defs, s.defs);
+    const { edges } = closeAll(s.state, defs, endT, s.config, 'auto');
     if (edges.length) {
       s.take.sink.append(edges);
       s.take.edges.push(...edges);
@@ -366,12 +398,14 @@ export const useTagging = create<TaggingState>((set, get) => ({
     // Retain the finished take so the sheet can still export it. The recorder writes
     // the JSONL into the take folder; this is the copy the USER can act on — without
     // it, ending a take silently discarded every annotation the app still held.
+    // `defs` is the same union the closeAll used, so every recorded annotation carries
+    // a label in the export — including one created mid-take.
     const lastTake: LastTake = {
       session: s.take.session,
       t0: s.take.t0,
       endT,
       edges: [...s.take.edges],
-      defs: [...s.take.defs],
+      defs,
       jsonl,
     };
     // An abandoned take (no clean stop => no media files on disk) publishes only if it

--- a/src/app/tagging/store.ts
+++ b/src/app/tagging/store.ts
@@ -22,7 +22,8 @@ import {
   emptyTagState,
   TagDefSchema,
   DEFAULT_TAGGING_CONFIG,
-  TAGS_SCHEMA_ID,
+  ANNOTATIONS_SCHEMA_ID,
+  type EdgeEvent,
   type TagDef,
   type TaggingConfig,
   type TagState,
@@ -42,7 +43,42 @@ import type { TagOverlaySnapshot } from '@/taglog/presentation';
 interface TakeContext {
   t0: number;
   session: string;
+  /** ISO wall-clock of the take start — carried into {@link LastTake} for file naming. */
+  startedAt: string;
   sink: TagEventSink;
+  /** Every edge emitted during this take, kept alongside the sink's serialized lines.
+   *  The sink only holds JSONL strings; resolving intervals for an export needs the
+   *  structured edges, so we retain them here rather than re-parsing our own output. */
+  edges: EdgeEvent[];
+}
+
+/**
+ * The take that just finished — retained so the user can still get their annotations
+ * OUT after the recording stops.
+ *
+ * Without this, `endTake` drained the sink and dropped everything on the floor: the only
+ * copy of an annotation log was the `.annotations.jsonl` inside the take folder, which
+ * (a) is JSONL of raw *absolute-clock* edges, not something you can open in an editor,
+ * and (b) is easy to miss entirely — a user who taps annotation buttons and then looks
+ * for "their data" finds nothing anywhere in the app. Keeping the last take lets the
+ * Annotations sheet offer a real export (Audacity / WebVTT / CSV / TextGrid / OTIO).
+ *
+ * `defs` is snapshotted at endTake so an export still carries the labels the annotations
+ * were recorded WITH, even if the user edits the set afterwards.
+ */
+export interface LastTake {
+  session: string;
+  /** Absolute engine-clock origin of the take (== manifest.t0). Export times are
+   *  `t - t0`, i.e. offsets into the recording — the same rule the manifest states. */
+  t0: number;
+  /** Absolute engine-clock time the take ended (used to close open intervals). */
+  endT: number;
+  /** ISO wall-clock of the take start — for naming the exported file. */
+  startedAt: string;
+  edges: EdgeEvent[];
+  defs: TagDef[];
+  /** The exact JSONL written into the take folder (offered as a raw export too). */
+  jsonl: string;
 }
 
 /** The presentation countdown for a just-opened tag with a lead-in (§6). */
@@ -65,6 +101,9 @@ interface TaggingState {
   state: TagState;
   /** The active recording take, or null when not recording. */
   take: TakeContext | null;
+  /** The take that just finished, kept so its annotations can still be exported. Null
+   *  until the first take of the session ends. See {@link LastTake}. */
+  lastTake: LastTake | null;
   /** The active lead-in countdown, or null. */
   countdown: CountdownState | null;
   /** Bumped whenever a point fires — a cheap signal for one-shot flash animations. */
@@ -162,6 +201,7 @@ export const useTagging = create<TaggingState>((set, get) => ({
   config: DEFAULT_TAGGING_CONFIG,
   state: emptyTagState(),
   take: null,
+  lastTake: null,
   countdown: null,
   pulse: 0,
   lastPoint: null,
@@ -238,7 +278,10 @@ export const useTagging = create<TaggingState>((set, get) => ({
     // rehearsal (no take) t is unused (nothing is logged).
     const t = perf;
     const { state, edges } = applyToggle(s.state, s.defs, { tagId, t, src }, s.config);
-    if (s.take && edges.length) s.take.sink.append(edges);
+    if (s.take && edges.length) {
+      s.take.sink.append(edges);
+      s.take.edges.push(...edges);
+    }
     const opened = edges.find((e) => e.tag === tagId && e.status === 'open');
     const firedPoint = edges.some((e) => e.status === 'point');
     set({
@@ -259,7 +302,10 @@ export const useTagging = create<TaggingState>((set, get) => ({
     // Absolute engine clock, same as toggle() (see the note there).
     const t = s.clock();
     const { state, edges } = closeAll(s.state, s.defs, t, s.config, src);
-    if (s.take && edges.length) s.take.sink.append(edges);
+    if (s.take && edges.length) {
+      s.take.sink.append(edges);
+      s.take.edges.push(...edges);
+    }
     set({ state, countdown: null });
   },
   clearCountdown: () => set({ countdown: null }),
@@ -277,19 +323,38 @@ export const useTagging = create<TaggingState>((set, get) => ({
       wallClockISO: startedAt,
       recStartPerf: t0 * 1000,
       session,
-      schema: TAGS_SCHEMA_ID,
+      schema: ANNOTATIONS_SCHEMA_ID,
     });
     // Fresh log per take: seq starts at 0, no carried-over open tags (the recorded
     // intervals are exactly what is toggled during the take).
-    set({ take: { t0, session, sink }, state: emptyTagState(), countdown: null });
+    set({
+      take: { t0, session, sink, edges: [], startedAt },
+      state: emptyTagState(),
+      countdown: null,
+    });
   },
   endTake: (endT) => {
     const s = get();
     if (!s.take) return '';
     const { edges } = closeAll(s.state, s.defs, endT, s.config, 'auto');
-    if (edges.length) s.take.sink.append(edges);
+    if (edges.length) {
+      s.take.sink.append(edges);
+      s.take.edges.push(...edges);
+    }
     const jsonl = s.take.sink.drain();
-    set({ take: null, state: emptyTagState(), countdown: null });
+    // Retain the finished take so the sheet can still export it. The recorder writes
+    // the JSONL into the take folder; this is the copy the USER can act on — without
+    // it, ending a take silently discarded every annotation the app still held.
+    const lastTake: LastTake = {
+      session: s.take.session,
+      t0: s.take.t0,
+      endT,
+      startedAt: s.take.startedAt,
+      edges: [...s.take.edges],
+      defs: [...s.defs],
+      jsonl,
+    };
+    set({ take: null, lastTake, state: emptyTagState(), countdown: null });
     return jsonl;
   },
 

--- a/src/app/useEngine.ts
+++ b/src/app/useEngine.ts
@@ -376,7 +376,7 @@ export function useThoreminEngine(source: SourceSpec = DEFAULT_SOURCE) {
         engine,
         resources: resourcesRef.current,
         instrument: recInstrumentRef.current,
-        // If tagging mode is on, tags.jsonl rides in the folder on the shared t0 (#92).
+        // If annotation mode is on, annotations.jsonl rides in the folder on the shared t0 (#92).
         tagSource: tagStreamSource,
       },
       recSession,

--- a/src/taglog/README.md
+++ b/src/taglog/README.md
@@ -40,7 +40,11 @@ nothing — is what makes extraction mechanical.
 ### `adapters/` — pure exporters (`ResolvedInterval[] -> string`)
 
 Audacity labels · WebVTT · CSV · Praat TextGrid · OTIO. Add a format by adding one
-entry to `ADAPTERS`.
+entry to `ADAPTERS`, declaring `honorsTime`: whether `opts.time`
+(`'corrected' | 'raw'`) changes the output. It is `false` for CSV, which emits both
+times as separate columns — so a UI must not offer a time basis for it. `ADAPTERS` is
+a registry, not a running order: key order carries no meaning, and a UI that wants a
+picker order or a default format declares those itself.
 
 ### `provider/` — persistence + the event sink
 

--- a/src/taglog/README.md
+++ b/src/taglog/README.md
@@ -1,9 +1,13 @@
 # taglog
 
 A live event-tagging tool: toggle a small set of **tags** on/off while recording,
-and each toggle appends a `(t, tag, status)` row to a `tags.jsonl` that later
-**segments** the recorded streams (video / audio / features) for analysis or ML
-training.
+and each toggle appends a `(t, tag, status)` row to an event-log JSONL — thoremin
+writes it as `<take>.annotations.jsonl` — that later **segments** the recorded
+streams (video / audio / features) for analysis or ML training.
+
+(Vocabulary: the nouns in this folder are deliberately generic — `tag`, `TagDef`,
+`TagEvent` — because it is built to lift out. thoremin's product surface calls the
+feature **annotations**; see `src/app/tagging/TaggingControls.tsx` for the mapping.)
 
 This folder is written to **lift out of thoremin into a standalone package**
 (working name `taglog`). It has no thoremin imports and no React; the thoremin-
@@ -72,6 +76,6 @@ sink.append(edges);
 
 // on stop:
 sink.append(closeAll(state, defs, tEnd, config, 'auto').edges);
-const jsonl = sink.drain();                          // -> {stem}.tags.jsonl
+const jsonl = sink.drain();                          // -> {stem}.annotations.jsonl
 const intervals = resolveIntervals(/* parsed edges */, { endT: tEnd });
 ```

--- a/src/taglog/adapters/index.ts
+++ b/src/taglog/adapters/index.ts
@@ -15,7 +15,11 @@
  *
  * Pure `ResolvedInterval[] -> string`. Adding a format is one entry in {@link ADAPTERS},
  * so the representation stays open/closed. By default each uses the lead-in-CORRECTED
- * times (the clean middle of the action); pass `time:'raw'` for the click instants.
+ * times (the clean middle of the action); pass `time:'raw'` for the click instants —
+ * EXCEPT CSV, which emits both times as separate columns and therefore ignores the
+ * choice. That asymmetry is declared on the adapter ({@link Adapter.honorsTime}), not
+ * left for each caller to rediscover: a UI that offers the choice for CSV would be
+ * promising an effect the renderer does not have.
  */
 import type { ResolvedInterval, TagDef } from '../affordances/schema';
 import { formatTimecode } from '../affordances/time';
@@ -84,7 +88,15 @@ export function toWebVTT(intervals: readonly ResolvedInterval[], opts: AdapterOp
   return `WEBVTT\n\n${cues.join('\n\n')}${cues.length ? '\n' : ''}`;
 }
 
-/** CSV: one row per resolved interval/point, with both raw and corrected times. */
+/**
+ * CSV: one row per resolved interval/point, with BOTH the raw and the corrected times as
+ * their own columns.
+ *
+ * It therefore — alone among the adapters — ignores `opts.time` by design: the choice is
+ * a choice about which pair of numbers to *drop*, and CSV drops neither. Callers must not
+ * offer the user a time basis for CSV (see {@link Adapter.honorsTime}); the columns are
+ * the answer.
+ */
 export function toCSV(intervals: readonly ResolvedInterval[], opts: AdapterOptions = {}): string {
   const head = 'tag,label,kind,start,end,startCorrected,endCorrected,degenerate,openEnded';
   // Quote on any CR/LF/quote/comma so a lone \r can't corrupt a CRLF-strict parser.
@@ -211,16 +223,35 @@ export interface Adapter {
   name: string;
   ext: string;
   mime: string;
+  /**
+   * Does `opts.time` actually change this adapter's output?
+   *
+   * `true` for every format that must commit to ONE pair of times (Audacity, WebVTT,
+   * TextGrid, OTIO). `false` for CSV, which carries the raw AND the corrected times in
+   * separate columns and so renders byte-identically either way (and for any future
+   * adapter that likewise emits both).
+   *
+   * Stated here, on the adapter, because it is a fact about the RENDERER — a UI cannot
+   * know it, and a UI that guesses it wrong lies to the user (offering a Times picker
+   * for CSV, whose file does not change). Required, not optional: a new adapter has to
+   * say which it is rather than inherit a default that may not hold.
+   */
+  honorsTime: boolean;
   render(intervals: readonly ResolvedInterval[], opts?: AdapterOptions): string;
 }
 
-/** The shipped adapter registry (open for extension). Keyed by format name. */
+/** The shipped adapter registry (open for extension). Keyed by format name.
+ *
+ * NOTE for callers: this is a REGISTRY, not a running order. Key order here is
+ * declaration order and carries no meaning — a UI that wants a stable picker order or a
+ * default format must declare those itself (thoremin does, in `app/tagging/export.ts`).
+ */
 export const ADAPTERS: Record<string, Adapter> = {
-  audacity: { name: 'audacity', ext: 'txt', mime: 'text/plain', render: toAudacityLabels },
-  webvtt: { name: 'webvtt', ext: 'vtt', mime: 'text/vtt', render: toWebVTT },
-  csv: { name: 'csv', ext: 'csv', mime: 'text/csv', render: toCSV },
-  textgrid: { name: 'textgrid', ext: 'TextGrid', mime: 'text/plain', render: toTextGrid },
-  otio: { name: 'otio', ext: 'otio', mime: 'application/json', render: toOTIO },
+  audacity: { name: 'audacity', ext: 'txt', mime: 'text/plain', honorsTime: true, render: toAudacityLabels },
+  webvtt: { name: 'webvtt', ext: 'vtt', mime: 'text/vtt', honorsTime: true, render: toWebVTT },
+  csv: { name: 'csv', ext: 'csv', mime: 'text/csv', honorsTime: false, render: toCSV },
+  textgrid: { name: 'textgrid', ext: 'TextGrid', mime: 'text/plain', honorsTime: true, render: toTextGrid },
+  otio: { name: 'otio', ext: 'otio', mime: 'application/json', honorsTime: true, render: toOTIO },
 };
 
 /** Look up an adapter by name (undefined for an unknown format).

--- a/src/taglog/adapters/index.ts
+++ b/src/taglog/adapters/index.ts
@@ -1,7 +1,8 @@
 /**
  * taglog — export adapters (the survey's non-negotiable I/O pattern, design §2/§4).
  *
- * The native log is `tags.jsonl` (raw events, written by the provider sink). These
+ * The native log is the raw event JSONL written by the provider sink (thoremin names it
+ * `<take>.annotations.jsonl`). These
  * adapters take the RESOLVED view (`ResolvedInterval[]` from `resolveIntervals`) and
  * emit standard interchange formats so a tag log opens in the tools researchers
  * already use — Audacity, Praat, a `<track>` preview, a spreadsheet, an NLE:
@@ -222,7 +223,12 @@ export const ADAPTERS: Record<string, Adapter> = {
   otio: { name: 'otio', ext: 'otio', mime: 'application/json', render: toOTIO },
 };
 
-/** Look up an adapter by name (undefined for an unknown format). */
+/** Look up an adapter by name (undefined for an unknown format).
+ *
+ * `hasOwn`, not `name in ADAPTERS` / a bare index: `ADAPTERS` is a plain object, so the
+ * prototype chain would answer for `'toString'`, `'constructor'`, … — handing a caller
+ * `Object.prototype.toString` (truthy, so their `if (!adapter) throw` guard passes) and
+ * blowing up later on `adapter.render is not a function`. */
 export function getAdapter(name: string): Adapter | undefined {
-  return ADAPTERS[name];
+  return Object.hasOwn(ADAPTERS, name) ? ADAPTERS[name] : undefined;
 }

--- a/src/taglog/affordances/schema.ts
+++ b/src/taglog/affordances/schema.ts
@@ -4,7 +4,8 @@
  * This is the reusable heart of the live-tagging tool (thoremin issue #92,
  * design research in discussion #81). It defines, with Zod, the two schemas the
  * whole system pivots on — the **TagDef** (a tag's definition, chosen before
- * recording) and the **TagEvent** (one wire row in `tags.jsonl`) — plus the
+ * recording) and the **TagEvent** (one wire row in the event log JSONL, which thoremin
+ * writes as `<take>.annotations.jsonl`) — plus the
  * neutral in-memory types (`TagAction`, `EdgeEvent`, `TagState`, `ResolvedInterval`)
  * the pure logic passes around.
  *
@@ -17,15 +18,17 @@
  */
 import { z } from 'zod';
 
-/** The schema id written into a `annotations.jsonl` anchor record (version from day one,
+/** The schema id written into an `annotations.jsonl` anchor record (version from day one,
  * per the annotation-systems survey). Overridable for a non-thoremin host.
  *
  * NOTE ON VOCABULARY: this library is `taglog` and its internal nouns are tag/TagDef/
  * TagEvent — a deliberately generic vocabulary, since it is built to be lifted out as a
- * standalone package. thoremin's *product* surface calls these **markers**, because
- * "tag" is already taken there by the instrument library (keywords on a saved preset),
- * and one word for two unrelated things was actively confusing. So: `tag` inside this
- * folder, `marker` in the UI and in the artifacts thoremin writes to disk. */
+ * standalone package. thoremin's *product* surface calls these **annotations**, because
+ * "tag" is already taken there by the instrument library (keywords on a saved preset).
+ * ("Marker" was not free either — `canvas_overlay` has "Control markers".) So: `tag`
+ * inside this folder, `annotation` in the UI and in the artifacts thoremin writes to
+ * disk. The full three-way mapping is written down in the header of
+ * `src/app/tagging/TaggingControls.tsx`, which is the SSOT for it. */
 export const ANNOTATIONS_SCHEMA_ID = 'thoremin.annotations/1' as const;
 
 /** A tag is either a labelled interval (open then close) or an instantaneous point. */
@@ -131,7 +134,7 @@ export type TaggingConfig = z.infer<typeof TaggingConfigSchema>;
 export const DEFAULT_TAGGING_CONFIG: TaggingConfig = TaggingConfigSchema.parse({});
 
 /**
- * The self-describing first line of a `tags.jsonl`: it records the anchor origin so
+ * The self-describing first line of the event log: it records the anchor origin so
  * a consumer can interpret the file without trusting file-creation dates (§5). `t` is
  * the absolute engine-clock **origin** (== manifest.t0); every event `t` minus this
  * is its offset into the take — the same rule the manifest applies to every stream.

--- a/src/taglog/affordances/schema.ts
+++ b/src/taglog/affordances/schema.ts
@@ -17,9 +17,16 @@
  */
 import { z } from 'zod';
 
-/** The schema id written into a `tags.jsonl` anchor record (version from day one,
- * per the annotation-systems survey). Overridable for a non-thoremin host. */
-export const TAGS_SCHEMA_ID = 'thoremin.tags/1' as const;
+/** The schema id written into a `annotations.jsonl` anchor record (version from day one,
+ * per the annotation-systems survey). Overridable for a non-thoremin host.
+ *
+ * NOTE ON VOCABULARY: this library is `taglog` and its internal nouns are tag/TagDef/
+ * TagEvent — a deliberately generic vocabulary, since it is built to be lifted out as a
+ * standalone package. thoremin's *product* surface calls these **markers**, because
+ * "tag" is already taken there by the instrument library (keywords on a saved preset),
+ * and one word for two unrelated things was actively confusing. So: `tag` inside this
+ * folder, `marker` in the UI and in the artifacts thoremin writes to disk. */
+export const ANNOTATIONS_SCHEMA_ID = 'thoremin.annotations/1' as const;
 
 /** A tag is either a labelled interval (open then close) or an instantaneous point. */
 export const TagKindSchema = z.enum(['interval', 'point']);
@@ -140,7 +147,7 @@ export const AnchorRecordSchema = z.object({
   recStartPerf: z.number(),
   /** Session/take id, for cross-file correlation. */
   session: z.string(),
-  /** Schema id + version (e.g. "thoremin.tags/1"). */
+  /** Schema id + version (e.g. "thoremin.annotations/1"). */
   schema: z.string(),
 });
 export type AnchorRecord = z.infer<typeof AnchorRecordSchema>;

--- a/src/taglog/index.ts
+++ b/src/taglog/index.ts
@@ -1,8 +1,9 @@
 /**
  * taglog — a live event-tagging tool, structured to lift out of thoremin into a
  * standalone reusable package (working name `taglog`). Toggle a small set of tags
- * on/off while recording; each toggle appends a `(t, tag, status)` row to a
- * `tags.jsonl` that later segments the recorded streams for analysis / ML training.
+ * on/off while recording; each toggle appends a `(t, tag, status)` row to an event-log
+ * JSONL (thoremin writes it as `<take>.annotations.jsonl`) that later segments the
+ * recorded streams for analysis / ML training.
  *
  * Three layers, strict dependency direction **presentation -> affordances <- provider**
  * (that one rule is what makes extraction mechanical):

--- a/test/recording_plan.test.ts
+++ b/test/recording_plan.test.ts
@@ -117,28 +117,28 @@ describe('planRecording — single-file escape hatch', () => {
   });
 });
 
-describe('planRecording — live-tagging stream (#92)', () => {
-  const planT = (s: RecordingSession, includeTags: boolean) =>
-    planRecording({ session: s, stem: STEM, audioMime: AUDIO_MIME, videoMime: VIDEO_MIME, includeTags });
+describe('planRecording — live-annotation stream (#92)', () => {
+  const planT = (s: RecordingSession, includeAnnotations: boolean) =>
+    planRecording({ session: s, stem: STEM, audioMime: AUDIO_MIME, videoMime: VIDEO_MIME, includeAnnotations });
 
-  it('adds a `.tags.jsonl` stream (before the manifest) when tagging is active', () => {
+  it('adds an `.annotations.jsonl` stream (before the manifest) when annotating is active', () => {
     const p = planT(session(), true);
-    const tags = p.files.find((f) => f.kind === 'tags');
-    expect(tags?.name).toBe(`${STEM}.tags.jsonl`);
-    expect(tags).toMatchObject({ role: 'tags', ext: 'jsonl' });
-    // ordering: tags sits right before the always-last manifest
+    const annotations = p.files.find((f) => f.kind === 'annotations');
+    expect(annotations?.name).toBe(`${STEM}.annotations.jsonl`);
+    expect(annotations).toMatchObject({ role: 'annotations', ext: 'jsonl' });
+    // ordering: annotations sit right before the always-last manifest
     const kinds = p.files.map((f) => f.kind);
-    expect(kinds.indexOf('tags')).toBe(kinds.indexOf('manifest') - 1);
+    expect(kinds.indexOf('annotations')).toBe(kinds.indexOf('manifest') - 1);
   });
 
-  it('omits the tags stream when tagging is inactive', () => {
-    expect(planT(session(), false).files.some((f) => f.kind === 'tags')).toBe(false);
+  it('omits the annotation stream when annotating is inactive', () => {
+    expect(planT(session(), false).files.some((f) => f.kind === 'annotations')).toBe(false);
   });
 
   it('forces folder mode even for an otherwise single-file-eligible take', () => {
     const p = planT(session({ singleFileWhenAlone: true, streams: { audio: true } }), true);
     expect(p.useFolder).toBe(true);
-    expect(p.files.some((f) => f.kind === 'tags')).toBe(true);
+    expect(p.files.some((f) => f.kind === 'annotations')).toBe(true);
     expect(p.files.some((f) => f.kind === 'manifest')).toBe(true);
   });
 });

--- a/test/tagging_export.test.ts
+++ b/test/tagging_export.test.ts
@@ -55,6 +55,26 @@ beforeEach(() => {
   });
 });
 
+/**
+ * The wire rows of a finished take's ARCHIVAL JSONL (the file the recorder drops in the
+ * take folder), filtered to one tag + status.
+ *
+ * The export can *look* right while the archival log is broken, so the log has to be
+ * asserted directly. `resolveIntervals` synthesizes an interval from a LONE open when it
+ * is given `endT` (its open-ended path), which means a start/end assertion on the export
+ * passes just as happily when the close edge was never written — the difference shows up
+ * only as `openEnded: true` and a missing `close` row. A consumer of the SSOT (which has
+ * no `endT`, only the file) has no such fallback: an unpaired open tells it nothing about
+ * where the interval ended.
+ */
+function wireRows(take: LastTake, tag: string, status: 'open' | 'close' | 'point'): unknown[] {
+  return take.jsonl
+    .trim()
+    .split('\n')
+    .map((line) => JSON.parse(line) as Record<string, unknown>)
+    .filter((row) => row.tag === tag && row.status === status);
+}
+
 /** Record a take: A spans [t0+1, t0+3], a point fires at t0+4, A reopens and is still
  *  open when the take stops at t0+6 (so it must be auto-closed at the end). */
 function recordTake(): LastTake {
@@ -114,7 +134,7 @@ describe('the take snapshots the annotation set it STARTED with', () => {
     expect(renderTake(last, 'audacity').body).toContain('Verse');
   });
 
-  it('an annotation deleted mid-take still gets its open interval closed at the end', () => {
+  it('an annotation deleted mid-take still gets its open interval CLOSED at the end', () => {
     const st = useTagging.getState();
     st.setDefs([A, P]);
     st.beginTake({ t0: T0, startedAt: 'x', session: 'sess_x' });
@@ -124,8 +144,39 @@ describe('the take snapshots the annotation set it STARTED with', () => {
     useTagging.getState().endTake(T0 + 6);
 
     const last = useTagging.getState().lastTake!;
-    // Closing against the LIVE defs would have dropped this interval on the floor.
-    expect(resolveTake(last)).toMatchObject([{ tag: 'a', start: 1, end: 6, kind: 'interval' }]);
+    const [iv] = resolveTake(last);
+    expect(iv).toMatchObject({ tag: 'a', start: 1, end: 6, kind: 'interval' });
+    // These two are the load-bearing assertions, and start/end are NOT: closing against
+    // the live defs (which no longer have `a`) drops the orphaned open and emits no close
+    // edge — yet resolveIntervals' open-ended path then synthesizes the very same
+    // {start: 1, end: 6} from the lone open. The observable difference is here.
+    expect(iv.openEnded).toBe(false);
+    expect(wireRows(last, 'a', 'close')).toHaveLength(1); // a real close in the archival log
+  });
+
+  it('an annotation ADDED mid-take is closed, labelled and exported like any other', () => {
+    const st = useTagging.getState();
+    st.setDefs([A]);
+    st.beginTake({ t0: T0, startedAt: 'x', session: 'sess_x' });
+    // Mid-performance: "I want to mark the bridge." The sheet stays openable, so add it
+    // and tap it. `toggle` opens against the LIVE defs, so it records from that instant —
+    // and therefore has to be closable and nameable at the end of the take.
+    useTagging.getState().addTag({ label: 'Bridge' });
+    const bridge = useTagging.getState().defs.find((d) => d.label === 'Bridge')!;
+    setNow(T0 + 2);
+    useTagging.getState().toggle(bridge.id, 'click');
+    useTagging.getState().endTake(T0 + 6);
+
+    const last = useTagging.getState().lastTake!;
+    const iv = resolveTake(last).find((x) => x.tag === bridge.id)!;
+    expect(iv).toMatchObject({ start: 2, end: 6, kind: 'interval', openEnded: false });
+    // Closing against the take's SNAPSHOT alone orphans this open (the def did not exist
+    // at beginTake): no close edge in the archival JSONL — an unpaired open no consumer
+    // can bound — and the export falls back to the raw generated id for want of a label.
+    expect(wireRows(last, bridge.id, 'close')).toHaveLength(1);
+    const body = renderTake(last, 'audacity').body;
+    expect(body).toContain('Bridge');
+    expect(body).not.toContain(bridge.id);
   });
 });
 

--- a/test/tagging_export.test.ts
+++ b/test/tagging_export.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Annotation export (#92) — the egress path that makes live annotating useful: a
+ * finished take must come back out as a file a real tool can open.
+ *
+ * The load-bearing detail here is the CLOCK. Edge events are stamped on the absolute
+ * engine clock, and every export wants take-relative seconds (0 = first frame of the
+ * recording). So these tests deliberately use a NON-ZERO `t0` — a zero t0 would let a
+ * missing `- t0` subtraction pass silently, which is exactly the bug worth catching.
+ */
+// localStorage shim for the node test env (persistence is best-effort/debounced).
+if (typeof (globalThis as { localStorage?: unknown }).localStorage === 'undefined') {
+  const store = new Map<string, string>();
+  (globalThis as { localStorage?: unknown }).localStorage = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => void store.set(k, String(v)),
+    removeItem: (k: string) => void store.delete(k),
+    clear: () => store.clear(),
+  };
+}
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useTagging, type LastTake } from '@/app/tagging/store';
+import {
+  EXPORT_FORMATS,
+  RAW_FORMAT,
+  isRenderableFormat,
+  renderTake,
+  resolveTake,
+  summarizeTake,
+  takeDuration,
+} from '@/app/tagging/export';
+import { emptyTagState, DEFAULT_TAGGING_CONFIG, TagDefSchema } from '@/taglog/affordances';
+
+const A = TagDefSchema.parse({ id: 'a', label: 'Verse', kind: 'interval' });
+const P = TagDefSchema.parse({ id: 'p', label: 'Hit', kind: 'point' });
+
+/** A deliberately non-round origin: the app has been up ~1000s before Record is hit. */
+const T0 = 1000;
+
+let now = 0;
+const setNow = (sec: number) => void (now = sec);
+
+beforeEach(() => {
+  now = 0;
+  useTagging.setState({
+    mode: false,
+    defs: [],
+    config: DEFAULT_TAGGING_CONFIG,
+    state: emptyTagState(),
+    take: null,
+    lastTake: null,
+    countdown: null,
+    pulse: 0,
+    clock: () => now,
+  });
+});
+
+/** Record a take: A spans [t0+1, t0+3], a point fires at t0+4, A reopens and is still
+ *  open when the take stops at t0+6 (so it must be auto-closed at the end). */
+function recordTake(): LastTake {
+  const st = useTagging.getState();
+  st.setDefs([A, P]);
+  st.beginTake({ t0: T0, startedAt: '2026-07-11T09:30:00.000Z', session: 'sess_x' });
+  setNow(T0 + 1);
+  st.toggle('a', 'click');
+  setNow(T0 + 3);
+  st.toggle('a', 'click'); // close A -> interval [1, 3] take-relative
+  setNow(T0 + 4);
+  st.toggle('p', 'key'); // point @ 4
+  setNow(T0 + 5);
+  st.toggle('a', 'click'); // reopen A, never closed by hand
+  useTagging.getState().endTake(T0 + 6); // auto-closes A at 6
+  const last = useTagging.getState().lastTake;
+  expect(last).not.toBeNull();
+  return last!;
+}
+
+describe('endTake retains the take', () => {
+  it('keeps the finished take so it can still be exported (it used to be discarded)', () => {
+    const last = recordTake();
+    expect(last.session).toBe('sess_x');
+    expect(last.t0).toBe(T0);
+    expect(last.endT).toBe(T0 + 6);
+    // The labels are snapshotted at endTake, so editing the set later can't rewrite history.
+    expect(last.defs.map((d) => d.label)).toEqual(['Verse', 'Hit']);
+    expect(last.jsonl).toContain('"anchor":true');
+  });
+
+  it('starting a new take does not clobber the previous one until that take ends', () => {
+    recordTake();
+    const st = useTagging.getState();
+    st.beginTake({ t0: T0 + 100, startedAt: '2026-07-11T09:40:00.000Z', session: 'sess_y' });
+    expect(useTagging.getState().lastTake!.session).toBe('sess_x'); // still the old one
+    useTagging.getState().endTake(T0 + 101);
+    expect(useTagging.getState().lastTake!.session).toBe('sess_y');
+  });
+});
+
+describe('resolveTake — times are take-relative, not absolute', () => {
+  it('shifts every edge by t0 so the first frame of the recording is 0', () => {
+    const resolved = resolveTake(recordTake());
+    const byTag = (tag: string) => resolved.filter((iv) => iv.tag === tag);
+
+    // Had we forgotten `- t0`, these would be 1001 / 1003 rather than 1 / 3.
+    expect(byTag('a')[0]).toMatchObject({ start: 1, end: 3, kind: 'interval' });
+    expect(byTag('p')[0]).toMatchObject({ start: 4, end: 4, kind: 'point' });
+  });
+
+  it('closes a still-open annotation at the end of the take, not at its own start', () => {
+    const resolved = resolveTake(recordTake());
+    const held = resolved.filter((iv) => iv.tag === 'a')[1];
+    // Held from 5 until Stop at 6 — the gesture plainly means "to the end".
+    expect(held).toMatchObject({ start: 5, end: 6 });
+  });
+
+  it('reports the take duration on the take clock', () => {
+    expect(takeDuration(recordTake())).toBe(6);
+  });
+});
+
+describe('summarizeTake', () => {
+  it('counts intervals and points separately', () => {
+    expect(summarizeTake(recordTake())).toEqual({ intervals: 2, points: 1, seconds: 6 });
+  });
+});
+
+describe('renderTake', () => {
+  it('renders Audacity labels with take-relative times and the human label', () => {
+    const { body, filename } = renderTake(recordTake(), 'audacity');
+    const rows = body.trim().split('\n').map((l) => l.split('\t'));
+    expect(rows[0]).toEqual(['1.000000', '3.000000', 'Verse']);
+    // A point is a zero-width label (start == end), which is how Audacity marks an instant.
+    expect(rows.find((r) => r[2] === 'Hit')).toEqual(['4.000000', '4.000000', 'Hit']);
+    expect(filename).toBe('2026-07-11T09-30-00-000.annotations.txt');
+  });
+
+  it('renders CSV with a header and one row per annotation', () => {
+    const { body, mime } = renderTake(recordTake(), 'csv');
+    expect(mime).toBe('text/csv');
+    expect(body.trim().split('\n')).toHaveLength(4); // header + 2 intervals + 1 point
+  });
+
+  it('hands back the archival JSONL verbatim for the raw format', () => {
+    const take = recordTake();
+    const { body, filename } = renderTake(take, RAW_FORMAT);
+    expect(body).toBe(take.jsonl); // byte-identical to the file in the take folder
+    expect(filename).toBe('2026-07-11T09-30-00-000.annotations.jsonl');
+  });
+
+  it('throws on an unknown format rather than silently downloading an empty file', () => {
+    expect(() => renderTake(recordTake(), 'nope')).toThrow(/Unknown annotation export format/);
+  });
+});
+
+describe('the format picker and the adapter registry cannot drift', () => {
+  it('every format offered in the UI is actually renderable', () => {
+    // Adding a format to the picker without an adapter would otherwise fail at the
+    // user's click, having already told them the export exists.
+    for (const f of EXPORT_FORMATS) {
+      expect(isRenderableFormat(f.id), `${f.id} has no adapter`).toBe(true);
+      expect(() => renderTake(recordTake(), f.id)).not.toThrow();
+    }
+  });
+});

--- a/test/tagging_export.test.ts
+++ b/test/tagging_export.test.ts
@@ -23,12 +23,12 @@ import { useTagging, type LastTake } from '@/app/tagging/store';
 import {
   EXPORT_FORMATS,
   RAW_FORMAT,
-  isRenderableFormat,
   renderTake,
   resolveTake,
   summarizeTake,
   takeDuration,
 } from '@/app/tagging/export';
+import { ADAPTERS, getAdapter } from '@/taglog/adapters';
 import { emptyTagState, DEFAULT_TAGGING_CONFIG, TagDefSchema } from '@/taglog/affordances';
 
 const A = TagDefSchema.parse({ id: 'a', label: 'Verse', kind: 'interval' });
@@ -81,7 +81,6 @@ describe('endTake retains the take', () => {
     expect(last.session).toBe('sess_x');
     expect(last.t0).toBe(T0);
     expect(last.endT).toBe(T0 + 6);
-    // The labels are snapshotted at endTake, so editing the set later can't rewrite history.
     expect(last.defs.map((d) => d.label)).toEqual(['Verse', 'Hit']);
     expect(last.jsonl).toContain('"anchor":true');
   });
@@ -93,6 +92,65 @@ describe('endTake retains the take', () => {
     expect(useTagging.getState().lastTake!.session).toBe('sess_x'); // still the old one
     useTagging.getState().endTake(T0 + 101);
     expect(useTagging.getState().lastTake!.session).toBe('sess_y');
+  });
+});
+
+describe('the take snapshots the annotation set it STARTED with', () => {
+  it('a mid-take rename does not rewrite the labels the take was recorded with', () => {
+    const st = useTagging.getState();
+    st.setDefs([A, P]);
+    st.beginTake({ t0: T0, startedAt: 'x', session: 'sess_x' });
+    setNow(T0 + 1);
+    useTagging.getState().toggle('a', 'click');
+    setNow(T0 + 3);
+    useTagging.getState().toggle('a', 'click');
+    // The sheet stays openable mid-take: rename "Verse" -> "Chorus" while recording.
+    useTagging.getState().updateTag('a', { label: 'Chorus' });
+    useTagging.getState().endTake(T0 + 6);
+
+    const last = useTagging.getState().lastTake!;
+    expect(last.defs.find((d) => d.id === 'a')!.label).toBe('Verse'); // what was recorded
+    expect(useTagging.getState().defs.find((d) => d.id === 'a')!.label).toBe('Chorus'); // live set moved on
+    expect(renderTake(last, 'audacity').body).toContain('Verse');
+  });
+
+  it('an annotation deleted mid-take still gets its open interval closed at the end', () => {
+    const st = useTagging.getState();
+    st.setDefs([A, P]);
+    st.beginTake({ t0: T0, startedAt: 'x', session: 'sess_x' });
+    setNow(T0 + 1);
+    useTagging.getState().toggle('a', 'click'); // A open…
+    useTagging.getState().removeTag('a'); // …and its definition is deleted from the live set
+    useTagging.getState().endTake(T0 + 6);
+
+    const last = useTagging.getState().lastTake!;
+    // Closing against the LIVE defs would have dropped this interval on the floor.
+    expect(resolveTake(last)).toMatchObject([{ tag: 'a', start: 1, end: 6, kind: 'interval' }]);
+  });
+});
+
+describe('an abandoned take does not clobber the last exportable one', () => {
+  it('keeps take A when take B is torn down without capturing anything', () => {
+    recordTake(); // take A: clean stop, exportable
+    const st = useTagging.getState();
+    st.beginTake({ t0: T0 + 100, startedAt: 'x', session: 'sess_b' });
+    // No annotations tapped; the recorder is disposed (source switch / unmount).
+    useTagging.getState().endTake(T0 + 101, { abandoned: true });
+
+    // Take B wrote no media files and captured nothing — take A must still be there.
+    expect(useTagging.getState().lastTake!.session).toBe('sess_x');
+    expect(useTagging.getState().take).toBeNull(); // …but the runtime is no longer "recording"
+  });
+
+  it('still publishes an abandoned take that DID capture annotations (that is user data)', () => {
+    recordTake();
+    const st = useTagging.getState();
+    st.beginTake({ t0: T0 + 100, startedAt: 'x', session: 'sess_b' });
+    setNow(T0 + 101);
+    useTagging.getState().toggle('a', 'click');
+    useTagging.getState().endTake(T0 + 102, { abandoned: true });
+
+    expect(useTagging.getState().lastTake!.session).toBe('sess_b');
   });
 });
 
@@ -131,7 +189,7 @@ describe('renderTake', () => {
     expect(rows[0]).toEqual(['1.000000', '3.000000', 'Verse']);
     // A point is a zero-width label (start == end), which is how Audacity marks an instant.
     expect(rows.find((r) => r[2] === 'Hit')).toEqual(['4.000000', '4.000000', 'Hit']);
-    expect(filename).toBe('2026-07-11T09-30-00-000.annotations.txt');
+    expect(filename).toBe('sess_x.annotations.txt');
   });
 
   it('renders CSV with a header and one row per annotation', () => {
@@ -144,21 +202,71 @@ describe('renderTake', () => {
     const take = recordTake();
     const { body, filename } = renderTake(take, RAW_FORMAT);
     expect(body).toBe(take.jsonl); // byte-identical to the file in the take folder
-    expect(filename).toBe('2026-07-11T09-30-00-000.annotations.jsonl');
+    expect(filename).toBe('sess_x.annotations.jsonl');
+  });
+
+  it('names the file after the take, so a download can be matched to its recording', () => {
+    // `session` IS the take's folder + file stem (the recorder's sanitized stem). If the
+    // user NAMED the take there is no timestamp in it at all, so anything derived from
+    // the clock would share nothing with the folder the recording landed in.
+    const st = useTagging.getState();
+    st.setDefs([A]);
+    st.beginTake({ t0: T0, startedAt: '2026-07-11T09:30:00.000Z', session: 'bridge-take-3' });
+    setNow(T0 + 1);
+    useTagging.getState().toggle('a', 'click');
+    useTagging.getState().endTake(T0 + 2);
+    const take = useTagging.getState().lastTake!;
+    expect(renderTake(take, 'csv').filename).toBe('bridge-take-3.annotations.csv');
+    expect(renderTake(take, RAW_FORMAT).filename).toBe('bridge-take-3.annotations.jsonl');
   });
 
   it('throws on an unknown format rather than silently downloading an empty file', () => {
     expect(() => renderTake(recordTake(), 'nope')).toThrow(/Unknown annotation export format/);
   });
+
+  it('throws on an inherited Object key rather than dying inside the adapter', () => {
+    // `'toString' in ADAPTERS` is TRUE via the prototype chain: a bare `in`/index lookup
+    // would hand back Object.prototype.toString (truthy, so the guard passes) and then
+    // blow up on `adapter.render is not a function`.
+    expect(getAdapter('toString')).toBeUndefined();
+    expect(() => renderTake(recordTake(), 'toString')).toThrow(/Unknown annotation export format/);
+  });
 });
 
-describe('the format picker and the adapter registry cannot drift', () => {
-  it('every format offered in the UI is actually renderable', () => {
-    // Adding a format to the picker without an adapter would otherwise fail at the
-    // user's click, having already told them the export exists.
+describe('lead-in correction is chosen, never silently applied', () => {
+  /** A tag with a 2s lead-in: opened at 0.5s, closed at 5.0s (take-relative). */
+  function leadInTake(): LastTake {
+    const st = useTagging.getState();
+    st.setDefs([TagDefSchema.parse({ id: 'a', label: 'Verse', kind: 'interval', leadIn: 2 })]);
+    st.beginTake({ t0: T0, startedAt: 'x', session: 'sess_l' });
+    setNow(T0 + 0.5);
+    useTagging.getState().toggle('a', 'click');
+    setNow(T0 + 5);
+    useTagging.getState().toggle('a', 'click');
+    useTagging.getState().endTake(T0 + 6);
+    return useTagging.getState().lastTake!;
+  }
+
+  it('defaults to the corrected times (open +leadIn, close -leadIn)', () => {
+    const rows = renderTake(leadInTake(), 'audacity').body.trim().split('\t');
+    expect([rows[0], rows[1]]).toEqual(['2.500000', '3.000000']);
+  });
+
+  it('exports the raw tap instants when asked — the times the user actually produced', () => {
+    const rows = renderTake(leadInTake(), 'audacity', 'raw').body.trim().split('\t');
+    expect([rows[0], rows[1]]).toEqual(['0.500000', '5.000000']);
+  });
+});
+
+describe('the format picker is derived from the adapter registry', () => {
+  it('offers every shipped adapter plus the raw log — and nothing that cannot render', () => {
+    // The picker is BUILT from ADAPTERS, so drift is impossible by construction; this
+    // pins the derivation (and that every offered id actually renders).
+    expect(EXPORT_FORMATS.map((f) => f.id)).toEqual([...Object.keys(ADAPTERS), RAW_FORMAT]);
     for (const f of EXPORT_FORMATS) {
-      expect(isRenderableFormat(f.id), `${f.id} has no adapter`).toBe(true);
-      expect(() => renderTake(recordTake(), f.id)).not.toThrow();
+      expect(() => renderTake(recordTake(), f.id), `${f.id} does not render`).not.toThrow();
+      expect(f.label, `${f.id} has no label`).toBeTruthy();
+      expect(f.note, `${f.id} has no note`).toBeTruthy();
     }
   });
 });

--- a/test/tagging_export.test.ts
+++ b/test/tagging_export.test.ts
@@ -21,6 +21,7 @@ if (typeof (globalThis as { localStorage?: unknown }).localStorage === 'undefine
 import { describe, it, expect, beforeEach } from 'vitest';
 import { useTagging, type LastTake } from '@/app/tagging/store';
 import {
+  DEFAULT_EXPORT_FORMAT,
   EXPORT_FORMATS,
   RAW_FORMAT,
   renderTake,
@@ -105,12 +106,20 @@ describe('endTake retains the take', () => {
     expect(last.jsonl).toContain('"anchor":true');
   });
 
-  it('starting a new take does not clobber the previous one until that take ends', () => {
-    recordTake();
+  it('CLEARS the export slot while a new take records — no stale take on offer', () => {
+    recordTake(); // take A, finished and exportable
     const st = useTagging.getState();
     st.beginTake({ t0: T0 + 100, startedAt: '2026-07-11T09:40:00.000Z', session: 'sess_y' });
-    expect(useTagging.getState().lastTake!.session).toBe('sess_x'); // still the old one
-    useTagging.getState().endTake(T0 + 101);
+
+    // The export panel reads `lastTake`. Leaving take A here showed the user, mid-take-B,
+    // take A's interval counts under an ENABLED Download button — they would be recording
+    // B and downloading A. "The last finished take" is nothing while one is running.
+    expect(useTagging.getState().lastTake).toBeNull();
+
+    setNow(T0 + 101);
+    useTagging.getState().toggle('a', 'click');
+    useTagging.getState().endTake(T0 + 102);
+    // …and only the END of a take populates it, with THAT take.
     expect(useTagging.getState().lastTake!.session).toBe('sess_y');
   });
 });
@@ -181,14 +190,18 @@ describe('the take snapshots the annotation set it STARTED with', () => {
 });
 
 describe('an abandoned take does not clobber the last exportable one', () => {
-  it('keeps take A when take B is torn down without capturing anything', () => {
+  it('gives take A the slot BACK when take B is torn down without capturing anything', () => {
     recordTake(); // take A: clean stop, exportable
     const st = useTagging.getState();
     st.beginTake({ t0: T0 + 100, startedAt: 'x', session: 'sess_b' });
+    // beginTake cleared the slot (nothing stale on offer while recording) — take A is
+    // parked in `take.prev` for exactly this case.
+    expect(useTagging.getState().lastTake).toBeNull();
     // No annotations tapped; the recorder is disposed (source switch / unmount).
     useTagging.getState().endTake(T0 + 101, { abandoned: true });
 
-    // Take B wrote no media files and captured nothing — take A must still be there.
+    // Take B wrote no media files and captured nothing — it is a phantom, and must not
+    // cost the user take A's export. The displaced take comes back.
     expect(useTagging.getState().lastTake!.session).toBe('sess_x');
     expect(useTagging.getState().take).toBeNull(); // …but the runtime is no longer "recording"
   });
@@ -309,15 +322,70 @@ describe('lead-in correction is chosen, never silently applied', () => {
   });
 });
 
-describe('the format picker is derived from the adapter registry', () => {
+describe('the format picker: metadata derived from the registry, order + default declared here', () => {
   it('offers every shipped adapter plus the raw log — and nothing that cannot render', () => {
-    // The picker is BUILT from ADAPTERS, so drift is impossible by construction; this
-    // pins the derivation (and that every offered id actually renders).
-    expect(EXPORT_FORMATS.map((f) => f.id)).toEqual([...Object.keys(ADAPTERS), RAW_FORMAT]);
+    // Metadata is BUILT from ADAPTERS, so drift is impossible by construction: an adapter
+    // cannot go missing from the picker, and a picker entry cannot lack an adapter.
+    expect([...EXPORT_FORMATS.map((f) => f.id)].sort()).toEqual([...Object.keys(ADAPTERS), RAW_FORMAT].sort());
     for (const f of EXPORT_FORMATS) {
       expect(() => renderTake(recordTake(), f.id), `${f.id} does not render`).not.toThrow();
       expect(f.label, `${f.id} has no label`).toBeTruthy();
       expect(f.note, `${f.id} has no note`).toBeTruthy();
     }
+  });
+
+  it('orders the picker in the APP, not by the library registry’s key order', () => {
+    // `Object.keys(ADAPTERS)` is declaration order inside src/taglog — a library built to
+    // be lifted out, with no knowledge of this UI. Deriving the order from it would let a
+    // harmless reshuffle there silently reorder thoremin's picker (and, since the default
+    // used to be "the first one", change the file a user gets). The order is thoremin's.
+    expect(EXPORT_FORMATS.map((f) => f.id)).toEqual(['audacity', 'csv', 'webvtt', 'textgrid', 'otio', RAW_FORMAT]);
+  });
+
+  it('pins the default export format (a product decision, not a side effect of a library edit)', () => {
+    expect(DEFAULT_EXPORT_FORMAT).toBe('audacity');
+    expect(EXPORT_FORMATS.some((f) => f.id === DEFAULT_EXPORT_FORMAT)).toBe(true);
+  });
+});
+
+describe('the Times choice is only offered where it changes the file', () => {
+  /** A tag with a 2s lead-in — the only way corrected and raw differ at all. */
+  function leadInTake(): LastTake {
+    const st = useTagging.getState();
+    st.setDefs([TagDefSchema.parse({ id: 'a', label: 'Verse', kind: 'interval', leadIn: 2 })]);
+    st.beginTake({ t0: T0, startedAt: 'x', session: 'sess_l' });
+    setNow(T0 + 0.5);
+    useTagging.getState().toggle('a', 'click');
+    setNow(T0 + 5);
+    useTagging.getState().toggle('a', 'click');
+    useTagging.getState().endTake(T0 + 6);
+    return useTagging.getState().lastTake!;
+  }
+
+  it('every format’s honorsTime flag matches what its renderer actually does', () => {
+    // The UI shows the Times picker iff `honorsTime`. If a format claims to honour the
+    // choice but renders byte-identically (CSV: it emits BOTH time columns), the picker
+    // is a lie — the user picks "Raw taps" and downloads the same file. And if a format
+    // renders differently while claiming not to, the choice is being made FOR them.
+    const take = leadInTake();
+    for (const f of EXPORT_FORMATS) {
+      const corrected = renderTake(take, f.id, 'corrected').body;
+      const raw = renderTake(take, f.id, 'raw').body;
+      if (f.honorsTime) {
+        expect(raw, `${f.id} claims to honour the time choice but ignores it`).not.toBe(corrected);
+      } else {
+        expect(raw, `${f.id} ignores the time choice — the UI must not offer it`).toBe(corrected);
+        expect(f.timeNote, `${f.id} offers no line explaining why the choice is absent`).toBeTruthy();
+      }
+    }
+  });
+
+  it('CSV is the one that carries both times, so it takes no choice', () => {
+    expect(EXPORT_FORMATS.find((f) => f.id === 'csv')!.honorsTime).toBe(false);
+    expect(EXPORT_FORMATS.find((f) => f.id === RAW_FORMAT)!.honorsTime).toBe(false);
+    // …and it says so on the row, rather than the CSV rows differing by choice.
+    const body = renderTake(leadInTake(), 'csv').body;
+    expect(body.split('\n')[0]).toContain('start,end,startCorrected,endCorrected');
+    expect(body).toContain('0.5,5,2.5,3'); // raw AND corrected, side by side
   });
 });

--- a/test/tagging_store.test.ts
+++ b/test/tagging_store.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tagging runtime store (#92) — the thoremin glue over the pure `taglog` core.
  * Drives the take lifecycle with an injected clock (deterministic media times) and
- * asserts the emitted `tags.jsonl`, exclusivity, the overlay snapshot, and that
+ * asserts the emitted `annotations.jsonl`, exclusivity, the overlay snapshot, and that
  * rehearsal toggles (no take) are NOT logged.
  */
 // localStorage shim for the node test env (persistence is best-effort/debounced).
@@ -51,7 +51,7 @@ describe('renumber', () => {
   });
 });
 
-describe('take lifecycle → tags.jsonl', () => {
+describe('take lifecycle → annotations.jsonl', () => {
   it('logs absolute engine-clock events with an origin anchor, closing still-open at endTake', () => {
     const st = useTagging.getState();
     st.setDefs([A, B, P]);
@@ -70,7 +70,7 @@ describe('take lifecycle → tags.jsonl', () => {
 
     const lines = jsonl.trim().split('\n').map((l) => JSON.parse(l));
     // The anchor's `t` is the origin (== t0), matching the manifest t0.
-    expect(lines[0]).toMatchObject({ anchor: true, t: 0, session: 'sess_1', schema: 'thoremin.tags/1', recStartPerf: 0 });
+    expect(lines[0]).toMatchObject({ anchor: true, t: 0, session: 'sess_1', schema: 'thoremin.annotations/1', recStartPerf: 0 });
     const events = lines.slice(1);
     // open A @1, auto-close A @3, open B @3, point p @4, close B @6 (all absolute engine time)
     expect(events.map((e) => [e.tag, e.status, e.t])).toEqual([

--- a/test/taglog_adapters.test.ts
+++ b/test/taglog_adapters.test.ts
@@ -145,4 +145,22 @@ describe('adapter registry', () => {
     expect(getAdapter('nope')).toBeUndefined();
     expect(getAdapter('webvtt')!.render(intervals, { defs }).startsWith('WEBVTT')).toBe(true);
   });
+
+  it('declares honorsTime, and each declaration matches what the renderer does', () => {
+    // A caller (a UI) cannot see whether `opts.time` reaches the output, so the adapter
+    // states it. Keep the two in step here: CSV emits BOTH time columns and so renders
+    // identically either way — offering a Times picker for it promises a file change that
+    // never happens.
+    const leadIn: ResolvedInterval[] = [
+      { tag: 'pluck', kind: 'interval', start: 1, end: 5, startCorrected: 2, endCorrected: 4, degenerate: false, openEnded: false, openSeq: 0, closeSeq: 1 },
+    ];
+    for (const [name, adapter] of Object.entries(ADAPTERS)) {
+      const corrected = adapter.render(leadIn, { defs, time: 'corrected' });
+      const raw = adapter.render(leadIn, { defs, time: 'raw' });
+      expect(raw !== corrected, `${name}.honorsTime is ${adapter.honorsTime} but its output says otherwise`).toBe(
+        adapter.honorsTime,
+      );
+    }
+    expect(getAdapter('csv')!.honorsTime).toBe(false);
+  });
 });

--- a/test/taglog_provider.test.ts
+++ b/test/taglog_provider.test.ts
@@ -34,7 +34,7 @@ describe('TagEventSink', () => {
     wallClockISO: '2026-07-10T00:00:00.000Z',
     recStartPerf: 1234.5,
     session: 'sess_1',
-    schema: 'thoremin.tags/1',
+    schema: 'thoremin.annotations/1',
   };
   const open: EdgeEvent = { tag: 'pluck', kind: 'interval', status: 'open', t: 5, tCorrected: 7, seq: 0, clock: 'media', src: 'key' };
   const point: EdgeEvent = { tag: 'boom', kind: 'point', status: 'point', t: 8, tCorrected: 8, seq: 1, clock: 'media', src: 'click' };
@@ -47,7 +47,7 @@ describe('TagEventSink', () => {
     expect(sink.count).toBe(3); // anchor + 2 rows
     const out = sink.drain();
     const lines = out.trim().split('\n').map((l) => JSON.parse(l));
-    expect(lines[0]).toMatchObject({ anchor: true, schema: 'thoremin.tags/1' });
+    expect(lines[0]).toMatchObject({ anchor: true, schema: 'thoremin.annotations/1' });
     expect(lines[1]).toMatchObject({ status: 'open', tag: 'pluck', t: 5 });
     expect(lines[2]).toMatchObject({ status: 'point', tag: 'boom' });
     expect(sink.drain()).toBe(''); // cleared


### PR DESCRIPTION
Closes two problems with live tagging as shipped in #123.

## 1. The data was write-only

You could tap tag buttons and there was **nowhere in the app to see or fetch what you recorded.**

It *was* being captured — into `<take>.tags.jsonl` in the take folder — but nothing said so, `endTake` then dropped the in-memory copy on the floor, and JSONL of absolute-clock edge events is not something anyone wants to open. Worse: tapping outside a recording logs nothing at all (by design — it's rehearsal), so trying the feature without hitting Record first shows no data anywhere, and it reads as broken.

Meanwhile `src/taglog/adapters/` had shipped renderers for **Audacity label tracks, WebVTT, CSV, Praat TextGrid and OTIO** that *nothing in the app ever imported*.

**Fix:** retain the finished take (`lastTake` in the store) and add an **Export panel** to the Annotations sheet — resolve the take to intervals, render through the existing adapters, download. The empty state now states plainly that annotations record only while Record is running, and where the file lands.

The load-bearing detail is the **clock**: edges are stamped on the absolute engine clock; every export format wants take-relative seconds (0 = first frame). We shift by `t0` once, on the edges, before resolving. The new tests use a **non-zero `t0` on purpose** — with `t0 = 0`, a missing subtraction passes silently.

Still-open annotations are closed at the take's end rather than dropped, so holding a button until Stop yields an interval running to the end of the recording.

## 2. "Tags" meant two unrelated things — with the same icon

The instrument library's tags (#116: keywords on a saved preset) and the live interval tags (#92) shared **both the word "Tags" and the lucide `Tags` icon**.

| | Was | Now |
|---|---|---|
| Live, time-anchored (this feature) | Tags · `Tags` icon | **Annotations** · `Highlighter` icon |
| Instrument library keywords | Tags · `Tags` icon | **Tags** · `Tags` icon (unchanged) |

> ⚠️ **"Markers" was the obvious candidate and is wrong.** `canvas_overlay` already has a **"Control markers"** element (the note-position guides drawn on the video), so adopting it would have *moved* the collision rather than removed it. "Annotation" was free — and says exactly what the feature does.

Renamed through the user-facing copy **and the recorded artifact**, since the format shipped days ago with no external consumers — this is the cheapest it will ever be to change:

- `<take>.tags.jsonl` → `<take>.annotations.jsonl`
- manifest `kind: 'tags'` → `kind: 'annotations'`
- schema id `thoremin.tags/1` → `thoremin.annotations/1`

`src/taglog/` keeps its generic `tag` vocabulary — it's built to be lifted out as a standalone package, and that's the right noun there. The three-way mapping (annotation / tag / marker) is written down in the `TaggingControls.tsx` header so the next reader doesn't have to rediscover it.

## Verification

- `npm test` — **723 passed** (75 files), including **11 new export tests**: the `t0` shift, auto-closing a held annotation at Stop, Audacity label formatting, byte-identical raw JSONL, and a guard pinning the format picker to the adapter registry so a format can't be offered without a renderer.
- `npm run typecheck` clean · `npm run build` clean.

Refs #92, #116. Export/save-location UX relates to #49.

https://claude.ai/code/session_01LsHz3ExTnCiZDfqQTjJnTH