### PR TITLE
#130: MP3 export via a lazy lamejs converter

### DIFF
--- a/docs/design/recording-v2.md
+++ b/docs/design/recording-v2.md
@@ -38,7 +38,7 @@ presentational.
 
 | Stream | Source | Notes |
 |---|---|---|
-| **audio** | master-bus tap (`MediaStreamAudioDestinationNode`) | always available; converted to the selected formats (webm/wav) on stop |
+| **audio** | master-bus tap (`MediaStreamAudioDestinationNode`) | always available; converted to the selected formats (webm/wav/mp3) on stop |
 | **video + overlays** | `canvas.captureStream(fps)` muxed with the audio tap | "what you see" (mirrored, with landmarks) |
 | **pure webcam** | the raw camera `MediaStream` (else `video.captureStream()`) | overlay-free; per-stream "include audio" (default off) |
 | **overlay-only (alpha)** | a transparent offscreen canvas the overlay node redraws to with the backdrop suppressed | **Chromium-only**, experimental (alpha WebM); feature-gated |
@@ -66,12 +66,33 @@ with a **secondary ext = the role** when streams share a primary ext:
 ```
 demo-theremin-2026-07-05T14-30-12/
   ….overlay.webm  ….camera.webm  ….alpha.webm
-  ….webm  ….wav  ….features.jsonl  ….annotations.jsonl  ….manifest.json
+  ….webm  ….wav  ….mp3  ….features.jsonl  ….annotations.jsonl  ….manifest.json
 ```
 
 `recordingStem()` + `fileName(stem,{role,ext})` are pure and unit-tested; every
 sink writes the identical names. An opt-in **single-file escape hatch** (one
 media stream, no features) saves a bare file with no folder.
+
+## Audio output formats (`formats.ts`, `wav.ts`, `mp3.ts`)
+
+`MediaRecorder` only produces WebM/Opus, so every other format is a **converter**
+in the open-closed `RECORDING_FORMATS` registry: an id + label + ext + a
+`load(): Promise<Converter>` that lazily `import()`s its encoder. Adding a format
+is appending one entry — no call site changes, and the settings sheet lists it
+automatically (it renders the registry). Today: `webm` (native passthrough),
+`wav` (in-house, dependency-free), `mp3` (#130 — lamejs, its own ~170 kB chunk,
+fetched only by a player who actually picks MP3). Still open: an `ffmpeg.wasm`
+"any format" escape hatch (multi-MB, so it must be opt-in and labelled as a heavy
+download).
+
+`convertAudioFormats(ids, {native, audio})` is the shared conversion loop: it
+decodes once (if any selected format needs PCM) and runs the converters in the
+plan's order. A converter that fails — its lazy encoder chunk will not load, the
+decode failed, the encoder rejects the audio — yields **no blob**, so **no file is
+written for it** and its id comes back in `RecordingResult.failedFormats` for an
+error toast. It deliberately does **not** fall back to the un-encoded native blob:
+a `.mp3` full of WebM bytes is a lie the player only discovers much later.
+Failures are per-format, so a broken MP3 encoder never costs you the WAV.
 
 ## Three-tier sink (`sink.ts`, `caps.ts`)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@ai-sdk/anthropic": "^4.0.12",
         "@ai-sdk/google": "^4.0.12",
         "@ai-sdk/openai": "^4.0.11",
+        "@breezystack/lamejs": "^1.2.7",
         "@google/genai": "^1.29.0",
         "@jsep-plugin/ternary": "^1.1.4",
         "@mediapipe/hands": "^0.4.1675469240",
@@ -477,6 +478,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@breezystack/lamejs": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@breezystack/lamejs/-/lamejs-1.2.7.tgz",
+      "integrity": "sha512-6wc7ck65ctA75Hq7FYHTtTvGnYs6msgdxiSUICQ+A01nVOWg6rqouZB8IdyteRlfpYYiFovkf67dIeOgWIUzTA==",
+      "license": "LGPL-3.0"
     },
     "node_modules/@csstools/color-helpers": {
       "version": "6.1.0",
@@ -2076,6 +2083,64 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@ai-sdk/anthropic": "^4.0.12",
     "@ai-sdk/google": "^4.0.12",
     "@ai-sdk/openai": "^4.0.11",
+    "@breezystack/lamejs": "^1.2.7",
     "@google/genai": "^1.29.0",
     "@jsep-plugin/ternary": "^1.1.4",
     "@mediapipe/hands": "^0.4.1675469240",

--- a/src/app/recording/formats.ts
+++ b/src/app/recording/formats.ts
@@ -5,11 +5,16 @@
  * from that on stop, lazily importing its encoder so a format the user never
  * picks costs nothing in the bundle.
  *
- * Adding a format = appending one entry here (no call-site changes). Planned
- * follow-ups slot in the same way:
- *   - MP3 via `lamejs` (small, lazy): `{ id:'mp3', needsDecode:true,
- *     load: async () => { const { encodeMp3 } = await import('./mp3'); ... } }`.
- *   - "Any format" via `ffmpeg.wasm` (heavy, opt-in, lazy): same shape.
+ * Adding a format = appending one entry here (no call-site changes) — MP3 (#130)
+ * was exactly that. The remaining planned follow-up slots in the same way:
+ *   - "Any format" via `ffmpeg.wasm` (a multi-MB lazy chunk, so strictly opt-in
+ *     and labelled as a heavy download): same shape, `needsDecode:true`.
+ *
+ * {@link convertAudioFormats} is the (pure) conversion loop every caller shares:
+ * it runs the selected converters in order and reports each one's outcome. A
+ * converter that fails yields `blob: null` — NOT the un-encoded native blob — so
+ * the caller writes no file and says so, instead of dropping WebM bytes into a
+ * `.mp3` the player would find unplayable later.
  */
 
 /** Inputs available to a converter: the native recording + its decoded audio. */
@@ -56,6 +61,25 @@ export const RECORDING_FORMATS: RecordingFormat[] = [
       };
     },
   },
