### PR TITLE
#129: gestures as the fourth command dispatcher — edge-triggered, held, cooled, user-bindable

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -26,6 +26,7 @@ import CommandPaletteOverlay from './CommandPaletteOverlay';
 import AssistantOverlay from '@/plugins/assistant/AssistantOverlay';
 import ToolsBar from './ToolsBar';
 import LabPanel from './LabPanel';
+import GesturesPanel from './GesturesPanel';
 import VersionBadge from './VersionBadge';
 
 /** A compact face-status chip, visible even when the controls panel is collapsed
@@ -125,6 +126,9 @@ export default function App({ source = DEFAULT_SOURCE }: { source?: SourceSpec }
 
       {/* The Feature Lab's surface (#119/#136) — renders when its tool is the open one. */}
       <LabPanel />
+
+      {/* The gesture-binding editor (#129) — renders when its tool is the open one. */}
+      <GesturesPanel />
 
       {/* Bottom-right: the multi-stream recorder (#88) — a button that morphs into
           a settings sheet (out-of-instrument config) then a compact HUD. Available

--- a/src/app/GesturesPanel.tsx
+++ b/src/app/GesturesPanel.tsx
@@ -1,0 +1,249 @@
+/**
+ * GesturesPanel — the shell surface for gesture dispatch (#129), opened from the
+ * tools bar (the Feature Lab precedent: a TOOL, not a settings-panel section,
+ * because a gesture binding is not an instrument parameter — it is a per-device
+ * preference, like a keymap, and must never ride an instrument preset).
+ *
+ * One row per bindable gesture (fist / open palm / pinch): a live "held now"
+ * indicator (from the transition-gated gestureStatus store), a command picker over
+ * the registry's gesture-bindable commands, and a fixed-args JSON field (a binding
+ * carries fixed params, exactly like the keyboard keymap). Plus the master enable
+ * toggle and the hold / cooldown sliders.
+ *
+ * Confirmation-gated commands (instrument load/save/create) are ABSENT from the
+ * picker by design — a hands-free flow cannot answer a confirmation dialog — and
+ * the panel says so. A stale persisted binding naming a command the registry no
+ * longer has is surfaced as a visible warning on its row (and refused with an
+ * error toast if it ever fires).
+ *
+ * All writes here go to the `gestures` tooling pref on the hot store (direct
+ * `setGestures`, like the Feature Lab's `setFeatureLab`) — this panel configures
+ * the DISPATCHER; it never writes a dial itself.
+ */
+import { useMemo, useState } from 'react';
+import { Hand, X } from 'lucide-react';
+import { registry } from './commands/registry';
+import { isGestureBindable } from './gestureDispatch';
+import {
+  GESTURE_IDS,
+  GESTURE_LABELS,
+  MAX_GESTURE_COOLDOWN_MS,
+  MAX_GESTURE_HOLD_MS,
+  type GestureBinding,
+  type GestureId,
+} from './gesturePrefs';
+import { useGestureStatus } from './gestureStatus';
+import { useControls } from './store';
+import { useTools } from './toolsStore';
+import { toolById } from './tools';
+
+const TOOL_ID = 'gestures';
+
+/** The sentinel <option> value for "no binding" (never a real command id). */
+const UNBOUND = '';
+
+/** The pickable commands: everything registered except the confirmation-gated
+ *  (destructive) ones, which a hands-free gesture could never approve. */
+function bindableCommands() {
+  return registry
+    .list()
+    .filter((c) => isGestureBindable(c.id))
+    .sort((a, b) => a.title.localeCompare(b.title));
+}
+
+/** One gesture row: live indicator + command picker + fixed-args JSON field. */
+function GestureRow({ gesture }: { gesture: GestureId }) {
+  const binding = useControls((s) => s.gestures.bindings[gesture]);
+  const heldNow = useGestureStatus((s) => s.poses.left === gesture || s.poses.right === gesture);
+  const commands = useMemo(bindableCommands, []);
+  const known = !binding || registry.has(binding.command);
+  // The args draft is local until it parses — a half-typed JSON must not clobber
+  // the stored binding (or crash), and an invalid draft is shown, not saved.
+  const [argsDraft, setArgsDraft] = useState<string | null>(null);
+  const argsValue = argsDraft ?? (binding?.args ? JSON.stringify(binding.args) : '');
+  const argsInvalid = argsDraft !== null;
+
+  const setBinding = (next: GestureBinding | undefined) => {
+    const { gestures, setGestures } = useControls.getState();
+    const bindings = { ...gestures.bindings };
+    if (next) bindings[gesture] = next;
+    else delete bindings[gesture];
+    setGestures({ bindings });
+  };
+
+  const onPick = (id: string) => {
+    setArgsDraft(null);
+    // Switching commands drops the old args (they belonged to the old command);
+    // re-picking the same command keeps them.
+    if (id === UNBOUND) setBinding(undefined);
+    else setBinding({ command: id, args: binding?.command === id ? binding.args : undefined });
+  };
+
+  const onArgs = (text: string) => {
+    if (!binding) return;
+    const trimmed = text.trim();
+    if (trimmed === '') {
+      setArgsDraft(null);
+      setBinding({ command: binding.command, args: undefined });
+      return;
+    }
+    try {
+      const parsed: unknown = JSON.parse(trimmed);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        setArgsDraft(null);
+        setBinding({ command: binding.command, args: parsed as Record<string, unknown> });
+        return;
+      }
+    } catch {
+      /* not (yet) valid JSON — keep it as a draft */
+    }
+    setArgsDraft(text);
+  };
+
+  return (
+    <div className="space-y-1 rounded-lg border border-white/10 bg-white/5 p-2">
+      <div className="flex items-center gap-2">
+        <span
+          aria-hidden
+          className={`h-2 w-2 shrink-0 rounded-full ${heldNow ? 'bg-emerald-400' : 'bg-white/15'}`}
+          title={heldNow ? 'Held right now' : 'Not currently held'}
+        />
+        <span className="flex-1 text-[11px] font-bold uppercase tracking-widest text-white/70">
+          {GESTURE_LABELS[gesture]}
+        </span>
+      </div>
+      <select
+        aria-label={`Command for ${GESTURE_LABELS[gesture]}`}
+        value={binding?.command ?? UNBOUND}
+        onChange={(e) => onPick(e.target.value)}
+        className="w-full rounded border border-white/10 bg-black/40 px-2 py-1 text-[11px] text-white/80"
+      >
+        <option value={UNBOUND}>(unbound)</option>
+        {/* A stale binding whose command vanished from the registry stays VISIBLE
+            (selected) so the player can see and fix it, rather than the select
+            silently snapping to unbound while the store still holds the binding. */}
+        {!known && binding && <option value={binding.command}>{binding.command} (unknown)</option>}
+        {commands.map((c) => (
+          <option key={c.id} value={c.id}>
+            {c.title} — {c.id}
+          </option>
+        ))}
+      </select>
+      {binding && (
+        <input
+          type="text"
+          aria-label={`Arguments for ${GESTURE_LABELS[gesture]}`}
+          value={argsValue}
+          onChange={(e) => onArgs(e.target.value)}
+          placeholder='Fixed args as JSON, e.g. {"value": 0}'
+          spellCheck={false}
+          className={`w-full rounded border bg-black/40 px-2 py-1 font-mono text-[10px] text-white/70 ${
+            argsInvalid ? 'border-rose-400/60' : 'border-white/10'
+          }`}
+        />
+      )}
+      {argsInvalid && <p className="text-[10px] text-rose-300/80">Not valid JSON — the last valid args are kept.</p>}
+      {!known && binding && (
+        <p className="text-[10px] text-rose-300/80">
+          Unknown command &ldquo;{binding.command}&rdquo; — it no longer exists; pick another.
+        </p>
+      )}
+    </div>
+  );
+}
+
+/** A labelled millisecond slider for the hold / cooldown timing prefs. */
+function MsSlider({
+  label,
+  value,
+  max,
+  step,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  max: number;
+  step: number;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <label className="block text-[10px] uppercase tracking-widest text-white/50">
+      <span className="flex justify-between">
+        <span>{label}</span>
+        <span className="text-white/70">{value} ms</span>
+      </span>
+      <input
+        type="range"
+        min={0}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="w-full"
+      />
+    </label>
+  );
+}
+
+export default function GesturesPanel() {
+  const open = useTools((s) => s.open) === TOOL_ID;
+  const close = useTools((s) => s.close);
+  const gestures = useControls((s) => s.gestures);
+  const setGestures = useControls((s) => s.setGestures);
+  if (!open) return null;
+
+  const tool = toolById(TOOL_ID);
+
+  return (
+    <div className="absolute bottom-14 left-3 z-40 flex max-h-[calc(100dvh-5rem)] w-96 max-w-[calc(100vw-1.5rem)] flex-col overflow-hidden rounded-2xl border border-white/10 bg-black/70 backdrop-blur">
+      <div className="flex items-center gap-2 border-b border-white/10 px-3 py-2">
+        <Hand className="h-3.5 w-3.5 shrink-0 text-emerald-300" aria-hidden />
+        <span className="flex-1 text-[11px] font-bold uppercase tracking-widest text-white/70">Gestures</span>
+        <button
+          onClick={close}
+          aria-label="Close the Gestures panel"
+          className="rounded p-1 text-white/60 transition hover:bg-white/10 hover:text-white"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+      <div className="space-y-3 overflow-auto p-4">
+        {tool && <p className="text-[10px] uppercase tracking-widest text-emerald-500/70">{tool.description}</p>}
+        <p className="text-[11px] leading-relaxed text-white/60">
+          Hold a pose for the hold time to fire its command once; it will not fire again until you
+          release, re-enter the pose, and the cooldown has passed. Either hand can trigger a binding.
+        </p>
+        <label className="flex items-center gap-2 text-[11px] text-white/80">
+          <input
+            type="checkbox"
+            aria-label="Enable gesture commands"
+            checked={gestures.enabled}
+            onChange={(e) => setGestures({ enabled: e.target.checked })}
+          />
+          Enable gesture commands
+        </label>
+        <MsSlider
+          label="Minimum hold"
+          value={gestures.holdMs}
+          max={MAX_GESTURE_HOLD_MS}
+          step={50}
+          onChange={(v) => setGestures({ holdMs: v })}
+        />
+        <MsSlider
+          label="Cooldown after firing"
+          value={gestures.cooldownMs}
+          max={MAX_GESTURE_COOLDOWN_MS}
+          step={100}
+          onChange={(v) => setGestures({ cooldownMs: v })}
+        />
+        {GESTURE_IDS.map((g) => (
+          <GestureRow key={g} gesture={g} />
+        ))}
+        <p className="text-[10px] leading-relaxed text-white/40">
+          Instrument load/save/create are not offered: they need a confirmation you cannot give
+          hands-free. Commands run with the fixed args shown; an empty args field dispatches none.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/ToolsBar.tsx
+++ b/src/app/ToolsBar.tsx
@@ -11,7 +11,7 @@
  * Purely presentational: it reads {@link useTools} for which tool is open and toggles it.
  * Each tool's actual surface mounts itself in App and renders when it is the open one.
  */
-import { FlaskConical, Command, BookOpen, type LucideIcon } from 'lucide-react';
+import { FlaskConical, Command, BookOpen, Hand, type LucideIcon } from 'lucide-react';
 import { TOOLS, type Tool } from './tools';
 import { useTools } from './toolsStore';
 import VersionBadge from './VersionBadge';
@@ -22,6 +22,7 @@ import VersionBadge from './VersionBadge';
 const ICONS: Record<string, LucideIcon> = {
   lab: FlaskConical,
   commands: Command,
+  gestures: Hand,
   manual: BookOpen,
 };
 

--- a/src/app/gestureDispatch.ts
+++ b/src/app/gestureDispatch.ts
@@ -149,11 +149,24 @@ export function createGestureDispatcher(overrides: Partial<GestureDispatcherDeps
           t.enteredAt = nowMs;
           t.consumed = !prefs.enabled;
         }
-        if (!prefs.enabled || t.consumed || !isGestureId(pose)) continue;
-        const binding = prefs.bindings[pose];
-        if (!binding) continue; // unbound: never dispatch, never consume, never cool down
+        if (!prefs.enabled) {
+          // Disabling spends every armed entry, symmetrically with born-consumed
+          // above: a pose held across a disable→enable cycle must NOT fire on
+          // re-enable — "enabling arms FUTURE transitions" has no exceptions.
+          t.consumed = true;
+          continue;
+        }
+        if (t.consumed || !isGestureId(pose)) continue;
         if (nowMs - t.enteredAt < prefs.holdMs) continue; // hold not yet met
-        t.consumed = true; // this entry is now spent, fire or not
+        // The hold has elapsed: this entry is now SPENT, bound or not, fired or
+        // not. Consuming before the binding lookup is what makes a binding
+        // created MID-hold inert until the next fresh transition (else "bind
+        // while posing" fires the instant the dropdown closes — fire on state,
+        // not edge). An unbound spend never touches lastFire, so it still
+        // burns no cooldown.
+        t.consumed = true;
+        const binding = prefs.bindings[pose];
+        if (!binding) continue;
         const last = lastFire.get(pose);
         if (last !== undefined && nowMs - last < prefs.cooldownMs) continue; // consumed silently
         lastFire.set(pose, nowMs);

--- a/src/app/gestureDispatch.ts
+++ b/src/app/gestureDispatch.ts
@@ -1,0 +1,164 @@
+/**
+ * Gesture dispatch (#129) — the FOURTH command dispatcher, alongside the keyboard,
+ * the palette and the AI assistant. An app-level subscriber (like
+ * `keyboardShortcuts.ts`, not a DAG node) that reads the gesture-classifier's
+ * per-hand pose stream each frame and turns held-pose TRANSITIONS into
+ * `registry.dispatch(commandId, args)` calls, per the user's binding map
+ * (`gesturePrefs.ts`, a per-device tooling pref).
+ *
+ * ## Firing semantics (pinned by `test/gesture_dispatch.test.ts`)
+ *
+ * A fire requires ALL of:
+ *
+ * 1. **Edge, never state** — a fresh TRANSITION into the gesture. A held pose fires
+ *    at most once per entry, no matter how long it is held (even far past the
+ *    cooldown). Re-firing requires releasing and re-entering.
+ * 2. **Minimum hold** — the pose must persist `holdMs` continuously from its entry
+ *    before the entry may fire (classifier flicker shorter than the hold never
+ *    fires at all).
+ * 3. **Per-gesture cooldown, consumed not deferred** — after a fire, the gesture is
+ *    refractory for `cooldownMs` (shared across hands, so two hands cannot
+ *    double-fire one binding). An entry whose hold completes while the cooldown is
+ *    still running is CONSUMED silently: it will not fire later even if held past
+ *    the cooldown's expiry. Deferral would turn threshold chatter into a delayed
+ *    surprise dispatch; suppression keeps "one deliberate gesture = at most one
+ *    fire". A re-entry whose hold completes AFTER the cooldown expired fires
+ *    normally. The cooldown starts at the fire ATTEMPT (including a refused
+ *    unknown/gated command), so a broken binding cannot machine-gun error toasts.
+ *
+ * Further rules:
+ * - **No binding, no dispatch** — a gesture with no binding-map entry never
+ *   dispatches (and never burns the cooldown). Same when `enabled` is off; an entry
+ *   begun while disabled stays inert even if gestures are enabled mid-hold
+ *   (enabling arms FUTURE transitions).
+ * - **Unknown command ids are surfaced, not dispatched** — a stale persisted
+ *   binding naming a command the registry doesn't have gets an error toast.
+ * - **Confirmation-gated (destructive) commands never fire from a gesture** — a
+ *   hands-free flow cannot answer a confirmation dialog, so `instrument.*` (per
+ *   {@link isGestureBindable}) is refused here AND filtered from the panel picker.
+ * - **Feedback** — a successful fire toasts "<gesture> → <command title>"; a failed
+ *   or refused dispatch toasts the error (the palette-toast precedent).
+ *
+ * Time is an INPUT (`tick(poses, nowMs)`), driven by the rAF loop in `useEngine`,
+ * so the semantics are tick-testable without fake timers. All dependencies are
+ * injectable for tests; the defaults bind the app singletons (registry, hot-store
+ * prefs, toasts) — the same import surface `keyboardShortcuts.ts` /
+ * `dispatchDial.ts` use, and none of what the command firewall forbids commands.
+ */
+import { isErr, type Result } from 'acture';
+import type { Pose } from '@/nodes';
+import { registry } from './commands/registry';
+import { defaultGetRisk } from './commands/confirmation';
+import { useControls } from './store';
+import { useToasts } from './toasts';
+import { GESTURE_LABELS, isGestureId, type GestureBinding, type GestureId, type GesturePrefs } from './gesturePrefs';
+import type { HandPoses } from './gestureStatus';
+
+/** Toast lifetimes: fires are frequent and small, errors need reading time. */
+const FIRE_TOAST_MS = 2500;
+const ERROR_TOAST_MS = 5000;
+
+/**
+ * True if a command may be bound to a gesture: everything except commands the
+ * confirmation gate classifies destructive (or explicitly confirmation-requiring).
+ * Shared by the dispatcher's refusal guard and the panel's picker filter (SSOT).
+ */
+export function isGestureBindable(id: string): boolean {
+  const risk = defaultGetRisk(id);
+  return !(risk.requiresConfirmation ?? risk.sideEffect === 'destructive');
+}
+
+/** The injectable seams (tests swap all of them; the app uses the defaults). */
+export interface GestureDispatcherDeps {
+  getPrefs(): GesturePrefs;
+  hasCommand(id: string): boolean;
+  commandTitle(id: string): string;
+  isBindable(id: string): boolean;
+  dispatch(command: string, args?: unknown): Promise<Result<unknown>>;
+  notify(message: string, level?: 'info' | 'error'): void;
+}
+
+function defaultDeps(): GestureDispatcherDeps {
+  return {
+    getPrefs: () => useControls.getState().gestures,
+    hasCommand: (id) => registry.has(id),
+    commandTitle: (id) => registry.get(id)?.title ?? id,
+    isBindable: isGestureBindable,
+    dispatch: (command, args) => registry.dispatch(command, args),
+    notify: (message, level = 'info') =>
+      useToasts.getState().push(message, level === 'error' ? ERROR_TOAST_MS : FIRE_TOAST_MS, level),
+  };
+}
+
+export interface GestureDispatcher {
+  /** Feed one frame's per-hand poses; `nowMs` is the frame timestamp. */
+  tick(poses: HandPoses, nowMs: number): void;
+}
+
+const HANDS = ['left', 'right'] as const;
+
+/** Per-hand entry tracking: which pose is held, since when, and whether this
+ *  entry has already been evaluated to completion (fired or consumed). */
+interface EntryTrack {
+  pose: Pose;
+  enteredAt: number;
+  consumed: boolean;
+}
+
+/** Build a gesture dispatcher (fresh timing state; one per engine run). */
+export function createGestureDispatcher(overrides: Partial<GestureDispatcherDeps> = {}): GestureDispatcher {
+  const deps: GestureDispatcherDeps = { ...defaultDeps(), ...overrides };
+  const tracks: Record<(typeof HANDS)[number], EntryTrack> = {
+    left: { pose: 'absent', enteredAt: 0, consumed: true },
+    right: { pose: 'absent', enteredAt: 0, consumed: true },
+  };
+  /** Last fire ATTEMPT per gesture — shared across hands (the cooldown clock). */
+  const lastFire = new Map<GestureId, number>();
+
+  function fire(gesture: GestureId, binding: GestureBinding): void {
+    const label = GESTURE_LABELS[gesture];
+    if (!deps.hasCommand(binding.command)) {
+      deps.notify(`${label}: unknown command "${binding.command}" — rebind it in the Gestures panel`, 'error');
+      return;
+    }
+    if (!deps.isBindable(binding.command)) {
+      deps.notify(`${label}: "${binding.command}" needs confirmation and cannot be fired by a gesture`, 'error');
+      return;
+    }
+    const title = deps.commandTitle(binding.command);
+    void deps.dispatch(binding.command, binding.args).then(
+      (result) => {
+        if (isErr(result)) deps.notify(`${label}: ${result.error.message}`, 'error');
+        else deps.notify(`${label} → ${title}`);
+      },
+      (e: unknown) => deps.notify(`${label}: ${e instanceof Error ? e.message : String(e)}`, 'error'),
+    );
+  }
+
+  return {
+    tick(poses, nowMs) {
+      const prefs = deps.getPrefs();
+      for (const hand of HANDS) {
+        const pose = poses[hand];
+        const t = tracks[hand];
+        if (pose !== t.pose) {
+          // The EDGE: a fresh entry arms exactly one future evaluation — unless
+          // dispatch is disabled right now, in which case the entry is born
+          // consumed (enabling mid-hold must not fire a pre-enable gesture).
+          t.pose = pose;
+          t.enteredAt = nowMs;
+          t.consumed = !prefs.enabled;
+        }
+        if (!prefs.enabled || t.consumed || !isGestureId(pose)) continue;
+        const binding = prefs.bindings[pose];
+        if (!binding) continue; // unbound: never dispatch, never consume, never cool down
+        if (nowMs - t.enteredAt < prefs.holdMs) continue; // hold not yet met
+        t.consumed = true; // this entry is now spent, fire or not
+        const last = lastFire.get(pose);
+        if (last !== undefined && nowMs - last < prefs.cooldownMs) continue; // consumed silently
+        lastFire.set(pose, nowMs);
+        fire(pose, binding);
+      }
+    },
+  };
+}

--- a/src/app/gesturePrefs.ts
+++ b/src/app/gesturePrefs.ts
@@ -1,0 +1,100 @@
+/**
+ * Gesture-dispatch preferences (#129) — the user-visible gesture → command binding
+ * map plus the dispatch timing knobs, as a Zod-validated PER-DEVICE tooling pref.
+ *
+ * Like `featureLab` / `faceCalibration`, this is persisted on the hot store via
+ * `partialize` but is NOT a preset field and NOT a dial: gestures bind to commands
+ * the way the keyboard does, and keybindings are not instrument state (loading an
+ * instrument must never rebind your hands). The schema is the SSOT the store's
+ * `mergeControls` heals a returning blob through, and the adapter
+ * (`gestureDispatch.ts`) + the Gestures panel both read.
+ *
+ * A binding names a command ID from the app registry plus the fixed args to
+ * dispatch it with (the same "binding carries fixed params" shape as the keyboard
+ * keymap). Whether the id actually exists is validated where it matters: the panel
+ * only offers registered, gesture-bindable commands and surfaces an unknown id on a
+ * stale binding; the dispatcher refuses an unknown id with an error toast instead
+ * of dispatching.
+ */
+import { z } from 'zod';
+
+/** The bindable gesture ids — exactly the meaningful poses the classifier emits
+ *  (`fist` / `open` / `pinch`; `neutral` and `absent` are non-poses and can never
+ *  fire). One id per pose, hand-agnostic: either hand can trigger a binding, the
+ *  hold is tracked per hand, and the cooldown is shared per gesture. */
+export const GESTURE_IDS = ['fist', 'open', 'pinch'] as const;
+export type GestureId = (typeof GESTURE_IDS)[number];
+
+/** True if `v` names a bindable gesture (narrows a classifier `Pose` string). */
+export const isGestureId = (v: string): v is GestureId =>
+  (GESTURE_IDS as readonly string[]).includes(v);
+
+/** Human labels, shared by the panel rows and the fire toasts. */
+export const GESTURE_LABELS: Record<GestureId, string> = {
+  fist: 'Fist',
+  open: 'Open palm',
+  pinch: 'Pinch',
+};
+
+/** How long a pose must persist before its entry can fire (anti-flicker). */
+export const DEFAULT_GESTURE_HOLD_MS = 400;
+/** Per-gesture refractory window after a fire (anti-repeat). */
+export const DEFAULT_GESTURE_COOLDOWN_MS = 1500;
+/** Slider bounds for the panel (the schema clamps to the same range). */
+export const MAX_GESTURE_HOLD_MS = 2000;
+export const MAX_GESTURE_COOLDOWN_MS = 10000;
+
+/** One gesture binding: a registry command id + the fixed args it dispatches with. */
+export const GestureBindingSchema = z.object({
+  command: z.string().min(1),
+  /** Fixed dispatch args (e.g. `{ value: 0 }` for a per-dial set command). Persisted
+   *  client data — the command's own param schema is what validates it at dispatch. */
+  args: z.record(z.string(), z.unknown()).optional(),
+});
+export type GestureBinding = z.infer<typeof GestureBindingSchema>;
+
+/** The whole gestures tooling pref. Every field carries a default so an older
+ *  (pre-#129) or partial blob heals cleanly in `mergeControls`. */
+export const GesturePrefsSchema = z.object({
+  /** Off by default: a camera gesture silently firing commands is the wrong surprise
+   *  for a first-time player. The Gestures shell tool is the (2-clicks-from-cold-load)
+   *  entry point that turns it on. */
+  enabled: z.boolean().default(false),
+  holdMs: z.number().min(0).max(MAX_GESTURE_HOLD_MS).default(DEFAULT_GESTURE_HOLD_MS),
+  cooldownMs: z.number().min(0).max(MAX_GESTURE_COOLDOWN_MS).default(DEFAULT_GESTURE_COOLDOWN_MS),
+  /** gesture id → binding. A missing key means UNBOUND (the dispatcher never fires
+   *  an unbound gesture), and unbinding a default is a user choice that persists. */
+  bindings: z.record(z.string(), GestureBindingSchema).default({}),
+});
+export type GesturePrefs = z.infer<typeof GesturePrefsSchema>;
+
+/**
+ * The shipped default bindings — 2 of the 3 reliable poses, both on real registry
+ * command ids (pinned by test to exist and be gesture-bindable):
+ *
+ * - `fist` → `dial.master.volume.set { value: 0 }` — hands-free SILENCE. The issue's
+ *   example ("fist → mute") cannot be honored literally: mute is deliberately a
+ *   non-dial store flag with no command (#91), and this adapter only ever dispatches
+ *   into the registry. Zeroing the master-volume dial is the closest real command.
+ * - `pinch` → `dial.reset { key: 'master.volume' }` — RESTORE the default volume,
+ *   the deliberate counterpart gesture.
+ * - `open` ships UNBOUND on purpose: an open palm is the natural playing posture, so
+ *   a default binding on it would fire constantly during normal play (a toast every
+ *   cooldown window). It stays bindable from the panel for players who want it.
+ */
+export function defaultGestureBindings(): Record<string, GestureBinding> {
+  return {
+    fist: { command: 'dial.master.volume.set', args: { value: 0 } },
+    pinch: { command: 'dial.reset', args: { key: 'master.volume' } },
+  };
+}
+
+/** A fresh, fully-populated default prefs object (the store initializer). */
+export function defaultGesturePrefs(): GesturePrefs {
+  return {
+    enabled: false,
+    holdMs: DEFAULT_GESTURE_HOLD_MS,
+    cooldownMs: DEFAULT_GESTURE_COOLDOWN_MS,
+    bindings: defaultGestureBindings(),
+  };
+}

--- a/src/app/gesturePrefs.ts
+++ b/src/app/gesturePrefs.ts
@@ -40,7 +40,10 @@ export const GESTURE_LABELS: Record<GestureId, string> = {
 export const DEFAULT_GESTURE_HOLD_MS = 400;
 /** Per-gesture refractory window after a fire (anti-repeat). */
 export const DEFAULT_GESTURE_COOLDOWN_MS = 1500;
-/** Slider bounds for the panel (the schema clamps to the same range). */
+/** Slider bounds for the panel. The schema heals a per-field out-of-range or
+ *  malformed timing to its DEFAULT (`.catch` below) rather than rejecting the
+ *  whole object — one bad field in an external/version-skewed blob must not
+ *  silently wipe every binding back to the shipped defaults. */
 export const MAX_GESTURE_HOLD_MS = 2000;
 export const MAX_GESTURE_COOLDOWN_MS = 10000;
 
@@ -60,8 +63,8 @@ export const GesturePrefsSchema = z.object({
    *  for a first-time player. The Gestures shell tool is the (2-clicks-from-cold-load)
    *  entry point that turns it on. */
   enabled: z.boolean().default(false),
-  holdMs: z.number().min(0).max(MAX_GESTURE_HOLD_MS).default(DEFAULT_GESTURE_HOLD_MS),
-  cooldownMs: z.number().min(0).max(MAX_GESTURE_COOLDOWN_MS).default(DEFAULT_GESTURE_COOLDOWN_MS),
+  holdMs: z.number().min(0).max(MAX_GESTURE_HOLD_MS).catch(DEFAULT_GESTURE_HOLD_MS).default(DEFAULT_GESTURE_HOLD_MS),
+  cooldownMs: z.number().min(0).max(MAX_GESTURE_COOLDOWN_MS).catch(DEFAULT_GESTURE_COOLDOWN_MS).default(DEFAULT_GESTURE_COOLDOWN_MS),
   /** gesture id → binding. A missing key means UNBOUND (the dispatcher never fires
    *  an unbound gesture), and unbinding a default is a user choice that persists. */
   bindings: z.record(z.string(), GestureBindingSchema).default({}),

--- a/src/app/gestureStatus.ts
+++ b/src/app/gestureStatus.ts
@@ -1,0 +1,29 @@
+/**
+ * gestureStatus — a tiny store the engine writes the classifier's live per-hand
+ * poses into (transition-gated: only when a pose CHANGES), so the Gestures panel
+ * can show which pose each hand is currently holding without re-rendering at
+ * frame rate. Ephemeral per-frame runtime state, exactly like `faceStatus` /
+ * `midiStatus` — the DAG produces it; React only displays it. The dispatch
+ * itself does NOT go through this store (it runs in the rAF loop, see
+ * `gestureDispatch.ts`); this is display only.
+ */
+import { create } from 'zustand';
+import type { Pose } from '@/nodes';
+
+/** The classifier's per-hand pose snapshot (the `poses` output port shape). */
+export type HandPoses = Record<'left' | 'right', Pose>;
+
+/** The snapshot before the engine has reported anything (or after teardown). */
+export const ABSENT_POSES: HandPoses = { left: 'absent', right: 'absent' };
+
+export interface GestureStatusState {
+  poses: HandPoses;
+  report(poses: HandPoses): void;
+  reset(): void;
+}
+
+export const useGestureStatus = create<GestureStatusState>((set) => ({
+  poses: ABSENT_POSES,
+  report: (poses) => set({ poses: { ...poses } }),
+  reset: () => set({ poses: ABSENT_POSES }),
+}));

--- a/src/app/graph.ts
+++ b/src/app/graph.ts
@@ -131,6 +131,14 @@ export function defaultGraph(selection?: SlotSelection, registry?: NodeRegistry)
       // nothing for a player who never opens the Lab.
       { id: 'faceVec', type: 'face-feature-vector', params: {} },
       { id: 'handVec', type: 'hand-feature-vector', params: {} },
+      // Gesture dispatch (#129): discrete pose classification (fist/open/pinch),
+      // tapped additively off the hand-features stream the mapping already reads.
+      // Nothing in the GRAPH consumes it — the app-level gesture dispatcher
+      // (src/app/gestureDispatch.ts, driven from the rAF loop in useEngine) reads
+      // its `poses` output each frame and turns held-pose transitions into command
+      // dispatches per the user's binding map. Pure per-tick classification, so it
+      // costs nothing meaningful when gesture bindings are disabled.
+      { id: 'gesture', type: 'gesture-classifier', params: {} },
       // #90: keyboard shortcuts moved OUT of the DAG to an app-level tinykeys
       // handler that dispatches dial commands; octave-shift / magnetism / mute now
       // flow from the store via `ui` (store-controls), so no keyboard nodes here.
@@ -243,6 +251,10 @@ export function defaultGraph(selection?: SlotSelection, registry?: NodeRegistry)
       { from: { node: 'cam', port: 'hands' }, to: { node: 'handVec', port: 'hands' } },
       { from: { node: 'faceVec', port: 'vector' }, to: { node: 'overlay', port: 'faceVector' } },
       { from: { node: 'handVec', port: 'vector' }, to: { node: 'overlay', port: 'handVector' } },
+      // Gesture dispatch (#129): the classifier taps the SAME hand-features stream
+      // the mapping/overlay read (additive fan-out — the original edges are
+      // untouched). Its `poses` output is read app-side by the gesture dispatcher.
+      { from: { node: 'feat', port: 'features' }, to: { node: 'gesture', port: 'features' } },
     ],
   };
 }

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -19,6 +19,7 @@ import type { ScaleTypeId } from '@/music/theory';
 import { DEFAULT_SOUND_RIGHT, DEFAULT_SOUND_LEFT } from '@/music/sounds';
 import { OverlayDialSchema, type OverlayDialParams } from '@/nodes/output/canvas_overlay';
 import { FeatureLabSchema, defaultFeatureLab, type FeatureLabConfig } from '@/features/labConfig';
+import { GesturePrefsSchema, defaultGesturePrefs, type GesturePrefs } from './gesturePrefs';
 import { FACE_MAPPINGS, legacyFaceToMapping, type VoiceParams, type FaceMapping } from '@/nodes';
 import {
   DEFAULT_FACE_CHORD,
@@ -129,6 +130,16 @@ export interface ControlState {
    *  instrument (so calibration is global). Persisted to localStorage, NOT part of a
    *  preset — it is a device property, not a musical parameter. Null = uncalibrated. */
   faceCalibration: Record<string, number> | null;
+  /**
+   * Gesture dispatch config (#129): enable flag, hold/cooldown timing, and the
+   * gesture → command binding map. A TOOLING preference like {@link featureLab} —
+   * persisted per-device via `partialize`, NOT a preset field and NOT a dial:
+   * gestures bind to commands the way the keyboard does, and keybindings are not
+   * instrument state (loading an instrument must never rebind your hands). Read
+   * each frame by the app-level gesture dispatcher (`gestureDispatch.ts`) and
+   * edited from the Gestures shell tool.
+   */
+  gestures: GesturePrefs;
   setVoice(side: 'right' | 'left', patch: Partial<VoiceControl>): void;
   setSync(v: boolean): void;
   setMasterVolume(v: number): void;
@@ -152,6 +163,9 @@ export interface ControlState {
   setHandMap(patch: Partial<HandMap>): void;
   /** Store (or clear, with null) the per-device expression calibration. */
   setFaceCalibration(map: Record<string, number> | null): void;
+  /** Shallow-patch the gesture-dispatch prefs (e.g. setGestures({ enabled: true }),
+   *  or a whole new `bindings` record for a binding change). */
+  setGestures(patch: Partial<GesturePrefs>): void;
   /** Replace all live controls from a settings snapshot (loading a preset). */
   applySettings(s: Settings): void;
 }
@@ -319,7 +333,20 @@ export function mergeControls(persisted: unknown, current: ControlState): Contro
       midi = current.midi;
     }
   }
-  return { ...current, ...p, overlay, featureLab, faceMapping, faceChord, faceExpr, handMap, midi };
+  // Heal the gesture prefs (#129) the same way as the other tooling prefs: complete
+  // a partial blob from the current (default) prefs, then validate — a pre-#129 blob
+  // has none → the defaults; a corrupt blob falls back rather than crashing a newer
+  // reader. Note the blob's `bindings` record replaces the default wholesale (an
+  // unbound-by-the-user gesture must STAY unbound, not be re-seeded every load).
+  let gestures = current.gestures;
+  if (p.gestures) {
+    try {
+      gestures = GesturePrefsSchema.parse({ ...current.gestures, ...p.gestures });
+    } catch {
+      gestures = current.gestures;
+    }
+  }
+  return { ...current, ...p, overlay, featureLab, faceMapping, faceChord, faceExpr, handMap, midi, gestures };
 }
 
 // localStorage in the browser; a no-op elsewhere (Node test runtime) so the
@@ -353,6 +380,7 @@ export const useControls = create<ControlState>()(
       handMap: defaultHandMap(),
       midi: { ...DEFAULT_MIDI },
       faceCalibration: null,
+      gestures: defaultGesturePrefs(),
       setVoice: (side, patch) =>
         set((s) => {
           const next = { ...s[side], ...patch };
@@ -389,6 +417,7 @@ export const useControls = create<ControlState>()(
       setFeatureLab: (patch) => set((s) => ({ featureLab: { ...s.featureLab, ...patch } })),
       setHandMap: (patch) => set((s) => ({ handMap: { ...s.handMap, ...patch } })),
       setFaceCalibration: (map) => set({ faceCalibration: map ? { ...map } : null }),
+      setGestures: (patch) => set((s) => ({ gestures: { ...s.gestures, ...patch } })),
       // Restore exactly the schema fields (the setters are left untouched). Derived
       // from SETTINGS_KEYS, so a new preset field needs no edit.
       applySettings: (st) => set(pickSettings(st as unknown as Record<string, unknown>)),
@@ -414,16 +443,22 @@ export const useControls = create<ControlState>()(
       // Version 8: #137 added the `midi` preset field (enabled/port). ADDITIVE with a
       // default (off / first available port), healed by mergeControls, so no data
       // transform is needed — the bump is the version marker for the schema growth.
-      version: 8,
+      // Version 9: #129 added the `gestures` per-device tooling pref (enable flag,
+      // hold/cooldown timing, gesture → command bindings). ADDITIVE with defaults
+      // (disabled; fist → silence, pinch → restore volume, open unbound), healed by
+      // mergeControls like featureLab, so no data transform is needed — the bump is
+      // the version marker for the schema growth.
+      version: 9,
       migrate: migrateControls,
       merge: mergeControls,
       storage: createJSONStorage(controlsStorage),
       // Persist the preset fields (schema-derived) + the per-device tooling prefs
-      // (calibration, feature lab), never the setter functions.
+      // (calibration, feature lab, gesture bindings), never the setter functions.
       partialize: (s) => ({
         ...pickSettings(s as unknown as Record<string, unknown>),
         faceCalibration: s.faceCalibration,
         featureLab: s.featureLab,
+        gestures: s.gestures,
       }),
     },
   ),

--- a/src/app/tools.ts
+++ b/src/app/tools.ts
@@ -62,6 +62,13 @@ export const TOOLS: readonly Tool[] = [
     hotkey: '⌘K',
   },
   {
+    id: 'gestures',
+    label: 'Gestures',
+    description:
+      'Bind hand poses (fist, open palm, pinch) to commands for hands-free control — hold a pose to fire it.',
+    kind: 'panel',
+  },
+  {
     id: 'manual',
     label: 'Manual',
     description: 'The generated capabilities manual: every node, dial, sound and overlay element.',

--- a/src/app/useEngine.ts
+++ b/src/app/useEngine.ts
@@ -24,6 +24,8 @@ import { prefillName } from './recording/naming';
 import { tagStreamSource, tagOverlayResource } from './tagging/runtime';
 import { useFaceStatus } from './faceStatus';
 import { useMidiStatus } from './midiStatus';
+import { useGestureStatus, type HandPoses } from './gestureStatus';
+import { createGestureDispatcher } from './gestureDispatch';
 import type { FaceStatus } from '@/nodes';
 import type { MidiStatus } from '@/nodes/browser';
 import type { ExpressionScores } from '@/music/expression';
@@ -248,6 +250,24 @@ export function useThoreminEngine(source: SourceSpec = DEFAULT_SOURCE) {
           lastMidiKey = key;
         };
 
+        // Gesture dispatch (#129): the classifier's per-hand poses are read off the
+        // DAG each frame — the dispatcher (fresh timing state per engine run) turns
+        // held-pose TRANSITIONS into command dispatches per the user's binding map,
+        // and the status store is written only when a pose CHANGES (transition-
+        // gated, like reportFace/reportMidi), so the Gestures panel's live
+        // indicators never re-render at frame rate.
+        const gestureDispatcher = createGestureDispatcher();
+        let lastPosesKey = '';
+        const reportGesture = (now: number) => {
+          const poses = engine.getOutput('gesture', 'poses') as HandPoses | undefined;
+          if (!poses) return;
+          gestureDispatcher.tick(poses, now);
+          const key = `${poses.left}|${poses.right}`;
+          if (key === lastPosesKey) return;
+          useGestureStatus.getState().report(poses);
+          lastPosesKey = key;
+        };
+
         const loop = () => {
           // Guard the tick: one node throwing on a frame (e.g. a degenerate
           // value) must never stop the loop — drop that frame and keep going,
@@ -257,6 +277,7 @@ export function useThoreminEngine(source: SourceSpec = DEFAULT_SOURCE) {
             engine.tick(t / 1000);
             reportFace(t);
             reportMidi(t);
+            reportGesture(t);
             // (#90) Mute is now a store flag toggled by the app-level keyboard
             // handler (the `m` key → toggleMuted) and flows INTO the graph via
             // store-controls, so there is no longer a graph→store mute mirror here.
@@ -284,6 +305,7 @@ export function useThoreminEngine(source: SourceSpec = DEFAULT_SOURCE) {
       engineRef.current = null;
       useFaceStatus.getState().reset();
       useMidiStatus.getState().reset();
+      useGestureStatus.getState().reset();
       sessionRecRef.current?.dispose();
       sessionRecRef.current = null;
       cameraStreamRef.current = null;

--- a/test/app_graph.test.ts
+++ b/test/app_graph.test.ts
@@ -47,9 +47,11 @@ describe('production app graph', () => {
     expect(order.indexOf('handVec')).toBeLessThan(order.indexOf('overlay'));
     // MIDI output taps the merged voices, so it evaluates after the merge (#13).
     expect(order.indexOf('merge')).toBeLessThan(order.indexOf('midiOut'));
+    // Gesture classification taps the hand features, so it evaluates after them (#129).
+    expect(order.indexOf('feat')).toBeLessThan(order.indexOf('gesture'));
     // 14 base nodes (#90 retired the kbd + kctrl nodes) + the two #119 feature-vector
-    // taps + the #13 midi-out sink.
-    expect(order).toHaveLength(17);
+    // taps + the #13 midi-out sink + the #129 gesture-classifier tap.
+    expect(order).toHaveLength(18);
   });
 
   it('wires the face overlays (mesh + expression readout + both chord highlights)', () => {
@@ -99,6 +101,22 @@ describe('production app graph', () => {
     // The original face-mesh + hand-feature edges are untouched (additive).
     expect(has('camFace', 'face', 'overlay', 'faceFrame')).toBe(true);
     expect(has('cam', 'hands', 'feat', 'hands')).toBe(true);
+  });
+
+  it('wires the gesture classifier additively off the hand features (#129)', () => {
+    const g = defaultGraph();
+    const has = (fn: string, fp: string, tn: string, tp: string) =>
+      g.edges.some((e) => e.from.node === fn && e.from.port === fp && e.to.node === tn && e.to.port === tp);
+    // The classifier taps the SAME hand-features stream the mapping/overlay read.
+    const gesture = g.nodes.find((n) => n.id === 'gesture');
+    expect(gesture?.type).toBe('gesture-classifier');
+    expect(has('feat', 'features', 'gesture', 'features')).toBe(true);
+    // The original hand-features edges are untouched (additive fan-out).
+    expect(has('feat', 'features', 'map', 'features')).toBe(true);
+    expect(has('feat', 'features', 'overlay', 'features')).toBe(true);
+    // Its output is deliberately consumed APP-side (useEngine reads `poses` off the
+    // engine each frame and feeds the gesture dispatcher) — the #137-style guard
+    // that the mounted node is actually read lives in test/gesture_dispatch.test.ts.
   });
 
   it('routes the mute to the merge so it silences the chords too (#91)', () => {

--- a/test/app_shell.test.ts
+++ b/test/app_shell.test.ts
@@ -21,6 +21,7 @@ const app = readFileSync(resolve(process.cwd(), 'src/app/App.tsx'), 'utf8');
 const SURFACES: Record<string, string> = {
   lab: 'LabPanel',
   commands: 'CommandPaletteOverlay',
+  gestures: 'GesturesPanel',
 };
 
 describe('app shell', () => {

--- a/test/app_store.test.ts
+++ b/test/app_store.test.ts
@@ -8,6 +8,7 @@
  */
 import { describe, it, expect, beforeEach } from 'vitest';
 import { useControls, toSettings, migrateControls, mergeControls } from '@/app/store';
+import { defaultGesturePrefs } from '@/app/gesturePrefs';
 import { DEFAULT_FACE_CHORD, SettingsSchema } from '@/settings/schema';
 import { storeControlsNode } from '@/nodes/browser';
 import { generateScale } from '@/music/theory';
@@ -275,6 +276,38 @@ describe('persist migration (v1 → v2, returning users)', () => {
       enabled: false,
       port: '',
     });
+  });
+
+  it('mergeControls heals the gesture prefs (#129): absent → defaults, partial → completed, corrupt → default', () => {
+    const initial = useControls.getInitialState();
+    // A pre-#129 blob has no gestures key at all → the defaults (disabled; fist +
+    // pinch bound, open unbound).
+    const absent = mergeControls({ masterVolume: 0.5 }, initial).gestures;
+    expect(absent).toEqual(defaultGesturePrefs());
+    // A partial blob keeps what it set and completes the rest from the defaults.
+    const partial = mergeControls({ gestures: { enabled: true } as never }, initial).gestures;
+    expect(partial.enabled).toBe(true);
+    expect(partial.holdMs).toBe(defaultGesturePrefs().holdMs);
+    expect(partial.bindings.fist).toEqual(defaultGesturePrefs().bindings.fist);
+    // The blob's bindings record replaces the default WHOLESALE: a gesture the user
+    // unbound must stay unbound, not be re-seeded on every load.
+    const unbound = mergeControls({ gestures: { bindings: {} } as never }, initial).gestures;
+    expect(unbound.bindings).toEqual({});
+    // A corrupt blob falls back to the default whole (never a crash, never undefined).
+    const corrupt = mergeControls(
+      { gestures: { enabled: 'yes', bindings: { fist: { command: 42 } } } as never },
+      initial,
+    ).gestures;
+    expect(corrupt).toEqual(defaultGesturePrefs());
+  });
+
+  it('setGestures shallow-patches the gesture prefs, leaving the rest', () => {
+    useControls.getState().setGestures({ enabled: true, holdMs: 250 });
+    const g = useControls.getState().gestures;
+    expect(g.enabled).toBe(true);
+    expect(g.holdMs).toBe(250);
+    expect(g.cooldownMs).toBe(defaultGesturePrefs().cooldownMs); // untouched
+    expect(g.bindings.fist).toEqual(defaultGesturePrefs().bindings.fist); // untouched
   });
 
   it('mergeControls clamps an unknown faceMapping to a safe value', () => {

--- a/test/gesture_dispatch.test.ts
+++ b/test/gesture_dispatch.test.ts
@@ -163,6 +163,44 @@ describe('gesture dispatch adapter (#129) — edge + hold + cooldown semantics',
     expect(h.fired).toHaveLength(1);
   });
 
+  it('a binding created MID-hold is inert — it arms only the next fresh transition', () => {
+    // The panel invites posing at the camera while editing bindings ("held now"
+    // dot). Binding a pose the player is ALREADY holding must not fire the
+    // instant the dropdown closes — that would be fire-on-state, and with a
+    // params-requiring command it fires straight into a validation-error toast.
+    const { prefs, fired, dispatcher } = makeHarness({ prefs: { holdMs: 400, bindings: {} } });
+    dispatcher.tick(P('fist'), 0); // enters unbound
+    dispatcher.tick(P('fist'), 1000); // hold long met; entry spends (no cooldown burned)
+    prefs.bindings = { fist: FIST }; // the user binds it while still posing
+    dispatcher.tick(P('fist'), 1100);
+    dispatcher.tick(P('fist'), 60000);
+    expect(fired).toHaveLength(0); // no fresh transition -> no fire
+    // Release and re-enter: the NEXT transition fires normally.
+    dispatcher.tick(P('open'), 60100);
+    dispatcher.tick(P('fist'), 60200);
+    dispatcher.tick(P('fist'), 60700);
+    expect(fired).toHaveLength(1);
+  });
+
+  it('a pose held across a disable -> enable cycle does not fire on re-enable', () => {
+    // Symmetric with born-consumed: "enabling arms FUTURE transitions" has no
+    // exceptions, including an entry that BEGAN while enabled and straddled a
+    // disabled span.
+    const { prefs, fired, dispatcher } = makeHarness({ prefs: { holdMs: 400 } });
+    dispatcher.tick(P('fist'), 0); // enters while enabled
+    prefs.enabled = false; // disabled before the hold completes
+    dispatcher.tick(P('fist'), 200);
+    prefs.enabled = true; // re-enabled much later, pose still held
+    dispatcher.tick(P('fist'), 60000);
+    dispatcher.tick(P('fist'), 61000);
+    expect(fired).toHaveLength(0);
+    // A fresh transition after re-enable fires normally.
+    dispatcher.tick(P('open'), 61100);
+    dispatcher.tick(P('fist'), 61200);
+    dispatcher.tick(P('fist'), 61700);
+    expect(fired).toHaveLength(1);
+  });
+
   it('hold is per hand, cooldown is per gesture: two hands cannot double-fire one binding', () => {
     const { fired, dispatcher } = makeHarness({ prefs: { holdMs: 400, cooldownMs: 1200 } });
     dispatcher.tick({ left: 'fist', right: 'absent' }, 0);

--- a/test/gesture_dispatch.test.ts
+++ b/test/gesture_dispatch.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Gesture dispatch (#129) — pins the adapter's firing semantics exactly as the
+ * module docstring states them, tick-driven (time is an input, no fake timers):
+ *
+ * - EDGE trigger: a fire needs a fresh transition into the gesture; held state
+ *   never re-fires, even long past the cooldown.
+ * - Minimum hold: an entry shorter than `holdMs` never fires.
+ * - Per-gesture cooldown, CONSUMED not deferred: an entry whose hold completes
+ *   inside the cooldown never fires — not even if held past the cooldown's expiry
+ *   — while a re-entry whose hold completes after expiry fires normally. Shared
+ *   across hands (two hands cannot double-fire one binding).
+ * - No binding ⇒ no dispatch; disabled ⇒ no dispatch (including an entry begun
+ *   while disabled that is still held when enabling).
+ * - Unknown / confirmation-gated command ids are refused with an error toast,
+ *   never dispatched.
+ * - Feedback: success toasts "<gesture> → <title>", a failed dispatch toasts the
+ *   error (the palette-toast precedent).
+ *
+ * Also pins that the SHIPPED default bindings name real, gesture-bindable registry
+ * commands with schema-valid args, and — the #137-style reachability guard — that
+ * the mounted classifier's output is actually read by the app path (a node wired
+ * into the graph but read by nobody is #120 all over again).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { ok, err, type Result } from 'acture';
+import { createGestureDispatcher, isGestureBindable, type GestureDispatcherDeps } from '@/app/gestureDispatch';
+import {
+  GESTURE_IDS,
+  defaultGesturePrefs,
+  isGestureId,
+  type GestureBinding,
+  type GesturePrefs,
+} from '@/app/gesturePrefs';
+import type { HandPoses } from '@/app/gestureStatus';
+import { createThoreminRegistry } from '@/app/commands/registry';
+import type { Pose } from '@/nodes';
+
+/** A poses frame: right-hand pose (the usual test subject) + optional left. */
+const P = (right: Pose, left: Pose = 'absent'): HandPoses => ({ left, right });
+
+/** Flush the microtask/timeout queue so fire-and-forget toast chains settle. */
+const flush = () => new Promise<void>((r) => setTimeout(r, 0));
+
+const FIST: GestureBinding = { command: 'test.fist.go', args: { value: 0 } };
+
+interface Notice {
+  message: string;
+  level: string;
+}
+
+/** A dispatcher with every dependency stubbed; `prefs` is LIVE (mutable per test). */
+function makeHarness(
+  opts: {
+    prefs?: Partial<GesturePrefs>;
+    result?: (command: string) => Result<unknown>;
+    known?: (id: string) => boolean;
+  } = {},
+) {
+  const prefs: GesturePrefs = {
+    ...defaultGesturePrefs(),
+    enabled: true,
+    bindings: { fist: FIST },
+    ...opts.prefs,
+  };
+  const fired: { command: string; args: unknown }[] = [];
+  const notices: Notice[] = [];
+  const deps: Partial<GestureDispatcherDeps> = {
+    getPrefs: () => prefs,
+    hasCommand: opts.known ?? (() => true),
+    commandTitle: (id) => `Title(${id})`,
+    isBindable: (id) => !id.startsWith('instrument.'),
+    dispatch: async (command, args) => {
+      fired.push({ command, args });
+      return (opts.result ?? (() => ok({})))(command);
+    },
+    notify: (message, level = 'info') => notices.push({ message, level }),
+  };
+  return { prefs, fired, notices, dispatcher: createGestureDispatcher(deps) };
+}
+
+describe('gesture dispatch adapter (#129) — edge + hold + cooldown semantics', () => {
+  it('fires once per transition after the minimum hold; held state NEVER re-fires', () => {
+    const { fired, dispatcher } = makeHarness({ prefs: { holdMs: 400, cooldownMs: 1000 } });
+    dispatcher.tick(P('fist'), 0);
+    dispatcher.tick(P('fist'), 399);
+    expect(fired).toHaveLength(0); // hold not yet met
+    dispatcher.tick(P('fist'), 400);
+    expect(fired).toHaveLength(1); // the edge fires exactly once
+    expect(fired[0]).toEqual({ command: 'test.fist.go', args: { value: 0 } });
+    // Held far past the hold AND past the cooldown: an edge trigger must not
+    // re-fire on state. (Mutation target: fire-on-state makes this re-fire.)
+    dispatcher.tick(P('fist'), 5000);
+    dispatcher.tick(P('fist'), 60000);
+    expect(fired).toHaveLength(1);
+  });
+
+  it('an entry released before the minimum hold never fires (classifier flicker is inert)', () => {
+    const { fired, notices, dispatcher } = makeHarness({ prefs: { holdMs: 400 } });
+    dispatcher.tick(P('fist'), 0);
+    dispatcher.tick(P('neutral'), 300); // released at 300 < 400
+    dispatcher.tick(P('fist'), 350);
+    dispatcher.tick(P('neutral'), 700); // released again at 350ms held
+    expect(fired).toHaveLength(0);
+    expect(notices).toHaveLength(0);
+  });
+
+  it('cooldown: a re-entry whose hold completes inside the cooldown is CONSUMED — not deferred, not fired', () => {
+    const { fired, dispatcher } = makeHarness({ prefs: { holdMs: 400, cooldownMs: 1200 } });
+    dispatcher.tick(P('fist'), 0);
+    dispatcher.tick(P('fist'), 400); // fire #1 at 400; cooldown until 1600
+    expect(fired).toHaveLength(1);
+    dispatcher.tick(P('neutral'), 500); // release
+    dispatcher.tick(P('fist'), 600); // re-enter during cooldown
+    dispatcher.tick(P('fist'), 1000); // hold completes at 1000 < 1600 → consumed
+    expect(fired).toHaveLength(1);
+    // Still held long past the cooldown's expiry: the consumed entry stays spent.
+    dispatcher.tick(P('fist'), 2000);
+    dispatcher.tick(P('fist'), 10000);
+    expect(fired).toHaveLength(1);
+    // A FRESH entry after the cooldown expired fires normally.
+    dispatcher.tick(P('neutral'), 10100);
+    dispatcher.tick(P('fist'), 10200);
+    dispatcher.tick(P('fist'), 10600);
+    expect(fired).toHaveLength(2);
+  });
+
+  it('cooldown: a re-entry whose hold completes AFTER the cooldown expired fires', () => {
+    const { fired, dispatcher } = makeHarness({ prefs: { holdMs: 400, cooldownMs: 1200 } });
+    dispatcher.tick(P('fist'), 0);
+    dispatcher.tick(P('fist'), 400); // fire #1; cooldown until 1600
+    dispatcher.tick(P('neutral'), 500);
+    dispatcher.tick(P('fist'), 1300); // re-enter INSIDE the cooldown...
+    dispatcher.tick(P('fist'), 1650); // ...but hold not met yet (350 < 400): not evaluated
+    expect(fired).toHaveLength(1);
+    dispatcher.tick(P('fist'), 1700); // hold completes at 1700 ≥ 1600 → fires
+    expect(fired).toHaveLength(2);
+  });
+
+  it('never dispatches a gesture with no binding-map entry (and burns no cooldown)', () => {
+    const { fired, notices, dispatcher } = makeHarness({ prefs: { holdMs: 100, bindings: {} } });
+    dispatcher.tick(P('open'), 0);
+    dispatcher.tick(P('open'), 5000); // held way past any hold
+    dispatcher.tick(P('fist'), 6000);
+    dispatcher.tick(P('fist'), 7000); // fist unbound too in this harness
+    expect(fired).toHaveLength(0);
+    expect(notices).toHaveLength(0);
+  });
+
+  it('disabled: no fires — and an entry begun while disabled stays inert after enabling mid-hold', () => {
+    const h = makeHarness({ prefs: { holdMs: 400, enabled: false } });
+    h.dispatcher.tick(P('fist'), 0);
+    h.dispatcher.tick(P('fist'), 400);
+    expect(h.fired).toHaveLength(0);
+    h.prefs.enabled = true; // enabled mid-hold: arms FUTURE transitions only
+    h.dispatcher.tick(P('fist'), 800);
+    h.dispatcher.tick(P('fist'), 5000);
+    expect(h.fired).toHaveLength(0);
+    h.dispatcher.tick(P('neutral'), 5100); // release...
+    h.dispatcher.tick(P('fist'), 5200); // ...and a fresh transition
+    h.dispatcher.tick(P('fist'), 5600);
+    expect(h.fired).toHaveLength(1);
+  });
+
+  it('hold is per hand, cooldown is per gesture: two hands cannot double-fire one binding', () => {
+    const { fired, dispatcher } = makeHarness({ prefs: { holdMs: 400, cooldownMs: 1200 } });
+    dispatcher.tick({ left: 'fist', right: 'absent' }, 0);
+    dispatcher.tick({ left: 'fist', right: 'fist' }, 100); // right enters 100ms later
+    dispatcher.tick({ left: 'fist', right: 'fist' }, 400); // left's hold completes → fire
+    expect(fired).toHaveLength(1);
+    dispatcher.tick({ left: 'fist', right: 'fist' }, 500); // right's hold completes → cooldown → consumed
+    dispatcher.tick({ left: 'fist', right: 'fist' }, 5000);
+    expect(fired).toHaveLength(1);
+  });
+
+  it('an unknown command id is surfaced as an error toast and never dispatched', async () => {
+    const { fired, notices, dispatcher } = makeHarness({
+      known: () => false,
+      prefs: { holdMs: 100, bindings: { fist: { command: 'nope.missing.cmd' } } },
+    });
+    dispatcher.tick(P('fist'), 0);
+    dispatcher.tick(P('fist'), 100);
+    await flush();
+    expect(fired).toHaveLength(0);
+    expect(notices).toHaveLength(1);
+    expect(notices[0].level).toBe('error');
+    expect(notices[0].message).toContain('nope.missing.cmd');
+  });
+
+  it('a confirmation-gated (destructive) command is refused, never dispatched', async () => {
+    const { fired, notices, dispatcher } = makeHarness({
+      prefs: { holdMs: 100, bindings: { fist: { command: 'instrument.load', args: { name: 'x' } } } },
+    });
+    dispatcher.tick(P('fist'), 0);
+    dispatcher.tick(P('fist'), 100);
+    await flush();
+    expect(fired).toHaveLength(0); // a hands-free flow cannot answer a confirmation dialog
+    expect(notices).toHaveLength(1);
+    expect(notices[0].level).toBe('error');
+    expect(notices[0].message).toMatch(/confirmation/i);
+  });
+
+  it('a successful fire toasts gesture + command title; a failed dispatch toasts the error', async () => {
+    const good = makeHarness({ prefs: { holdMs: 100 } });
+    good.dispatcher.tick(P('fist'), 0);
+    good.dispatcher.tick(P('fist'), 100);
+    await flush();
+    expect(good.notices).toEqual([{ message: 'Fist → Title(test.fist.go)', level: 'info' }]);
+
+    const bad = makeHarness({
+      prefs: { holdMs: 100 },
+      result: () => err('invalid_value', 'Nope, out of range.'),
+    });
+    bad.dispatcher.tick(P('fist'), 0);
+    bad.dispatcher.tick(P('fist'), 100);
+    await flush();
+    expect(bad.fired).toHaveLength(1); // it DID dispatch; the registry refused it
+    expect(bad.notices).toEqual([{ message: 'Fist: Nope, out of range.', level: 'error' }]);
+  });
+});
+
+describe('the shipped default bindings (#129)', () => {
+  it('every default binding names a REAL, gesture-bindable registry command with schema-valid args', () => {
+    const registry = createThoreminRegistry();
+    const prefs = defaultGesturePrefs();
+    const bound = Object.entries(prefs.bindings);
+    expect(bound.length).toBeGreaterThanOrEqual(2); // fist + pinch ship bound
+    for (const [gesture, binding] of bound) {
+      expect(isGestureId(gesture), `"${gesture}" must be a bindable gesture id`).toBe(true);
+      const cmd = registry.get(binding.command);
+      expect(cmd, `${gesture} → "${binding.command}" must exist in the registry`).toBeTruthy();
+      expect(
+        isGestureBindable(binding.command),
+        `${gesture} → "${binding.command}" must not be confirmation-gated`,
+      ).toBe(true);
+      // The fixed args must satisfy the command's own param schema — a default
+      // binding that fires straight into a validation error is not a default.
+      expect(
+        () => (cmd!.params as { parse(v: unknown): unknown }).parse(binding.args ?? {}),
+        `${gesture} → "${binding.command}" default args must parse`,
+      ).not.toThrow();
+    }
+    // `open` ships deliberately UNBOUND: an open palm is the natural playing
+    // posture, so a default binding on it would fire during normal play.
+    expect(prefs.bindings.open).toBeUndefined();
+    expect(GESTURE_IDS).toContain('open'); // ...but it stays a bindable gesture
+  });
+
+  it('gestures are disabled by default (a camera must not fire commands unasked)', () => {
+    expect(defaultGesturePrefs().enabled).toBe(false);
+  });
+});
+
+describe('the classifier output reaches the app dispatch path (the #137-style guard)', () => {
+  it('useEngine reads the mounted gesture node and ticks the dispatcher', () => {
+    // The graph half (node mounted + fed by `feat`) is asserted structurally in
+    // app_graph.test.ts. This is the other half MIDI-out shipped without (#120/#137):
+    // the app actually READING the output. A rewiring that drops either line makes
+    // the gesture feature silently unreachable while every unit test stays green.
+    const src = readFileSync(resolve(process.cwd(), 'src/app/useEngine.ts'), 'utf8');
+    expect(src).toMatch(/getOutput\(\s*'gesture'\s*,\s*'poses'\s*\)/);
+    expect(src).toMatch(/createGestureDispatcher\(/);
+    expect(src).toMatch(/gestureDispatcher\.tick\(/);
+    expect(src).toMatch(/reportGesture\(t\)/); // wired into the rAF loop, not just defined
+  });
+});

--- a/test/tools_shell.test.tsx
+++ b/test/tools_shell.test.tsx
@@ -16,15 +16,18 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { render, screen, cleanup, fireEvent, act } from '@testing-library/react';
 import ToolsBar from '@/app/ToolsBar';
 import LabPanel from '@/app/LabPanel';
+import GesturesPanel from '@/app/GesturesPanel';
 import { TOOLS, TOOL_IDS } from '@/app/tools';
 import { useTools } from '@/app/toolsStore';
 import { useControls } from '@/app/store';
 import { defaultFeatureLab } from '@/features/labConfig';
+import { GESTURE_IDS, GESTURE_LABELS, defaultGesturePrefs } from '@/app/gesturePrefs';
 import { OVERLAY_CONTROLS, controlsForSurface } from '@/app/overlayControls';
 
 beforeEach(() => {
   useTools.setState({ open: null });
   useControls.getState().setFeatureLab(defaultFeatureLab());
+  useControls.setState({ gestures: defaultGesturePrefs() });
 });
 afterEach(cleanup);
 
@@ -99,6 +102,57 @@ describe('the Feature Lab is reachable and explains itself', () => {
     expect(screen.queryByText(/Start measuring/i)).toBeNull();
     fireEvent.click(screen.getByText('Feature Lab'));
     expect(screen.getByText(/Start measuring/i)).toBeTruthy();
+  });
+});
+
+describe('the Gestures panel is reachable and edits the binding map (#129)', () => {
+  it('is closed until its tool is open', () => {
+    const { container } = render(<GesturesPanel />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('the whole chain works: shell button -> open state -> a row per known gesture with a command picker', () => {
+    render(
+      <>
+        <ToolsBar />
+        <GesturesPanel />
+      </>,
+    );
+    expect(screen.queryByLabelText('Enable gesture commands')).toBeNull();
+    fireEvent.click(screen.getByText('Gestures'));
+    expect(useTools.getState().open).toBe('gestures');
+    // Every gesture the classifier can emit gets a labelled row and a picker.
+    for (const g of GESTURE_IDS) expect(screen.getByText(GESTURE_LABELS[g])).toBeTruthy();
+    expect(screen.getAllByRole('combobox')).toHaveLength(GESTURE_IDS.length);
+    // The enable toggle and BOTH timing sliders (hold + cooldown) are present.
+    expect(screen.getByLabelText('Enable gesture commands')).toBeTruthy();
+    expect(document.querySelectorAll('input[type="range"]')).toHaveLength(2);
+    // The confirmation-gating exclusion is STATED, not silent (#129 point 8).
+    expect(screen.getByText(/confirmation/i)).toBeTruthy();
+  });
+
+  it('the enable toggle writes the per-device gestures pref (not a dial, not a preset)', () => {
+    useTools.setState({ open: 'gestures' });
+    render(<GesturesPanel />);
+    fireEvent.click(screen.getByLabelText('Enable gesture commands'));
+    expect(useControls.getState().gestures.enabled).toBe(true);
+  });
+
+  it('the command picker binds and unbinds a gesture, and never offers a confirmation-gated command', () => {
+    useTools.setState({ open: 'gestures' });
+    render(<GesturesPanel />);
+    // Rows render in GESTURE_IDS order; 'open' ships unbound.
+    const openSelect = screen.getByLabelText(`Command for ${GESTURE_LABELS.open}`) as HTMLSelectElement;
+    expect(openSelect.value).toBe('');
+    // No instrument.* (destructive → confirmation-gated) option anywhere.
+    const optionIds = [...openSelect.querySelectorAll('option')].map((o) => o.value);
+    expect(optionIds.some((id) => id.startsWith('instrument.'))).toBe(false);
+    // Bind it to a real per-dial command...
+    fireEvent.change(openSelect, { target: { value: 'dial.master.magnetism.set' } });
+    expect(useControls.getState().gestures.bindings.open?.command).toBe('dial.master.magnetism.set');
+    // ...and unbind it again (the dispatcher never fires an unbound gesture).
+    fireEvent.change(openSelect, { target: { value: '' } });
+    expect(useControls.getState().gestures.bindings.open).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
Closes #129.

The gesture classifier (built in PR #27, never consumed) becomes the fourth dispatcher into the command registry, alongside the keyboard, the palette, and the AI assistant.

## What a player gets

A **Gestures** shell tool (2 clicks from cold load): an enable toggle (off by default — a camera must not fire commands unasked), hold/cooldown sliders, and a per-gesture command picker. Defaults: **fist → silence** (`dial.master.volume.set {value: 0}`), **pinch → restore volume** (`dial.reset {key: 'master.volume'}`), **open palm deliberately unbound** (it is the natural playing posture). A fire toasts gesture + command title.

## Design decisions

- **Edge + hold + cooldown** (the issue's stated hard part): a fire needs a fresh transition INTO the pose, a continuous `holdMs` hold (default 400 ms), and an expired per-gesture cooldown (default 1.5 s) at hold completion. A hold completing inside the cooldown is **consumed, not deferred** (deferral turns threshold chatter into delayed surprise dispatches). Hold is per hand; cooldown is per gesture (two hands cannot double-fire one binding).
- **Deviation from the issue's example, documented**: 'fist → mute' is impossible literally — mute is a non-dial store flag with no command (#91). Silence-via-volume is the honest equivalent until #91 grows a command.
- **Confirmation-gated (`instrument.*`) commands are not gesture-bindable** — a hands-free flow cannot answer a confirmation dialog; filtered from the picker AND refused by the adapter.
- **The binding map is a per-device tooling pref** (featureLab precedent), not a dial: gestures bind to commands the way keybindings do, and keybindings are not instrument state. Persist v8→v9, healed per-field.

## What the adversarial review caught (fixed + mutation-verified)

- **Bind-mid-hold fired instantly** (found independently by both reviewers): an unbound entry was never spent, so binding a pose you were already holding fired the moment the dropdown closed. Entries now spend when the hold elapses, bound or not; a mid-hold bind arms only the next fresh transition.
- A pose held across a disable→enable cycle fired on re-enable — disabling now spends armed entries.
- One out-of-range timing field in a version-skewed blob wiped every binding (whole-object parse fallback) — timing fields heal per-field now.

## Verified

`npm run typecheck` clean · **910 tests, 87 files, all passing** (15 gesture tests + graph/store/shell updates) · `npm run build` clean · catalog idempotent · two independent mutation-verifications (edge-detection off → 3 tests red; consume-reordering → bind-mid-hold pin red).

## Live verification (→ #146)

Classifier-in-the-loop feel: effective latency = classifier dwell + holdMs (~0.5–0.7 s total at defaults) needs a webcam judgment; the fist→silence flow during actual play; toast noise level during a performance.

https://claude.ai/code/session_01GUjT9e7sAyckG1SR9czApr