### PR TITLE
fix(deploy): stop shipping 296MB of dev-only media to production

### DIFF
--- a/app.toml
+++ b/app.toml
@@ -16,3 +16,14 @@ frontend_dir = "frontend"
 install  = ["npm", "ci", "--no-audit", "--no-fund", "--no-progress"]
 build    = ["npm", "run", "build"]
 env_vars = ["VITE_PUBLIC_BASE"]
+
+# Dev-only working directories. The server has NO use for these: this is a pure frontend
+# app, enlace serves only `frontend/` (the Vite build output), and the bundle does not
+# reference media/ or wips/ at all. Without these excludes the app-dir rsync shipped ~300MB
+# of a laptop's working files to production on every single deploy — never served, never
+# deleted (that rsync has no --delete), quietly filling the disk.
+#
+# Note the distinction from [data]: [data] is for data the server DOES need but which the
+# code deploy must not manage. This is for data the server never needed in the first place.
+[deploy]
+exclude = ["media", "wips"]


### PR DESCRIPTION
`media/` (296MB) and `wips/` are gitignored working directories — but the platform's app-dir rsync has no exclude for them, so **~300MB of laptop working files were pushed to production on every single deploy.**

They were never served (thoremin is a pure frontend app; enlace serves only `frontend/`, and the bundle references neither `media/` nor `wips/`), and never deleted (that rsync has no `--delete`). They just accumulated.

Declares them in the new `app.toml` `[deploy] exclude`, honoured by tw_platform's `deploy.py` (thorwhalen/tw_platform#64).

Server: **387MB → 89MB**. Verified thoremin still serves 200.

https://claude.ai/code/session_012UDueMjHcMhYB2yit1fnh3