+  {
+    id: 'mp3',
+    // Parallel to the WAV label. Deliberately does NOT restate the bitrate: that
+    // constant is the encoder's (`./mp3`), and naming it here would either
+    // duplicate the number or force an eager import of the module we keep lazy.
+    label: 'MP3 (compressed, smaller)',
+    ext: 'mp3',
+    needsDecode: true,
+    load: async () => {
+      // Two lazy hops on purpose: this `import()` splits `./mp3` off, and `./mp3`
+      // only pulls in lamejs itself when it actually encodes — so neither the
+      // adapter nor the ~250 kB encoder is in the main bundle.
+      const { encodeMp3 } = await import('./mp3');
+      return ({ audio }) => {
+        if (!audio) throw new Error('MP3 export needs decoded audio');
+        return encodeMp3(audio);
+      };
+    },
+  },
 ];
 
 /**
@@ -71,4 +95,44 @@ export const DEFAULT_RECORDING_FORMATS: readonly string[] = ['webm'];
 
 export function recordingFormat(id: string): RecordingFormat | undefined {
   return RECORDING_FORMATS.find((f) => f.id === id);
+}
+
+/** What one selected format produced. `blob === null` means the converter failed
+ * (its encoder would not load, or would not encode this audio) — the caller must
+ * write NO file for it and report the failure. */
+export interface ConvertedFormat {
+  id: string;
+  blob: Blob | null;
+  /** Why it failed. Only set when `blob` is null. */
+  error?: unknown;
+}
+
+/**
+ * Run each selected format's converter over one take, in order. Returns one
+ * outcome per requested id, positionally aligned with `ids` (so it lines up with
+ * the audio files `planRecording` laid out from the same ids) — a failure is a
+ * `null` blob in place, never a dropped or substituted entry.
+ *
+ * Failures are contained per format: a broken MP3 encoder must not cost the
+ * player the WAV they also asked for.
+ */
+export async function convertAudioFormats(
+  ids: readonly string[],
+  input: ConverterInput,
+): Promise<ConvertedFormat[]> {
+  const out: ConvertedFormat[] = [];
+  for (const id of ids) {
+    const fmt = recordingFormat(id);
+    if (!fmt) {
+      out.push({ id, blob: null, error: new Error(`Unknown recording format: ${id}`) });
+      continue;
+    }
+    try {
+      const convert = await fmt.load();
+      out.push({ id, blob: await convert(input) });
+    } catch (error) {
+      out.push({ id, blob: null, error });
+    }
+  }
+  return out;
 }

