### PR TITLE
docs(#128): retire the legacy AI-DJ; split the real feature out as #141

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -42,7 +42,7 @@ sensors   normalized   feature→     tonal           sound            audio +
 | **Feature** | Raw data → normalized control signals | `@mediapipe/tasks-vision` hands + 52-blendshape face. Nodes: `hand-features`, `face-features`, `face-expression`, `face-controls` (head/jaw/brow pose), `gesture-classifier`, and the Feature Lab taps `face-feature-vector` / `hand-feature-vector` (#119). |
 | **Mapping** | Features → engine params, across the direct↔indirect spectrum | `voice-mapping` (direct — the default). `indirect-map` (→ weighted prompts) is built and tested but **not wired into the default graph**. |
 | **Music-logic** | Tonal guidance: scale snap, chords | `src/music/theory.ts` (magnetic snapping) in the hot path; `expression-chord` / `pose-chord` play diatonic chords from the face; Tonal.js backs `chord` / `progression` (built + tested, not in the default graph) and the voicings. |
-| **Synthesis / Generation** | Make sound | `webaudio-synth` (declarative timbre presets from `src/music/sounds.ts`). The `lyria` node + `GenerativeEngine` facade exist and are unit-tested, but the only *running* generative surface is the AI-DJ plugin in the **frozen** legacy app (#128 decides its fate). |
+| **Synthesis / Generation** | Make sound | `webaudio-synth` (declarative timbre presets from `src/music/sounds.ts`). The `lyria` node + `GenerativeEngine` facade exist and are unit-tested, but the only *running* generative surface is the AI-DJ plugin in the **frozen** legacy app — retired to `?engine=legacy` (#128); a DAG-native, gesture-steered generative layer is the new-feature issue #141. |
 | **Output** | Audio + video + visual guides + MIDI | Web Audio out; `canvas-overlay` (video, landmarks, markers, pitch guides, chord cues, feature-lab meters, annotation HUD); `midi-out` (WEBMIDI.js, shipped #13, off by default). |
 
 ## The DAG runtime (`src/dag/`)
@@ -146,12 +146,12 @@ legacy app is **frozen** (maintainer decision): it stays reachable so the
 generative work is not lost, but it receives no new features and is excluded from
 refactors. The DAG side already has a `lyria` node and an `indirect-map` node,
 both unit-tested against a mock engine; what is *not* done is wiring a generative
-layer into the default graph. Issue **#128** decides that: port it in, or formally
-retire the legacy view.
+layer into the default graph. #128 retired the legacy AI-DJ to `?engine=legacy`; a
+DAG-native, gesture-steered generative layer is now the new-feature issue #141.
 
 ## Roadmap
 
 See [`docs/ROADMAP.md`](ROADMAP.md) and the GitHub issues. The DAG instrument is
 the shipped product; the engine milestones M0–M6 are done or superseded, and the
 live tracks are the Stream Applier (M8 / #101), the command-dispatch write-path
-sweep (#126), and the generative-layer decision (#128).
+sweep (#126, done), and the retired generative layer (#128 → #141).

--- a/docs/MAPPING_SPECTRUM.md
+++ b/docs/MAPPING_SPECTRUM.md
@@ -44,9 +44,8 @@ and since #75 they draw from a **chord-source scale decoupled from the melody sc
 ## Indirect end — built + tested, NOT wired into the default graph
 
 The nodes exist and are unit-tested (against a mock engine); no generative layer runs
-in the DAG app. The only *running* generative surface is the AI-DJ plugin in the
-**frozen** legacy view (`?engine=legacy`). Issue **#128** decides whether this gets
-ported into the default graph or the legacy view is formally retired.
+in the DAG app. The legacy AI-DJ is retired to `?engine=legacy` (#128); a DAG-native, gesture-steered generative layer is the new-feature issue #141. The only *running* generative surface today is the (frozen) AI-DJ plugin in the
+**frozen** legacy view (`?engine=legacy`).
 
 - `indirect-map` **(built, not wired)**: gesture features AND/OR face expressions → a
   **weighted-prompt vector** + config dials (density, brightness, bpm, tension),

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -95,12 +95,16 @@ right shape and stays. Recorded in
 [design/stream-applier.md](design/stream-applier.md#m-c-resolved-host-side-source-for-video-node-swap-for-frame-emitters).
 Ready to build; not scheduled.
 
-### #128 — the generative layer
+### #128 — the generative layer: **DECIDED (retired to `?engine=legacy`)**
 
-The `lyria` node + `indirect-map` node are built and unit-tested, but no generative
-layer runs in the DAG app; the only working one is the AI-DJ plugin in the **frozen**
-legacy view (`?engine=legacy`). Decide: port it into the default graph, or formally
-retire the legacy view. Nothing else blocks on this.
+The legacy AI-DJ is retired to `?engine=legacy` — a status decision, no code change; it
+keeps working there. The reframing fact: the legacy AI-DJ is **slider**-steered, and the
+compelling version (hand/face features steering a generative model) exists only as the
+`indirect-map` node, which has never run in a browser. So "port it forward" was really
+"first-run an unproven feature", now split out and budgeted honestly as **#141**
+(gesture-steered generative layer, DAG-native) — which depends on the #126 dials/command
+surface, now merged. The `lyria` / `indirect-map` / `generative` nodes stay in the registry,
+catalogued and role-tested, so this is fully reversible.
 
 ---
 
@@ -169,7 +173,7 @@ these rather than inside them, so read the status column, not the milestone numb
 | **M0** | Baseline + node contract: DAG engine, recorder/replay, pure node library, music theory, headless tests. | done |
 | **M1** | First real video→sound vertical slice in the browser, on-device. | done |
 | **M2** | Fixture record/replay infra + persisted per-edge feature streams on disk + CI gate. | done |
-| **M3** | Wire the deployed app through the DAG. | **done** — the DAG view is the default at the bare URL (PR #58); the legacy app is frozen at `?engine=legacy`. The Lyria half (a generative node in the *default graph*) is not done and is now **#128**. |
+| **M3** | Wire the deployed app through the DAG. | **done** — the DAG view is the default at the bare URL (PR #58); the legacy app is frozen at `?engine=legacy`. The Lyria half (a generative node in the *default graph*) was decided in **#128** — the legacy AI-DJ is retired to `?engine=legacy`; a DAG-native, gesture-steered generative layer is now the new-feature issue **#141**. |
 | **M4** | Broaden the feature surface + tonal depth. | done and then some — face blendshapes, face expression, head/jaw/brow pose control, gesture classifier, Tonal.js chords/voicings, and the ~200-feature catalog (#119). |
 | **M5** | Conductor mode: immutable `score` node + `performance` overlay + humanization. | nodes built + tested (`transport` / `score` / `performance`); **not wired into the default graph**. |
 | **M6** | `midi-out` + a React Flow patcher UI + deploy as a tw_platform static app. | partial — deploy done; `midi-out` shipped (#13 / PR #120); the patcher (#14) is open. |
@@ -186,5 +190,6 @@ these rather than inside them, so read the status column, not the milestone numb
    Python/`theremin` or generative service can plug in later (M7). The AI assistant
    deliberately follows this too: client-side, BYO-key, no `aix`.
 4. **Fixture videos** — commit small derived NDJSON; raw `.mp4`s optional/external.
-5. **Lyria API key** — key-in-localStorage; a proxy/platform-managed key only if the
-   generative layer returns to the default app (#128).
+5. **Lyria API key** — key-in-localStorage; a proxy/platform-managed key only if a
+   generative layer comes to the default app (**#141**; the legacy AI-DJ that used it is
+   retired to `?engine=legacy` per #128).

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -229,5 +229,7 @@ generative music with weighted text "strains" (you supply a Gemini API key, stor
 only in your browser).
 
 It is kept reachable so that work is not lost, but it is **frozen**: no new features,
-and it is excluded from refactors. Whether the generative layer moves into the main
+and it is excluded from refactors. The legacy AI-DJ is retired there (#128); a
+DAG-native, gesture-steered generative layer is tracked as a new feature (#141). Whether
+that generative layer moves into the main
 app or the legacy view is retired is tracked in issue #128.


### PR DESCRIPTION
Executes the #128 decision (retire to `?engine=legacy`) at the docs level, and points every stale reference at the new-feature follow-up #141. Docs-only; `npm run catalog` idempotent. See #128 and #141 for the reasoning.