### PR TITLE
#136: give the Feature Lab an entry point, and stop filing it as an instrument

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,27 @@ and the non-dial `muted` flag (#91) is not a command yet.
 When you add a write path: dispatch it. When you touch a panel, prefer moving it onto
 `dispatchDialSet` rather than adding another direct `setDial`.
 
+## Shipping rule: a feature nobody can find is not shipped
+
+The Feature Lab (#119) was merged, deployed, and live in the production bundle for weeks
+while being, in practice, **unreachable**: no entry point in the app shell, defaulting to
+off, buried inside a per-instrument editor. MIDI out (#120) is worse — it has no UI, no
+dial, and its `enabled` input is left unconnected in `graph.ts` (#137). Both passed every
+test in the suite.
+
+So, when you add a user-facing capability:
+
+1. **Give it an entry point in the shell.** Register it in `src/app/tools.ts` if it is a
+   *tool* (something you use ON the instrument: the Lab, the palette, the manual); give it
+   a dial in `src/settings/dials.ts` if it is an *instrument parameter* (which also earns
+   it a panel control, a palette entry, a per-dial command and an AI tool surface for
+   free). If it is neither, say why in the PR.
+2. **Ask "how many clicks from a cold load?"** and write the answer in the PR. If the
+   answer needs the phrase "then scroll", reconsider.
+3. **Test the reachability, not just the logic.** `test/tools_shell.test.tsx` (jsdom) and
+   `test/app_shell.test.ts` are the pattern. A green unit suite says the code runs; it
+   says nothing about whether a player can get to it.
+
 ## Where things live
 
 | Area | Path |
@@ -144,7 +165,8 @@ When you add a write path: dispatch it. When you touch a panel, prefer moving it
 | **Dials** — settings schema store + named **instruments** (saved profiles) | `src/app/dials/` (`settingsStore.ts`, `instruments.ts`, panels) |
 | Dials schema / presets SSOT | `src/settings/` (`schema.ts`, `dials.ts`, `presets.ts`) |
 | **Feature catalog** (#119) — data-driven features, safe formula compiler, online normalizer | `src/features/` (`catalog.ts`, `formula.ts`, `normalizer.ts`) |
-| **Feature Lab** views (#119) — saved lab configs (zodal collection) | `src/app/lab/` + `src/app/LabControls.tsx` |
+| **Feature Lab** (#119/#136) — config SSOT, the shell panel, saved views (zodal collection) | `src/features/labConfig.ts`, `src/app/LabPanel.tsx`, `src/app/LabControls.tsx`, `src/app/lab/` |
+| **Shell tools** (#136) — the registry of non-instrument surfaces + the bar that exposes them | `src/app/tools.ts`, `src/app/ToolsBar.tsx`, `src/app/toolsStore.ts` |
 | **Instrument library** (#113/#114/#115) — favorites, tags, system tags, summaries | `src/app/library/` |
 | **Recording v2** (#88) — session, plan, naming, manifest, sinks, feature tap | `src/app/recording/` + `src/app/RecordButton.tsx` |
 | **Annotations** (#92) — thoremin glue for the tagging tool | `src/app/tagging/` |

--- a/docs/design/feature-lab.md
+++ b/docs/design/feature-lab.md
@@ -1,8 +1,9 @@
 # Feature Instrumentation Lab — a measuring instrument for face & hand features
 
-> **Status:** implemented (2026-07, issue #119, PR #122). This document is the single
-> source of truth for the feature catalog (`src/features/`) and the lab
-> (`src/app/lab/`, `src/app/LabControls.tsx`, the `featureLab` overlay element).
+> **Status:** implemented (2026-07, issue #119, PR #122); made *reachable* and moved out
+> of the instrument in #136. This document is the single source of truth for the feature
+> catalog (`src/features/`) and the lab (`src/features/labConfig.ts`, `src/app/lab/`,
+> `src/app/LabPanel.tsx`, `src/app/LabControls.tsx`, the `featureLab` overlay element).
 > Follow-up work is tracked in #131.
 
 ## The idea in one line
@@ -22,6 +23,44 @@ makes that visible instead of guessed.
 
 It is deliberately **not** a sound. It produces no audio, changes no dial, and costs
 nothing when it is off.
+
+## Where it lives, and how you find it (#136)
+
+The paragraph above was the intent from day one. The first implementation did not honour
+it: the lab's config was a sub-object of the `overlay` **dial**, so the Lab *was* a dial —
+toggling a meter marked your instrument as having unsaved edits, and loading an instrument
+silently reconfigured your meters. And its only control lived inside the per-instrument
+settings editor, three clicks and a scroll deep, defaulting to off. The result was a
+248-feature subsystem that shipped to production, passed 759 tests, and that nobody —
+including its author — could find.
+
+Two corrections, both of which follow from taking "it is a measuring instrument" literally:
+
+1. **The config is a tooling preference, not an instrument parameter.** It lives on the
+   hot control store (`useControls.featureLab`), persisted per-device and excluded from
+   `SettingsSchema`, exactly like the per-device `faceCalibration` and exactly as
+   recording settings were moved out of the instrument in #88. `store-controls` composes
+   it into the overlay node's params each tick, so the engine still sees one overlay
+   config and the meters keep working. `OverlayDialSchema` is the node's params minus
+   `featureLab` and is what the dial and the saved settings use.
+
+2. **It has an entry point.** The Lab is a *tool*, registered in `src/app/tools.ts` and
+   opened from the shell's tools bar (bottom-left, alongside the command palette and the
+   manual). It opens on an intro that says what the meters measure, because "248
+   normalized meters" means nothing to a player who has not read this document.
+
+A third correction falls out of the same principle. The face model used to load only when
+`face.mapping !== 'none'`, so you could not look at a face meter without also putting your
+face in charge of the sound: a measuring instrument that could not observe without
+altering. `faceActive` (webcam_face.ts) now returns true when *either* the mapping wants
+the face *or* the Lab is measuring face groups.
+
+**The rule this cost us, stated once:** a feature only findable by someone who read the PR
+is not shipped. `test/tools_shell.test.tsx` and `test/app_shell.test.ts` hold the line —
+every registered tool has a labelled button in the shell, and every button opens a surface
+the shell actually mounts. The pre-existing "every overlay element has a control
+descriptor" test passed throughout this bug: a descriptor proves an element is
+*controllable*, not that a player can *find* the control.
 
 ## The feature catalog (`src/features/`) — data-driven, like the node registry
 
@@ -165,8 +204,8 @@ and out of the live control store's persist version — a lab view is an *analys
 workspace*, not a sound. Every field carries a `.default(...)`, so a view saved by an
 older build still parses.
 
-Loading a view hydrates the live `featureLab` overlay config (synchronous zustand);
-edits debounce-save back. Nothing here is ever awaited in the tick loop.
+Loading a view hydrates the live `featureLab` config on the control store (synchronous
+zustand); edits debounce-save back. Nothing here is ever awaited in the tick loop.
 
 ## What is verified
 
@@ -174,7 +213,10 @@ Pure logic — the catalog, the formula compiler (including its rejection cases)
 normalizer, the vector nodes, the overlay element, the lab views — is unit-tested
 (`test/feature_catalog.test.ts`, `test/feature_formula.test.ts`,
 `test/feature_normalizer.test.ts`, `test/feature_vector_nodes.test.ts`,
-`test/feature_lab_overlay.test.ts`, `test/lab_views.test.ts`).
+`test/feature_lab_overlay.test.ts`, `test/lab_views.test.ts`). Since #136, so is the
+lab's *separation from the instrument* and its *reachability from the shell*
+(`test/feature_lab_config.test.ts`, `test/tools_shell.test.tsx`,
+`test/app_shell.test.ts`).
 
 ## Open follow-up (#131)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,10 @@
         "zustand": "^5.0.14"
       },
       "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.2",
         "@types/node": "^22.14.0",
+        "jsdom": "^27.0.1",
         "tailwindcss": "^4.1.14",
         "tsx": "^4.21.0",
         "typescript": "~5.8.2",
@@ -147,6 +150,61 @@
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -418,6 +476,146 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+      "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+      "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2093,6 +2291,54 @@
         }
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tonaljs/abc-notation": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/@tonaljs/abc-notation/-/abc-notation-4.9.1.tgz",
@@ -2381,6 +2627,13 @@
         "@tonaljs/note": "4.12.1",
         "@tonaljs/voice-leading": "5.1.2"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2801,6 +3054,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2847,6 +3110,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/bignumber.js": {
@@ -3023,6 +3296,46 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -3030,6 +3343,67 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
+      "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^15.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/debug": {
@@ -3049,10 +3423,27 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
       "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3082,6 +3473,13 @@
       "dependencies": {
         "@babel/runtime": "^7.20.6"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -3121,6 +3519,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-module-lexer": {
@@ -3450,6 +3861,33 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -3461,6 +3899,19 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/inflight": {
@@ -3488,6 +3939,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -3534,6 +3992,83 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.0.1.tgz",
+      "integrity": "sha512-SNSQteBL1IlV2zqhwwolaG9CwhIhTvVHWg3kTss/cLE7H/X4644mtPQqYvCfsSrGQWt9hSZcgOXX8bOZaMN+kA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/dom-selector": "^6.7.2",
+        "cssstyle": "^5.3.1",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.1.0",
+        "ws": "^8.18.3",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/jsep": {
       "version": "1.4.0",
@@ -3894,6 +4429,16 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3902,6 +4447,13 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/minimatch": {
       "version": "9.0.9",
@@ -4064,6 +4616,19 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -4167,6 +4732,44 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/protobufjs": {
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
@@ -4191,6 +4794,16 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
@@ -4211,6 +4824,13 @@
       "peerDependencies": {
         "react": "^19.2.4"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -4288,6 +4908,16 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -4368,6 +4998,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -4387,6 +5024,26 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -4588,6 +5245,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
@@ -4676,6 +5340,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.8",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.8.tgz",
+      "integrity": "sha512-htwgN/8KRB3z3vnC0BOETVh2m499g5GmyTK9Wq5JBLX3FNz6tSBveAd+fQhzy9hkjif8vy2jwDMR1sGhLtZl2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.8"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.8",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.8.tgz",
+      "integrity": "sha512-c1P7u0EhACHj7lPy4MJm8iTFEU8+nB0LCtddH0fhP7noaVoXAqafMtOOeX+ulpuPBqnrRgRhw494RICT3mbhnw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tonal": {
       "version": "6.4.3",
       "resolved": "https://registry.npmjs.org/tonal/-/tonal-6.4.3.tgz",
@@ -4705,6 +5389,19 @@
         "@tonaljs/voice-leading": "5.1.2",
         "@tonaljs/voicing": "5.1.3",
         "@tonaljs/voicing-dictionary": "5.1.3"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -5470,6 +6167,19 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -5498,6 +6208,30 @@
       },
       "optionalDependencies": {
         "jzz": "^1.8.5"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/whatwg-url": {
@@ -5659,6 +6393,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,10 @@
     "zustand": "^5.0.14"
   },
   "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^22.14.0",
+    "jsdom": "^27.0.1",
     "tailwindcss": "^4.1.14",
     "tsx": "^4.21.0",
     "typescript": "~5.8.2",

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -10,28 +10,35 @@
  * this component is purely presentational + lifecycle.
  */
 import { useEffect } from 'react';
-import { Play, BookOpen, VolumeX } from 'lucide-react';
+import { Play, VolumeX } from 'lucide-react';
 import { useThoreminEngine } from './useEngine';
 import { DEFAULT_SOURCE, type SourceSpec } from './sourceSpec';
 import { installKeyboardShortcuts } from './keyboardShortcuts';
 import { installTaggingKeymap } from './tagging/keymap';
 import { useControls } from './store';
 import { useFaceStatus } from './faceStatus';
+import { labWantsFace } from '@/features/labConfig';
 import InstrumentsPanel from './dials/InstrumentsPanel';
 import RecordButton from './RecordButton';
 import TaggingControls from './tagging/TaggingControls';
 import Toaster from './Toaster';
 import CommandPaletteOverlay from './CommandPaletteOverlay';
 import AssistantOverlay from '@/plugins/assistant/AssistantOverlay';
+import ToolsBar from './ToolsBar';
+import LabPanel from './LabPanel';
 import VersionBadge from './VersionBadge';
 
 /** A compact face-status chip, visible even when the controls panel is collapsed
- * (issue #65): only shown once a face mapping is active. */
+ * (issue #65): shown whenever the face model is running — whether because a face
+ * MAPPING is driving the sound or because the Feature Lab is measuring face groups
+ * (#136). The chip is the player's only cue that the camera's face model is live, so it
+ * must track the model, not just the mapping. */
 function FaceChip() {
   const faceMapping = useControls((s) => s.faceMapping);
+  const featureLab = useControls((s) => s.featureLab);
   const status = useFaceStatus((s) => s.status);
   const label = useFaceStatus((s) => s.label);
-  if (faceMapping === 'none') return null;
+  if (faceMapping === 'none' && !labWantsFace(featureLab)) return null;
 
   let dot = 'bg-white/40';
   let text = 'face starting…';
@@ -111,13 +118,13 @@ export default function App({ source = DEFAULT_SOURCE }: { source?: SourceSpec }
       {/* Top-center: unmissable "muted" cue (audio silenced by the m key). */}
       <MutedBadge />
 
-      {/* Bottom-left: link to the generated capabilities manual. */}
-      <a
-        href="manual.html"
-        className="absolute bottom-3 left-3 flex items-center gap-1 rounded-full bg-black/40 px-3 py-1 text-[10px] uppercase tracking-widest text-white/60 backdrop-blur transition hover:text-white"
-      >
-        <BookOpen className="h-3 w-3" /> manual
-      </a>
+      {/* Bottom-left: the tools bar — one labelled button per registered shell tool
+          (Feature Lab, command palette, manual). This is the app's answer to "what else
+          is here": a tool with no entry point here is a tool nobody will ever find (#136). */}
+      <ToolsBar />
+
+      {/* The Feature Lab's surface (#119/#136) — renders when its tool is the open one. */}
+      <LabPanel />
 
       {/* Bottom-right: the multi-stream recorder (#88) — a button that morphs into
           a settings sheet (out-of-instrument config) then a compact HUD. Available
@@ -182,9 +189,6 @@ export default function App({ source = DEFAULT_SOURCE }: { source?: SourceSpec }
       {/* AI assistant — chat that parametrizes the instrument via the same command
           registry, behind a BYO-key multi-provider client-side backend (#87 Phase 3). */}
       <AssistantOverlay />
-
-      {/* Unobtrusive "what's deployed" badge (commit + date), read from /_meta. */}
-      <VersionBadge />
     </div>
   );
 }

--- a/src/app/CommandPaletteOverlay.tsx
+++ b/src/app/CommandPaletteOverlay.tsx
@@ -10,27 +10,40 @@
  *
  * The palette itself is headless cmdk; the dark-HUD theme is in `index.css` under
  * `.thoremin-palette`.
+ *
+ * Its open state lives in the shared {@link useTools} store rather than in local state,
+ * so the ⌘K hotkey and the tools-bar button are the SAME switch. Before #136 the hotkey
+ * was the only way in and nothing in the app — not even the app's own keyboard
+ * cheat-sheet — mentioned it existed.
  */
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { CommandPalette } from 'acture-palette-react';
 import { AutoForm } from 'acture-forms-autoform';
 import { registry } from './commands';
 import { useToasts } from './toasts';
+import { useTools } from './toolsStore';
+
+const TOOL_ID = 'commands';
 
 export default function CommandPaletteOverlay() {
-  const [open, setOpen] = useState(false);
+  const open = useTools((s) => s.open) === TOOL_ID;
+  const setOpen = (v: boolean) =>
+    v ? useTools.getState().openTool(TOOL_ID) : useTools.getState().close();
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && (e.key === 'k' || e.key === 'K')) {
         e.preventDefault(); // toggle; beat the browser's own Cmd-K
-        setOpen((o) => !o);
+        useTools.getState().toggleTool(TOOL_ID);
       } else if (e.key === 'Escape' && !e.defaultPrevented) {
         // A parameter sub-view (enum picker / AutoForm) handles Escape itself to
         // step BACK — it calls preventDefault, so we only close from the top-level
         // list (where Escape isn't prevented). Otherwise the whole palette would
         // tear down instead of returning to the command list.
-        setOpen(false);
+        //
+        // Only the palette's own Escape closes it: `close()` here would also dismiss a
+        // different open tool, so we guard on being the open one.
+        if (useTools.getState().open === TOOL_ID) useTools.getState().close();
       }
     };
     window.addEventListener('keydown', onKey);

--- a/src/app/LabControls.tsx
+++ b/src/app/LabControls.tsx
@@ -1,30 +1,30 @@
 /**
- * LabControls — the Feature Instrumentation Lab settings panel (#119).
+ * LabControls — the Feature Instrumentation Lab's controls (#119), rendered inside
+ * {@link LabPanel}: the meters on/off, which feature GROUPS are measured + shown, the
+ * online-normalizer mode + grid columns, a stats reset, the safe DERIVED-feature editor
+ * (live-validated against the same jsep whitelist compiler the engine uses), and
+ * SAVE/LOAD of named lab views (a zodal collection, the project persistence rule — its
+ * own store, out of the control-store version).
  *
- * Drives the `featureLab` overlay-element config (a sub-object of the single
- * `overlay` dial value): the panel on/off, which feature GROUPS are measured +
- * shown, the online-normalizer mode + grid columns, a stats reset, the safe
- * DERIVED-feature editor (live-validated against the same jsep whitelist compiler
- * the engine uses), and SAVE/LOAD of named lab views (a zodal collection, the
- * project persistence rule — its own store, out of the control-store version).
- *
- * Like {@link DialsControlsPanel}'s OverlayControls, every edit merges a copy back
- * through `useDialsSettings().set('overlay', ...)`, which mirrors into the
- * synchronous hot store the DAG reads each tick — so meters respond live. Loading
- * a saved view hydrates that config; nothing here is ever awaited in the tick loop.
+ * Every edit writes the per-device `featureLab` config on the hot control store, which
+ * `store-controls` composes into the overlay node's params each tick — so meters respond
+ * live. It deliberately does NOT write a dial (#136): the Lab measures the instrument
+ * rather than being part of it, so a meter toggle must not mark an instrument as having
+ * unsaved edits, and loading an instrument must not silently reconfigure the meters.
+ * Loading a saved view hydrates that config; nothing here is ever awaited in the tick loop.
  */
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { FEATURE_GROUPS, ALL_SAFE_NAMES } from '@/features/catalog';
 import { compileFormula, DEFAULT_HELPERS } from '@/features/formula';
-import { useDialsSettings } from './dials/useDialsSettings';
-import type { OverlayParams } from '@/nodes/output/canvas_overlay';
+import { useControls } from './store';
+import type { FeatureLabConfig } from '@/features/labConfig';
 import { createLabViewStore } from './lab/labViews';
 import type { LabViewConfig, LabViewSummary } from './lab/schema';
 
 const selectCls = 'rounded bg-white/10 px-2 py-1 text-xs outline-none focus:bg-white/20';
 const btnCls = 'rounded bg-white/10 px-2 py-0.5 text-[10px] text-white/80 hover:bg-white/20';
 
-type FeatureLab = OverlayParams['featureLab'];
+type FeatureLab = FeatureLabConfig;
 
 /** Validate a formula the same way the engine compiles it; return an error string
  *  or null. Pure (no side effects), so it's safe to run on every keystroke. */
@@ -39,11 +39,8 @@ function formulaError(formula: string): string | null {
 }
 
 export default function LabControls() {
-  const { state, set } = useDialsSettings();
-  const overlay = state.effective['overlay'] as OverlayParams;
-  const fl = overlay.featureLab;
-  const patch = (p: Partial<FeatureLab>) =>
-    set('overlay', { ...overlay, featureLab: { ...fl, ...p } });
+  const fl = useControls((s) => s.featureLab);
+  const patch = useControls((s) => s.setFeatureLab);
 
   const toggleGroup = (id: string, on: boolean) =>
     patch({ groups: on ? [...new Set([...fl.groups, id])] : fl.groups.filter((g) => g !== id) });
@@ -52,7 +49,7 @@ export default function LabControls() {
     <div className="space-y-3">
       <label className="flex items-center gap-2 text-xs">
         <input type="checkbox" checked={fl.show} onChange={(e) => patch({ show: e.target.checked })} />
-        Show the lab (a dense grid of normalized feature meters)
+        Show the meters over the video
       </label>
 
       <div className={fl.show ? 'space-y-3' : 'space-y-3 opacity-40'}>

--- a/src/app/LabPanel.tsx
+++ b/src/app/LabPanel.tsx
@@ -1,0 +1,119 @@
+/**
+ * LabPanel — the Feature Instrumentation Lab's own surface in the app shell (#136).
+ *
+ * Lives here and not under `lab/` on purpose: `src/app/lab` is inside the strict DAG
+ * typecheck project (tsconfig.dag.json), which ships no @types/react — the files under
+ * it are the framework-agnostic lab pieces (the view schema + store). A React component
+ * there breaks that typecheck.
+ *
+ * The Lab (#119) was built, merged and deployed, and then nobody could find it: it had
+ * no entry point, it defaulted to off, and its controls were buried inside the
+ * per-instrument settings editor — a *measuring* tool filed under the thing it measures.
+ * This panel is its home: opened from the tools bar, closable, and (unlike a dial) it
+ * never marks an instrument dirty.
+ *
+ * It opens on an INTRO state rather than a wall of checkboxes, because "248 normalized
+ * meters" means nothing to someone who has not read the design doc. Starting the meters
+ * is one click from there.
+ */
+import { FlaskConical, X } from 'lucide-react';
+import { useControls } from './store';
+import { useTools } from './toolsStore';
+import { toolById } from './tools';
+import { ALL_FEATURES } from '@/features/catalog';
+import { labWantsFace } from '@/features/labConfig';
+import { useFaceStatus } from './faceStatus';
+import LabControls from './LabControls';
+
+const TOOL_ID = 'lab';
+
+/** What the Lab is, in the words of someone who has never seen it. Shown until the
+ *  meters are running, and reachable again by turning them off. */
+function LabIntro({ onStart }: { onStart: () => void }) {
+  return (
+    <div className="space-y-3">
+      <p className="text-[11px] leading-relaxed text-white/60">
+        Thoremin plays from <span className="text-white/90">{ALL_FEATURES.length} raw features</span> it
+        extracts from your face and hands every frame — how open your mouth is, how far your
+        fingers are spread, where your head is pointing. The Lab draws them as live meters so
+        you can see what the instrument is actually reading from you.
+      </p>
+      <p className="text-[11px] leading-relaxed text-white/60">
+        Every feature is on a different natural scale, so each meter is{' '}
+        <span className="text-white/90">normalized online</span> against the range that feature has
+        actually taken since you started: a full bar means &ldquo;high for you, today&rdquo;, not
+        &ldquo;high on some absolute scale&rdquo;. That is what makes a brow-raise and a finger-spread
+        comparable at a glance. You can also combine features into your own{' '}
+        <span className="text-white/90">derived</span> meters with a formula.
+      </p>
+      <p className="text-[11px] leading-relaxed text-white/40">
+        The meters draw over the video, and measuring changes nothing about how the instrument
+        sounds — turning on a face meter loads the face model but does not put your face in
+        charge of the audio.
+      </p>
+      <button
+        type="button"
+        onClick={onStart}
+        className="w-full rounded-lg bg-emerald-500 px-3 py-2 text-[11px] font-bold uppercase tracking-widest text-black transition hover:brightness-110"
+      >
+        Start measuring
+      </button>
+    </div>
+  );
+}
+
+/** A one-line status for the face half of the Lab: the meters need the face model, which
+ *  the Lab itself now requests (see `faceActive`) — so the honest thing to report is the
+ *  LOAD, not a "turn on face mapping" instruction the player no longer needs to follow. */
+function FaceModelNote() {
+  const featureLab = useControls((s) => s.featureLab);
+  const phase = useFaceStatus((s) => s.status.phase);
+  if (!labWantsFace(featureLab)) return null;
+  if (phase === 'ready') return null;
+  const text =
+    phase === 'error'
+      ? 'The face model failed to load — the face meters will stay empty.'
+      : 'Loading the face model for the face meters…';
+  return (
+    <p className={`text-[10px] ${phase === 'error' ? 'text-rose-300/80' : 'text-white/40'}`}>{text}</p>
+  );
+}
+
+export default function LabPanel() {
+  const open = useTools((s) => s.open) === TOOL_ID;
+  const close = useTools((s) => s.close);
+  const featureLab = useControls((s) => s.featureLab);
+  const setFeatureLab = useControls((s) => s.setFeatureLab);
+  if (!open) return null;
+
+  const tool = toolById(TOOL_ID);
+
+  return (
+    <div className="absolute bottom-14 left-3 z-40 flex max-h-[calc(100dvh-5rem)] w-96 max-w-[calc(100vw-1.5rem)] flex-col overflow-hidden rounded-2xl border border-white/10 bg-black/70 backdrop-blur">
+      <div className="flex items-center gap-2 border-b border-white/10 px-3 py-2">
+        <FlaskConical className="h-3.5 w-3.5 shrink-0 text-emerald-300" aria-hidden />
+        <span className="flex-1 text-[11px] font-bold uppercase tracking-widest text-white/70">
+          Feature Lab
+        </span>
+        <button
+          onClick={close}
+          aria-label="Close the Feature Lab"
+          className="rounded p-1 text-white/60 transition hover:bg-white/10 hover:text-white"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+      <div className="space-y-3 overflow-auto p-4">
+        {tool && <p className="text-[10px] uppercase tracking-widest text-emerald-500/70">{tool.description}</p>}
+        {featureLab.show ? (
+          <>
+            <FaceModelNote />
+            <LabControls />
+          </>
+        ) : (
+          <LabIntro onStart={() => setFeatureLab({ show: true })} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/ToolsBar.tsx
+++ b/src/app/ToolsBar.tsx
@@ -1,0 +1,92 @@
+/**
+ * ToolsBar — the bottom-left strip of shell affordances, one button per {@link TOOLS}
+ * entry (#136).
+ *
+ * This is the answer to "how does a player find the Feature Lab / the command palette",
+ * and the reason both were invisible: nothing in the shell ever mentioned them. Every
+ * button carries a visible TEXT label, not just an icon — the AI assistant's unlabelled
+ * robot icon and the palette's hotkey-only affordance are exactly the two things a first
+ * time player never discovers.
+ *
+ * Purely presentational: it reads {@link useTools} for which tool is open and toggles it.
+ * Each tool's actual surface mounts itself in App and renders when it is the open one.
+ */
+import { FlaskConical, Command, BookOpen, type LucideIcon } from 'lucide-react';
+import { TOOLS, type Tool } from './tools';
+import { useTools } from './toolsStore';
+import VersionBadge from './VersionBadge';
+
+/** The icon per tool id. Kept here (not in `tools.ts`) so the registry stays React-free
+ *  and importable from plain Node tests. A tool with no icon still renders — label-only
+ *  is fine, an icon-only button is not. */
+const ICONS: Record<string, LucideIcon> = {
+  lab: FlaskConical,
+  commands: Command,
+  manual: BookOpen,
+};
+
+const btnCls =
+  'pointer-events-auto flex items-center gap-1.5 rounded-full border px-3 py-1 text-[10px] uppercase tracking-widest backdrop-blur transition';
+
+function ToolButton({ tool }: { tool: Tool }) {
+  const open = useTools((s) => s.open);
+  const toggleTool = useTools((s) => s.toggleTool);
+  const Icon = ICONS[tool.id];
+  const isOpen = open === tool.id;
+
+  const content = (
+    <>
+      {Icon && <Icon className="h-3 w-3 shrink-0" aria-hidden />}
+      <span>{tool.label}</span>
+      {tool.hotkey && (
+        <kbd className="ml-0.5 rounded bg-white/10 px-1 py-px font-mono text-[9px] tracking-normal text-white/50">
+          {tool.hotkey}
+        </kbd>
+      )}
+    </>
+  );
+
+  // A link tool leaves the app; it has no open state.
+  if (tool.kind === 'link') {
+    return (
+      <a
+        href={tool.href}
+        title={tool.description}
+        data-tool={tool.id}
+        className={`${btnCls} border-white/10 bg-black/40 text-white/60 hover:text-white`}
+      >
+        {content}
+      </a>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => toggleTool(tool.id)}
+      title={tool.description}
+      data-tool={tool.id}
+      aria-pressed={isOpen}
+      className={`${btnCls} ${
+        isOpen
+          ? 'border-emerald-400/40 bg-emerald-500/20 text-emerald-200'
+          : 'border-white/10 bg-black/40 text-white/60 hover:text-white'
+      }`}
+    >
+      {content}
+    </button>
+  );
+}
+
+export default function ToolsBar() {
+  return (
+    <div className="absolute bottom-3 left-3 z-40 flex max-w-[min(28rem,calc(100vw-1.5rem))] flex-wrap items-center gap-1.5">
+      {TOOLS.map((t) => (
+        <ToolButton key={t.id} tool={t} />
+      ))}
+      {/* The deployed-commit badge rides the same meta strip (it used to be absolutely
+          positioned into what is now the bar's space). */}
+      <VersionBadge />
+    </div>
+  );
+}

--- a/src/app/VersionBadge.tsx
+++ b/src/app/VersionBadge.tsx
@@ -51,7 +51,7 @@ export default function VersionBadge() {
       target="_blank"
       rel="noreferrer"
       title={`Deployed ${sha}${meta?.deployed_at ? ` at ${meta.deployed_at}` : ''}`}
-      className="pointer-events-auto absolute bottom-3 left-24 font-mono text-[9px] uppercase tracking-widest text-white/30 backdrop-blur transition hover:text-white/70"
+      className="pointer-events-auto pl-1 font-mono text-[9px] uppercase tracking-widest text-white/30 transition hover:text-white/70"
     >
       {short}
       {date ? ` · ${date}` : ''}

--- a/src/app/dials/DialsControlsPanel.tsx
+++ b/src/app/dials/DialsControlsPanel.tsx
@@ -21,7 +21,6 @@
  */
 import { useDialsSettings } from './useDialsSettings';
 import { dispatchDialSet } from '../dispatchDial';
-import LabControls from '../LabControls';
 import { TopSection } from './primitives';
 import { VoiceControls } from './panels/voice';
 import { HandControls } from './panels/hand';
@@ -64,18 +63,16 @@ export default function DialsControlsPanel() {
         <OverlayControls />
       </TopSection>
 
-      {/* Feature Instrumentation Lab (#119): a measuring instrument for the raw
-          face/hand feature vectors — grouped normalized meters, derived formulas,
-          and saved views. */}
-      <TopSection label="Feature Lab">
-        <LabControls />
-      </TopSection>
+      {/* The Feature Lab is NOT here. It measures the instrument rather than being part
+          of it, so it lives in the shell's tools bar with the other tools (#136); putting
+          it in this editor is what made it unfindable in the first place. */}
 
       <TopSection label="Keyboard">
         <div className="text-[10px] leading-relaxed text-white/50">
           <p>↑ / ↓ — octave shift</p>
           <p>← / → — less / more scale-snap</p>
           <p>m — mute</p>
+          <p>⌘K / Ctrl-K — command palette (set any dial by name)</p>
         </div>
       </TopSection>
     </div>

--- a/src/app/dials/instruments.ts
+++ b/src/app/dials/instruments.ts
@@ -28,7 +28,7 @@ import type { Layer } from '@zodal/dials-core';
 import { thoreminDials, settingsToLayer, layerToSettings } from '@/settings/dials';
 import type { Settings } from '@/settings/schema';
 import { DEFAULT_HAND_MAP, RECOMMENDED_FINGER_ROUTES, type HandMap, type FingerRoute, type FingerTarget } from '@/nodes/mapping/hand_map';
-import { OverlayParamsSchema } from '@/nodes/output/canvas_overlay';
+import { OverlayDialSchema } from '@/nodes/output/canvas_overlay';
 import type { FingerName } from '@/nodes/domain';
 import { dialsStore } from './settingsStore';
 
@@ -54,7 +54,7 @@ const handMap = (over: Partial<HandMap>): HandMap => ({ ...structuredClone(DEFAU
  *  demo cues like the finger→effect lines / bars). Parsed through the schema so a
  *  partial sub-object override still ships a COMPLETE, valid overlay layer. */
 const overlay = (over: Record<string, unknown>): Settings['overlay'] =>
-  OverlayParamsSchema.parse({ ...DEFAULTS.overlay, ...over }) as Settings['overlay'];
+  OverlayDialSchema.parse({ ...DEFAULTS.overlay, ...over }) as Settings['overlay'];
 
 /** Reserved profile name (a legacy autosave) — filtered out of the visible list. */
 export const LAST_MODIFIED = 'Last modified';
@@ -328,13 +328,34 @@ function isFreshBrowser(): boolean {
 // --- Orchestration over the dials store (framework-agnostic, unit-tested) ---------
 
 /**
+ * Normalize a layer loaded from storage before it reaches the dials store.
+ *
+ * `dialsStore.setLayer` stores a layer VERBATIM (no schema parse), and the dirty check is
+ * a structural compare against the baseline. So a stale key inside a whole-object dial is
+ * not harmless: an instrument saved before #136 carries `overlay.featureLab`, while the
+ * working layer (seeded from the hot store, whose overlay no longer has it) does not — and
+ * every returning player's instrument would read DIRTY on load, forever, having changed
+ * nothing. Re-parsing `overlay` through the lab-free {@link OverlayDialSchema} drops the
+ * stale key on the way in, which is exactly what the schema is for.
+ */
+export function normalizeLayer(layer: Layer): Layer {
+  if (!layer.overlay) return layer;
+  try {
+    return { ...layer, overlay: OverlayDialSchema.parse(layer.overlay) };
+  } catch {
+    return layer; // unparseable → leave it; the dials validation surface reports it
+  }
+}
+
+/**
  * Load an instrument's layer into the dials store as the clean dirty-baseline
  * (setLayer + markSaved), so subsequent edits read as dirty and re-selecting reverts.
  * Returns the layer, or null if the instrument is gone (the caller reverts its UI).
  */
 export async function selectInstrument(name: string): Promise<Layer | null> {
-  const layer = await instruments.load(name);
-  if (!layer) return null;
+  const raw = await instruments.load(name);
+  if (!raw) return null;
+  const layer = normalizeLayer(raw);
   dialsStore.setLayer(layer);
   dialsStore.markSaved();
   return layer;
@@ -357,7 +378,8 @@ export async function restoreSession(): Promise<string | null> {
   await ensureSeeded();
   const workingLayer = dialsStore.getState().layer; // current working state (from the hot store)
   let sel = getSelectedName();
-  const selLayer = sel ? (await instruments.load(sel)) ?? null : null;
+  const selRaw = sel ? (await instruments.load(sel)) ?? null : null;
+  const selLayer = selRaw ? normalizeLayer(selRaw) : null;
   if (sel && !selLayer) {
     sel = null;
     setSelectedName(''); // the selected instrument was deleted — clear the stale name
@@ -368,7 +390,8 @@ export async function restoreSession(): Promise<string | null> {
   // restore writes the hot-store key, so a re-mount takes the resume path.
   if (!selLayer && isFreshBrowser()) {
     const def = getDefaultName();
-    const defLayer = def ? (await instruments.load(def)) ?? null : null;
+    const defRaw = def ? (await instruments.load(def)) ?? null : null;
+    const defLayer = defRaw ? normalizeLayer(defRaw) : null;
     if (def && !defLayer) setDefaultName(''); // the default instrument was deleted — clear it
     if (defLayer) {
       setSelectedName(def!);

--- a/src/app/dials/panels/overlay.tsx
+++ b/src/app/dials/panels/overlay.tsx
@@ -2,8 +2,8 @@
  * The OVERLAY section of the settings panel — data-driven by the overlay element
  * registry, so adding an overlay element makes its controls appear here automatically.
  */
-import { OVERLAY_ELEMENTS, OVERLAY_CATEGORIES, type OverlayParams } from '@/nodes/output/canvas_overlay';
-import { OVERLAY_CONTROLS, type OverlayControlDesc } from '../../overlayControls';
+import { OVERLAY_ELEMENTS, OVERLAY_CATEGORIES, type OverlayDialParams } from '@/nodes/output/canvas_overlay';
+import { controlsForSurface, type OverlayControlDesc } from '../../overlayControls';
 import { useDialsSettings } from '../useDialsSettings';
 import { CollapsibleSection, Toggle, selectCls } from '../primitives';
 
@@ -16,17 +16,26 @@ import { CollapsibleSection, Toggle, selectCls } from '../primitives';
  * appear here automatically (a test enforces every element has a descriptor), so
  * this is a general framework, not a hand-maintained list. The whole overlay object
  * is one dial value; each edit writes a merged copy back.
+ *
+ * Only the descriptors whose home is the INSTRUMENT are rendered here. An element can
+ * declare another surface as its home — the Feature Lab does (#136), because it is a
+ * tool for measuring the instrument rather than a property of it, and belongs in the
+ * shell where a player can find it. See {@link OverlaySurface}.
  */
 export function OverlayControls() {
   const { state, set } = useDialsSettings();
-  const overlay = state.effective['overlay'] as OverlayParams;
+  const overlay = state.effective['overlay'] as OverlayDialParams;
   const faceActive = state.effective['face.mapping'] !== 'none';
   const categoryOf = new Map(OVERLAY_ELEMENTS.map((e) => [e.name, e.category]));
-  const patch = (name: keyof OverlayParams, p: object) =>
-    set('overlay', { ...overlay, [name]: { ...(overlay[name] as object), ...p } });
+  const ours = controlsForSurface('instrument');
+  // `name` is a descriptor key, which is typed over the NODE's overlay params (a
+  // superset of the dial's — the Lab element lives only on the node side). `ours`
+  // filters it down to the dial's keys at runtime.
+  const patch = (name: string, p: object) =>
+    set('overlay', { ...overlay, [name]: { ...(overlay[name as keyof OverlayDialParams] as object), ...p } });
 
   const renderControl = (d: OverlayControlDesc) => {
-    const elt = overlay[d.name] as { show: boolean } & Record<string, unknown>;
+    const elt = overlay[d.name as keyof OverlayDialParams] as { show: boolean } & Record<string, unknown>;
     const off = !!d.needsFace && !faceActive;
     return (
       <div key={d.name} className="space-y-1.5">
@@ -78,7 +87,7 @@ export function OverlayControls() {
   return (
     <div className="space-y-3">
       {OVERLAY_CATEGORIES.map((cat) => {
-        const descs = OVERLAY_CONTROLS.filter((d) => categoryOf.get(d.name) === cat.id);
+        const descs = ours.filter((d) => categoryOf.get(d.name) === cat.id);
         if (descs.length === 0) return null;
         return (
           <CollapsibleSection key={cat.id} label={cat.label} defaultOpen={cat.id !== 'backdrop'}>

--- a/src/app/graph.ts
+++ b/src/app/graph.ts
@@ -126,7 +126,9 @@ export function defaultGraph(selection?: SlotSelection, registry?: NodeRegistry)
       { id: 'poseChord', type: 'pose-chord', params: {} },
       // Feature Instrumentation Lab (#119): pure feature-vector taps off the
       // existing face/hand sources; the overlay's featureLab element normalizes +
-      // draws them. Idle (empty vector) unless the lab panel is shown.
+      // draws them. Idle (empty vector) unless the Lab's meters are on — the nodes read
+      // the live lab config off the control store (resolveLabGate), so the catalog costs
+      // nothing for a player who never opens the Lab.
       { id: 'faceVec', type: 'face-feature-vector', params: {} },
       { id: 'handVec', type: 'hand-feature-vector', params: {} },
       // #90: keyboard shortcuts moved OUT of the DAG to an app-level tinykeys

--- a/src/app/overlayControls.ts
+++ b/src/app/overlayControls.ts
@@ -15,11 +15,31 @@
  */
 import type { OverlayParams } from '@/nodes/output/canvas_overlay';
 
+/**
+ * Which UI SURFACE owns an overlay element's controls.
+ *
+ * `'instrument'` — the Overlay section of the per-instrument settings panel: the
+ * element is a property of the instrument, saved and loaded with it.
+ *
+ * `'lab'` — the Feature Lab panel ({@link LabPanel}), a TOOLING surface reached from
+ * the app shell's tools bar. Its element's config is per-device, not per-instrument.
+ *
+ * This field exists because the old invariant ("every element has a descriptor") was
+ * satisfied while the Feature Lab was, in practice, unreachable (#136): a descriptor
+ * proves an element is *controllable*, not that a player can *find* the control. Every
+ * surface named here must be reachable from the app shell — `tools.ts` is the registry
+ * of shell surfaces and a test ties the two together.
+ */
+export type OverlaySurface = 'instrument' | 'lab';
+
 export interface OverlayControlDesc {
   /** The overlay element / params key this descriptor controls. */
   name: keyof OverlayParams;
   /** Label for the primary on/off toggle. */
   label: string;
+  /** Which UI surface renders this descriptor. Defaults to the instrument's Overlay
+   *  panel; see {@link OverlaySurface}. */
+  surface?: OverlaySurface;
   /** Dependent boolean sub-toggles (disabled when the element's `show` is off). */
   toggles?: { key: string; label: string }[];
   /** A 0..1 slider param (disabled when the element's `show` is off). */
@@ -30,16 +50,19 @@ export interface OverlayControlDesc {
   needsFace?: boolean;
 }
 
-/** Per-element control descriptors, in within-category display order. */
+/** Per-element control descriptors, in within-category display order. Every overlay
+ *  element has exactly one (a test enforces it) — but see {@link OverlaySurface}: the
+ *  descriptor says *what* the control is, `surface` says *where the player finds it*. */
 export const OVERLAY_CONTROLS: OverlayControlDesc[] = [
   { name: 'landmarks', label: 'Hand landmarks' },
   { name: 'faceLandmarks', label: 'Face mesh', needsFace: true },
   {
-    // Feature Instrumentation Lab (#119). The group selection + normalizer mode
-    // are a richer surface (the dedicated Lab panel); the simple toggles here are
-    // the panel's on/off + per-meter decorations.
+    // Feature Instrumentation Lab (#119) — owned by the LAB panel, not the instrument's
+    // Overlay section: the Lab measures the instrument, so its config is a per-device
+    // tooling pref rather than a saved instrument parameter (#136).
     name: 'featureLab',
     label: 'Feature Lab',
+    surface: 'lab',
     toggles: [
       { key: 'showMarkers', label: 'Percentile ticks' },
       { key: 'showValues', label: 'Raw values' },
@@ -94,3 +117,10 @@ export const OVERLAY_CONTROLS: OverlayControlDesc[] = [
   // into the recorded video. Shown only while a take records; toggle to hide the burn-in.
   { name: 'tagHud', label: 'Annotation HUD (recorded)' },
 ];
+
+/** The descriptors rendered by a given UI surface. `surface` is optional on a
+ *  descriptor (the instrument's Overlay panel is the default home), so the filter
+ *  defaults the same way — a new element lands in the instrument panel unless it
+ *  explicitly names another home. */
+export const controlsForSurface = (surface: OverlaySurface): OverlayControlDesc[] =>
+  OVERLAY_CONTROLS.filter((d) => (d.surface ?? 'instrument') === surface);

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -17,7 +17,8 @@ import { create } from 'zustand';
 import { persist, createJSONStorage, type StateStorage } from 'zustand/middleware';
 import type { ScaleTypeId } from '@/music/theory';
 import { DEFAULT_SOUND_RIGHT, DEFAULT_SOUND_LEFT } from '@/music/sounds';
-import { OverlayParamsSchema, type OverlayParams } from '@/nodes/output/canvas_overlay';
+import { OverlayDialSchema, type OverlayDialParams } from '@/nodes/output/canvas_overlay';
+import { FeatureLabSchema, defaultFeatureLab, type FeatureLabConfig } from '@/features/labConfig';
 import { FACE_MAPPINGS, legacyFaceToMapping, type VoiceParams, type FaceMapping } from '@/nodes';
 import {
   DEFAULT_FACE_CHORD,
@@ -83,8 +84,9 @@ export interface ControlState {
   /**
    * What the player's facial expression maps to: `none` (off, default), `timbre`
    * (smile→brightness, open mouth→vibrato), or `chord` (expression selects a
-   * diatonic triad). Any non-`none` mode lazy-loads the `webcam-face` model. Read
-   * by the nodes each tick via `ctx.resources.controls`.
+   * diatonic triad). Any non-`none` mode lazy-loads the `webcam-face` model — as does
+   * the Feature Lab when it measures face groups (#136), so this is no longer the only
+   * switch on the model. Read by the nodes each tick via `ctx.resources.controls`.
    */
   faceMapping: FaceMapping;
   /** How the face chord sounds (sound / volume / voicing / rendering / tempo).
@@ -94,8 +96,23 @@ export interface ControlState {
    *  `face-expression`) + per-expression scale-degree map (read live by
    *  `expression-chord`). */
   faceExpr: FaceExpr;
-  /** Composable overlay element config (see canvas_overlay.ts). Live-controlled. */
-  overlay: OverlayParams;
+  /** Composable overlay element config (see canvas_overlay.ts). Live-controlled.
+   *  This is the DIAL-facing overlay — the Feature Lab is deliberately not in it
+   *  (see {@link featureLab}). */
+  overlay: OverlayDialParams;
+  /**
+   * Feature Instrumentation Lab config (#119): which feature groups are measured,
+   * how they are normalized, the derived formulas.
+   *
+   * A TOOLING preference, not an instrument parameter — like {@link faceCalibration},
+   * it is persisted per-device but is NOT a preset field, so it never rides an
+   * instrument. Before #136 it lived inside the `overlay` dial, which meant opening a
+   * measuring tool marked the instrument dirty and loading an instrument silently
+   * reconfigured the meters. `store-controls` composes it into the overlay node's
+   * params each tick, and `webcam-face` reads it to decide whether the face model is
+   * wanted (so you can measure the face without the face driving the sound).
+   */
+  featureLab: FeatureLabConfig;
   /** The hand→sound mapping: note source (index/wrist), finger→effect routing, and
    *  the once-static voice knobs. Read live by `voice-mapping` via
    *  `ctx.resources.controls`. See src/nodes/mapping/hand_map.ts. */
@@ -120,7 +137,9 @@ export interface ControlState {
   /** Set the scale degree (0..6) an expression maps to. */
   setExpressionDegree(expr: string, degree: number): void;
   /** Patch one overlay element's options (e.g. setOverlayElement('indexGuide', { show: true })). */
-  setOverlayElement<K extends keyof OverlayParams>(key: K, patch: Partial<OverlayParams[K]>): void;
+  setOverlayElement<K extends keyof OverlayDialParams>(key: K, patch: Partial<OverlayDialParams[K]>): void;
+  /** Patch the Feature Lab config (e.g. setFeatureLab({ show: true })). */
+  setFeatureLab(patch: Partial<FeatureLabConfig>): void;
   /** Shallow-patch the hand map (e.g. setHandMap({ positionSource: 'wrist' }), or a new
    *  `fingers` object for a route change). */
   setHandMap(patch: Partial<HandMap>): void;
@@ -145,7 +164,7 @@ const defaultVoice = (sound: VoiceParams['sound']): VoiceControl => ({
 });
 
 /** The overlay element defaults (all on except the opt-in index-finger guide). */
-const defaultOverlay = (): OverlayParams => OverlayParamsSchema.parse({});
+const defaultOverlay = (): OverlayDialParams => OverlayDialSchema.parse({});
 
 /** Pick exactly the preset fields ({@link SETTINGS_KEYS}) from a state-like object. */
 function pickSettings(s: Record<string, unknown>): Settings {
@@ -199,6 +218,22 @@ export function migrateControls(persisted: unknown, version: number): ControlSta
       }
     }
   }
+  if (version < 7) {
+    // #136: the Feature Lab moved OUT of the `overlay` dial (an instrument parameter)
+    // and onto its own per-device tooling field. Carry a returning player's lab config
+    // across rather than dropping it on the floor — `overlay` is re-parsed through the
+    // lab-free OverlayDialSchema in mergeControls, which would strip it silently.
+    const ov = s.overlay as Record<string, unknown> | undefined;
+    if (ov?.featureLab !== undefined) {
+      if (s.featureLab === undefined) s.featureLab = ov.featureLab;
+      // Copy rather than `delete` on the caller's object: `persisted` is only shallow-
+      // copied above, so `s.overlay` IS their object. (mergeControls re-parses `overlay`
+      // through the lab-free schema and would drop the key anyway — this keeps the
+      // directly-tested migrate honest about not mutating its input.)
+      const { featureLab: _lifted, ...rest } = ov;
+      s.overlay = rest;
+    }
+  }
   return s as unknown as ControlState;
 }
 
@@ -216,9 +251,18 @@ export function mergeControls(persisted: unknown, current: ControlState): Contro
   let overlay = current.overlay;
   if (p.overlay) {
     try {
-      overlay = OverlayParamsSchema.parse(p.overlay);
+      overlay = OverlayDialSchema.parse(p.overlay);
     } catch {
       overlay = current.overlay;
+    }
+  }
+  // Heal the lab config the same way (an older blob has none → the default meters).
+  let featureLab = current.featureLab;
+  if (p.featureLab) {
+    try {
+      featureLab = FeatureLabSchema.parse(p.featureLab);
+    } catch {
+      featureLab = current.featureLab;
     }
   }
   // Re-parse faceChord: complete a partial blob from the defaults, then validate,
@@ -259,7 +303,7 @@ export function mergeControls(persisted: unknown, current: ControlState): Contro
       handMap = current.handMap;
     }
   }
-  return { ...current, ...p, overlay, faceMapping, faceChord, faceExpr, handMap };
+  return { ...current, ...p, overlay, featureLab, faceMapping, faceChord, faceExpr, handMap };
 }
 
 // localStorage in the browser; a no-op elsewhere (Node test runtime) so the
@@ -289,6 +333,7 @@ export const useControls = create<ControlState>()(
         degrees: { ...DEFAULT_FACE_EXPR.degrees },
       },
       overlay: defaultOverlay(),
+      featureLab: defaultFeatureLab(),
       handMap: defaultHandMap(),
       faceCalibration: null,
       setVoice: (side, patch) =>
@@ -322,8 +367,9 @@ export const useControls = create<ControlState>()(
         })),
       setOverlayElement: (key, patch) =>
         set((s) => ({
-          overlay: { ...s.overlay, [key]: { ...s.overlay[key], ...patch } } as OverlayParams,
+          overlay: { ...s.overlay, [key]: { ...s.overlay[key], ...patch } } as OverlayDialParams,
         })),
+      setFeatureLab: (patch) => set((s) => ({ featureLab: { ...s.featureLab, ...patch } })),
       setHandMap: (patch) => set((s) => ({ handMap: { ...s.handMap, ...patch } })),
       setFaceCalibration: (map) => set({ faceCalibration: map ? { ...map } : null }),
       // Restore exactly the schema fields (the setters are left untouched). Derived
@@ -344,15 +390,20 @@ export const useControls = create<ControlState>()(
       // v4: added the `handMap`. v3: `instrument` → `sound` rename. v2: the face-mapping
       // chooser (#64). See migrateControls (field renames/bumps) and mergeControls (heals
       // stale nested `overlay`/`faceChord`/`faceExpr`/`handMap` + clamps `faceMapping`).
-      version: 6,
+      // Version 7: #136 lifted the Feature Lab out of the `overlay` dial onto its own
+      // per-device `featureLab` field (a tooling pref, like `faceCalibration`). The
+      // migrate carries a returning player's lab config across before mergeControls
+      // re-parses `overlay` through the now lab-free OverlayDialSchema.
+      version: 7,
       migrate: migrateControls,
       merge: mergeControls,
       storage: createJSONStorage(controlsStorage),
-      // Persist the preset fields (schema-derived) + the per-device calibration,
-      // never the setter functions.
+      // Persist the preset fields (schema-derived) + the per-device tooling prefs
+      // (calibration, feature lab), never the setter functions.
       partialize: (s) => ({
         ...pickSettings(s as unknown as Record<string, unknown>),
         faceCalibration: s.faceCalibration,
+        featureLab: s.featureLab,
       }),
     },
   ),

--- a/src/app/tools.ts
+++ b/src/app/tools.ts
@@ -1,0 +1,75 @@
+/**
+ * TOOLS — the registry of the app shell's non-instrument surfaces (#136).
+ *
+ * A *tool* is something you use ON the instrument rather than a part of it: the
+ * Feature Lab (measure the raw feature vectors), the command palette (set any dial by
+ * name), the capabilities manual. Each entry declares what it is, how it opens, and —
+ * crucially — that it opens **from the shell at all**.
+ *
+ * This registry exists because thoremin has shipped subsystems to production that no
+ * player could find. The Feature Lab (#119) was live in the bundle for weeks, three
+ * clicks deep inside a per-instrument editor, defaulting to off; MIDI out (#120) has no
+ * entry point at all (#137). Both passed every test. The rule this file encodes:
+ *
+ *   **A feature only findable by someone who read the PR is not shipped.**
+ *
+ * So: add a tool here, and `ToolsBar` grows a labelled button for it automatically. A test
+ * asserts the shell mounts a surface for every entry — registering a tool without giving
+ * it a home fails the build, and building a tool without registering it means no button,
+ * which is the failure mode we are pricing in.
+ *
+ * Kept React-free (plain data, no icons) so it is importable in plain Node tests; the
+ * icon for each id is chosen in {@link ToolsBar}.
+ */
+
+/** How a tool opens. */
+export type ToolKind =
+  /** A panel in the shell, toggled by the tools bar (and tracked in {@link useTools}). */
+  | 'panel'
+  /** An overlay with its own hotkey; the bar button opens it too. */
+  | 'overlay'
+  /** A plain link out of the app (the generated manual). */
+  | 'link';
+
+export interface Tool {
+  /** Stable id — the key `useTools.open` holds, and the `data-tool` test hook. */
+  id: string;
+  /** The button label. Shown, not just an aria-label: an unlabelled icon is how the
+   *  command palette stayed invisible for a whole release. */
+  label: string;
+  /** One line, shown as the button's tooltip and as the panel's intro strapline. */
+  description: string;
+  kind: ToolKind;
+  /** Displayed on the button and in the keyboard cheat-sheet, e.g. `⌘K`. */
+  hotkey?: string;
+  /** For `kind: 'link'` — the href. */
+  href?: string;
+}
+
+export const TOOLS: readonly Tool[] = [
+  {
+    id: 'lab',
+    label: 'Feature Lab',
+    description:
+      'Measure the raw face and hand features the instrument plays from — live, normalized meters.',
+    kind: 'panel',
+  },
+  {
+    id: 'commands',
+    label: 'Commands',
+    description: 'Search every dial by name and set it — the same command path the AI assistant uses.',
+    kind: 'overlay',
+    hotkey: '⌘K',
+  },
+  {
+    id: 'manual',
+    label: 'Manual',
+    description: 'The generated capabilities manual: every node, dial, sound and overlay element.',
+    kind: 'link',
+    href: 'manual.html',
+  },
+] as const;
+
+export const TOOL_IDS: readonly string[] = TOOLS.map((t) => t.id);
+
+export const toolById = (id: string): Tool | undefined => TOOLS.find((t) => t.id === id);

--- a/src/app/toolsStore.ts
+++ b/src/app/toolsStore.ts
@@ -1,0 +1,29 @@
+/**
+ * Which shell tool is open — a one-field zustand store shared by the tools bar (which
+ * opens them) and each tool's surface (which renders when open).
+ *
+ * At most one tool is open at a time: they are full panels over a live instrument, and
+ * the video is the primary cue. Opening a tool closes the previous one.
+ *
+ * The command palette's ⌘K hotkey writes here too, so the hotkey and the bar button are
+ * the same open state rather than two independent flags that can disagree.
+ */
+import { create } from 'zustand';
+
+interface ToolsState {
+  /** The open tool's id (see {@link TOOLS}), or null when none is open. */
+  open: string | null;
+  /** Open a tool (closing any other). */
+  openTool(id: string): void;
+  /** Close whatever is open. */
+  close(): void;
+  /** Open `id` if closed, close it if it is the one already open. */
+  toggleTool(id: string): void;
+}
+
+export const useTools = create<ToolsState>()((set) => ({
+  open: null,
+  openTool: (id) => set({ open: id }),
+  close: () => set({ open: null }),
+  toggleTool: (id) => set((s) => ({ open: s.open === id ? null : id })),
+}));

--- a/src/features/labConfig.ts
+++ b/src/features/labConfig.ts
@@ -1,0 +1,125 @@
+/**
+ * The Feature Instrumentation Lab's configuration (#119) — its schema, defaults, and
+ * the "does the lab need the face model?" predicate.
+ *
+ * This lives on its own (rather than inline in the overlay node's params, where it
+ * started) because the Lab is a **tooling preference, not an instrument parameter**.
+ * It is the same call `#88` made for recording settings: how you *measure* the
+ * instrument is not part of the instrument, so it must not ride the per-instrument
+ * `overlay` dial — otherwise opening a measuring tool marks your instrument dirty and
+ * switching instruments silently re-configures your meters (#136).
+ *
+ * Two consumers share this SSOT:
+ *  - the `canvas-overlay` node, whose `featureLab` element draws the meters (the node's
+ *    params still carry the config — `store-controls` composes it in each tick);
+ *  - the app's hot control store, which owns the value and persists it per-device.
+ */
+import { z } from 'zod';
+import { DEFAULT_LAB_GROUPS, DERIVED_GROUP, FEATURE_GROUPS } from './catalog';
+
+/**
+ * A dense grid of grouped, online-normalized meters over the raw face/hand feature
+ * vectors, so heterogeneous ranges read as comparable levels.
+ *
+ * `groups` is the display *and* compute selection: the feature-vector nodes read it off
+ * the control snapshot ({@link resolveLabGate}), so it drives what is *measured*, not only
+ * what is drawn — with the meters off, the nodes emit an empty vector and the catalog
+ * costs nothing. `normalizer` picks the level mapping.
+ */
+export const FeatureLabSchema = z
+  .object({
+    show: z.boolean().default(false),
+    groups: z.array(z.string()).default([...DEFAULT_LAB_GROUPS]),
+    normalizer: z.enum(['minmax', 'quantile', 'zscore']).default('minmax'),
+    /** Number of newspaper-flow columns in the meter grid. */
+    columns: z.number().int().min(1).max(8).default(3),
+    /** Draw the percentile-band reference ticks on each meter. */
+    showMarkers: z.boolean().default(true),
+    /** Print the raw value beside each meter. */
+    showValues: z.boolean().default(false),
+    /** User-defined derived features: a safe formula (jsep whitelist) over feature
+     *  safe-names (`face.geom.mouth.openness` → `face_geom_mouth_openness`) + the
+     *  helper set. Evaluated over the merged face+hand vector; shown under the
+     *  `derived` group. An invalid formula is skipped (the editor shows the error). */
+    derived: z.array(z.object({ id: z.string(), formula: z.string() })).default([]),
+    /** Bump to re-zero the online statistics (a manual "recalibrate"). */
+    resetNonce: z.number().default(0),
+  })
+  .prefault({});
+
+export type FeatureLabConfig = z.infer<typeof FeatureLabSchema>;
+
+/** A fresh default config (never a shared mutable — `groups`/`derived` are arrays). */
+export const defaultFeatureLab = (): FeatureLabConfig => FeatureLabSchema.parse({});
+
+/**
+ * The feature groups sourced from the FACE. `DERIVED_GROUP` is excluded even though
+ * the catalog files it under `source: 'face'` — a derived formula may reference only
+ * hand features, so it is not on its own evidence that the face model is wanted.
+ */
+export const FACE_GROUP_IDS: readonly string[] = FEATURE_GROUPS.filter(
+  (g) => g.source === 'face' && g.id !== DERIVED_GROUP,
+).map((g) => g.id);
+
+/**
+ * Does the Lab need the face model loaded?
+ *
+ * This is what lets the Lab be a true *measuring* instrument: before #136 the face
+ * model loaded only when `faceMapping !== 'none'`, so you could not look at a face
+ * meter without also putting your face in charge of the sound — you could not observe
+ * without altering. `webcam-face` now gates on the mapping OR on this, so measuring
+ * the face costs exactly the model load and nothing musical.
+ */
+export function labWantsFace(cfg: FeatureLabConfig | undefined): boolean {
+  if (!cfg?.show) return false;
+  return cfg.groups.some((g) => FACE_GROUP_IDS.includes(g));
+}
+
+// ---- The compute gate the feature-vector nodes share ------------------------------
+
+/** The slice of the lab config the feature-vector nodes need off a control snapshot. */
+export interface LiveLabConfig {
+  show?: boolean;
+  groups?: string[];
+}
+
+/**
+ * A control snapshot as seen through `ctx.resources.controls`, which is the RAW control
+ * store — NOT the composed `store-controls` output. So the lab config is at the top
+ * level. The nested `overlay.featureLab` is also accepted: that is the composed shape
+ * (what `canvas-overlay` receives) and the pre-#136 store shape, and honouring both is
+ * what keeps a caller that passes either from silently reading `undefined`.
+ */
+export type LabControlsSnapshot = {
+  featureLab?: LiveLabConfig;
+  overlay?: { featureLab?: LiveLabConfig };
+};
+
+/** Read the live lab config off a control snapshot, whichever shape it is in. */
+export function readLiveLab(controls: LabControlsSnapshot | undefined): LiveLabConfig | undefined {
+  return controls?.featureLab ?? controls?.overlay?.featureLab;
+}
+
+/**
+ * The feature-vector nodes' gate: are we computing at all, and which groups?
+ *
+ * Shared by `face-feature-vector` and `hand-feature-vector` — they each carried their own
+ * copy, and when #136 moved the config off `overlay` both copies kept reading the old
+ * path, silently returning `undefined`. An `undefined` live config means "headless", which
+ * means "always active": the gate did not fail closed, it failed OPEN, and every user
+ * started evaluating the whole 248-feature catalog every frame with the Lab switched off.
+ * One copy, in the module that owns the config.
+ *
+ * `undefined` live config (a headless test / a host that wires no controls) → active with
+ * the params' groups. A live config → active only when the meters are shown.
+ */
+export function resolveLabGate(
+  params: { groups?: string[] },
+  controls: LabControlsSnapshot | undefined,
+): { active: boolean; enabled: (group: string) => boolean } {
+  const live = readLiveLab(controls);
+  const active = live ? live.show === true : true;
+  const groups = live?.groups ?? params.groups;
+  const set = groups ? new Set(groups) : null;
+  return { active, enabled: (group: string) => (set ? set.has(group) : true) };
+}

--- a/src/nodes/domain.ts
+++ b/src/nodes/domain.ts
@@ -127,7 +127,10 @@ export interface SynthParams {
  *  - `controls` : deliberate head/face *pose* axes play a chord instrument (#76) —
  *                 head-yaw→degree, head-pitch→octave, jaw-open→gate, smile→timbre,
  *                 brow→add-7th. The honest, controllable alternative to emotion mode.
- * Any non-`none` mode lazy-loads the `webcam-face` model.
+ * Any non-`none` mode lazy-loads the `webcam-face` model — but the mapping is no longer
+ * the ONLY thing that can want the model: the Feature Lab requests it too when it is
+ * measuring face groups, so a player can observe their face features without the face
+ * driving the sound (see `faceActive` in webcam_face.ts, #136).
  */
 export const FACE_MAPPINGS = ['none', 'timbre', 'chord', 'controls'] as const;
 export type FaceMapping = (typeof FACE_MAPPINGS)[number];

--- a/src/nodes/features/face_feature_vector.ts
+++ b/src/nodes/features/face_feature_vector.ts
@@ -11,7 +11,8 @@
  * NaN and the online normalizer never sees one (one NaN permanently poisons a
  * running mean — see the #119 appendix).
  *
- * Which groups compute is, in priority order: the live lab config
+ * Which groups compute is, in priority order: the live lab config (read off the control
+ * store — the top-level `featureLab`, since #136)
  * (`ctx.resources.controls().overlay.featureLab`), then the static `groups`
  * param, then ALL face groups. The lab is "active" when its overlay element is
  * shown; when hidden (and a live config is present) the node emits an empty
@@ -24,6 +25,7 @@ import { defineNode } from '@/dag';
 import type { NodeContext } from '@/dag';
 import type { FaceFrame } from '../domain';
 import { buildFaceCtx, FACE_FEATURES, type FeatureVector } from '@/features/catalog';
+import { resolveLabGate, type LabControlsSnapshot } from '@/features/labConfig';
 
 const Params = z.object({
   /** Which feature groups to compute (default: all face groups). A live lab
@@ -32,21 +34,13 @@ const Params = z.object({
 });
 type Params = z.infer<typeof Params>;
 
-/** The live lab config slice the vector nodes read off the control snapshot. */
-interface LiveLabConfig {
-  show?: boolean;
-  groups?: string[];
-}
-type ControlsGetter = () => { overlay?: { featureLab?: LiveLabConfig } } | undefined;
+type ControlsGetter = () => LabControlsSnapshot | undefined;
 
-/** Resolve the active flag + enabled-group predicate from live config or params. */
+/** Resolve the active flag + enabled-group predicate. The rule itself lives in
+ *  `@/features/labConfig` — it is shared with the hand/face twin, and keeping two copies
+ *  of it is how #136 silently un-gated the whole catalog. */
 function resolveGroups(p: Params, ctx: NodeContext): { active: boolean; enabled: (group: string) => boolean } {
-  const live = (ctx.resources.controls as ControlsGetter | undefined)?.()?.overlay?.featureLab;
-  // Headless (no live config): always active, groups from params.
-  const active = live ? live.show === true : true;
-  const groups = live?.groups ?? p.groups;
-  const set = groups ? new Set(groups) : null;
-  return { active, enabled: (group: string) => (set ? set.has(group) : true) };
+  return resolveLabGate(p, (ctx.resources.controls as ControlsGetter | undefined)?.());
 }
 
 export const faceFeatureVectorNode = defineNode<Params>({

--- a/src/nodes/features/hand_feature_vector.ts
+++ b/src/nodes/features/hand_feature_vector.ts
@@ -30,6 +30,7 @@ import {
   type HandCtx,
   type HandSide,
 } from '@/features/catalog';
+import { resolveLabGate, type LabControlsSnapshot } from '@/features/labConfig';
 
 const Params = z.object({
   /** Mirror image-x so moving right increases x (selfie view), matching hand-features. */
@@ -41,18 +42,13 @@ const Params = z.object({
 });
 type Params = z.infer<typeof Params>;
 
-interface LiveLabConfig {
-  show?: boolean;
-  groups?: string[];
-}
-type ControlsGetter = () => { overlay?: { featureLab?: LiveLabConfig } } | undefined;
+type ControlsGetter = () => LabControlsSnapshot | undefined;
 
+/** Resolve the active flag + enabled-group predicate. The rule itself lives in
+ *  `@/features/labConfig` — it is shared with the hand/face twin, and keeping two copies
+ *  of it is how #136 silently un-gated the whole catalog. */
 function resolveGroups(p: Params, ctx: NodeContext): { active: boolean; enabled: (group: string) => boolean } {
-  const live = (ctx.resources.controls as ControlsGetter | undefined)?.()?.overlay?.featureLab;
-  const active = live ? live.show === true : true;
-  const groups = live?.groups ?? p.groups;
-  const set = groups ? new Set(groups) : null;
-  return { active, enabled: (group: string) => (set ? set.has(group) : true) };
+  return resolveLabGate(p, (ctx.resources.controls as ControlsGetter | undefined)?.());
 }
 
 export const handFeatureVectorNode = defineNode<Params>({

--- a/src/nodes/output/canvas_overlay.ts
+++ b/src/nodes/output/canvas_overlay.ts
@@ -39,8 +39,8 @@ import {
 import { EMOTIONS, type ExpressionScores } from '@/music/expression';
 import { clamp01 } from '@/features/math';
 import { createLabMeterComputer, type FeatureMeters } from '@/features/labMeters';
+import { FeatureLabSchema } from '@/features/labConfig';
 import {
-  DEFAULT_LAB_GROUPS,
   DERIVED_GROUP,
   FEATURE_BY_ID,
   FEATURE_GROUPS,
@@ -144,36 +144,13 @@ const Params = z.object({
     })
     .prefault({}),
   /**
-   * Feature Instrumentation Lab (#119): a dense grid of grouped, online-normalized
-   * meters for the raw face/hand feature vectors, so heterogeneous ranges read as
-   * comparable levels. `groups` is the display + compute selection (the vector
-   * nodes read it too via the control snapshot, so it drives what is measured, not
-   * only what is drawn); `normalizer` picks the level mapping. Opt-in (a large,
-   * exploratory panel). Group/derived state that can't live here (arbitrary derived
-   * formulas, reset) rides the separate lab store (ctx.resources.lab).
+   * Feature Instrumentation Lab (#119). The schema lives in `@/features/labConfig`
+   * because the Lab is a TOOLING preference, not an instrument parameter: the value
+   * is owned by the hot control store (per-device, persisted) and composed into these
+   * node params by `store-controls` each tick — it is deliberately NOT part of the
+   * `overlay` dial (see {@link OverlayDialSchema} and #136).
    */
-  featureLab: z
-    .object({
-      show: z.boolean().default(false),
-      groups: z.array(z.string()).default([...DEFAULT_LAB_GROUPS]),
-      normalizer: z.enum(['minmax', 'quantile', 'zscore']).default('minmax'),
-      /** Number of newspaper-flow columns in the meter grid. */
-      columns: z.number().int().min(1).max(8).default(3),
-      /** Draw the percentile-band reference ticks on each meter. */
-      showMarkers: z.boolean().default(true),
-      /** Print the raw value beside each meter. */
-      showValues: z.boolean().default(false),
-      /** User-defined derived features: a safe formula (jsep whitelist) over feature
-       *  safe-names (`face.geom.mouth.openness` → `face_geom_mouth_openness`) + the
-       *  helper set. Evaluated over the merged face+hand vector; shown under the
-       *  `derived` group. An invalid formula is skipped (the editor shows the error). */
-      derived: z
-        .array(z.object({ id: z.string(), formula: z.string() }))
-        .default([]),
-      /** Bump to re-zero the online statistics (a manual "recalibrate"). */
-      resetNonce: z.number().default(0),
-    })
-    .prefault({}),
+  featureLab: FeatureLabSchema,
   /**
    * Live-tagging burned-in corner HUD (#92): while a take is recording with tagging
    * on, paints the open tags + a media timecode + a ~1 Hz REC blink into the
@@ -192,11 +169,26 @@ const Params = z.object({
 type Params = z.infer<typeof Params>;
 
 /**
- * The overlay's per-element params schema, exported so it is the single source of
- * truth for the overlay portion of saved settings and for the overlay settings panel.
+ * The overlay NODE's params — every element, including the Feature Lab. This is the
+ * engine-facing contract: `store-controls` composes it each tick from the instrument's
+ * overlay dial plus the per-device lab config.
  */
 export const OverlayParamsSchema = Params;
 export type OverlayParams = Params;
+
+/**
+ * The overlay DIAL's schema — the node's params minus `featureLab`, and so the single
+ * source of truth for the overlay portion of saved settings and of the overlay settings
+ * panel.
+ *
+ * The Lab is omitted on purpose (#136): it is a measuring tool, not a property of the
+ * instrument being measured. Leaving it in the dial meant that toggling a meter marked
+ * the instrument as having unsaved edits, and that loading an instrument silently
+ * re-configured the meters — the same reason recording settings were moved out of the
+ * instrument in #88.
+ */
+export const OverlayDialSchema = Params.omit({ featureLab: true });
+export type OverlayDialParams = z.infer<typeof OverlayDialSchema>;
 
 const RIGHT_COLOR = '#10b981';
 const LEFT_COLOR = '#3b82f6';

--- a/src/nodes/sources/store_controls.ts
+++ b/src/nodes/sources/store_controls.ts
@@ -14,7 +14,8 @@ import { generateScale, defaultChordSpecFor, type ScaleSpec, type ScaleTypeId } 
 import type { SoundId } from '@/music/sounds';
 import { legacyFaceToMapping, type FaceMapping } from '@/nodes/domain';
 import type { FaceChord, FaceExpr } from '@/settings/schema';
-import type { OverlayParams } from '@/nodes/output/canvas_overlay';
+import type { OverlayDialParams } from '@/nodes/output/canvas_overlay';
+import { defaultFeatureLab, type FeatureLabConfig } from '@/features/labConfig';
 
 export interface VoiceControlSnapshot {
   root: number;
@@ -39,8 +40,14 @@ export interface ControlSnapshot {
   /** Master mute, read by voice-mapping + synth-merge (#90 — the `m` key toggles
    *  `store.muted`, which flows here instead of through `keyboard-control`). */
   muted?: boolean;
-  /** Live overlay element config; forwarded to canvas-overlay's overlayConfig. */
-  overlay?: OverlayParams;
+  /** Live overlay element config (the INSTRUMENT's overlay — no Feature Lab). Composed
+   *  with {@link featureLab} into canvas-overlay's `overlayConfig`. */
+  overlay?: OverlayDialParams;
+  /** The Feature Lab config (#119) — a per-device TOOLING pref, not an instrument
+   *  parameter (#136), so it is carried separately and merged into the overlay node's
+   *  params here. Also read by `webcam-face`, which loads the face model when the Lab
+   *  is measuring face groups even if the face drives no sound. */
+  featureLab?: FeatureLabConfig;
   /** Legacy face on/off flag; superseded by {@link faceMapping}. Kept so older
    *  hosts / saved data still gate the `webcam-face` model load. */
   faceEnabled?: boolean;
@@ -151,7 +158,9 @@ export const storeControlsNode = defineNode<Record<string, never>>({
             : c.faceExpr.sensitivity;
           out.expressionDegrees = c.faceExpr.degrees;
         }
-        if (c.overlay) out.overlay = c.overlay;
+        // Recompose the overlay node's params: the instrument's overlay elements plus
+        // the per-device Feature Lab config, which is owned outside the instrument (#136).
+        if (c.overlay) out.overlay = { ...c.overlay, featureLab: c.featureLab ?? defaultFeatureLab() };
         return out;
       },
     };

--- a/src/nodes/sources/webcam_face.ts
+++ b/src/nodes/sources/webcam_face.ts
@@ -26,6 +26,7 @@ import { z } from 'zod';
 import { defineNode } from '@/dag';
 import type { NodeContext } from '@/dag';
 import { matrixToHeadPose, type FaceFrame, type FaceMapping, type FaceStatus } from '../domain';
+import { labWantsFace, type FeatureLabConfig } from '@/features/labConfig';
 
 // MediaPipe FaceLandmarker assets, loaded from a CDN on demand (mirrors how
 // `webcam-hands` resolves its MediaPipe solution from jsDelivr). The wasm
@@ -105,12 +106,30 @@ interface TasksVisionModule {
 
 /** Reads the face-mapping mode off the live controls snapshot. `faceMapping`
  * supersedes the legacy boolean `faceEnabled` (kept for back-compat / tests). */
-type FaceControlsGetter = () => { faceEnabled?: boolean; faceMapping?: FaceMapping };
+type FaceControlsGetter = () => {
+  faceEnabled?: boolean;
+  faceMapping?: FaceMapping;
+  featureLab?: FeatureLabConfig;
+};
 
-/** Is any face mode active? `faceMapping !== 'none'`, falling back to the legacy
- * `faceEnabled` flag when the newer field is absent (older callers / tests). */
-function faceActive(controls: ReturnType<FaceControlsGetter> | undefined): boolean {
+/**
+ * Should the face model be loaded and run?
+ *
+ * Two independent consumers can want the face, and either is sufficient:
+ *  - the MAPPING wants it — the face drives sound (`faceMapping !== 'none'`), falling
+ *    back to the legacy `faceEnabled` flag when the newer field is absent (older
+ *    callers / tests);
+ *  - the LAB wants it — the Feature Instrumentation Lab is measuring face groups
+ *    ({@link labWantsFace}). Before #136 only the mapping could turn the model on, so
+ *    you could not look at a face meter without also handing the face control of the
+ *    sound: a measuring instrument that cannot observe without altering.
+ *
+ * Exported so the app shell can tell the player the face camera is running for either
+ * reason (the FaceChip), and so the rule is directly testable.
+ */
+export function faceActive(controls: ReturnType<FaceControlsGetter> | undefined): boolean {
   if (!controls) return false;
+  if (labWantsFace(controls.featureLab)) return true;
   if (controls.faceMapping !== undefined) return controls.faceMapping !== 'none';
   return controls.faceEnabled === true;
 }

--- a/src/settings/dials.ts
+++ b/src/settings/dials.ts
@@ -19,7 +19,7 @@ import { SOUND_IDS, type SoundId } from '@/music/sounds';
 import { VOICINGS, RENDERINGS, type VoicingId, type RenderingId } from '@/music/voicing';
 import { FACE_MAPPINGS, type FaceMapping } from '@/nodes/domain';
 import { DEFAULT_EXPRESSION_SENSITIVITY, DEFAULT_EXPRESSION_TO_DEGREE } from '@/music/expression';
-import { OverlayParamsSchema } from '@/nodes/output/canvas_overlay';
+import { OverlayDialSchema } from '@/nodes/output/canvas_overlay';
 import { DEFAULT_HAND_MAP } from '@/nodes/mapping/hand_map';
 import { SettingsSchema, HandMapSchema, DEFAULT_FACE_CHORD, type Settings } from './schema';
 
@@ -98,7 +98,7 @@ export const thoreminDials = defineDials(
       .record(z.string(), z.number().int().min(-1).max(6))
       .default({ ...DEFAULT_EXPRESSION_TO_DEGREE })
       .meta({ facets: ['Face', 'advanced'], title: 'Expression chord map' }),
-    overlay: OverlayParamsSchema.default(OverlayParamsSchema.parse({})).meta({ facets: ['Overlay'], title: 'Overlay' }),
+    overlay: OverlayDialSchema.default(OverlayDialSchema.parse({})).meta({ facets: ['Overlay'], title: 'Overlay' }),
     // The hand→sound mapping (note source + finger routing + knobs) — a whole-object
     // dial rendered by the bespoke Hand widget, like `overlay` / the expression maps.
     handMap: HandMapSchema.default(DEFAULT_HAND_MAP).meta({ facets: ['Hand'], title: 'Hand mapping' }),

--- a/src/settings/schema.ts
+++ b/src/settings/schema.ts
@@ -14,7 +14,7 @@ import { SCALE_TYPES, type ScaleTypeId } from '@/music/theory';
 import { SOUND_IDS, type SoundId } from '@/music/sounds';
 import { VOICINGS, RENDERINGS, type VoicingId, type RenderingId } from '@/music/voicing';
 import { FACE_MAPPINGS, legacyFaceToMapping, type FaceMapping } from '@/nodes/domain';
-import { OverlayParamsSchema } from '@/nodes/output/canvas_overlay';
+import { OverlayDialSchema } from '@/nodes/output/canvas_overlay';
 import { DEFAULT_EXPRESSION_SENSITIVITY, DEFAULT_EXPRESSION_TO_DEGREE } from '@/music/expression';
 import {
   EFFECTS,
@@ -169,7 +169,7 @@ export const SettingsSchema = z.object({
   // Per-emotion sensitivity + per-expression degree map; `.default(...)` keeps
   // presets saved before the expression-mapping editor valid.
   faceExpr: FaceExprSchema,
-  overlay: OverlayParamsSchema,
+  overlay: OverlayDialSchema,
   // Note source + finger→effect routing + the once-static voice-mapping knobs.
   handMap: HandMapSchema,
 });

--- a/test/app_shell.test.ts
+++ b/test/app_shell.test.ts
@@ -1,0 +1,41 @@
+/**
+ * The app shell mounts a surface for every registered tool (#136).
+ *
+ * `ToolsBar` renders a button per {@link TOOLS} entry — which means it can render a
+ * button for a tool whose panel nobody mounted, i.e. a button that does nothing. This is
+ * the guard against that, and against the shell quietly dropping the tools bar itself.
+ *
+ * It is a SOURCE check rather than a render: mounting App boots the webcam and the ML
+ * engine, which no unit test should do. The rendering half of the chain (button → open
+ * state → panel) is covered in `tools_shell.test.tsx`.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { TOOLS } from '@/app/tools';
+
+const app = readFileSync(resolve(process.cwd(), 'src/app/App.tsx'), 'utf8');
+
+/** The component that renders each non-link tool's surface. A tool with no entry here
+ *  fails the test below — registering a tool obliges you to give it a home. */
+const SURFACES: Record<string, string> = {
+  lab: 'LabPanel',
+  commands: 'CommandPaletteOverlay',
+};
+
+describe('app shell', () => {
+  it('renders the ToolsBar (the only place a player learns these tools exist)', () => {
+    expect(app).toMatch(/<ToolsBar\s*\/>/);
+  });
+
+  it('mounts a surface component for every non-link tool', () => {
+    for (const tool of TOOLS) {
+      if (tool.kind === 'link') continue;
+      const component = SURFACES[tool.id];
+      expect(component, `tool '${tool.id}' has no surface listed in SURFACES`).toBeTruthy();
+      expect(app, `App.tsx does not mount <${component} /> for tool '${tool.id}'`).toContain(
+        `<${component} />`,
+      );
+    }
+  });
+});

--- a/test/feature_lab_config.test.ts
+++ b/test/feature_lab_config.test.ts
@@ -1,0 +1,177 @@
+/**
+ * The Feature Lab as a TOOLING preference rather than an instrument parameter (#136).
+ *
+ * Three claims are pinned here, each of which was FALSE before #136:
+ *  1. the Lab is not part of an instrument — it is not a dial, not a preset field, and
+ *     so cannot be dirtied by editing it or clobbered by loading an instrument;
+ *  2. the engine still sees one composed overlay config, so the meters keep working;
+ *  3. the Lab can turn the face model on by itself — you can measure the face without
+ *     handing the face control of the sound.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { thoreminDials } from '@/settings/dials';
+import { SettingsSchema } from '@/settings/schema';
+import { OverlayDialSchema, OverlayParamsSchema } from '@/nodes/output/canvas_overlay';
+import { defaultFeatureLab, labWantsFace, FACE_GROUP_IDS } from '@/features/labConfig';
+import { faceActive } from '@/nodes/sources/webcam_face';
+import { storeControlsNode, type ControlSnapshot } from '@/nodes/sources/store_controls';
+import { faceFeatureVectorNode } from '@/nodes/features/face_feature_vector';
+import { normalizeLayer } from '@/app/dials/instruments';
+import { useControls, toSettings, migrateControls, mergeControls } from '@/app/store';
+import type { NodeContext } from '@/dag';
+
+describe('the Feature Lab is not part of the instrument', () => {
+  it('is not a dial — the overlay dial carries no featureLab', () => {
+    // The whole bug: a measuring tool filed as an instrument parameter. If this ever
+    // goes back into the dial, editing a meter marks the instrument dirty again.
+    expect(Object.keys(OverlayDialSchema.shape)).not.toContain('featureLab');
+    expect(thoreminDials.keys).not.toContain('featureLab');
+    const overlayDial = thoreminDials.schema.shape.overlay;
+    expect(Object.keys((overlayDial as unknown as typeof OverlayDialSchema).shape ?? {})).not.toContain(
+      'featureLab',
+    );
+  });
+
+  it('is not a preset field — an instrument snapshot never carries it', () => {
+    expect(Object.keys(SettingsSchema.shape)).not.toContain('featureLab');
+    useControls.getState().setFeatureLab({ show: true, columns: 7 });
+    expect(toSettings(useControls.getState())).not.toHaveProperty('featureLab');
+  });
+
+  it('survives loading an instrument (an instrument cannot reconfigure the meters)', () => {
+    useControls.getState().setFeatureLab({ show: true, columns: 7 });
+    const settings = SettingsSchema.parse(toSettings(useControls.getState()));
+    useControls.getState().applySettings(settings);
+    expect(useControls.getState().featureLab.show).toBe(true);
+    expect(useControls.getState().featureLab.columns).toBe(7);
+  });
+
+  it('IS still an overlay ELEMENT on the node side (the meters are drawn by the overlay)', () => {
+    expect(Object.keys(OverlayParamsSchema.shape)).toContain('featureLab');
+  });
+});
+
+describe('persistence: the lab is a per-device tooling pref', () => {
+  it('migrates a v6 blob, lifting overlay.featureLab out of the instrument', () => {
+    const v6 = { overlay: { featureLab: { show: true, columns: 5 } } };
+    const migrated = migrateControls(v6, 6) as unknown as Record<string, unknown>;
+    expect(migrated.featureLab).toMatchObject({ show: true, columns: 5 });
+    // …and it is GONE from the overlay, which the lab-free schema would otherwise strip
+    // silently — that is the difference between migrating the value and losing it.
+    expect((migrated.overlay as Record<string, unknown>).featureLab).toBeUndefined();
+  });
+
+  it('heals a corrupt lab blob back to the defaults rather than throwing', () => {
+    const current = useControls.getState();
+    const merged = mergeControls({ featureLab: { columns: 'banana' } }, current);
+    expect(merged.featureLab).toEqual(current.featureLab);
+  });
+
+  it('defaults to meters OFF (the Lab is opt-in — but now findable)', () => {
+    expect(defaultFeatureLab().show).toBe(false);
+  });
+});
+
+describe('store-controls composes the two back into one overlay config', () => {
+  const runNode = (c: ControlSnapshot) => {
+    const node = storeControlsNode.make({} as never);
+    return node.process({}, { resources: { controls: () => c } } as unknown as NodeContext);
+  };
+  const baseVoice = { root: 0, type: 'pentatonic' as const, octaves: 2, baseOctave: 3, sound: 'warmPad' as const };
+
+  it('merges the per-device lab config into the overlay node params', () => {
+    const out = runNode({
+      right: baseVoice,
+      left: baseVoice,
+      overlay: OverlayDialSchema.parse({}),
+      featureLab: { ...defaultFeatureLab(), show: true, columns: 6 },
+    });
+    const overlay = out.overlay as Record<string, unknown>;
+    expect(overlay.featureLab).toMatchObject({ show: true, columns: 6 });
+    // The instrument's own elements are still there — this is a merge, not a swap.
+    expect(overlay.landmarks).toBeDefined();
+  });
+
+  it('falls back to the lab defaults when the snapshot carries none', () => {
+    const out = runNode({ right: baseVoice, left: baseVoice, overlay: OverlayDialSchema.parse({}) });
+    expect((out.overlay as Record<string, unknown>).featureLab).toEqual(defaultFeatureLab());
+  });
+});
+
+describe('the Lab can observe the face without altering the sound', () => {
+  it('labWantsFace is true only when the meters are on AND a face group is selected', () => {
+    const off = { ...defaultFeatureLab(), show: false, groups: [...FACE_GROUP_IDS] };
+    const handOnly = { ...defaultFeatureLab(), show: true, groups: ['hand.whole'] };
+    const faceOn = { ...defaultFeatureLab(), show: true, groups: [FACE_GROUP_IDS[0]] };
+    expect(labWantsFace(off)).toBe(false);
+    expect(labWantsFace(handOnly)).toBe(false);
+    expect(labWantsFace(faceOn)).toBe(true);
+    expect(labWantsFace(undefined)).toBe(false);
+  });
+
+  it('the face model loads for the Lab even with faceMapping = none', () => {
+    // THE point of #136's face fix: before it, a face meter was unobservable unless you
+    // also put your face in charge of the audio.
+    const featureLab = { ...defaultFeatureLab(), show: true, groups: [FACE_GROUP_IDS[0]] };
+    expect(faceActive({ faceMapping: 'none', featureLab })).toBe(true);
+    expect(faceActive({ faceMapping: 'none' })).toBe(false);
+  });
+
+  it('still loads for a face MAPPING with the Lab closed (the old rule is intact)', () => {
+    expect(faceActive({ faceMapping: 'timbre' })).toBe(true);
+    expect(faceActive({ faceEnabled: true })).toBe(true);
+    expect(faceActive(undefined)).toBe(false);
+  });
+});
+
+beforeEach(() => {
+  useControls.getState().setFeatureLab(defaultFeatureLab());
+});
+
+describe('the compute gate: the catalog costs nothing when the meters are off', () => {
+  // The regression this file exists for. `ctx.resources.controls` is the RAW control
+  // store (useEngine wires `() => useControls.getState()`), NOT the composed
+  // store-controls output — so a vector node that reads `overlay.featureLab` reads
+  // `undefined` since #136, and an undefined live config means "headless", which means
+  // "always on". The gate failed OPEN: every user would evaluate all 248 features every
+  // frame with the Lab switched off.
+  //
+  // So this drives the REAL store rather than a hand-shaped fake. The pre-existing
+  // `feature_vector_nodes.test.ts` faked `{ overlay: { featureLab } }` and stayed green
+  // through the whole bug — a test of a shape production does not produce.
+  const liveControls = () => ({ resources: { controls: () => useControls.getState() } }) as unknown as NodeContext;
+  const faceFrame = { present: true, blendshapes: { jawOpen: 0.5 }, landmarks: [] };
+
+  it('emits an EMPTY vector when the meters are off (the default)', () => {
+    expect(useControls.getState().featureLab.show).toBe(false);
+    const node = faceFeatureVectorNode.make({} as never);
+    const out = node.process({ face: faceFrame } as never, liveControls());
+    expect(out.vector).toEqual({});
+  });
+
+  it('emits features once the meters are on', () => {
+    useControls.getState().setFeatureLab({ show: true });
+    const node = faceFeatureVectorNode.make({} as never);
+    const out = node.process({ face: faceFrame } as never, liveControls());
+    expect(Object.keys(out.vector as object).length).toBeGreaterThan(0);
+  });
+});
+
+describe('a legacy saved instrument does not read as dirty on load', () => {
+  // The mirror-image bug. `dialsStore.setLayer` stores a layer verbatim and dirty is a
+  // structural compare, so an instrument saved BEFORE #136 (whose overlay still carries
+  // featureLab) differs from the working layer (whose overlay no longer does) — and every
+  // returning player's instrument would show unsaved-edits, forever, having changed nothing.
+  it('normalizeLayer strips a stale overlay.featureLab from a stored layer', () => {
+    const legacy = { overlay: { ...OverlayDialSchema.parse({}), featureLab: { show: true } } };
+    const normalized = normalizeLayer(legacy as never);
+    expect((normalized.overlay as Record<string, unknown>).featureLab).toBeUndefined();
+    // and it is otherwise untouched
+    expect(normalized.overlay).toEqual(OverlayDialSchema.parse({}));
+  });
+
+  it('leaves a modern layer structurally identical (no spurious dirty)', () => {
+    const modern = { overlay: OverlayDialSchema.parse({}), 'master.volume': 0.4 };
+    expect(normalizeLayer(modern as never)).toEqual(modern);
+  });
+});

--- a/test/feature_vector_nodes.test.ts
+++ b/test/feature_vector_nodes.test.ts
@@ -51,13 +51,25 @@ describe('face-feature-vector (unit)', () => {
   });
 
   it('the live lab config gates activity (hidden lab → empty) and overrides groups', () => {
+    // The PRODUCTION shape: `ctx.resources.controls` is the raw control store, whose lab
+    // config is top-level since #136. This test used to drive only the nested
+    // `overlay.featureLab` shape — and stayed green when #136 moved the field, because an
+    // unreadable config reads as "headless", which means "always on". It was asserting a
+    // shape production no longer produced. See test/feature_lab_config.test.ts, which
+    // drives the real store end-to-end.
     const handlers = faceFeatureVectorNode.make(faceFeatureVectorNode.params.parse({}));
-    const hidden = bareCtx({ controls: () => ({ overlay: { featureLab: { show: false, groups: ['face.blendshape.jaw'] } } }) });
+    const hidden = bareCtx({ controls: () => ({ featureLab: { show: false, groups: ['face.blendshape.jaw'] } }) });
     expect(Object.keys((handlers.process({ face: frame }, hidden) as { vector: FeatureVector }).vector)).toHaveLength(0);
-    const shown = bareCtx({ controls: () => ({ overlay: { featureLab: { show: true, groups: ['face.blendshape.brow'] } } }) });
+    const shown = bareCtx({ controls: () => ({ featureLab: { show: true, groups: ['face.blendshape.brow'] } }) });
     const { vector } = handlers.process({ face: frame }, shown) as { vector: FeatureVector };
     expect(vector['face.blendshape.brow.innerUp']).toBeCloseTo(0.2);
     expect(vector['face.blendshape.jaw.open']).toBeUndefined(); // brow-only via live config
+  });
+
+  it('still honours the COMPOSED overlay.featureLab shape (canvas-overlay / pre-#136 hosts)', () => {
+    const handlers = faceFeatureVectorNode.make(faceFeatureVectorNode.params.parse({}));
+    const hidden = bareCtx({ controls: () => ({ overlay: { featureLab: { show: false, groups: [] } } }) });
+    expect(Object.keys((handlers.process({ face: frame }, hidden) as { vector: FeatureVector }).vector)).toHaveLength(0);
   });
 });
 

--- a/test/tools_shell.test.tsx
+++ b/test/tools_shell.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+/**
+ * The shell-reachability tests (#136) — the tests that did not exist when the Feature
+ * Lab shipped to production unreachable behind 759 green ones.
+ *
+ * The old invariant (`test/overlay_elements.test.ts`) asserted every overlay element has
+ * a control DESCRIPTOR, and it passed the whole time the Lab was unfindable: a
+ * descriptor proves an element is *controllable*, not that a player can *find* the
+ * control. These tests assert the missing half — that every registered tool has a
+ * labelled button in the shell, and that pressing it actually opens the thing.
+ *
+ * This is the only jsdom test file in the repo; the rest of the suite is pure-TS DAG
+ * work that has no DOM. See the `test` block in vite.config.ts.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, act } from '@testing-library/react';
+import ToolsBar from '@/app/ToolsBar';
+import LabPanel from '@/app/LabPanel';
+import { TOOLS, TOOL_IDS } from '@/app/tools';
+import { useTools } from '@/app/toolsStore';
+import { useControls } from '@/app/store';
+import { defaultFeatureLab } from '@/features/labConfig';
+import { OVERLAY_CONTROLS, controlsForSurface } from '@/app/overlayControls';
+
+beforeEach(() => {
+  useTools.setState({ open: null });
+  useControls.getState().setFeatureLab(defaultFeatureLab());
+});
+afterEach(cleanup);
+
+describe('the tools bar is the shell entry point for every tool', () => {
+  it('renders one button per registered tool, each with a VISIBLE text label', () => {
+    render(<ToolsBar />);
+    for (const tool of TOOLS) {
+      // getByText, not getByLabelText: an icon with only an aria-label is how the
+      // command palette stayed invisible. If a player cannot read it, it is not an
+      // entry point.
+      expect(screen.getByText(tool.label)).toBeTruthy();
+    }
+    expect(document.querySelectorAll('[data-tool]')).toHaveLength(TOOLS.length);
+  });
+
+  it('shows the command palette hotkey, so ⌘K is discoverable without reading the source', () => {
+    render(<ToolsBar />);
+    expect(screen.getByText('⌘K')).toBeTruthy();
+  });
+
+  it('clicking a panel tool opens it (the button is wired, not decorative)', () => {
+    render(<ToolsBar />);
+    fireEvent.click(screen.getByText('Feature Lab'));
+    expect(useTools.getState().open).toBe('lab');
+    fireEvent.click(screen.getByText('Feature Lab'));
+    expect(useTools.getState().open).toBe(null); // and it toggles back closed
+  });
+
+  it('at most one tool is open at a time', () => {
+    render(<ToolsBar />);
+    fireEvent.click(screen.getByText('Feature Lab'));
+    fireEvent.click(screen.getByText('Commands'));
+    expect(useTools.getState().open).toBe('commands');
+  });
+});
+
+describe('the Feature Lab is reachable and explains itself', () => {
+  it('is closed until its tool is open', () => {
+    const { container } = render(<LabPanel />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('opens on an INTRO state that says what the meters measure', () => {
+    useTools.setState({ open: 'lab' });
+    render(<LabPanel />);
+    // The empty state is the deliverable: "248 normalized meters" means nothing to
+    // someone who has not read the design doc.
+    expect(screen.getByText(/raw features/i)).toBeTruthy();
+    expect(screen.getByText(/normalized online/i)).toBeTruthy();
+    expect(screen.getByText(/Start measuring/i)).toBeTruthy();
+  });
+
+  it('starting the meters from the intro turns them on and reveals the controls', async () => {
+    useTools.setState({ open: 'lab' });
+    render(<LabPanel />);
+    // `act` so the saved-views store's async list() settles inside the test rather than
+    // after it (React would otherwise warn about an update outside act).
+    await act(async () => {
+      fireEvent.click(screen.getByText(/Start measuring/i));
+    });
+    expect(useControls.getState().featureLab.show).toBe(true);
+    expect(screen.getByText(/Show the meters over the video/i)).toBeTruthy();
+  });
+
+  it('the whole chain works: shell button -> open state -> panel renders', () => {
+    render(
+      <>
+        <ToolsBar />
+        <LabPanel />
+      </>,
+    );
+    expect(screen.queryByText(/Start measuring/i)).toBeNull();
+    fireEvent.click(screen.getByText('Feature Lab'));
+    expect(screen.getByText(/Start measuring/i)).toBeTruthy();
+  });
+});
+
+describe('every control surface has a home in the shell', () => {
+  it('each overlay element whose home is not the instrument names a REGISTERED tool', () => {
+    // The generalized rule. An element may live somewhere other than the instrument
+    // panel — but "somewhere" has to be a surface the shell actually offers, or we have
+    // rebuilt the #136 bug with a different element.
+    for (const d of OVERLAY_CONTROLS) {
+      const surface = d.surface ?? 'instrument';
+      if (surface === 'instrument') continue;
+      expect(TOOL_IDS).toContain(surface);
+    }
+  });
+
+  it('the Feature Lab element is homed on the lab tool, not the instrument panel', () => {
+    expect(controlsForSurface('lab').map((d) => d.name)).toEqual(['featureLab']);
+    expect(controlsForSurface('instrument').map((d) => d.name)).not.toContain('featureLab');
+  });
+});

--- a/tsconfig.dag.json
+++ b/tsconfig.dag.json
@@ -7,5 +7,7 @@
     "noUnusedParameters": true,
     "types": ["node", "vitest/globals"]
   },
-  "include": ["src/dag", "src/nodes", "src/music", "src/features", "src/settings", "src/taglog", "src/app/graph.ts", "src/app/lab", "test", "scripts"]
+  "include": ["src/dag", "src/nodes", "src/music", "src/features", "src/settings", "src/taglog", "src/app/graph.ts", "src/app/lab", "test", "scripts"],
+  "//exclude": "The jsdom SHELL tests are .tsx (they render React components) and this project ships no @types/react by design — same reason the React app layer is excluded. Vitest still runs them; Vite/esbuild type-erases the JSX.",
+  "exclude": ["test/**/*.test.tsx"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,12 +27,18 @@ export default defineConfig(({mode}) => {
     server: {
       hmr: process.env.DISABLE_HMR !== 'true',
     },
-    // Vitest config: the DAG core/nodes/music tests are pure TS (no DOM/audio),
-    // so they run in the fast Node environment with no camera/GPU.
+    // Vitest config: the DAG core/nodes/music tests are pure TS (no DOM/audio), so
+    // `node` is the DEFAULT environment — they need no camera/GPU and stay fast.
+    //
+    // A `.test.tsx` file opts INTO jsdom with a `// @vitest-environment jsdom` docblock.
+    // Those are the SHELL tests: whether a feature is reachable from the app's UI is a
+    // question only a rendered component can answer, and the absence of any such test is
+    // how a whole subsystem (the Feature Lab, #136) shipped to production unreachable
+    // with 759 green tests.
     test: {
       globals: true,
       environment: 'node',
-      include: ['test/**/*.test.ts'],
+      include: ['test/**/*.test.{ts,tsx}'],
     },
   };
 });


### PR DESCRIPTION
Closes #136.

## The bug

The Feature Instrumentation Lab (#119, PR #122) was merged, deployed, and has been live in
the production bundle for weeks. The maintainer could not find it and assumed it had never
shipped. A 248-feature subsystem with a jsep formula compiler and an online normalizer,
reachable by nobody, behind 759 green tests.

Three things were wrong, and they turn out to be the same thing: **the Lab was filed as
part of the instrument it exists to measure.**

## What changed

**1. It has an entry point.** A tools bar in the app shell (bottom-left), rendered from a
registry of shell surfaces (`src/app/tools.ts`), with a **labelled** button per tool. It
carries the Feature Lab, the manual, and the command palette — which until now was ⌘K-only
with zero affordance anywhere in the app, *including its own keyboard cheat-sheet*. The Lab
opens on an intro state that says what the meters measure, because "248 normalized meters"
means nothing to someone who has not read the design doc.

**2. It is no longer an instrument parameter.** `featureLab` was a sub-object of the
`overlay` **dial** — so toggling a meter marked your instrument as having unsaved edits,
and loading an instrument silently reconfigured your meters. It is now a per-device tooling
pref on the hot control store, excluded from `SettingsSchema`, exactly like the existing
per-device `faceCalibration` and exactly as recording settings were moved out of the
instrument in #88. `OverlayDialSchema` = the node's params minus `featureLab`;
`store-controls` composes the two back together each tick, so the engine sees one overlay
config and the meters are unchanged.

The design doc already said *"It is deliberately not a sound. It produces no audio, changes
no dial"*. The implementation had never honoured its own doc.

**3. You can now observe without altering.** The face model loaded only when
`face.mapping !== 'none'`, so you could not look at a face meter without also putting your
face in charge of the audio. `faceActive` now returns true when **either** the mapping wants
the face **or** the Lab is measuring face groups. A measuring instrument that cannot observe
without altering is broken.

## Testing UI reachability, for the first time

This repo had 759 tests and **zero component tests**. That is not incidental to the bug —
whether a player can *reach* a feature is a question only a rendered component can answer.
So this adds jsdom + `@testing-library/react` and `test/tools_shell.test.tsx`: every
registered tool has a **visible text label** in the shell (`getByText`, not
`getByLabelText` — an icon with only an aria-label is how the palette stayed invisible),
clicking it opens the surface, and the shell mounts a surface for every tool it advertises.

The pre-existing `overlay_elements.test.ts` asserts *"every overlay element has a UI control
descriptor (the panel is data-driven, no silent drop)"* — and it **passed for the entire
duration of this bug**. A descriptor proves an element is *controllable*, not that a player
can *find* the control. Descriptors now name their home surface, and a test ties every home
to a tool the shell actually offers.

Every new guard was mutation-tested: the thing it protects was broken on purpose and the
test confirmed red. That includes putting `featureLab` back in the dial, stripping the
labels off the tools bar, dropping the migration, and un-wiring the face gate.

## Two bugs an adversarial review caught in this branch

Worth recording, because both were invisible to the (green) suite:

- **The compute gate failed OPEN.** The two feature-vector nodes each carried their own
  copy of the "is the Lab on?" check, reading `controls.overlay.featureLab` — which this
  change made permanently `undefined`. An unreadable config reads as "headless", which
  reads as "always active", so **every user** would have started evaluating the whole
  248-feature catalog every frame with the Lab switched off. There is now one copy of the
  gate, in the module that owns the config, and a test that drives the **real** store. The
  old test faked `{ overlay: { featureLab } }` — a shape production no longer produces —
  and would have stayed green.
- **Every returning user's instrument would have read dirty.** `setLayer` stores a layer
  verbatim and dirty is a structural compare, so an instrument saved before this change
  (whose overlay still carries `featureLab`) differs from the working layer (whose overlay
  does not) — the unsaved-edits badge would light up on every load, forever, having changed
  nothing. Stored layers are now normalized through the lab-free schema on the way in.

## Follow-on

**#137** — MIDI out (PR #120) is the same bug, worse: no UI, no dial, and its `enabled`
input is left unconnected in `graph.ts`. It is not buried, it is absent. Filed separately.

`CLAUDE.md` now carries the rule this cost us: **a feature only findable by someone who
read the PR is not shipped.**

## Verification

`npm run typecheck` clean · `npx vitest run` **788 passing** (80 files) · `npm run build`
clean · `npm run catalog` idempotent. Not yet driven in a real browser — the Lab meters and
the tools bar are on the live-verification checklist.