--- a/src/app/recording/mp3.ts
+++ b/src/app/recording/mp3.ts
@@ -1,0 +1,137 @@
+/**
+ * Browser MP3 encoder (#130) — the `mp3` entry of the recording format registry
+ * (`./formats`). The live take is captured as WebM/Opus; on stop it is decoded to
+ * an `AudioBuffer` and re-encoded here as MPEG-1 Layer III via `lamejs` (the
+ * maintained `@breezystack/lamejs` fork), a pure-JS LAME port.
+ *
+ * The encoder is ~250 kB, so it is NEVER imported at module load: `loadEncoder`
+ * dynamic-imports it on first use, which keeps it in its own lazy chunk that a
+ * player who never picks MP3 never downloads. If that import fails (offline, a
+ * blocked chunk), {@link encodeMp3} rejects with {@link Mp3EncoderUnavailable} —
+ * it does not quietly hand back the un-encoded audio, so the caller can report an
+ * honest failure rather than write WebM bytes into a `.mp3`.
+ *
+ * Like `./wav`, `encodeMp3` takes a structural {@link PcmSource} (the slice of
+ * `AudioBuffer` it reads) and an injectable `loadEncoder`, so it is unit-testable
+ * headlessly with a synthetic PCM buffer and no real `AudioBuffer`.
+ */
+import type { PcmSource } from './wav';
+
+/** Default output bitrate. 192 kbps is transparent enough for an instrument take
+ * while staying ~10x smaller than the WAV. Override per call via
+ * {@link EncodeMp3Options.bitrateKbps}. */
+export const DEFAULT_MP3_BITRATE_KBPS = 192;
+
+/** One MPEG-1 Layer III granule pair: the block size LAME expects per call. */
+const SAMPLES_PER_FRAME = 1152;
+
+/** MP3 is mono or stereo; extra channels of a multi-channel buffer are dropped. */
+const MAX_CHANNELS = 2;
+
+/** Full-scale for 16-bit PCM (matches the WAV encoder's quantization). */
+const INT16_SCALE = 32767;
+
+/** The slice of the lamejs encoder we drive (kept structural so a test can pass a
+ * fake module in place of the real, lazily-loaded one). */
+export interface Mp3EncoderLike {
+  encodeBuffer(left: Int16Array, right?: Int16Array): Uint8Array;
+  flush(): Uint8Array;
+}
+
+/** The slice of the lamejs module we need: its `Mp3Encoder` constructor. */
+export interface Mp3EncoderCtor {
+  new (channels: number, sampleRate: number, kbps: number): Mp3EncoderLike;
+}
+
+/** The MP3 encoder could not be loaded (or the module that loaded is not one).
+ * Distinct from an encoding failure so callers can tell "no encoder here" from
+ * "this audio would not encode". */
+export class Mp3EncoderUnavailable extends Error {
+  constructor(cause?: unknown) {
+    super('MP3 encoder could not be loaded', { cause });
+    this.name = 'Mp3EncoderUnavailable';
+  }
+}
+
+export interface EncodeMp3Options {
+  /** Constant bitrate in kbps. Defaults to {@link DEFAULT_MP3_BITRATE_KBPS}. */
+  bitrateKbps?: number;
+  /** How to obtain the encoder. Defaults to a lazy `import()` of lamejs; tests
+   * (and any future alternative encoder) inject their own. */
+  loadEncoder?: () => Promise<Mp3EncoderCtor>;
+}
+
+/** Lazily pull in lamejs. The `import()` lives HERE and nowhere else, so the
+ * encoder stays out of every eagerly-loaded module. */
+async function loadLameEncoder(): Promise<Mp3EncoderCtor> {
+  const mod = await import('@breezystack/lamejs');
+  return mod.Mp3Encoder;
+}
+
+/**
+ * Quantize one window of float samples to 16-bit PCM, reusing `into` (so a long
+ * take does not allocate a fresh array per frame). Returns the filled prefix.
+ * Same clamp-then-scale as `./wav`, so WAV and MP3 quantize identically.
+ */
+function pcm16(src: Float32Array, offset: number, count: number, into: Int16Array): Int16Array {
+  for (let i = 0; i < count; i++) {
+    let s = src[offset + i] ?? 0;
+    s = s < -1 ? -1 : s > 1 ? 1 : s;
+    into[i] = Math.round(s * INT16_SCALE);
+  }
+  return into.subarray(0, count);
+}
+
+/** Concatenate the encoded frames into one contiguous buffer the Blob can own. */
+function concat(parts: Uint8Array[]): Uint8Array {
+  let total = 0;
+  for (const p of parts) total += p.length;
+  const out = new Uint8Array(total);
+  let at = 0;
+  for (const p of parts) {
+    out.set(p, at);
+    at += p.length;
+  }
+  return out;
+}
+
+/**
+ * Encode an AudioBuffer-like source to MP3.
+ *
+ * Rejects with {@link Mp3EncoderUnavailable} if the encoder cannot be loaded, and
+ * propagates whatever the encoder throws (e.g. an MP3-illegal sample rate) — it
+ * never returns a non-MP3 blob.
+ */
+export async function encodeMp3(audio: PcmSource, opts: EncodeMp3Options = {}): Promise<Blob> {
+  const { bitrateKbps = DEFAULT_MP3_BITRATE_KBPS, loadEncoder = loadLameEncoder } = opts;
+
+  let Encoder: Mp3EncoderCtor;
+  try {
+    Encoder = await loadEncoder();
+  } catch (e) {
+    throw new Mp3EncoderUnavailable(e);
+  }
+  if (typeof Encoder !== 'function') throw new Mp3EncoderUnavailable();
+
+  const channels = Math.min(MAX_CHANNELS, Math.max(1, audio.numberOfChannels));
+  const encoder = new Encoder(channels, audio.sampleRate, bitrateKbps);
+
+  const left = audio.getChannelData(0);
+  const right = channels > 1 ? audio.getChannelData(1) : null;
+  const leftFrame = new Int16Array(SAMPLES_PER_FRAME);
+  const rightFrame = right ? new Int16Array(SAMPLES_PER_FRAME) : null;
+
+  const parts: Uint8Array[] = [];
+  for (let i = 0; i < audio.length; i += SAMPLES_PER_FRAME) {
+    const n = Math.min(SAMPLES_PER_FRAME, audio.length - i);
+    const l = pcm16(left, i, n, leftFrame);
+    const r = right && rightFrame ? pcm16(right, i, n, rightFrame) : undefined;
+    const chunk = encoder.encodeBuffer(l, r);
+    // Copy: the frame buffers above are reused, and lamejs may hand back a view.
+    if (chunk.length) parts.push(new Uint8Array(chunk));
+  }
+  const tail = encoder.flush();
+  if (tail.length) parts.push(new Uint8Array(tail));
+
+  return new Blob([concat(parts)], { type: 'audio/mpeg' });
+}

--- a/src/app/recording/mp3.ts
+++ b/src/app/recording/mp3.ts
@@ -31,6 +31,14 @@ const MAX_CHANNELS = 2;
 /** Full-scale for 16-bit PCM (matches the WAV encoder's quantization). */
 const INT16_SCALE = 32767;
 
