### PR TITLE
#131: invariance labels + residual/deconfound helpers (items 1+2)

### DIFF
--- a/src/app/LabControls.tsx
+++ b/src/app/LabControls.tsx
@@ -14,7 +14,7 @@
  * Loading a saved view hydrates that config; nothing here is ever awaited in the tick loop.
  */
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { FEATURE_GROUPS, ALL_SAFE_NAMES } from '@/features/catalog';
+import { FEATURE_GROUPS, ALL_SAFE_NAMES, groupInvarianceSummary } from '@/features/catalog';
 import { compileFormula, DEFAULT_HELPERS } from '@/features/formula';
 import { useControls } from './store';
 import type { FeatureLabConfig } from '@/features/labConfig';
@@ -97,7 +97,10 @@ function GroupPicker({ groups, onToggle }: { groups: string[]; onToggle: (id: st
   const handGroups = FEATURE_GROUPS.filter((g) => g.source === 'hand');
   const derivedGroup = FEATURE_GROUPS.find((g) => g.id === 'derived');
   const Row = ({ id, label }: { id: string; label: string }) => (
-    <label className="flex items-center gap-2 text-[11px]">
+    // The tooltip carries the group's declared confound profile (#131) — what the
+    // features are invariant to and what will contaminate them — so a performer
+    // picking channels sees the honesty labels where they choose.
+    <label className="flex items-center gap-2 text-[11px]" title={groupInvarianceSummary(id)}>
       <input type="checkbox" checked={enabled.has(id)} onChange={(e) => onToggle(id, e.target.checked)} />
       {label}
     </label>

--- a/src/features/catalog.ts
+++ b/src/features/catalog.ts
@@ -13,7 +13,7 @@ import { dist3, type Vec3 } from './math';
 import { iod as iodOf, type FaceLandmarks } from './landmarks';
 import { FACE_FEATURES } from './face_catalog';
 import { HAND_PAIR_FEATURES, HAND_SIDE_FEATURES } from './hand_catalog';
-import type { Controllability, FaceCtx, FeatureSource, HandCtx } from './types';
+import type { Controllability, FaceCtx, FeatureSource, HandCtx, Invariance } from './types';
 
 export type { Controllability, FaceCtx, HandCtx, TwoHandCtx, FeatureDef, FeatureSource, FeatureVector } from './types';
 export { FACE_FEATURES } from './face_catalog';
@@ -32,6 +32,9 @@ export interface FlatFeature {
   /** Angular feature on a circle (see FeatureDef.circular): the normalizer maps it
    *  against its declared range verbatim instead of an adaptive envelope. */
   circular?: boolean;
+  /** Declared confound profile (see FeatureDef.invariantTo): absent = unassessed,
+   *  [] = invariant to nothing listed. */
+  invariantTo?: readonly Invariance[];
   controllability?: Controllability;
   description?: string;
 }
@@ -93,6 +96,27 @@ export function safeName(id: string): string {
 /** Group ids, in display order. */
 export const FEATURE_GROUP_IDS: readonly string[] = FEATURE_GROUPS.map((g) => g.id);
 
+/**
+ * A one-line human summary of a group's declared confound profile (#131), for
+ * the Lab's group-picker tooltips: what the group's features are invariant to,
+ * and — the actionable half — what will contaminate them. Derived from the
+ * per-feature `invariantTo` labels; undefined when the group has no assessed
+ * features (no claim is better than a made-up one).
+ */
+export function groupInvarianceSummary(groupId: string): string | undefined {
+  const assessed = ALL_FEATURES.filter((f) => f.group === groupId && f.invariantTo !== undefined);
+  if (!assessed.length) return undefined;
+  const axes: Invariance[] = ['scale', 'position', 'yaw', 'pitch', 'roll'];
+  const shared = axes.filter((a) => assessed.every((f) => f.invariantTo!.includes(a)));
+  const contaminating = axes.filter((a) => !shared.includes(a));
+  const inv = shared.length ? `invariant to ${shared.join(', ')}` : 'invariant to none of the confound axes';
+  const bad = contaminating.length
+    ? ` — contaminated by ${contaminating.join(', ')} (correct with residual(x, z) in a formula)`
+    : ' — fully confound-invariant as labeled';
+  const partial = assessed.length < ALL_FEATURES.filter((f) => f.group === groupId).length ? ' (some features unassessed)' : '';
+  return `${inv}${bad}${partial}`;
+}
+
 /** A sensible default set of DISPLAYED/computed groups: high-signal, readable
  *  channels, so the lab opens with a useful (not overwhelming) grid. The raw
  *  blendshape families, raw hand positions, and two-hand groups are opt-in. */
@@ -115,15 +139,15 @@ export const ALL_FEATURES: readonly FlatFeature[] = buildAllFeatures();
 function buildAllFeatures(): FlatFeature[] {
   const out: FlatFeature[] = [];
   for (const f of FACE_FEATURES) {
-    out.push({ id: f.id, group: f.group, source: f.source, range: f.range, circular: f.circular, controllability: f.controllability, description: f.description });
+    out.push({ id: f.id, group: f.group, source: f.source, range: f.range, circular: f.circular, invariantTo: f.invariantTo, controllability: f.controllability, description: f.description });
   }
   for (const side of HAND_SIDES) {
     for (const f of HAND_SIDE_FEATURES) {
-      out.push({ id: `hand.${side}.${f.id}`, group: f.group, source: f.source, range: f.range, circular: f.circular, controllability: f.controllability, description: f.description });
+      out.push({ id: `hand.${side}.${f.id}`, group: f.group, source: f.source, range: f.range, circular: f.circular, invariantTo: f.invariantTo, controllability: f.controllability, description: f.description });
     }
   }
   for (const f of HAND_PAIR_FEATURES) {
-    out.push({ id: `hand.${f.id}`, group: f.group, source: f.source, range: f.range, circular: f.circular, controllability: f.controllability, description: f.description });
+    out.push({ id: `hand.${f.id}`, group: f.group, source: f.source, range: f.range, circular: f.circular, invariantTo: f.invariantTo, controllability: f.controllability, description: f.description });
   }
   return out;
 }

--- a/src/features/catalog.ts
+++ b/src/features/catalog.ts
@@ -110,8 +110,10 @@ export function groupInvarianceSummary(groupId: string): string | undefined {
   const shared = axes.filter((a) => assessed.every((f) => f.invariantTo!.includes(a)));
   const contaminating = axes.filter((a) => !shared.includes(a));
   const inv = shared.length ? `invariant to ${shared.join(', ')}` : 'invariant to none of the confound axes';
+  // "not invariant ACROSS the group", not "contaminated by": in a mixed group an
+  // axis outside the shared set may still be fine for individual members.
   const bad = contaminating.length
-    ? ` — contaminated by ${contaminating.join(', ')} (correct with residual(x, z) in a formula)`
+    ? ` — not invariant across the group to: ${contaminating.join(', ')} (correct with residual(x, z) in a formula)`
     : ' — fully confound-invariant as labeled';
   const partial = assessed.length < ALL_FEATURES.filter((f) => f.group === groupId).length ? ' (some features unassessed)' : '';
   return `${inv}${bad}${partial}`;

--- a/src/features/face_catalog.ts
+++ b/src/features/face_catalog.ts
@@ -105,6 +105,10 @@ function blendshapeFeatures(): FaceFeature[] {
         group,
         source: 'face',
         range: [0, 1],
+        // Model outputs over the aligned face crop: camera distance and frame
+        // position are normalized away. Pose robustness is model-internal and
+        // degrades toward extreme yaw/pitch — deliberately NOT claimed (#131).
+        invariantTo: ['scale', 'position'],
         controllability: ctrl,
         description: `MediaPipe blendshape ${bsName}`,
         compute: (ctx) => ctx.bs(bsName),
@@ -145,6 +149,11 @@ function geomFeatures(): FaceFeature[] {
     id,
     group,
     source: 'face',
+    // IOD-normalized 2D mesh distances: camera distance and frame position
+    // cancel; in-plane roll rotates numerator and IOD together. Yaw/pitch
+    // foreshorten out-of-plane — the #131 example ("a smile that drifts purely
+    // from turning the head"); correct with residual(x, face_head_yaw).
+    invariantTo: ['scale', 'position', 'roll'],
     controllability,
     description,
     compute: (ctx) => (ctx.hasLandmarks ? compute(ctx.landmarks, ctx.iod) : NaN),
@@ -195,6 +204,10 @@ function gazeFeatures(): FaceFeature[] {
     id,
     group: 'face.gaze',
     source: 'face',
+    // Iris offset normalized within each eye's own span: scale/position cancel.
+    // Head yaw/pitch move the iris in-socket geometry out of plane (a straight
+    // gaze reads off-center on a turned head) — not claimed.
+    invariantTo: ['scale', 'position'],
     controllability,
     description,
     compute: (ctx) => (ctx.hasLandmarks ? compute(ctx.landmarks) : NaN),
@@ -221,6 +234,10 @@ function headFeatures(): FaceFeature[] {
     id,
     group: 'face.head',
     source: 'face',
+    // These MEASURE the pose axes (from the transform matrix), independent of
+    // where and how far the face sits in frame. They are the confound
+    // regressors residual()/deconfound() want on their z side.
+    invariantTo: ['scale', 'position'],
     controllability: 'easy',
     description,
     compute: (ctx) => (ctx.headPose ? ctx.headPose[key] : NaN),
@@ -229,9 +246,9 @@ function headFeatures(): FaceFeature[] {
     pose('face.head.yaw', 'yaw', 'Head turn left/right (degrees)'),
     pose('face.head.pitch', 'pitch', 'Head nod up/down (degrees)'),
     pose('face.head.roll', 'roll', 'Head tilt ear-to-shoulder (degrees)'),
-    { id: 'face.head.x', group: 'face.head', source: 'face', controllability: 'easy', description: 'Nose-tip horizontal position', compute: (ctx) => (ctx.hasLandmarks ? lx(ctx.landmarks, FL.noseTip) : NaN) },
-    { id: 'face.head.y', group: 'face.head', source: 'face', controllability: 'easy', description: 'Nose-tip vertical position', compute: (ctx) => (ctx.hasLandmarks ? ly(ctx.landmarks, FL.noseTip) : NaN) },
-    { id: 'face.head.scale', group: 'face.head', source: 'face', controllability: 'easy', description: 'Face scale (IOD) — proxy for camera distance', compute: (ctx) => ctx.iod },
+    { id: 'face.head.x', group: 'face.head', source: 'face', invariantTo: [], controllability: 'easy', description: 'Nose-tip horizontal position', compute: (ctx) => (ctx.hasLandmarks ? lx(ctx.landmarks, FL.noseTip) : NaN) },
+    { id: 'face.head.y', group: 'face.head', source: 'face', invariantTo: [], controllability: 'easy', description: 'Nose-tip vertical position', compute: (ctx) => (ctx.hasLandmarks ? ly(ctx.landmarks, FL.noseTip) : NaN) },
+    { id: 'face.head.scale', group: 'face.head', source: 'face', invariantTo: ['position', 'roll'], controllability: 'easy', description: 'Face scale (IOD) — proxy for camera distance', compute: (ctx) => ctx.iod },
     {
       id: 'face.head.distanceProxy',
       group: 'face.head',
@@ -256,12 +273,12 @@ function headFeatures(): FaceFeature[] {
 
 function symmetryFeatures(): FaceFeature[] {
   return [
-    { id: 'face.symmetry.smile', group: 'face.symmetry', source: 'face', controllability: 'moderate', description: 'Smile right - left (asymmetric grin)', compute: (ctx) => ctx.bs('mouthSmileRight') - ctx.bs('mouthSmileLeft') },
-    { id: 'face.symmetry.browOuter', group: 'face.symmetry', source: 'face', controllability: 'moderate', description: 'Outer-brow raise right - left', compute: (ctx) => ctx.bs('browOuterUpRight') - ctx.bs('browOuterUpLeft') },
-    { id: 'face.symmetry.eye', group: 'face.symmetry', source: 'face', controllability: 'moderate', description: 'EAR right - left (wink)', compute: (ctx) => (ctx.hasLandmarks ? ear(ctx.landmarks, 'right') - ear(ctx.landmarks, 'left') : NaN) },
-    { id: 'face.symmetry.mouthCorner', group: 'face.symmetry', source: 'face', controllability: 'moderate', description: 'Mouth-corner height difference / IOD', compute: (ctx) => (ctx.hasLandmarks ? safeDiv(ly(ctx.landmarks, FL.mouthCornerL) - ly(ctx.landmarks, FL.mouthCornerR), ctx.iod) : NaN) },
-    { id: 'face.symmetry.cheek', group: 'face.symmetry', source: 'face', controllability: 'involuntary', description: 'Cheek squint right - left', compute: (ctx) => ctx.bs('cheekSquintRight') - ctx.bs('cheekSquintLeft') },
-    { id: 'face.symmetry.mouthSideShift', group: 'face.symmetry', source: 'face', controllability: 'easy', description: 'Mouth shift right - left', compute: (ctx) => ctx.bs('mouthRight') - ctx.bs('mouthLeft') },
+    { id: 'face.symmetry.smile', group: 'face.symmetry', source: 'face', invariantTo: ['scale', 'position'], controllability: 'moderate', description: 'Smile right - left (asymmetric grin)', compute: (ctx) => ctx.bs('mouthSmileRight') - ctx.bs('mouthSmileLeft') },
+    { id: 'face.symmetry.browOuter', group: 'face.symmetry', source: 'face', invariantTo: ['scale', 'position'], controllability: 'moderate', description: 'Outer-brow raise right - left', compute: (ctx) => ctx.bs('browOuterUpRight') - ctx.bs('browOuterUpLeft') },
+    { id: 'face.symmetry.eye', group: 'face.symmetry', source: 'face', invariantTo: ['scale', 'position'], controllability: 'moderate', description: 'EAR right - left (wink)', compute: (ctx) => (ctx.hasLandmarks ? ear(ctx.landmarks, 'right') - ear(ctx.landmarks, 'left') : NaN) },
+    { id: 'face.symmetry.mouthCorner', group: 'face.symmetry', source: 'face', invariantTo: ['scale', 'position'], controllability: 'moderate', description: 'Mouth-corner height difference / IOD', compute: (ctx) => (ctx.hasLandmarks ? safeDiv(ly(ctx.landmarks, FL.mouthCornerL) - ly(ctx.landmarks, FL.mouthCornerR), ctx.iod) : NaN) },
+    { id: 'face.symmetry.cheek', group: 'face.symmetry', source: 'face', invariantTo: ['scale', 'position'], controllability: 'involuntary', description: 'Cheek squint right - left', compute: (ctx) => ctx.bs('cheekSquintRight') - ctx.bs('cheekSquintLeft') },
+    { id: 'face.symmetry.mouthSideShift', group: 'face.symmetry', source: 'face', invariantTo: ['scale', 'position'], controllability: 'easy', description: 'Mouth shift right - left', compute: (ctx) => ctx.bs('mouthRight') - ctx.bs('mouthLeft') },
   ];
 }
 
@@ -276,6 +293,9 @@ function auFeatures(): FaceFeature[] {
     group: 'face.au',
     source: 'face',
     range: [0, 1],
+    // Composites of blendshapes (['scale','position']) and IOD-normalized geom
+    // (adds roll) — the composite honestly claims only the intersection.
+    invariantTo: ['scale', 'position'],
     controllability,
     description,
     compute,

--- a/src/features/face_catalog.ts
+++ b/src/features/face_catalog.ts
@@ -17,7 +17,7 @@
  */
 import { clamp01, safeDiv } from './math';
 import { dL, ear, FL, iod as iodOf, L, mar, type FaceLandmarks } from './landmarks';
-import type { Controllability, FaceCtx, FeatureDef } from './types';
+import type { Controllability, FaceCtx, FeatureDef, Invariance } from './types';
 
 type FaceFeature = FeatureDef<FaceCtx>;
 
@@ -145,19 +145,26 @@ function geomFeatures(): FaceFeature[] {
     controllability: Controllability,
     compute: (l: FaceLandmarks | undefined, iod: number) => number,
     description: string,
+    invariantTo: readonly Invariance[] = ['scale', 'position', 'roll'],
   ): FaceFeature => ({
     id,
     group,
     source: 'face',
-    // IOD-normalized 2D mesh distances: camera distance and frame position
-    // cancel; in-plane roll rotates numerator and IOD together. Yaw/pitch
-    // foreshorten out-of-plane — the #131 example ("a smile that drifts purely
-    // from turning the head"); correct with residual(x, face_head_yaw).
-    invariantTo: ['scale', 'position', 'roll'],
+    // Default: IOD-normalized 2D mesh DISTANCES (and relative z) — camera
+    // distance and frame position cancel; in-plane roll rotates numerator and
+    // IOD together. Yaw/pitch foreshorten out-of-plane — the #131 example ("a
+    // smile that drifts purely from turning the head"); correct with
+    // residual(x, face_head_yaw). Features whose numerator is a single-AXIS
+    // PROJECTION (an x or y offset) pass PROJECTION_INVARIANCE instead: roll
+    // rotates the offset vector out of the projection axis (measured: a 5-10
+    // degree head roll moves jaw.lateralShift by ~0.12-0.24 IOD with ZERO jaw
+    // motion), so claiming roll there would be the over-claim #131 forbids.
+    invariantTo,
     controllability,
     description,
     compute: (ctx) => (ctx.hasLandmarks ? compute(ctx.landmarks, ctx.iod) : NaN),
   });
+  const PROJECTION_INVARIANCE: readonly Invariance[] = ['scale', 'position'];
 
   return [
     // face.geom.eye
@@ -171,27 +178,27 @@ function geomFeatures(): FaceFeature[] {
     g('face.geom.mouth.aspectRatio', 'face.geom.mouth', 'easy', (l) => mar(l), 'Mouth aspect ratio (open/close)'),
     g('face.geom.mouth.openness', 'face.geom.mouth', 'easy', (l, iod) => safeDiv(dL(l, FL.lipTopInner, FL.lipBottomInner), iod), 'Inner-lip gap / IOD'),
     g('face.geom.mouth.width', 'face.geom.mouth', 'moderate', (l, iod) => safeDiv(dL(l, FL.mouthCornerL, FL.mouthCornerR), iod), 'Mouth corner-to-corner width / IOD'),
-    g('face.geom.mouth.cornerPullLeft', 'face.geom.mouth', 'moderate', (l, iod) => safeDiv((ly(l, FL.lipTopInner) + ly(l, FL.lipBottomInner)) / 2 - ly(l, FL.mouthCornerL), iod), 'Left corner lift above lip center / IOD'),
-    g('face.geom.mouth.cornerPullRight', 'face.geom.mouth', 'moderate', (l, iod) => safeDiv((ly(l, FL.lipTopInner) + ly(l, FL.lipBottomInner)) / 2 - ly(l, FL.mouthCornerR), iod), 'Right corner lift above lip center / IOD'),
+    g('face.geom.mouth.cornerPullLeft', 'face.geom.mouth', 'moderate', (l, iod) => safeDiv((ly(l, FL.lipTopInner) + ly(l, FL.lipBottomInner)) / 2 - ly(l, FL.mouthCornerL), iod), 'Left corner lift above lip center / IOD', PROJECTION_INVARIANCE),
+    g('face.geom.mouth.cornerPullRight', 'face.geom.mouth', 'moderate', (l, iod) => safeDiv((ly(l, FL.lipTopInner) + ly(l, FL.lipBottomInner)) / 2 - ly(l, FL.mouthCornerR), iod), 'Right corner lift above lip center / IOD', PROJECTION_INVARIANCE),
     g('face.geom.mouth.protrusion', 'face.geom.mouth', 'moderate', (l, iod) => safeDiv(lz(l, FL.noseTip) - (lz(l, FL.lipTopInner) + lz(l, FL.lipBottomInner)) / 2, iod), 'Lip forward protrusion (relative z) / IOD'),
     // face.geom.brow (iris-with-lid fallback for the vertical reference)
-    g('face.geom.brow.raiseLeft', 'face.geom.brow', 'easy', (l, iod) => safeDiv(firstY(l, [FL.irisR, FL.eyeUpperR]) - ly(l, FL.browMidR), iod), 'Subject-left brow height above eye / IOD'),
-    g('face.geom.brow.raiseRight', 'face.geom.brow', 'easy', (l, iod) => safeDiv(firstY(l, [FL.irisL, FL.eyeUpperL]) - ly(l, FL.browMidL), iod), 'Subject-right brow height above eye / IOD'),
+    g('face.geom.brow.raiseLeft', 'face.geom.brow', 'easy', (l, iod) => safeDiv(firstY(l, [FL.irisR, FL.eyeUpperR]) - ly(l, FL.browMidR), iod), 'Subject-left brow height above eye / IOD', PROJECTION_INVARIANCE),
+    g('face.geom.brow.raiseRight', 'face.geom.brow', 'easy', (l, iod) => safeDiv(firstY(l, [FL.irisL, FL.eyeUpperL]) - ly(l, FL.browMidL), iod), 'Subject-right brow height above eye / IOD', PROJECTION_INVARIANCE),
     g('face.geom.brow.raiseAvg', 'face.geom.brow', 'easy', (l, iod) => {
       const a = safeDiv(firstY(l, [FL.irisR, FL.eyeUpperR]) - ly(l, FL.browMidR), iod);
       const b = safeDiv(firstY(l, [FL.irisL, FL.eyeUpperL]) - ly(l, FL.browMidL), iod);
       return (a + b) / 2;
-    }, 'Mean brow raise / IOD'),
+    }, 'Mean brow raise / IOD', PROJECTION_INVARIANCE),
     g('face.geom.brow.furrow', 'face.geom.brow', 'moderate', (l, iod) => safeDiv(dL(l, FL.browInnerL, FL.browInnerR), iod), 'Inner-brow separation / IOD (inverse of furrow)'),
-    g('face.geom.brow.innerRaise', 'face.geom.brow', 'easy', (l, iod) => safeDiv((firstY(l, [FL.irisL, FL.eyeUpperL]) + firstY(l, [FL.irisR, FL.eyeUpperR])) / 2 - (ly(l, FL.browInnerL) + ly(l, FL.browInnerR)) / 2, iod), 'Inner-brow height above eyes / IOD'),
+    g('face.geom.brow.innerRaise', 'face.geom.brow', 'easy', (l, iod) => safeDiv((firstY(l, [FL.irisL, FL.eyeUpperL]) + firstY(l, [FL.irisR, FL.eyeUpperR])) / 2 - (ly(l, FL.browInnerL) + ly(l, FL.browInnerR)) / 2, iod), 'Inner-brow height above eyes / IOD', PROJECTION_INVARIANCE),
     // face.geom.nose
     g('face.geom.nose.wrinkle', 'face.geom.nose', 'involuntary', (l, iod) => safeDiv(dL(l, FL.noseAlaL, FL.eyeInnerL) + dL(l, FL.noseAlaR, FL.eyeInnerR), 2 * iod), 'Nose-to-inner-eye compression / IOD'),
     // face.geom.cheek
-    g('face.geom.cheek.raiseLeft', 'face.geom.cheek', 'moderate', (l, iod) => safeDiv(ly(l, FL.cheekR) - ly(l, FL.eyeLowerR), iod), 'Subject-left cheek raise toward eye / IOD'),
-    g('face.geom.cheek.raiseRight', 'face.geom.cheek', 'moderate', (l, iod) => safeDiv(ly(l, FL.cheekL) - ly(l, FL.eyeLowerL), iod), 'Subject-right cheek raise toward eye / IOD'),
+    g('face.geom.cheek.raiseLeft', 'face.geom.cheek', 'moderate', (l, iod) => safeDiv(ly(l, FL.cheekR) - ly(l, FL.eyeLowerR), iod), 'Subject-left cheek raise toward eye / IOD', PROJECTION_INVARIANCE),
+    g('face.geom.cheek.raiseRight', 'face.geom.cheek', 'moderate', (l, iod) => safeDiv(ly(l, FL.cheekL) - ly(l, FL.eyeLowerL), iod), 'Subject-right cheek raise toward eye / IOD', PROJECTION_INVARIANCE),
     // face.geom.jaw
-    g('face.geom.jaw.lateralShift', 'face.geom.jaw', 'easy', (l, iod) => safeDiv(lx(l, FL.chin) - lx(l, FL.glabella), iod), 'Chin horizontal offset from face center / IOD'),
-    g('face.geom.jaw.drop', 'face.geom.jaw', 'easy', (l, iod) => safeDiv(ly(l, FL.chin) - ly(l, FL.subnasale), iod), 'Chin drop below nose base / IOD'),
+    g('face.geom.jaw.lateralShift', 'face.geom.jaw', 'easy', (l, iod) => safeDiv(lx(l, FL.chin) - lx(l, FL.glabella), iod), 'Chin horizontal offset from face center / IOD', PROJECTION_INVARIANCE),
+    g('face.geom.jaw.drop', 'face.geom.jaw', 'easy', (l, iod) => safeDiv(ly(l, FL.chin) - ly(l, FL.subnasale), iod), 'Chin drop below nose base / IOD', PROJECTION_INVARIANCE),
     g('face.geom.jaw.thrust', 'face.geom.jaw', 'moderate', (l, iod) => safeDiv(lz(l, FL.chin) - lz(l, FL.glabella), iod), 'Chin forward thrust (relative z) / IOD'),
   ];
 }

--- a/src/features/formula.ts
+++ b/src/features/formula.ts
@@ -71,6 +71,82 @@ export const DEFAULT_HELPERS: Readonly<Record<string, HelperFn>> = {
   deadzone: (x: number, dz: number) => (Math.abs(x) <= dz ? 0 : x),
 };
 
+/**
+ * A factory producing a fresh helper closure PER FORMULA CALL SITE — for helpers
+ * that carry state across frames (the #131 rolling regressions). Instantiated
+ * once during compilation for each call expression, so two `residual(...)` calls
+ * in one formula never share state, and a re-compile (config edit) starts clean.
+ * `arity` is the call site's argument count — validate it here so a wrong-shaped
+ * call fails at COMPILE time with a clear message, like every other formula error.
+ */
+export type StatefulHelperFactory = (arity: number) => HelperFn;
+
+/** Default EW window (frames) for the deconfounding regressions: ~6 s at 30fps,
+ *  matching the online normalizer's drift time constant. */
+const DEFAULT_REGRESSION_WINDOW = 180;
+
+/**
+ * One exponentially-weighted linear regression of x on z (O(1) per frame):
+ * returns `x - beta * (z - mean_z)` — x with z's linear component regressed out,
+ * still in x's units. Until the regression warms up beta is 0, so the output
+ * starts as plain x and sharpens as evidence accrues (never NaN-blocked at the
+ * start). Non-finite inputs return NaN WITHOUT updating the state, so one bad
+ * frame can't poison the running moments.
+ */
+function makeEwRegression(): (x: number, z: number, window?: number) => number {
+  let mx = 0;
+  let mz = 0;
+  let cxz = 0;
+  let vz = 0;
+  let seeded = false;
+  return (x, z, window = DEFAULT_REGRESSION_WINDOW) => {
+    if (!Number.isFinite(x) || !Number.isFinite(z)) return NaN;
+    if (!seeded) {
+      mx = x;
+      mz = z;
+      seeded = true;
+      return x; // beta is 0 with one sample
+    }
+    const a = 1 / Math.max(2, window);
+    const dx = x - mx; // deltas vs the PRE-update means (West-style EW moments)
+    const dz = z - mz;
+    mx += a * dx;
+    mz += a * dz;
+    cxz = (1 - a) * (cxz + a * dx * dz);
+    vz = (1 - a) * (vz + a * dz * dz);
+    const beta = vz > 1e-12 ? cxz / vz : 0;
+    return x - beta * (z - mz);
+  };
+}
+
+/**
+ * The stateful helper set (#131): per-call-site rolling regressions for
+ * correcting a confounded feature (see FeatureDef.invariantTo).
+ *
+ * - `residual(x, z[, window])` — x with z's linear component regressed out over
+ *   an EW window (frames, default 180 ≈ 6 s at 30fps). E.g. a pose-corrected
+ *   smile: `residual(face_geom_mouth_smileWidth, face_head_yaw)`.
+ * - `deconfound(x, z1[, z2, ...])` — sequential residualization against several
+ *   confounds (each with its own regression state); equivalent to nesting
+ *   `residual(residual(x, z1), z2)` with the default window.
+ */
+export const STATEFUL_HELPERS: Readonly<Record<string, StatefulHelperFactory>> = {
+  residual: (arity) => {
+    if (arity < 2 || arity > 3) throw new FormulaError('residual(x, z[, window]) takes 2 or 3 arguments.');
+    const reg = makeEwRegression();
+    return (x: number, z: number, window?: number) => reg(x, z, window);
+  },
+  deconfound: (arity) => {
+    if (arity < 2) throw new FormulaError('deconfound(x, z1[, z2, ...]) needs at least one confound.');
+    const regs = Array.from({ length: arity - 1 }, makeEwRegression);
+    return (...args: number[]) => {
+      let r = args[0];
+      for (let i = 1; i < args.length; i++) r = regs[i - 1](r, args[i]);
+      return r;
+    };
+  },
+};
+
 /** The whitelisted binary operators (comparisons return 1/0 so they compose). */
 const BINARY: Record<string, (a: number, b: number) => number> = {
   '+': (a, b) => a + b,
@@ -106,6 +182,8 @@ export interface CompileOptions {
   variables: ReadonlySet<string>;
   /** The callable helper set (defaults to {@link DEFAULT_HELPERS}). */
   helpers?: Readonly<Record<string, HelperFn>>;
+  /** Per-call-site stateful helper factories (defaults to {@link STATEFUL_HELPERS}). */
+  statefulHelpers?: Readonly<Record<string, StatefulHelperFactory>>;
 }
 
 // Minimal structural types over the jsep AST nodes we accept.
@@ -122,6 +200,8 @@ interface Node {
 export function compileFormula(source: string, opts: CompileOptions): CompiledFormula {
   ensureJsep();
   const helpers = opts.helpers ?? DEFAULT_HELPERS;
+  const statefulHelpers = opts.statefulHelpers ?? STATEFUL_HELPERS;
+  const allHelperNames = () => [...Object.keys(helpers), ...Object.keys(statefulHelpers)].join(', ');
   const used = new Set<string>();
 
   let ast: Node;
@@ -141,7 +221,7 @@ export function compileFormula(source: string, opts: CompileOptions): CompiledFo
       case 'Identifier': {
         const name = node.name as string;
         if (!opts.variables.has(name)) {
-          throw new FormulaError(`Unknown variable "${name}". Available: feature names + helpers (${Object.keys(helpers).join(', ')}).`);
+          throw new FormulaError(`Unknown variable "${name}". Available: feature names + helpers (${allHelperNames()}).`);
         }
         used.add(name);
         // Absent this frame → NaN (dropped downstream), never a throw.
@@ -180,16 +260,25 @@ export function compileFormula(source: string, opts: CompileOptions): CompiledFo
         const callee = node.callee as Node;
         if (callee.type !== 'Identifier') throw new FormulaError('Only direct calls to named helper functions are allowed.');
         const name = callee.name as string;
-        // Own-property check only — a bare `helpers[name]` would resolve INHERITED
+        const argNodes = node.arguments as Node[];
+        // Own-property checks only — a bare `helpers[name]` would resolve INHERITED
         // Object.prototype members (`constructor`, `hasOwnProperty`, `valueOf`, ...),
         // which both bypasses the whitelist (reaching a global constructor) and, for
         // the `this`-less prototype methods, throws at eval time, breaking the
         // never-throws contract. Reject any non-own key at compile time.
+        if (Object.prototype.hasOwnProperty.call(statefulHelpers, name)) {
+          // Stateful helper (#131): instantiate a FRESH closure for THIS call
+          // site, so state (the rolling regression moments) is per-site and
+          // resets on re-compile. Arity errors surface here, at compile time.
+          const fn = statefulHelpers[name](argNodes.length);
+          const args = argNodes.map((a) => walk(a));
+          return (s) => fn(...args.map((a) => a(s)));
+        }
         if (!Object.prototype.hasOwnProperty.call(helpers, name)) {
-          throw new FormulaError(`Unknown function "${name}". Allowed: ${Object.keys(helpers).join(', ')}.`);
+          throw new FormulaError(`Unknown function "${name}". Allowed: ${allHelperNames()}.`);
         }
         const fn = helpers[name];
-        const args = (node.arguments as Node[]).map((a) => walk(a));
+        const args = argNodes.map((a) => walk(a));
         return (s) => fn(...args.map((a) => a(s)));
       }
       case 'MemberExpression':

--- a/src/features/formula.ts
+++ b/src/features/formula.ts
@@ -100,7 +100,10 @@ function makeEwRegression(): (x: number, z: number, window?: number) => number {
   let vz = 0;
   let seeded = false;
   return (x, z, window = DEFAULT_REGRESSION_WINDOW) => {
-    if (!Number.isFinite(x) || !Number.isFinite(z)) return NaN;
+    // The window is an input too: a NaN alpha (e.g. `residual(x, z, w)` with w
+    // absent this frame, or Infinity = a silent never-learn) would poison the
+    // moments PERMANENTLY — reject it exactly like a bad x/z, state untouched.
+    if (!Number.isFinite(x) || !Number.isFinite(z) || !Number.isFinite(window)) return NaN;
     if (!seeded) {
       mx = x;
       mz = z;
@@ -201,6 +204,15 @@ export function compileFormula(source: string, opts: CompileOptions): CompiledFo
   ensureJsep();
   const helpers = opts.helpers ?? DEFAULT_HELPERS;
   const statefulHelpers = opts.statefulHelpers ?? STATEFUL_HELPERS;
+  // The stateful registry is consulted FIRST at call sites, so a shared name
+  // would silently shadow the plain helper — refuse the ambiguity outright.
+  // (Note: restricting `helpers` does NOT restrict `statefulHelpers` — pass
+  // `statefulHelpers: {}` explicitly to compile with no stateful set.)
+  for (const k of Object.keys(statefulHelpers)) {
+    if (Object.prototype.hasOwnProperty.call(helpers, k)) {
+      throw new FormulaError(`Helper "${k}" is defined in both the plain and stateful helper sets.`);
+    }
+  }
   const allHelperNames = () => [...Object.keys(helpers), ...Object.keys(statefulHelpers)].join(', ');
   const used = new Set<string>();
 

--- a/src/features/hand_catalog.ts
+++ b/src/features/hand_catalog.ts
@@ -29,7 +29,7 @@
  */
 import { LM } from '@/nodes/domain';
 import { angleAt, angleBetween, centroid, cross, dist2, dist3, normalize, sub, type Vec3 } from './math';
-import type { FeatureDef, HandCtx, TwoHandCtx } from './types';
+import type { FeatureDef, HandCtx, Invariance, TwoHandCtx } from './types';
 
 type HandFeature = FeatureDef<HandCtx>;
 type PairFeature = FeatureDef<TwoHandCtx>;
@@ -140,6 +140,39 @@ function spanRatio(c: HandCtx, a: number, b: number): number {
 }
 
 // ---- Side-relative feature templates ---------------------------------------
+
+/**
+ * The invariance profile of a feature computed from WORLD-landmark 3D geometry
+ * (joint angles, span-normalized distances): metric and carried with the hand,
+ * so camera distance, frame position, and hand orientation all cancel — ON THE
+ * WORLD PATH. When world landmarks are absent (the synthetic source and the
+ * recorded fixtures), these features fall back to image keypoints and become
+ * in-plane approximations: the pose invariances degrade. The label describes
+ * the live app (world landmarks on), per #131.
+ */
+const WORLD_GEOMETRY_INVARIANCE: readonly Invariance[] = ['scale', 'position', 'yaw', 'pitch', 'roll'];
+
+/**
+ * Group-level invariance defaults (#131), applied at assembly for the groups
+ * whose members share one honest profile; mixed groups (hand.whole, the pair
+ * features) label per feature instead. Absent from both = not yet assessed.
+ */
+const GROUP_INVARIANCE: Record<string, readonly Invariance[]> = {
+  // Raw image positions ARE their confounds: assessed, invariant to nothing.
+  'hand.position.raw': [],
+  // 3D joint/spread angles + span ratios (see WORLD_GEOMETRY_INVARIANCE).
+  'hand.finger.flexion': WORLD_GEOMETRY_INVARIANCE,
+  'hand.finger.spread': WORLD_GEOMETRY_INVARIANCE,
+  'hand.distances.pinch': WORLD_GEOMETRY_INVARIANCE,
+  // Orientation features MEASURE the pose axes (the confound regressors).
+  'hand.palm.orientation': ['scale', 'position'],
+};
+
+/** Fill a group-default invariance where the feature doesn't label itself. */
+function withGroupInvariance<T extends { group: string; invariantTo?: readonly Invariance[] }>(f: T): T {
+  if (f.invariantTo !== undefined || GROUP_INVARIANCE[f.group] === undefined) return f;
+  return { ...f, invariantTo: GROUP_INVARIANCE[f.group] };
+}
 
 function positionFeatures(): HandFeature[] {
   const out: HandFeature[] = [];
@@ -304,6 +337,7 @@ function wholeFeatures(): HandFeature[] {
       id: 'openness',
       group: 'hand.whole',
       source: 'hand',
+      invariantTo: WORLD_GEOMETRY_INVARIANCE, // span-normalized 3D reach
       controllability: 'easy',
       description: 'Mean fingertip reach from wrist / palm span',
       compute: (c) => {
@@ -321,6 +355,7 @@ function wholeFeatures(): HandFeature[] {
       // Five fingers, each curl 0..3pi -> 0..15pi theoretical (advisory; the
       // normalizer does the real per-user ranging).
       range: [0, 15 * Math.PI],
+      invariantTo: WORLD_GEOMETRY_INVARIANCE, // sum of 3D joint angles
       controllability: 'easy',
       description: 'Sum of all five finger curls (rad)',
       compute: (c) => FINGERS.reduce((s, f) => s + fingerCurl(c, f), 0),
@@ -329,6 +364,9 @@ function wholeFeatures(): HandFeature[] {
       id: 'size',
       group: 'hand.whole',
       source: 'hand',
+      // The camera-distance proxy itself: varies with scale BY DESIGN. In-plane
+      // roll preserves the 2D span; out-of-plane yaw/pitch foreshorten it.
+      invariantTo: ['position', 'roll'],
       controllability: 'easy',
       description: 'Wrist->middle-MCP image distance (px) — camera-distance proxy',
       compute: (c) => { const w = c.P(LM.wrist); const m = c.P(LM.middle_mcp); return w && m ? dist2(w, m) : NaN; },
@@ -339,6 +377,7 @@ function wholeFeatures(): HandFeature[] {
       source: 'hand',
       range: [-Math.PI, Math.PI],
       circular: true, // atan2: ±pi are the same pose — see FeatureDef.circular (#144)
+      invariantTo: ['scale', 'position'], // it MEASURES the in-plane roll axis
       controllability: 'easy',
       description: 'In-plane hand tilt (up-positive, rad, circular)',
       compute: (c) => {
@@ -354,6 +393,7 @@ function wholeFeatures(): HandFeature[] {
       group: 'hand.whole',
       source: 'hand',
       range: [-Math.PI / 2, Math.PI / 2],
+      invariantTo: ['scale', 'position'], // measures the pointing-pitch axis
       controllability: 'moderate',
       description: 'Pointing pitch as a wrist-flexion proxy (no forearm reference)',
       compute: (c) => { const u = pointingAxis(c); return u ? Math.asin(Math.max(-1, Math.min(1, -u.y))) : NaN; },
@@ -363,6 +403,7 @@ function wholeFeatures(): HandFeature[] {
       group: 'hand.whole',
       source: 'hand',
       range: [0, Math.PI],
+      invariantTo: WORLD_GEOMETRY_INVARIANCE, // mean of 3D spread angles
       controllability: 'moderate',
       description: 'Mean adjacent-finger spread (rad)',
       compute: (c) => {
@@ -448,6 +489,10 @@ function pairFeatures(): PairFeature[] {
     id,
     group: 'hand.twohand.relational',
     source: 'hand',
+    // Mean-hand-size-normalized image relations: distance and frame position
+    // cancel; per-hand foreshortening (pose) still contaminates — not claimed.
+    // midX/midY override this to [] below (they are raw positions).
+    invariantTo: ['scale', 'position'],
     controllability,
     description,
     compute,
@@ -463,8 +508,8 @@ function pairFeatures(): PairFeature[] {
       range: [-Math.PI, Math.PI] as const,
       circular: true,
     },
-    pf('pair.midX', 'easy', (tc) => { const b = both(tc); if (!b) return NaN; const w = tc.left?.width ?? tc.right?.width ?? 0; if (!(w > 0)) return NaN; const mx = (b.L.centroid.x + b.R.centroid.x) / 2 / w; return tc.mirrorX ? 1 - mx : mx; }, 'Midpoint horizontal position'),
-    pf('pair.midY', 'easy', (tc) => { const b = both(tc); if (!b) return NaN; const h = tc.left?.height ?? tc.right?.height ?? 0; return h > 0 ? (b.L.centroid.y + b.R.centroid.y) / 2 / h : NaN; }, 'Midpoint vertical position'),
+    { ...pf('pair.midX', 'easy', (tc) => { const b = both(tc); if (!b) return NaN; const w = tc.left?.width ?? tc.right?.width ?? 0; if (!(w > 0)) return NaN; const mx = (b.L.centroid.x + b.R.centroid.x) / 2 / w; return tc.mirrorX ? 1 - mx : mx; }, 'Midpoint horizontal position'), invariantTo: [] },
+    { ...pf('pair.midY', 'easy', (tc) => { const b = both(tc); if (!b) return NaN; const h = tc.left?.height ?? tc.right?.height ?? 0; return h > 0 ? (b.L.centroid.y + b.R.centroid.y) / 2 / h : NaN; }, 'Midpoint vertical position'), invariantTo: [] },
     pf('pair.sizeRatio', 'moderate', (tc) => { const b = both(tc); return b ? b.L.size / b.R.size : NaN; }, 'Left/right hand image-size ratio'),
   ];
 }
@@ -477,7 +522,7 @@ export const HAND_SIDE_FEATURES: readonly HandFeature[] = [
   ...orientationFeatures(),
   ...wholeFeatures(),
   ...distanceFeatures(),
-];
+].map(withGroupInvariance);
 
 /** Two-hand relational feature templates (keyed `hand.pair.*`). */
 export const HAND_PAIR_FEATURES: readonly PairFeature[] = pairFeatures();

--- a/src/features/labMeters.ts
+++ b/src/features/labMeters.ts
@@ -113,7 +113,13 @@ export function createLabMeterComputer(): LabMeterComputer {
       return undefined;
     }
     // Re-zero the stats when the lab is (re)opened or an explicit reset fires.
-    if (!prevShow || cfg.resetNonce !== resetNonce) normalizer.reset();
+    // That includes the derived formulas' per-call-site regression state (#131):
+    // clearing the compile cache forces a recompile, whose call sites start
+    // clean — "recalibrate" must reset EVERY online statistic, not all-but-one.
+    if (!prevShow || cfg.resetNonce !== resetNonce) {
+      normalizer.reset();
+      derivedSig = '';
+    }
     prevShow = true;
     resetNonce = cfg.resetNonce;
     normalizer.setMode(cfg.normalizer);

--- a/src/features/types.ts
+++ b/src/features/types.ts
@@ -30,6 +30,12 @@ export type Controllability = 'easy' | 'moderate' | 'involuntary';
 /** Which raw source a feature reads. */
 export type FeatureSource = 'face' | 'hand';
 
+/** The confound axes a feature can declare invariance to (#131): `scale` =
+ *  camera distance, `position` = translation in the frame, `yaw`/`pitch`/`roll`
+ *  = the subject's pose (head pose for face features, hand orientation for hand
+ *  features). See {@link FeatureDef.invariantTo} for the exact semantics. */
+export type Invariance = 'scale' | 'position' | 'yaw' | 'pitch' | 'roll';
+
 /**
  * One scalar feature. `compute` is pure: same context → same value. It returns
  * `NaN` to signal "not measurable this frame" (missing landmark, degenerate
@@ -45,6 +51,23 @@ export interface FeatureDef<Ctx> {
    *  ranging). Absent for open-ended geometric ratios. For a `circular` feature the
    *  range is NOT advisory — it is the exact period the normalizer maps against. */
   range?: readonly [number, number];
+  /**
+   * What this feature's value is HONESTLY invariant to (#131) — the declared
+   * confound profile. A feature measured off a landmark stream is rarely a pure
+   * measurement of the thing it names: camera distance rescales pixel distances,
+   * head/hand pose foreshortens 2D geometry, frame position moves everything.
+   * The vocabulary ({@link Invariance}): `scale` = camera distance, `position` =
+   * translation in the frame, `yaw`/`pitch`/`roll` = the subject's pose axes
+   * (head pose for face features, hand orientation for hand features).
+   *
+   * Semantics: ABSENT = not yet assessed (no claim either way); `[]` = assessed
+   * and invariant to NOTHING listed (e.g. a raw position — it IS its confound);
+   * a listed axis = "moving only along that axis should not move this feature
+   * (to the fidelity of the underlying model)". Use `residual(x, z)` /
+   * `deconfound(x, z1, z2, ...)` in a Lab formula to correct a feature for a
+   * confound it is NOT invariant to.
+   */
+  invariantTo?: readonly Invariance[];
   /** True for an ANGULAR feature whose value lives on a circle: the two `range`
    *  endpoints (e.g. -pi and +pi from `atan2`) are the SAME physical pose, so the
    *  single-frame jump between them is a representation artifact, not motion. The

--- a/test/feature_catalog.test.ts
+++ b/test/feature_catalog.test.ts
@@ -229,11 +229,31 @@ describe('flat feature registry', () => {
   });
 
   it('summarizes a group confound profile for the Lab tooltips (#131)', () => {
-    expect(groupInvarianceSummary('face.geom.mouth')).toMatch(/invariant to scale, position, roll/);
-    expect(groupInvarianceSummary('face.geom.mouth')).toMatch(/contaminated by yaw, pitch/);
+    // face.geom.mouth mixes distance features (roll-invariant) with y-projection
+    // corner pulls (not) — the shared profile is scale+position only.
+    expect(groupInvarianceSummary('face.geom.mouth')).toMatch(/invariant to scale, position/);
+    expect(groupInvarianceSummary('face.geom.mouth')).toMatch(/not invariant across the group to: yaw, pitch, roll/);
     expect(groupInvarianceSummary('hand.finger.flexion')).toMatch(/fully confound-invariant/);
     // A group with no assessed features makes NO claim.
     expect(groupInvarianceSummary('no.such.group')).toBeUndefined();
+  });
+
+  it('projection-numerator geom features do NOT claim roll; distance/z ones do (#131 review)', () => {
+    // Roll rotates an x/y-offset numerator out of its projection axis (measured
+    // ~0.12 IOD per 5 degrees on jaw.lateralShift with zero jaw motion).
+    for (const id of [
+      'face.geom.jaw.lateralShift',
+      'face.geom.jaw.drop',
+      'face.geom.mouth.cornerPullLeft',
+      'face.geom.brow.raiseAvg',
+      'face.geom.cheek.raiseLeft',
+    ]) {
+      expect(FEATURE_BY_ID[id].invariantTo, id).toEqual(['scale', 'position']);
+    }
+    // Euclidean distances and relative-z numerators rotate WITH the IOD.
+    for (const id of ['face.geom.mouth.width', 'face.geom.mouth.aspectRatio', 'face.geom.jaw.thrust', 'face.geom.brow.furrow']) {
+      expect(FEATURE_BY_ID[id].invariantTo, id).toEqual(['scale', 'position', 'roll']);
+    }
   });
 
   it('depthZ is gone — it read 0 forever (wrist IS the image-space depth origin, #144)', () => {

--- a/test/feature_catalog.test.ts
+++ b/test/feature_catalog.test.ts
@@ -14,6 +14,7 @@ import {
   FACE_FEATURES,
   FEATURE_BY_ID,
   FEATURE_GROUP_IDS,
+  groupInvarianceSummary,
   HAND_SIDE_FEATURES,
 } from '@/features/catalog';
 import { FL } from '@/features/landmarks';
@@ -204,6 +205,35 @@ describe('flat feature registry', () => {
     for (const f of ALL_FEATURES) {
       if (f.circular) expect(f.range, f.id).toBeTruthy();
     }
+  });
+
+  it('carries honest invariance labels on the assessed features (#131)', () => {
+    // The confound regressors themselves: pose measures, invariant to scale/position.
+    expect(FEATURE_BY_ID['face.head.yaw'].invariantTo).toEqual(['scale', 'position']);
+    expect(FEATURE_BY_ID['hand.left.palm.pitch'].invariantTo).toEqual(['scale', 'position']);
+    // IOD-normalized geometry: scale/position/roll cancel; yaw/pitch foreshorten
+    // (the issue's "smile drifts from turning the head" example must NOT claim them).
+    const smileish = ALL_FEATURES.find((f) => f.group === 'face.geom.mouth');
+    expect(smileish?.invariantTo).toEqual(['scale', 'position', 'roll']);
+    // Raw positions are assessed-and-invariant-to-nothing ([]), not unassessed.
+    expect(FEATURE_BY_ID['face.head.x'].invariantTo).toEqual([]);
+    expect(FEATURE_BY_ID['hand.left.wrist.x'].invariantTo).toEqual([]);
+    expect(FEATURE_BY_ID['hand.pair.midX'].invariantTo).toEqual([]);
+    // World-geometry hand features carry the full profile (the live world path).
+    expect(FEATURE_BY_ID['hand.right.index.curl'].invariantTo).toEqual(['scale', 'position', 'yaw', 'pitch', 'roll']);
+    // Every declared label uses only the vocabulary (no typo axes).
+    const axes = new Set(['scale', 'position', 'yaw', 'pitch', 'roll']);
+    for (const f of ALL_FEATURES) {
+      for (const a of f.invariantTo ?? []) expect(axes.has(a), `${f.id}: ${a}`).toBe(true);
+    }
+  });
+
+  it('summarizes a group confound profile for the Lab tooltips (#131)', () => {
+    expect(groupInvarianceSummary('face.geom.mouth')).toMatch(/invariant to scale, position, roll/);
+    expect(groupInvarianceSummary('face.geom.mouth')).toMatch(/contaminated by yaw, pitch/);
+    expect(groupInvarianceSummary('hand.finger.flexion')).toMatch(/fully confound-invariant/);
+    // A group with no assessed features makes NO claim.
+    expect(groupInvarianceSummary('no.such.group')).toBeUndefined();
   });
 
   it('depthZ is gone — it read 0 forever (wrist IS the image-space depth origin, #144)', () => {

--- a/test/feature_formula.test.ts
+++ b/test/feature_formula.test.ts
@@ -176,6 +176,32 @@ describe('stateful helpers — residual / deconfound (#131)', () => {
     expect(a.eval(scope)).toBe(b.eval(scope)); // ...and it changed nothing
   });
 
+  it('a non-finite WINDOW argument is rejected like a bad frame — never poisons the state', () => {
+    // The window is an input too: 1/Math.max(2, NaN) is NaN, and a NaN alpha
+    // would corrupt the moments PERMANENTLY (every later delta = finite - NaN).
+    const a = compileFormula('residual(x, z, w)', { variables: new Set(['x', 'z', 'w']) });
+    const b = compileFormula('residual(x, z, w)', { variables: new Set(['x', 'z', 'w']) });
+    for (let i = 0; i < 50; i++) {
+      const scope = { x: 2 * Math.sin(i / 5), z: Math.sin(i / 5), w: 20 };
+      a.eval(scope);
+      b.eval(scope);
+    }
+    // Only A sees frames with the window variable absent (NaN) / Infinity.
+    expect(Number.isNaN(a.eval({ x: 1, z: 0.5 } as never))).toBe(true); // w absent -> NaN
+    expect(Number.isNaN(a.eval({ x: 1, z: 0.5, w: Infinity }))).toBe(true);
+    const scope = { x: 2 * Math.sin(50 / 5), z: Math.sin(50 / 5), w: 20 };
+    expect(a.eval(scope)).toBe(b.eval(scope)); // state untouched by the bad frames
+  });
+
+  it('a name shared by the plain and stateful helper sets is refused at compile time', () => {
+    expect(() =>
+      compileFormula('residual(x, z)', {
+        variables: new Set(['x', 'z']),
+        helpers: { residual: (x: number) => x },
+      }),
+    ).toThrow(/both the plain and stateful/);
+  });
+
   it('arity errors surface at COMPILE time with clear messages', () => {
     expect(() => compileFormula('residual(x)', { variables: VARS })).toThrow(/residual\(x, z\[, window\]\)/);
     expect(() => compileFormula('deconfound(x)', { variables: VARS })).toThrow(/deconfound/);

--- a/test/feature_formula.test.ts
+++ b/test/feature_formula.test.ts
@@ -101,3 +101,92 @@ describe('formula compiler — runtime contract (never throws in the loop)', () 
     }
   });
 });
+
+describe('stateful helpers — residual / deconfound (#131)', () => {
+  const VARS = new Set(['x', 'z', 'z2']);
+
+  it('residual regresses out a perfectly linear confound (over the EW window)', () => {
+    // x = 2*z, noiseless, with the confound varying much FASTER than the EW
+    // window (period ~19 frames vs window 120), so the regression sees many
+    // cycles and beta converges. Assert the reduction RATIO over the last
+    // stretch: most of the linear component must be gone.
+    const f = compileFormula('residual(x, z, 120)', { variables: VARS });
+    let rssRes = 0;
+    let rssRaw = 0;
+    for (let i = 0; i < 900; i++) {
+      const z = Math.sin(i / 3);
+      const out = f.eval({ x: 2 * z, z });
+      if (i >= 840) {
+        rssRes += out * out;
+        rssRaw += (2 * z) * (2 * z);
+      }
+    }
+    expect(Math.sqrt(rssRes / rssRaw)).toBeLessThan(0.25); // >75% of the swing removed
+  });
+
+  it('residual leaves an INDEPENDENT signal essentially alone', () => {
+    const f = compileFormula('residual(x, z, 30)', { variables: VARS });
+    let out = 0;
+    for (let i = 0; i < 600; i++) {
+      out = f.eval({ x: Math.sin(i / 7), z: Math.cos(i / 13) }); // uncorrelated-ish
+    }
+    // The independent signal keeps most of its swing (beta stays small).
+    expect(Math.abs(out - Math.sin(599 / 7))).toBeLessThan(0.4);
+  });
+
+  it('two residual call sites in ONE formula keep separate state', () => {
+    const f = compileFormula('residual(x, z, 10) - residual(x, z2, 10)', { variables: VARS });
+    // If the two call sites shared state, feeding them different confounds would
+    // corrupt each other; a same-inputs eval must be exactly 0 either way, and a
+    // different-confounds sequence must produce a finite, non-NaN difference.
+    let out = NaN;
+    for (let i = 0; i < 100; i++) {
+      out = f.eval({ x: Math.sin(i / 5), z: Math.sin(i / 5), z2: Math.cos(i / 5) });
+    }
+    expect(Number.isFinite(out)).toBe(true);
+    // x == z exactly, so the first residual is ~0; the second keeps most of x.
+    expect(Math.abs(out)).toBeGreaterThan(0.05);
+  });
+
+  it('deconfound(x, z1, z2) ~ residual(residual(x, z1), z2)', () => {
+    const a = compileFormula('deconfound(x, z, z2)', { variables: VARS });
+    const b = compileFormula('residual(residual(x, z), z2)', { variables: VARS });
+    let va = 0;
+    let vb = 0;
+    for (let i = 0; i < 300; i++) {
+      const scope = { x: Math.sin(i / 9) + 0.5 * Math.cos(i / 4), z: Math.cos(i / 4), z2: Math.sin(i / 6) };
+      va = a.eval(scope);
+      vb = b.eval(scope);
+    }
+    expect(va).toBeCloseTo(vb, 10);
+  });
+
+  it('non-finite inputs return NaN without poisoning the regression state', () => {
+    // Twin instances fed identical good frames; one also receives a NaN frame.
+    // If the NaN mutated any state, the next outputs would diverge.
+    const a = compileFormula('residual(x, z, 20)', { variables: VARS });
+    const b = compileFormula('residual(x, z, 20)', { variables: VARS });
+    for (let i = 0; i < 100; i++) {
+      const scope = { x: 2 * Math.sin(i / 10), z: Math.sin(i / 10) };
+      a.eval(scope);
+      b.eval(scope);
+    }
+    expect(Number.isNaN(a.eval({ x: NaN, z: 1 }))).toBe(true); // only A sees the bad frame
+    const scope = { x: 2 * Math.sin(100 / 10), z: Math.sin(100 / 10) };
+    expect(a.eval(scope)).toBe(b.eval(scope)); // ...and it changed nothing
+  });
+
+  it('arity errors surface at COMPILE time with clear messages', () => {
+    expect(() => compileFormula('residual(x)', { variables: VARS })).toThrow(/residual\(x, z\[, window\]\)/);
+    expect(() => compileFormula('deconfound(x)', { variables: VARS })).toThrow(/deconfound/);
+  });
+
+  it('a fresh compile starts from clean state (config edits reset the regressions)', () => {
+    const warm = compileFormula('residual(x, z, 10)', { variables: VARS });
+    for (let i = 0; i < 200; i++) warm.eval({ x: 2 * Math.sin(i / 10), z: Math.sin(i / 10) });
+    const fresh = compileFormula('residual(x, z, 10)', { variables: VARS });
+    // First eval of a fresh instance returns plain x (beta 0), regardless of
+    // what any other instance has learned.
+    expect(fresh.eval({ x: 1.5, z: 0.75 })).toBe(1.5);
+  });
+});


### PR DESCRIPTION
Closes #131 (items 1+2; item 3 — the correlation view — split to its own issue with design notes).

## What shipped

1. **`invariantTo` labels on `FeatureDef`** — vocabulary `scale | position | yaw | pitch | roll`; absent = unassessed, `[]` = assessed-invariant-to-nothing. Labeled with per-site reasoning: blendshapes/gaze/AU claim scale+position (pose robustness is model-internal, NOT claimed); IOD-normalized **distance** geometry adds roll; the 10 **projection**-numerator geom features (corner pulls, brow/cheek raises, jaw shift/drop) deliberately do NOT claim roll — an adversarial reviewer measured ~0.12 IOD of leakage per 5° of head roll with zero jaw motion, exactly the over-claim this issue exists to prevent; pose measures claim scale+position (they are the confound regressors); world-landmark hand geometry claims the full profile with the image-fallback caveat documented. Surfaced as Lab group-picker tooltips via `groupInvarianceSummary()`.
2. **Stateful formula helpers**: `residual(x, z[, window])` and `deconfound(x, z1[, z2, ...])` — per-call-site EW linear regressions (default window 180 frames ≈ 6 s at 30fps, matching the normalizer's drift tau). A user writes `residual(face_geom_mouth_smileWidth, face_head_yaw)` and gets a pose-corrected smile with no new node.

## Hardening (from a focused adversarial review, all fixed + tested)

- Non-finite **window** argument (absent variable / Infinity) would have NaN-poisoned the regression moments permanently → rejected like a bad frame, state untouched (twin-instance test).
- Lab **recalibrate** now clears the formula compile cache too, so regression state re-zeroes with every other online statistic.
- A helper name in both the plain and stateful sets is refused at compile time (silent shadowing).
- Prototype-key attacks on the new call path verified rejected; the never-throws eval contract holds on all paths.

## Verified

`npm run typecheck` clean · **888 tests, 86 files, all passing** (12 new) · `npm run build` clean · catalog idempotent.

https://claude.ai/code/session_01GUjT9e7sAyckG1SR9czApr