### PR TITLE
ci: add the test gate this repo never had (typecheck / test / build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+# The test gate.
+#
+# Until this file existed, `.github/workflows/` held exactly one workflow —
+# deploy.yml — and main AUTO-DEPLOYS to production. So an untested change went
+# live with nothing standing in the way: typecheck/test/build were local-only
+# conventions, enforced by whoever remembered to run them. docs/TESTING.md even
+# claimed "Tiers 1-3 are the CI gate: npm test", which was an aspiration, not a
+# fact.
+#
+# This workflow makes the claim true. It runs the same three commands the repo
+# already documents as its gate, in the same order a developer would:
+#
+#   npm run typecheck   strict DAG typecheck (tsconfig.dag.json)
+#   npm test            vitest, Node env, no camera/GPU/audio
+#   npm run build       vite build — this is what verifies the React layer,
+#                       which tsconfig.dag.json deliberately does not cover
+#
+# It runs on pull_request (so a change is gated BEFORE it can merge) and on
+# push to main (so the deploy that fires from the same push has a visible
+# verdict beside it). It deliberately does NOT gate deploy.yml: making the
+# deploy `needs:` this job would be a behaviour change to the deploy path, and
+# is a separate decision. Today the value is the signal — a red X on the PR.
+#
+# Fast by design: one Node version, npm cache on, no matrix. The suite is
+# ~900 tests in ~5s; the wall time here is dominated by `npm ci` and the vite
+# build, which is why the cache matters more than parallelism.
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# A newer push to the same ref makes the older run's verdict irrelevant.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  gate:
+    name: typecheck / test / build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install (lockfile-exact)
+        run: npm ci
+
+      - name: Typecheck (strict DAG)
+        run: npm run typecheck
+
+      - name: Test (vitest)
+        run: npm test
+
+      - name: Build (vite — verifies the React layer)
+        run: npm run build

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -53,6 +53,7 @@ while main auto-deployed to production.
 | `npm test` | **yes** | same |
 | `npm run build` | **yes** | same |
 | `npm run catalog` | **no** — still yours to run | run it locally after adding/renaming a node or changing a port/param, and commit the result |
+| `npm run lint` | **no**, deliberately | `tsc --noEmit` over the *whole* tree, including the React layer the repo ships no `@types/react` for. It is red (19 errors as of 2026-08-17) and has been for a long time. Adding a known-red check would train everyone to ignore the X, which is worse than not having it. `npm run typecheck` (strict, `tsconfig.dag.json`) plus `npm run build` (which is what actually verifies the React layer) is the honest pair. |
 
 The CI job is *advisory to the deploy*, not a precondition for it: `deploy.yml` still
 fires on its own push trigger and does not `needs:` the gate. So a red X and a live

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -29,7 +29,7 @@ Tiers 1–3 are the CI gate: `npm test` (vitest, Node env, no camera/GPU/audio).
 
 ```bash
 npm run typecheck   # strict DAG typecheck (tsconfig.dag.json)
-npm test            # vitest — 75+ test files
+npm test            # vitest — 87+ test files
 npm run build       # vite build (this is what verifies the React layer)
 npm run catalog     # regenerate docs/CATALOG.md + public/manual.html + public/catalog.json
 ```
@@ -37,6 +37,28 @@ npm run catalog     # regenerate docs/CATALOG.md + public/manual.html + public/c
 `npm run catalog` belongs in the gate because those three files are **generated from
 the node registry** and must never be hand-edited: add or rename a node, or change a
 port/param, and they go stale silently. Run it and commit the result.
+
+### What is enforced, and where
+
+Be precise about this, because for a long time this document was not: the sentence
+above ("Tiers 1–3 are the CI gate") was an *aspiration* committed as documentation.
+Until `.github/workflows/ci.yml` was added, `.github/workflows/` contained exactly one
+workflow — `deploy.yml` — and no test workflow had ever existed in this repo's history.
+The three commands were local conventions, enforced by whoever remembered to run them,
+while main auto-deployed to production.
+
+| Command | Enforced by CI? | Where |
+|---|---|---|
+| `npm run typecheck` | **yes** | `.github/workflows/ci.yml`, on every pull request and every push to main |
+| `npm test` | **yes** | same |
+| `npm run build` | **yes** | same |
+| `npm run catalog` | **no** — still yours to run | run it locally after adding/renaming a node or changing a port/param, and commit the result |
+
+The CI job is *advisory to the deploy*, not a precondition for it: `deploy.yml` still
+fires on its own push trigger and does not `needs:` the gate. So a red X and a live
+deploy can coexist on the same commit. Wiring the deploy behind the gate is a change to
+the deploy path and a separate decision; what exists today is the signal — a visible
+verdict on the PR, before merge.
 
 ## The test families
 


### PR DESCRIPTION
Closes #153.

## The problem

`.github/workflows/` contained exactly **one** workflow — `deploy.yml` — and

```
git log --all --name-only -- '.github/**'
```

returns a single commit touching a single file. **No test workflow has ever existed in this repo.** `npm test` / `npm run typecheck` / `npm run build` were local-only conventions, enforced by whoever remembered to run them.

Meanwhile **main auto-deploys to production** (`deploy.yml` dispatches the tw_platform deploy on every push to main). So an untested change reached the live site with nothing standing in the way.

Two things made this actively misleading rather than merely absent:

- `docs/TESTING.md` asserted *"Tiers 1–3 are the CI gate: `npm test`"* — an unenforced claim committed as documentation.
- The M2 checklist in #5 counts a "CI gate" among its shipped deliverables. It was never built.

## What this does

**`.github/workflows/ci.yml`** — on `pull_request` and on `push` to `main`:

```
npm ci
npm run typecheck   # strict DAG typecheck (tsconfig.dag.json)
npm test            # vitest, Node env, no camera/GPU/audio
npm run build       # vite build — verifies the React layer, which the DAG tsconfig deliberately does not cover
```

Kept fast: one Node version (22), `cache: npm`, no matrix, `timeout-minutes: 15`, and a `concurrency` group that cancels superseded runs. The suite is ~900 tests in ~5s, so wall time is dominated by install + the vite build — which is why the cache matters more than parallelism would. **This PR's own run took 57s.** Actions pinned to current majors: `actions/checkout@v7`, `actions/setup-node@v7`.

## The three decisions #153 asked to be made deliberately

1. **Keep `build` in the job — load-bearing, not belt-and-braces.** `tsconfig.dag.json` does not cover `src/app/*.tsx` or `src/components`; `npm run build` is the only thing that checks them. Confirmed and kept.

2. **`npm run lint` stays OUT.** #153 guessed it was red; it is — **19 `error TS` lines**, mostly the React layer this repo ships no `@types/react` for. The issue suggested adding it non-blocking. I did not, on the grounds that a permanently-red check trains everyone to ignore the X, which is worse than its absence. `typecheck` + `build` is the honest pair. Recorded in `docs/TESTING.md` so the next person does not re-litigate it from scratch.

3. **The gate runs on `push: main` too, but the deploy is NOT made conditional on it.** The stronger posture (`deploy` `needs:` the gate) is a behaviour change to the deploy path, which this PR's brief explicitly excludes and which is the maintainer's call — so `deploy.yml` is untouched. What the `push: main` trigger buys today is a visible verdict *beside* the deploy on the same commit. A red X and a live deploy can still coexist; that is stated plainly in `docs/TESTING.md` rather than left to be discovered.

## Docs

`docs/TESTING.md` now tells the truth: a table of what CI enforces (typecheck / test / build) versus what does not (`npm run catalog`, which regenerates three files from the node registry and cannot be checked without running it; `npm run lint`, red by design), plus an explicit note that the old "Tiers 1–3 are the CI gate" claim was aspirational.

## Gates

Run locally on this branch:

```
$ npm run typecheck
> tsc -p tsconfig.dag.json --noEmit
TYPECHECK EXIT=0

$ npm test
 Test Files  87 passed (87)
      Tests  910 passed (910)
   Duration  4.79s

$ npm run build
✓ built in 5.41s
```

And the workflow gates itself — the first run on this PR went green in 57s.

## Issues

- **Closes #153.**
- Satisfies the **M2 "CI gate"** deliverable of #5. #5 stays open — it is a live umbrella epic with M3/M6/M7 outstanding.

https://claude.ai/code/session_01GPpn5ixPgqGqk7uJH7cC6o