+/** Frames encoded between yields — 128 frames ≈ 3 s of audio at 44.1/48 kHz. Small enough
+ *  that the page stays responsive, large enough that the yields cost nothing measurable. */
+const YIELD_EVERY_FRAMES = 128;
+
+/** Hand the event loop back so the rAF/render loop can run mid-encode. A macrotask
+ *  (`setTimeout`), not a microtask — a promise chain would not let paint or input through. */
+const yieldToEventLoop = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+
 /** The slice of the lamejs encoder we drive (kept structural so a test can pass a
  * fake module in place of the real, lazily-loaded one). */
 export interface Mp3EncoderLike {
@@ -122,6 +130,7 @@ export async function encodeMp3(audio: PcmSource, opts: EncodeMp3Options = {}): 
   const rightFrame = right ? new Int16Array(SAMPLES_PER_FRAME) : null;
 
   const parts: Uint8Array[] = [];
+  let framesSinceYield = 0;
   for (let i = 0; i < audio.length; i += SAMPLES_PER_FRAME) {
     const n = Math.min(SAMPLES_PER_FRAME, audio.length - i);
     const l = pcm16(left, i, n, leftFrame);
@@ -129,6 +138,15 @@ export async function encodeMp3(audio: PcmSource, opts: EncodeMp3Options = {}): 
     const chunk = encoder.encodeBuffer(l, r);
     // Copy: the frame buffers above are reused, and lamejs may hand back a view.
     if (chunk.length) parts.push(new Uint8Array(chunk));
+    // YIELD. `encodeBuffer` is synchronous and MP3 encoding is ~11x the cost of the WAV
+    // pass over the same buffer, so encoding a whole take in one task freezes the page:
+    // measured ~45x realtime on a fast machine, i.e. a 10-minute take is tens of seconds
+    // of a hung tab (canvas frozen, "Page unresponsive") on a mid-range laptop. Handing
+    // the event loop back every ~3 s of audio keeps the UI alive at a negligible cost.
+    if (++framesSinceYield >= YIELD_EVERY_FRAMES) {
+      framesSinceYield = 0;
+      await yieldToEventLoop();
+    }
   }
   const tail = encoder.flush();
   if (tail.length) parts.push(new Uint8Array(tail));

--- a/src/app/recording/session.ts
+++ b/src/app/recording/session.ts
@@ -33,6 +33,13 @@ export interface RecordingResult extends SinkResult {
   /** Ids of the selected audio formats that could not be encoded. Empty on a
    * clean take. */
   failedFormats: string[];
+  /** How many actual STREAM files landed (audio/video/features/annotations) — the
+   *  manifest does not count. The sink's `count` includes the manifest, which is always
+   *  planned and always written: with (say) MP3 as the only selected audio format and the
+   *  encoder unavailable, `count` would be 1 and the UI would toast "Saved" over an
+   *  archive containing nothing but a manifest with `streams: []`. That is precisely the
+   *  lie this change set out to remove, so the UI gates on this instead. */
+  streamCount: number;
 }
 
 export interface SessionRecorderDeps {
@@ -376,7 +383,7 @@ export class SessionRecorder {
 
     this.tap = null;
 
-    if (this.sink) return { ...(await this.sink.close()), failedFormats };
+    if (this.sink) return { ...(await this.sink.close()), failedFormats, streamCount: written.length };
     // Single-file escape hatch: exactly one bare file was written via saveBlob in
     // writeFile; report it (honoring a dismissed Save-As dialog as a cancellation
     // rather than a false success). If that single file was the one format that
@@ -389,6 +396,7 @@ export class SessionRecorder {
       viaPicker: false,
       cancelled: this.lastSaveCancelled,
       failedFormats,
+      streamCount: written.length,
     };
   }
 

--- a/src/app/recording/session.ts
+++ b/src/app/recording/session.ts
@@ -12,7 +12,7 @@
  * covered by the app's build (not the Node strict typecheck), like `useEngine`.
  */
 import type { Engine } from '@/dag';
-import { recordingFormat } from './formats';
+import { recordingFormat, convertAudioFormats, type ConvertedFormat } from './formats';
 import { recordingStem, prefillName } from './naming';
 import { planRecording, audioFormatIds, type RecordingPlan, type PlannedFile } from './plan';
 import { buildManifest, serializeManifest, type RecordingStreamEntry } from './manifest';
@@ -25,6 +25,15 @@ import type { TagStreamSource } from './tagStream';
 
 /** Chunk media into ~2s slices so long takes stay constant-memory (#88 §1). */
 const TIMESLICE_MS = 2000;
+
+/** What a finished take produced: the sink's result plus any output format whose
+ * encoder failed. A failed format writes NO file (see {@link convertAudioFormats}),
+ * so the UI must say so rather than toast an unqualified "Saved" (#130). */
+export interface RecordingResult extends SinkResult {
+  /** Ids of the selected audio formats that could not be encoded. Empty on a
+   * clean take. */
+  failedFormats: string[];
+}
 
 export interface SessionRecorderDeps {
   audioContext: AudioContext;
@@ -273,9 +282,9 @@ export class SessionRecorder {
   /**
    * Stop every recorder, convert audio to the selected formats, write all files +
    * the manifest through the sink (or save one bare file), and clean up. Returns
-   * the sink result for a "saved …" toast.
+   * the sink result (plus any format that failed to encode) for the "saved …" toast.
    */
-  async stop(): Promise<SinkResult> {
+  async stop(): Promise<RecordingResult> {
     if (!this.running) throw new Error('Not recording');
     this.running = false;
 
@@ -311,10 +320,11 @@ export class SessionRecorder {
     if (this.alphaCanvas) delete this.deps.resources.overlayAlphaCanvas;
     this.stopOwnedStreams();
 
-    // Convert audio to each selected format (decode once if any needs it).
-    const audioOutputs = audioBlob
-      ? await this.convertAudio(audioBlob)
-      : [];
+    // Convert audio to each selected format (decode once if any needs it). A format
+    // whose encoder failed comes back with a null blob: no file is written for it and
+    // its id is reported, rather than saving the un-encoded audio under that extension.
+    const audioOutputs = audioBlob ? await this.convertAudio(audioBlob) : [];
+    const failedFormats = audioOutputs.filter((o) => !o.blob).map((o) => o.id);
 
     // Map plan files → captured bytes and write them.
     const written: RecordingStreamEntry[] = [];
@@ -328,8 +338,10 @@ export class SessionRecorder {
     for (const file of this.plan.files) {
       switch (file.kind) {
         case 'audio': {
+          // Positional, so a failed format leaves ITS slot empty without shifting
+          // the others (convertAudioFormats keeps the ids' order).
           const out = audioOutputs[audioIdx++];
-          if (out) await putFile(file, out);
+          if (out?.blob) await putFile(file, out.blob);
           break;
         }
         case 'overlayVideo':
@@ -364,16 +376,19 @@ export class SessionRecorder {
 
     this.tap = null;
 
-    if (this.sink) return this.sink.close();
+    if (this.sink) return { ...(await this.sink.close()), failedFormats };
     // Single-file escape hatch: exactly one bare file was written via saveBlob in
     // writeFile; report it (honoring a dismissed Save-As dialog as a cancellation
-    // rather than a false success).
+    // rather than a false success). If that single file was the one format that
+    // failed to encode, nothing was written at all — say so.
     const only = this.plan.files[0];
+    const wrote = !this.lastSaveCancelled && failedFormats.length === 0;
     return {
       label: only?.name ?? this.stem,
-      count: this.lastSaveCancelled ? 0 : 1,
+      count: wrote ? 1 : 0,
       viaPicker: false,
       cancelled: this.lastSaveCancelled,
+      failedFormats,
     };
   }
 
@@ -392,10 +407,17 @@ export class SessionRecorder {
     if (res === null) this.lastSaveCancelled = true;
   }
 
-  /** Convert the native audio blob to each selected output format, decoding once
-   * if any format needs it. Returns blobs in the SAME order as the plan's audio
-   * files (= `audioFormatIds` order). */
-  private async convertAudio(native: Blob): Promise<Blob[]> {
+  /**
+   * Convert the native audio blob to each selected output format, decoding once if
+   * any format needs it. Returns one outcome per format in the SAME order as the
+   * plan's audio files (= `audioFormatIds` order).
+   *
+   * A format that fails (its lazy encoder would not load, or would not encode this
+   * audio) comes back with a null blob. It is NOT filled in with the native WebM:
+   * a `.mp3` holding WebM bytes is a file the player only discovers is broken much
+   * later, so the take reports the failure instead (#130).
+   */
+  private async convertAudio(native: Blob): Promise<ConvertedFormat[]> {
     const effectiveIds = audioFormatIds(this.session);
     let audio: AudioBuffer | null = null;
     if (effectiveIds.some((id) => recordingFormat(id)?.needsDecode)) {
@@ -405,22 +427,11 @@ export class SessionRecorder {
         console.error('[thoremin] could not decode recording for conversion', e);
       }
     }
-    const out: Blob[] = [];
-    for (const id of effectiveIds) {
-      const fmt = recordingFormat(id);
-      if (!fmt) continue;
-      try {
-        const convert = await fmt.load();
-        out.push(await convert({ native, audio }));
-      } catch (e) {
-        console.error(`[thoremin] failed to convert recording to ${id}`, e);
-        // Keep alignment with the plan: on failure fall back to the native blob so
-        // the file slot is still filled (a corrupt-but-present file beats a
-        // shifted mapping).
-        out.push(native);
-      }
+    const converted = await convertAudioFormats(effectiveIds, { native, audio });
+    for (const c of converted) {
+      if (!c.blob) console.error(`[thoremin] failed to convert recording to ${c.id}`, c.error);
     }
-    return out;
+    return converted;
   }
 
   /** Stop the tracks of every capture stream we created (canvas/alpha/element

--- a/src/app/useEngine.ts
+++ b/src/app/useEngine.ts
@@ -424,9 +424,14 @@ export function useThoreminEngine(source: SourceSpec = DEFAULT_SOURCE) {
         // The take recorded fine but the user dismissed the Save-As dialog — be
         // honest that nothing was written rather than toasting a false "Saved".
         useToasts.getState().push('Recording not saved (save cancelled)', 5000, 'error');
-      } else if (res.count > 0) {
+      } else if (res.streamCount > 0) {
+        // streamCount, not count: the manifest is always written, so `count` is >= 1 even
+        // on a take where every audio format failed to encode and nothing else was
+        // selected. "Saved" must mean a stream actually landed.
         const suffix = res.count > 1 ? ` (${res.count} files)` : '';
         useToasts.getState().push(`Saved ${res.label}${suffix}`);
+      } else if (!res.failedFormats.length) {
+        useToasts.getState().push('Nothing was recorded — no streams were saved', 6000, 'error');
       }
     } catch (e) {
       console.error('[thoremin] recording save failed', e);

--- a/src/app/useEngine.ts
+++ b/src/app/useEngine.ts
@@ -413,11 +413,18 @@ export function useThoreminEngine(source: SourceSpec = DEFAULT_SOURCE) {
     setRecPhase('saving');
     try {
       const res = await rec.stop();
+      // An output format whose encoder failed to load/run wrote NO file (#130).
+      // Name it: the rest of the take was still saved, but the player must not
+      // believe they have an MP3 they don't have.
+      if (res.failedFormats.length) {
+        const names = res.failedFormats.map((f) => f.toUpperCase()).join(', ');
+        useToasts.getState().push(`Couldn't encode ${names} — that file was not saved`, 7000, 'error');
+      }
       if (res.cancelled) {
         // The take recorded fine but the user dismissed the Save-As dialog — be
         // honest that nothing was written rather than toasting a false "Saved".
         useToasts.getState().push('Recording not saved (save cancelled)', 5000, 'error');
-      } else {
+      } else if (res.count > 0) {
         const suffix = res.count > 1 ? ` (${res.count} files)` : '';
         useToasts.getState().push(`Saved ${res.label}${suffix}`);
       }

--- a/test/recording_mp3.test.ts
+++ b/test/recording_mp3.test.ts
@@ -230,3 +230,34 @@ describe('convertAudioFormats', () => {
     expect(out[1].blob).toBe(native);
   });
 });
+
+describe('the encode does not freeze the page', () => {
+  // MP3 encoding is ~11x the cost of the WAV pass over the same buffer and lamejs's
+  // encodeBuffer is synchronous, so encoding a take in ONE task hangs the tab: ~45x
+  // realtime on a fast machine, i.e. tens of seconds of frozen canvas for a 10-minute
+  // take on a mid-range laptop. The loop must hand the event loop back periodically.
+  it('yields to the event loop during a multi-frame encode', async () => {
+    const { Ctor } = fakeEncoder();
+    // Long enough to cross the yield threshold (128 frames x 1152 samples).
+    const audio = pcm([ramp(300 * 1152)]);
+
+    // A macrotask queued BEFORE the encode. If the encode never yields, it cannot run
+    // until the encode has finished — which is exactly what a frozen page is.
+    let macrotaskRan = false;
+    setTimeout(() => {
+      macrotaskRan = true;
+    }, 0);
+
+    await encodeMp3(audio, { loadEncoder: async () => Ctor });
+    expect(macrotaskRan).toBe(true);
+  });
+
+  it('a SHORT take still encodes correctly (the yield never drops a frame)', async () => {
+    const { Ctor, calls } = fakeEncoder();
+    const audio = pcm([ramp(300 * 1152)]);
+    const blob = await encodeMp3(audio, { loadEncoder: async () => Ctor });
+    expect(calls.blocks).toHaveLength(300); // every frame encoded, none skipped by a yield
+    expect(calls.flushed).toBe(1);
+    expect(blob.type).toBe('audio/mpeg');
+  });
+});

--- a/test/recording_mp3.test.ts
+++ b/test/recording_mp3.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Tests MP3 export (#130): the `mp3` entry of the recording format registry, the
+ * lamejs adapter (`@/app/recording/mp3`) driven with a synthetic PCM buffer and an
+ * injected encoder, the real lazily-loaded encoder end-to-end, and — the point of
+ * the exercise — the FAILURE path: a format whose encoder cannot be loaded must
+ * yield no blob, never the un-encoded native audio under an `.mp3` name.
+ *
+ * Pure TS (vitest `environment: 'node'`): the adapter takes a structural PcmSource,
+ * so no `AudioBuffer`, `AudioContext` or DOM is needed.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  encodeMp3,
+  Mp3EncoderUnavailable,
+  DEFAULT_MP3_BITRATE_KBPS,
+  type Mp3EncoderCtor,
+  type Mp3EncoderLike,
+} from '@/app/recording/mp3';
+import {
+  RECORDING_FORMATS,
+  recordingFormat,
+  convertAudioFormats,
+} from '@/app/recording/formats';
+import type { PcmSource } from '@/app/recording/wav';
+
+/** A structural AudioBuffer stand-in for headless encoding (as in recording.test.ts). */
+const pcm = (channels: Float32Array[], sampleRate = 44100): PcmSource => ({
+  numberOfChannels: channels.length,
+  sampleRate,
+  length: channels[0]?.length ?? 0,
+  getChannelData: (c) => channels[c],
+});
+
+/** A ramp of `n` samples in [-1, 1] — enough signal for the encoder to chew on. */
+const ramp = (n: number): Float32Array =>
+  Float32Array.from({ length: n }, (_, i) => Math.sin((i / n) * 2 * Math.PI));
+
+interface FakeCalls {
+  ctor: { channels: number; sampleRate: number; kbps: number }[];
+  blocks: { left: number[]; right: number[] | null }[];
+  flushed: number;
+}
+
+/** A fake lamejs `Mp3Encoder` that records exactly how the adapter drove it and
+ * emits one recognizable byte per call, so the output bytes are checkable. */
+function fakeEncoder(): { Ctor: Mp3EncoderCtor; calls: FakeCalls } {
+  const calls: FakeCalls = { ctor: [], blocks: [], flushed: 0 };
+  class Fake implements Mp3EncoderLike {
+    constructor(channels: number, sampleRate: number, kbps: number) {
+      calls.ctor.push({ channels, sampleRate, kbps });
+    }
+    encodeBuffer(left: Int16Array, right?: Int16Array): Uint8Array {
+      calls.blocks.push({ left: [...left], right: right ? [...right] : null });
+      return new Uint8Array([1, left.length & 0xff]);
+    }
+    flush(): Uint8Array {
+      calls.flushed++;
+      return new Uint8Array([9]);
+    }
+  }
+  return { Ctor: Fake, calls };
+}
+
+const bytes = async (blob: Blob): Promise<number[]> => [...new Uint8Array(await blob.arrayBuffer())];
+
+describe('mp3 format registry entry', () => {
+  it('is registered, needs decoded audio, and carries the mp3 extension', () => {
+    const fmt = recordingFormat('mp3');
+    expect(fmt).toBeDefined();
+    expect(fmt?.ext).toBe('mp3');
+    expect(fmt?.needsDecode).toBe(true);
+    // The settings sheet renders RECORDING_FORMATS, so being in the list IS being
+    // offered to the user — there is no separate UI list to keep in sync.
+    expect(RECORDING_FORMATS.map((f) => f.id)).toContain('mp3');
+  });
+
+  it('converts decoded audio to an audio/mpeg blob (and errors without it)', async () => {
+    const convert = await recordingFormat('mp3')!.load();
+    const audio = pcm([ramp(2400)]) as unknown as AudioBuffer;
+    const out = await convert({ native: new Blob([]), audio });
+    expect(out.type).toBe('audio/mpeg');
+    expect(out.size).toBeGreaterThan(0);
+    await expect(async () => convert({ native: new Blob([]), audio: null })).rejects.toThrow(
+      /decoded audio/i,
+    );
+  });
+});
+
+describe('encodeMp3', () => {
+  it('drives the encoder with the buffer geometry and the default bitrate', async () => {
+    const { Ctor, calls } = fakeEncoder();
+    await encodeMp3(pcm([ramp(10), ramp(10)], 48000), { loadEncoder: async () => Ctor });
+    expect(calls.ctor).toEqual([{ channels: 2, sampleRate: 48000, kbps: DEFAULT_MP3_BITRATE_KBPS }]);
+    expect(DEFAULT_MP3_BITRATE_KBPS).toBe(192);
+  });
+
+  it('honours an explicit bitrate', async () => {
+    const { Ctor, calls } = fakeEncoder();
+    await encodeMp3(pcm([ramp(10)]), { loadEncoder: async () => Ctor, bitrateKbps: 320 });
+    expect(calls.ctor[0].kbps).toBe(320);
+  });
+
+  it('quantizes to 16-bit PCM with the same clamp/scale as the WAV encoder', async () => {
+    const { Ctor, calls } = fakeEncoder();
+    const samples = new Float32Array([0, 1, -1, 2, -2, 0.5]);
+    await encodeMp3(pcm([samples]), { loadEncoder: async () => Ctor });
+    // 2.0 clamps to 1.0 -> 32767 ; -2.0 clamps to -1.0 -> -32767 ; 0.5 -> 16384 (round)
+    expect(calls.blocks[0].left).toEqual([0, 32767, -32767, 32767, -32767, 16384]);
+    expect(calls.blocks[0].right).toBeNull(); // mono: no right channel passed
+  });
+
+  it('feeds the encoder in 1152-sample frames and appends flush()', async () => {
+    const { Ctor, calls } = fakeEncoder();
+    const blob = await encodeMp3(pcm([ramp(1152 * 2 + 5)]), { loadEncoder: async () => Ctor });
+    expect(calls.blocks.map((b) => b.left.length)).toEqual([1152, 1152, 5]);
+    expect(calls.flushed).toBe(1);
+    // 3 encodeBuffer chunks ([1, len & 0xff]) then the flush tail ([9]).
+    expect(await bytes(blob)).toEqual([1, 1152 & 0xff, 1, 1152 & 0xff, 1, 5, 9]);
+    expect(blob.type).toBe('audio/mpeg');
+  });
+
+  it('passes both channels for stereo, and drops channels beyond the second', async () => {
+    const { Ctor, calls } = fakeEncoder();
+    const l = new Float32Array([1, 0]);
+    const r = new Float32Array([-1, 0]);
+    const extra = new Float32Array([0.5, 0.5]);
+    await encodeMp3(pcm([l, r, extra]), { loadEncoder: async () => Ctor });
+    expect(calls.ctor[0].channels).toBe(2); // MP3 is mono/stereo only
+    expect(calls.blocks[0].left).toEqual([32767, 0]);
+    expect(calls.blocks[0].right).toEqual([-32767, 0]);
+  });
+
+  it('really encodes with the lazily-loaded lamejs (MP3 frame sync in the bytes)', async () => {
+    const blob = await encodeMp3(pcm([ramp(4096), ramp(4096)], 44100));
+    expect(blob.type).toBe('audio/mpeg');
+    const data = new Uint8Array(await blob.arrayBuffer());
+    expect(data.length).toBeGreaterThan(100);
+    // Every MP3 frame starts with 11 set sync bits: 0xFF followed by 0xEx/0xFx.
+    expect(data[0]).toBe(0xff);
+    expect(data[1] & 0xe0).toBe(0xe0);
+  });
+});
+
+describe('encodeMp3 failure path', () => {
+  it('rejects with Mp3EncoderUnavailable when the encoder will not load', async () => {
+    const boom = new Error('chunk load failed');
+    await expect(
+      encodeMp3(pcm([ramp(10)]), {
+        loadEncoder: async () => {
+          throw boom;
+        },
+      }),
+    ).rejects.toBeInstanceOf(Mp3EncoderUnavailable);
+  });
+
+  it('keeps the underlying load error as the cause', async () => {
+    const boom = new Error('chunk load failed');
+    const err = await encodeMp3(pcm([ramp(10)]), {
+      loadEncoder: async () => {
+        throw boom;
+      },
+    }).catch((e: unknown) => e);
+    expect((err as Error).cause).toBe(boom);
+  });
+
+  it('rejects with Mp3EncoderUnavailable when the loaded module is not an encoder', async () => {
+    await expect(
+      encodeMp3(pcm([ramp(10)]), {
+        loadEncoder: async () => undefined as unknown as Mp3EncoderCtor,
+      }),
+    ).rejects.toBeInstanceOf(Mp3EncoderUnavailable);
+  });
+
+  it('propagates an encoding failure instead of returning a non-MP3 blob', async () => {
+    const Ctor = class implements Mp3EncoderLike {
+      encodeBuffer(): Uint8Array {
+        throw new Error('unsupported sample rate');
+      }
+      flush(): Uint8Array {
+        return new Uint8Array();
+      }
+    } as unknown as Mp3EncoderCtor;
+    await expect(
+      encodeMp3(pcm([ramp(10)], 12345), { loadEncoder: async () => Ctor }),
+    ).rejects.toThrow(/unsupported sample rate/);
+  });
+});
+
+describe('convertAudioFormats', () => {
+  const native = new Blob(['native-webm-bytes'], { type: 'audio/webm' });
+
+  it('returns one outcome per id, in order, with the encoded blobs', async () => {
+    const audio = pcm([ramp(1200)]) as unknown as AudioBuffer;
+    const out = await convertAudioFormats(['webm', 'wav', 'mp3'], { native, audio });
+    expect(out.map((o) => o.id)).toEqual(['webm', 'wav', 'mp3']);
+    expect(out.map((o) => o.blob?.type)).toEqual(['audio/webm', 'audio/wav', 'audio/mpeg']);
+  });
+
+  it('reports a failed format as a null blob — never the un-encoded native audio', async () => {
+    // audio: null makes every decode-needing converter (wav, mp3) fail, exactly as a
+    // failed decode or a failed lazy encoder chunk would.
+    const out = await convertAudioFormats(['webm', 'mp3', 'wav'], { native, audio: null });
+    expect(out.map((o) => o.id)).toEqual(['webm', 'mp3', 'wav']); // positions preserved
+    expect(out[0].blob).toBe(native); // the native passthrough still works
+    expect(out[1].blob).toBeNull();
+    expect(out[2].blob).toBeNull();
+    expect(out[1].error).toBeInstanceOf(Error);
+    // The whole point: no silent fallback to the native blob under an mp3/wav name.
+    expect(out.some((o) => o.id !== 'webm' && o.blob === native)).toBe(false);
+  });
+
+  it('contains a failure to its own format (a broken mp3 does not lose the wav)', async () => {
+    const mp3 = recordingFormat('mp3')!;
+    const load = vi.spyOn(mp3, 'load').mockRejectedValue(new Mp3EncoderUnavailable());
+    try {
+      const audio = pcm([ramp(1200)]) as unknown as AudioBuffer;
+      const out = await convertAudioFormats(['mp3', 'wav'], { native, audio });
+      expect(out[0]).toMatchObject({ id: 'mp3', blob: null });
+      expect(out[0].error).toBeInstanceOf(Mp3EncoderUnavailable);
+      expect(out[1].blob?.type).toBe('audio/wav');
+    } finally {
+      load.mockRestore();
+    }
+  });
+
+  it('reports an unknown id as a failure rather than shifting the results', async () => {
+    const out = await convertAudioFormats(['nope', 'webm'], { native, audio: null });
+    expect(out.map((o) => o.id)).toEqual(['nope', 'webm']);
+    expect(out[0].blob).toBeNull();
+    expect(out[1].blob).toBe(native);
+  });
+});


### PR DESCRIPTION
Closes #130.

MP3 as a recording output format, via a **lazily-imported** lamejs encoder plugged into
the existing open-closed converter registry. No call site special-cases MP3 — the
recording sheet renders `RECORDING_FORMATS`, so the checkbox appeared for free.

## Bundle cost: zero for anyone who doesn't pick MP3

| chunk | before | after |
|---|---|---|
| `index` (main) | 974.35 kB / gzip 271.47 | 975.15 kB / gzip 271.70 (**+0.8 kB**) |
| `mp3` (lazy, new) | — | 1.20 kB |
| `lamejs` (lazy, new) | — | 168.95 kB / gzip 58.02 |

Two lazy hops: the registry `import()`s `./mp3`, which only `import()`s lamejs when it
actually encodes. A player who never selects MP3 downloads neither chunk.

## A pre-existing lie this had to fix first

The conversion loop caught a converter failure and **wrote the native WebM blob into the
target slot** — producing a `.wav` full of WebM bytes. Rather than inherit that for MP3,
failure is now honest across all formats: no blob → no file → reported → error toast
("Couldn't encode MP3 — that file was not saved"), contained per-format so a broken MP3
encoder never costs you the WAV.

## Two defects an adversarial review caught in this branch

Both were invisible to the green suite, and both are fixed in the second commit:

- **The encode froze the page.** `encodeBuffer` is synchronous and the frame loop had no
  yield point, so an entire take encoded in one long task — measured **~45x realtime on a
  fast machine**, i.e. tens of seconds of hung tab (frozen canvas, "Page unresponsive") for
  a 10-minute take on a mid-range laptop. MP3 is ~11x the cost of the WAV pass over the
  same buffer, so nothing before this branch stalled like it. Now yields every 128 frames
  (~3 s of audio); a test pins that a macrotask queued before the encode runs *during* it.
- **"Saved" over an archive containing nothing.** The manifest is always planned and
  always written, so the sink's file count is ≥1 even when every selected audio format
  failed to encode. With MP3 as the only audio format and the encoder unavailable, you got
  "Couldn't encode MP3" *and* "Saved thoremin-…", plus a zip holding one manifest with
  `streams: []` — exactly the class of lie this PR set out to remove. The result now
  carries `streamCount` and the toast gates on that.

## Verified

Quantization/clipping (`+1.0 → 32767`, out-of-range hard-clamps with no wraparound, `NaN →
0`), 1152-sample framing with a correct partial final frame, `flush()` always called,
mono/stereo interleaving round-tripped through ffmpeg (L = 440 Hz, R = 1760 Hz), 44.1k /
48k / 96k all produce valid playable MP3s, `audio/mpeg` MIME, and a failed dynamic import
surfaces as `Mp3EncoderUnavailable` rather than being swallowed.

Every test was mutation-tested (17 mutations, each turned the suite red, then restored).

`npm run typecheck` clean · `npx vitest run` **806 passing** (81 files) · `npm run build`
clean · `npm run catalog` idempotent.

## Not covered / open

- **The `streamCount` toast fix has no unit test.** `session.ts` and `useEngine.ts` have no
  unit tests in this repo (they need `MediaRecorder` + an `AudioContext`), so this one is
  verified by reading, not by a test. It is on the live-verification checklist.
- **The browser path is unverified end-to-end** — that a real take lands a playable `.mp3`.
  Verified headlessly: the real, lazily-imported lamejs encodes synthetic PCM into bytes
  with valid MP3 frame sync.
- **`@breezystack/lamejs` is LGPL-3.0** — the first copyleft library in the *shipped browser
  bundle* (existing MPL deps are build-time only), and thoremin is publicly deployed. It is
  the library the issue asked for, and it lands in its own separable chunk, so this is
  reversible — but it wants a decision and probably a NOTICE.
- **ffmpeg.wasm** (the issue's optional second path) not implemented; noted as a follow-up
  in `docs/design/recording-v2.md`.
