### PR TITLE
#76: expose the face/head control axes as a live-wired dial (the dials lap, deliberately before the sign check)

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -107,7 +107,7 @@ Reads the live UI control store → scale + sound + overlay port values.
 
 - **roles:** source, control
 - **in:** —
-- **out:** scaleRight:number[], scaleLeft:number[], soundRight:sound, soundLeft:sound, octaveShift:number, magnetism:number, mute:boolean, overlay:overlay-config, rightSpec:scale-spec, chordSpec:scale-spec, chordScale:number[], faceMapping:face-mapping, chordConfig:chord-config, expressionSensitivity:expression-sensitivity, expressionDegrees:expression-degrees, midiEnabled:boolean, midiPort:string
+- **out:** scaleRight:number[], scaleLeft:number[], soundRight:sound, soundLeft:sound, octaveShift:number, magnetism:number, mute:boolean, overlay:overlay-config, rightSpec:scale-spec, chordSpec:scale-spec, chordScale:number[], faceMapping:face-mapping, chordConfig:chord-config, expressionSensitivity:expression-sensitivity, expressionDegrees:expression-degrees, midiEnabled:boolean, midiPort:string, faceControls:face-controls-config
 - **params:** —
 
 #### `synthetic-hands` — Synthetic Hands
@@ -149,7 +149,7 @@ Face blendshapes → normalized expression controls (smile, mouthOpen, brow, bli
 Face frame → deliberate control axes (head yaw/pitch/roll, jaw-open, smile↔frown, brow-raise, lip-pucker), each with gain/deadzone/smoothing.
 
 - **roles:** feature
-- **in:** face:face-frame
+- **in:** face:face-frame, config:face-controls-config
 - **out:** controls:face-controls
 - **params:** smoothing (number=0.3), headRangeDeg (number=30), headDeadzoneDeg (number=3), yawZeroDeg (number=0), pitchZeroDeg (number=0), rollZeroDeg (number=0), yawGain (number=1), pitchGain (number=1), rollGain (number=1), mouthDeadzone (number=0.08), browDeadzone (number=0.1), puckerDeadzone (number=0.12), smileDeadzone (number=0.06), mouthGain (number=1), browGain (number=1), puckerGain (number=1), smileGain (number=1)
 

--- a/public/catalog.json
+++ b/public/catalog.json
@@ -292,6 +292,10 @@
       {
         "name": "face",
         "kind": "face-frame"
+      },
+      {
+        "name": "config",
+        "kind": "face-controls-config"
       }
     ],
     "outputs": [
@@ -1274,6 +1278,10 @@
       {
         "name": "midiPort",
         "kind": "string"
+      },
+      {
+        "name": "faceControls",
+        "kind": "face-controls-config"
       }
     ],
     "params": []

--- a/public/manual.html
+++ b/public/manual.html
@@ -121,7 +121,7 @@
       <dl>
         <dt>roles</dt><dd>source, control</dd>
         <dt>in</dt><dd>—</dd>
-        <dt>out</dt><dd>scaleRight:number[], scaleLeft:number[], soundRight:sound, soundLeft:sound, octaveShift:number, magnetism:number, mute:boolean, overlay:overlay-config, rightSpec:scale-spec, chordSpec:scale-spec, chordScale:number[], faceMapping:face-mapping, chordConfig:chord-config, expressionSensitivity:expression-sensitivity, expressionDegrees:expression-degrees, midiEnabled:boolean, midiPort:string</dd>
+        <dt>out</dt><dd>scaleRight:number[], scaleLeft:number[], soundRight:sound, soundLeft:sound, octaveShift:number, magnetism:number, mute:boolean, overlay:overlay-config, rightSpec:scale-spec, chordSpec:scale-spec, chordScale:number[], faceMapping:face-mapping, chordConfig:chord-config, expressionSensitivity:expression-sensitivity, expressionDegrees:expression-degrees, midiEnabled:boolean, midiPort:string, faceControls:face-controls-config</dd>
         <dt>params</dt><dd>—</dd>
       </dl>
     </div>
@@ -171,7 +171,7 @@
       <p>Face frame → deliberate control axes (head yaw/pitch/roll, jaw-open, smile↔frown, brow-raise, lip-pucker), each with gain/deadzone/smoothing.</p>
       <dl>
         <dt>roles</dt><dd>feature</dd>
-        <dt>in</dt><dd>face:face-frame</dd>
+        <dt>in</dt><dd>face:face-frame, config:face-controls-config</dd>
         <dt>out</dt><dd>controls:face-controls</dd>
         <dt>params</dt><dd>smoothing (number=0.3), headRangeDeg (number=30), headDeadzoneDeg (number=3), yawZeroDeg (number=0), pitchZeroDeg (number=0), rollZeroDeg (number=0), yawGain (number=1), pitchGain (number=1), rollGain (number=1), mouthDeadzone (number=0.08), browDeadzone (number=0.1), puckerDeadzone (number=0.12), smileDeadzone (number=0.06), mouthGain (number=1), browGain (number=1), puckerGain (number=1), smileGain (number=1)</dd>
       </dl>

--- a/src/app/dials/panels/face.tsx
+++ b/src/app/dials/panels/face.tsx
@@ -1,18 +1,56 @@
 /**
  * The FACE section of the settings panel: the face-mapping chooser (off / expression→
- * timbre / expression→chord / head-pose→chord), the live face-model status readout, and
- * the disclosure of the mode-specific editors (chord sound, expression mapping, pose moves).
+ * timbre / expression→chord / head-pose→chord), the live face-model status readout, the
+ * disclosure of the mode-specific editors (chord sound, expression mapping, pose moves),
+ * and — in `controls` mode — the per-axis TUNING for the head/face control axes (#76).
+ *
+ * The axis editor exists because those axes shipped (PR #86) with their gains, deadzones
+ * and neutral zeros reachable only by editing `face_controls.ts` and rebuilding. That is
+ * the #136 rule ("a feature nobody can find is not shipped") applied to a parameter
+ * rather than a tool. It also changes what a maintainer has to do about the one thing
+ * this repo genuinely cannot verify headlessly: whether a real camera's yaw/pitch/roll
+ * signs match the intended felt direction. No fixture can answer that. With the axes on
+ * a live-wired dial, the answer costs one click of "Flip" while looking at the camera.
  */
+import type { ReactNode } from 'react';
 import type { FaceMapping } from '@/nodes';
-import { dispatchDialSet } from '../../dispatchDial';
+import { type FaceControlsDialParams } from '@/nodes/features/face_controls';
+import { dispatchDialSet, dispatchDialSetIn, dispatchDialReset } from '../../dispatchDial';
 import { ExpressionHelpButton } from '../../ExpressionHelpPanel';
 import { POSE_MOVES } from '../../poseControlsHelp';
 import { useFaceStatus } from '../../faceStatus';
 import { useDialsSettings } from '../useDialsSettings';
 import { FACE_MODE_OPTIONS, FACE_MODE_HINT } from '../labels';
-import { selectCls } from '../primitives';
+import { CollapsibleSection, selectCls } from '../primitives';
 import { ChordControls } from './chord';
 import { ExpressionMapping } from './expression';
+
+/** The three head-pose axes, each with its gain and neutral-zero leaf names. Data, not
+ *  markup, so adding an axis to the node's params is a one-line change here. */
+const HEAD_AXES = [
+  { key: 'yaw', label: 'Turn (yaw)', gain: 'yawGain', zero: 'yawZeroDeg' },
+  { key: 'pitch', label: 'Nod (pitch)', gain: 'pitchGain', zero: 'pitchZeroDeg' },
+  { key: 'roll', label: 'Tilt (roll)', gain: 'rollGain', zero: 'rollZeroDeg' },
+] as const satisfies ReadonlyArray<{
+  key: string;
+  label: string;
+  gain: keyof FaceControlsDialParams;
+  zero: keyof FaceControlsDialParams;
+}>;
+
+/** The blendshape-driven axes: gain + deadzone. `mouthOpen` gates the chord, so its
+ *  deadzone is the difference between "resting face plays" and "nothing ever plays". */
+const FACE_AXES = [
+  { key: 'mouth', label: 'Jaw open', gain: 'mouthGain', dead: 'mouthDeadzone' },
+  { key: 'smile', label: 'Smile / frown', gain: 'smileGain', dead: 'smileDeadzone' },
+  { key: 'brow', label: 'Brow raise', gain: 'browGain', dead: 'browDeadzone' },
+  { key: 'pucker', label: 'Lip pucker', gain: 'puckerGain', dead: 'puckerDeadzone' },
+] as const satisfies ReadonlyArray<{
+  key: string;
+  label: string;
+  gain: keyof FaceControlsDialParams;
+  dead: keyof FaceControlsDialParams;
+}>;
 
 /** Live face-model status + detected expression, driven by the engine (#65). The
  *  classified emotion `label` is shown only when it actually drives the sound — in
@@ -70,6 +108,189 @@ function PoseMovesHelp() {
   );
 }
 
+/**
+ * Per-axis tuning for the head/face control axes (#76).
+ *
+ * The write-path split here is the repo rule, not a local choice
+ * (`test/dials_write_path.test.ts` enforces it): a continuous `type="range"` drag fires a
+ * write per pointer-move frame and stays a direct merged write (**Decision B**), while
+ * every DISCRETE control — the Flip buttons, Reset — dispatches a command, so it is
+ * equally reachable from the Cmd/Ctrl-K palette, a keybinding and the AI assistant.
+ *
+ * `faceControls` is a whole-object dial (like `overlay` / `handMap`), so it has no
+ * per-dial `set` command; the discrete writes address one scalar LEAF by dotted path and
+ * dispatch `dial.setIn`, which does the deep-set and the validation inside the command.
+ */
+function FaceAxisControls() {
+  const { state, set } = useDialsSettings();
+  const fc = state.effective['faceControls'] as FaceControlsDialParams;
+
+  /** CONTINUOUS (a slider being dragged) — a direct merged write. Decision B: the ONLY
+   *  sanctioned direct writer in this panel. */
+  const patchLive = (patch: Partial<FaceControlsDialParams>) => set('faceControls', { ...fc, ...patch });
+
+  /** DISCRETE — through the registry, addressing the leaf by path. */
+  const setLeaf = (leaf: keyof FaceControlsDialParams, value: number) =>
+    dispatchDialSetIn(`faceControls.${String(leaf)}`, value);
+
+  /** Flip an axis's felt direction by negating its gain. This is the whole point of the
+   *  panel: the yaw/pitch/roll SIGN conventions cannot be asserted headlessly, so the
+   *  check is "does turning right raise the chord?" — and if not, one click fixes it. */
+  const flip = (leaf: keyof FaceControlsDialParams) => setLeaf(leaf, -(fc[leaf] as number));
+
+  /**
+   * The chrome of a slider row — label, live value, and a slot for the input.
+   *
+   * Presentational ONLY, and the input is deliberately NOT inside it: the write-path
+   * guard sanctions a direct dials write by the source range of the literal
+   * `<input type="range">` element, so wrapping the input in a component would hide the
+   * exception from the AST — and, as that guard's own comment says, sanctioning a render
+   * helper's body would sanctify the whole panel. Keeping the input at the call site
+   * keeps Decision B auditable instead of laundered.
+   */
+  const Row = ({ label, value, children }: { label: string; value: number; children: ReactNode }) => (
+    <label className="flex items-center justify-between gap-2 text-xs" title={`${label}: ${value}`}>
+      <span className="text-white/70">{label}</span>
+      <span className="flex items-center gap-1.5">
+        <span className="w-9 text-right tabular-nums text-[10px] text-white/40">{value}</span>
+        {children}
+      </span>
+    </label>
+  );
+
+  return (
+    <CollapsibleSection label="Control axes" defaultOpen={false}>
+      <p className="text-[10px] leading-relaxed text-white/40">
+        Tune each axis while the camera runs. If an axis feels backwards, hit <em>Flip</em> — the
+        camera's sign convention is the one thing that cannot be checked without a face in frame.
+      </p>
+
+      {HEAD_AXES.map((a) => (
+        <div key={a.key} className="space-y-1 border-l border-white/10 pl-2">
+          <div className="flex items-center justify-between gap-2 text-xs">
+            <span className="text-white/70">{a.label}</span>
+            <button
+              type="button"
+              className="rounded bg-white/10 px-2 py-0.5 text-[10px] transition hover:bg-white/20"
+              onClick={() => flip(a.gain)}
+              title="Reverse this axis (negate its gain)"
+            >
+              Flip {(fc[a.gain] as number) < 0 ? '(reversed)' : ''}
+            </button>
+          </div>
+          <Row label="Gain" value={fc[a.gain] as number}>
+            <input
+              type="range"
+              min={-3}
+              max={3}
+              step={0.1}
+              value={fc[a.gain] as number}
+              onChange={(e) => {
+                const v = Number(e.target.value);
+                patchLive({ [a.gain]: v } as Partial<FaceControlsDialParams>);
+              }}
+            />
+          </Row>
+          <Row label="Neutral (deg)" value={fc[a.zero] as number}>
+            <input
+              type="range"
+              min={-45}
+              max={45}
+              step={1}
+              value={fc[a.zero] as number}
+              onChange={(e) => {
+                const v = Number(e.target.value);
+                patchLive({ [a.zero]: v } as Partial<FaceControlsDialParams>);
+              }}
+            />
+          </Row>
+        </div>
+      ))}
+
+      <Row label="Head range (deg)" value={fc.headRangeDeg}>
+        <input
+          type="range"
+          min={5}
+          max={90}
+          step={1}
+          value={fc.headRangeDeg}
+          onChange={(e) => {
+            const v = Number(e.target.value);
+            patchLive({ headRangeDeg: v });
+          }}
+        />
+      </Row>
+      <Row label="Head deadzone (deg)" value={fc.headDeadzoneDeg}>
+        <input
+          type="range"
+          min={0}
+          max={20}
+          step={0.5}
+          value={fc.headDeadzoneDeg}
+          onChange={(e) => {
+            const v = Number(e.target.value);
+            patchLive({ headDeadzoneDeg: v });
+          }}
+        />
+      </Row>
+
+      {FACE_AXES.map((a) => (
+        <div key={a.key} className="space-y-1 border-l border-white/10 pl-2">
+          <div className="text-xs text-white/70">{a.label}</div>
+          <Row label="Gain" value={fc[a.gain] as number}>
+            <input
+              type="range"
+              min={0}
+              max={3}
+              step={0.1}
+              value={fc[a.gain] as number}
+              onChange={(e) => {
+                const v = Number(e.target.value);
+                patchLive({ [a.gain]: v } as Partial<FaceControlsDialParams>);
+              }}
+            />
+          </Row>
+          <Row label="Deadzone" value={fc[a.dead] as number}>
+            <input
+              type="range"
+              min={0}
+              max={0.9}
+              step={0.01}
+              value={fc[a.dead] as number}
+              onChange={(e) => {
+                const v = Number(e.target.value);
+                patchLive({ [a.dead]: v } as Partial<FaceControlsDialParams>);
+              }}
+            />
+          </Row>
+        </div>
+      ))}
+
+      <Row label="Smoothing" value={fc.smoothing}>
+        <input
+          type="range"
+          min={0}
+          max={0.95}
+          step={0.01}
+          value={fc.smoothing}
+          onChange={(e) => {
+            const v = Number(e.target.value);
+            patchLive({ smoothing: v });
+          }}
+        />
+      </Row>
+
+      <button
+        type="button"
+        className="rounded bg-white/10 px-2 py-1 text-[10px] transition hover:bg-white/20"
+        onClick={() => dispatchDialReset('faceControls')}
+      >
+        Reset axes to defaults
+      </button>
+    </CollapsibleSection>
+  );
+}
+
 export function FaceControls() {
   const { state } = useDialsSettings();
   const v = state.effective;
@@ -98,6 +319,7 @@ export function FaceControls() {
       </div>
       <p className="text-[10px] leading-relaxed text-white/40">{FACE_MODE_HINT[faceMapping]}</p>
       {faceMapping === 'controls' && <PoseMovesHelp />}
+      {faceMapping === 'controls' && <FaceAxisControls />}
       {/* Both chord instruments (emotion + pose) share the same sound settings. */}
       {(faceMapping === 'chord' || faceMapping === 'controls') && <ChordControls />}
       {/* The per-emotion sensitivity / degree editor applies only to the emotion

--- a/src/app/dials/panels/face.tsx
+++ b/src/app/dials/panels/face.tsx
@@ -12,7 +12,6 @@
  * signs match the intended felt direction. No fixture can answer that. With the axes on
  * a live-wired dial, the answer costs one click of "Flip" while looking at the camera.
  */
-import type { ReactNode } from 'react';
 import type { FaceMapping } from '@/nodes';
 import { type FaceControlsDialParams } from '@/nodes/features/face_controls';
 import { dispatchDialSet, dispatchDialSetIn, dispatchDialReset } from '../../dispatchDial';
@@ -21,7 +20,7 @@ import { POSE_MOVES } from '../../poseControlsHelp';
 import { useFaceStatus } from '../../faceStatus';
 import { useDialsSettings } from '../useDialsSettings';
 import { FACE_MODE_OPTIONS, FACE_MODE_HINT } from '../labels';
-import { CollapsibleSection, selectCls } from '../primitives';
+import { CollapsibleSection, ValueRow, selectCls } from '../primitives';
 import { ChordControls } from './chord';
 import { ExpressionMapping } from './expression';
 
@@ -138,26 +137,6 @@ function FaceAxisControls() {
    *  check is "does turning right raise the chord?" — and if not, one click fixes it. */
   const flip = (leaf: keyof FaceControlsDialParams) => setLeaf(leaf, -(fc[leaf] as number));
 
-  /**
-   * The chrome of a slider row — label, live value, and a slot for the input.
-   *
-   * Presentational ONLY, and the input is deliberately NOT inside it: the write-path
-   * guard sanctions a direct dials write by the source range of the literal
-   * `<input type="range">` element, so wrapping the input in a component would hide the
-   * exception from the AST — and, as that guard's own comment says, sanctioning a render
-   * helper's body would sanctify the whole panel. Keeping the input at the call site
-   * keeps Decision B auditable instead of laundered.
-   */
-  const Row = ({ label, value, children }: { label: string; value: number; children: ReactNode }) => (
-    <label className="flex items-center justify-between gap-2 text-xs" title={`${label}: ${value}`}>
-      <span className="text-white/70">{label}</span>
-      <span className="flex items-center gap-1.5">
-        <span className="w-9 text-right tabular-nums text-[10px] text-white/40">{value}</span>
-        {children}
-      </span>
-    </label>
-  );
-
   return (
     <CollapsibleSection label="Control axes" defaultOpen={false}>
       <p className="text-[10px] leading-relaxed text-white/40">
@@ -178,7 +157,7 @@ function FaceAxisControls() {
               Flip {(fc[a.gain] as number) < 0 ? '(reversed)' : ''}
             </button>
           </div>
-          <Row label="Gain" value={fc[a.gain] as number}>
+          <ValueRow label="Gain" value={fc[a.gain] as number}>
             <input
               type="range"
               min={-3}
@@ -190,8 +169,8 @@ function FaceAxisControls() {
                 patchLive({ [a.gain]: v } as Partial<FaceControlsDialParams>);
               }}
             />
-          </Row>
-          <Row label="Neutral (deg)" value={fc[a.zero] as number}>
+          </ValueRow>
+          <ValueRow label="Neutral (deg)" value={fc[a.zero] as number}>
             <input
               type="range"
               min={-45}
@@ -203,11 +182,11 @@ function FaceAxisControls() {
                 patchLive({ [a.zero]: v } as Partial<FaceControlsDialParams>);
               }}
             />
-          </Row>
+          </ValueRow>
         </div>
       ))}
 
-      <Row label="Head range (deg)" value={fc.headRangeDeg}>
+      <ValueRow label="Head range (deg)" value={fc.headRangeDeg}>
         <input
           type="range"
           min={5}
@@ -219,8 +198,8 @@ function FaceAxisControls() {
             patchLive({ headRangeDeg: v });
           }}
         />
-      </Row>
-      <Row label="Head deadzone (deg)" value={fc.headDeadzoneDeg}>
+      </ValueRow>
+      <ValueRow label="Head deadzone (deg)" value={fc.headDeadzoneDeg}>
         <input
           type="range"
           min={0}
@@ -232,12 +211,12 @@ function FaceAxisControls() {
             patchLive({ headDeadzoneDeg: v });
           }}
         />
-      </Row>
+      </ValueRow>
 
       {FACE_AXES.map((a) => (
         <div key={a.key} className="space-y-1 border-l border-white/10 pl-2">
           <div className="text-xs text-white/70">{a.label}</div>
-          <Row label="Gain" value={fc[a.gain] as number}>
+          <ValueRow label="Gain" value={fc[a.gain] as number}>
             <input
               type="range"
               min={0}
@@ -249,8 +228,8 @@ function FaceAxisControls() {
                 patchLive({ [a.gain]: v } as Partial<FaceControlsDialParams>);
               }}
             />
-          </Row>
-          <Row label="Deadzone" value={fc[a.dead] as number}>
+          </ValueRow>
+          <ValueRow label="Deadzone" value={fc[a.dead] as number}>
             <input
               type="range"
               min={0}
@@ -262,11 +241,11 @@ function FaceAxisControls() {
                 patchLive({ [a.dead]: v } as Partial<FaceControlsDialParams>);
               }}
             />
-          </Row>
+          </ValueRow>
         </div>
       ))}
 
-      <Row label="Smoothing" value={fc.smoothing}>
+      <ValueRow label="Smoothing" value={fc.smoothing}>
         <input
           type="range"
           min={0}
@@ -278,7 +257,7 @@ function FaceAxisControls() {
             patchLive({ smoothing: v });
           }}
         />
-      </Row>
+      </ValueRow>
 
       <button
         type="button"

--- a/src/app/dials/primitives.tsx
+++ b/src/app/dials/primitives.tsx
@@ -59,6 +59,43 @@ export function CollapsibleSection({
 }
 
 /**
+ * A labelled row with a live numeric readout and a SLOT for its control — the chrome
+ * around a settings slider.
+ *
+ * It lives here, at module scope, rather than inside the panel that uses it, and that is
+ * load-bearing rather than tidiness: a component declared inside another component's body
+ * is a NEW function identity on every render, so React's reconciler sees a different
+ * element type and unmounts the subtree instead of updating it. For an
+ * `<input type="range">` that is fatal — the DOM node under the pointer is replaced after
+ * the first pointer-move, ending the native drag, and keyboard focus drops to <body> after
+ * one arrow key. `test/face_axes_panel.test.tsx` pins the resulting node identity.
+ *
+ * The control is a `children` slot rather than a prop so the `<input type="range">` stays
+ * at the CALL SITE: `test/dials_write_path.test.ts` sanctions a direct dials write by the
+ * source range of the literal range element, and burying the input in a helper would hide
+ * Decision B from that AST guard instead of keeping it auditable.
+ */
+export function ValueRow({
+  label,
+  value,
+  children,
+}: {
+  label: string;
+  value: number;
+  children: ReactNode;
+}) {
+  return (
+    <label className="flex items-center justify-between gap-2 text-xs" title={`${label}: ${value}`}>
+      <span className="text-white/70">{label}</span>
+      <span className="flex items-center gap-1.5">
+        <span className="w-9 text-right tabular-nums text-[10px] text-white/40">{value}</span>
+        {children}
+      </span>
+    </label>
+  );
+}
+
+/**
  * A top-level collapsible group (Sound / Face / Overlay / …) — the accordion that
  * keeps the panel from overwhelming as settings grow. More prominent than the
  * inner {@link CollapsibleSection}; a ▸/▾ marker and a divider above.

--- a/src/app/dispatchDial.ts
+++ b/src/app/dispatchDial.ts
@@ -12,6 +12,7 @@
  *   Structured dials get no per-dial command and a command's value must stay SCALAR (an
  *   object param emits a JSON Schema Gemini rejects), so a path is what makes the overlay
  *   / hand-map / expression-map dispatchable at all. See `commands/paths.ts`.
+ * - {@link dispatchDialReset} — one dial back to its default.
  * - {@link dispatchDialPatch} — several dials ATOMICALLY, for the controls whose single
  *   gesture is genuinely several writes: the chord-source flip that seeds root+type, and a
  *   synced-hands voice edit that mirrors onto the other hand. All-or-nothing, so a
@@ -51,6 +52,13 @@ export function dispatchDialSet(key: string, value: unknown): void {
  *  dial (`overlay.*`, `handMap.*`, `faceExpr.degrees.*`), addressed by its dotted path. */
 export function dispatchDialSetIn(path: string, value: unknown): void {
   toastOnFailure(registry.dispatch('dial.setIn', { path, value }));
+}
+
+/** Dispatch `dial.reset` to return one dial to its default (the lower default scope
+ *  re-wins). Discrete by nature — a "reset these axes" button is one click, not a drag —
+ *  so it goes through the registry like every other discrete panel write. */
+export function dispatchDialReset(key: string): void {
+  toastOnFailure(registry.dispatch('dial.reset', { key }));
 }
 
 /** Dispatch `dial.patch` for a discrete panel write that is ATOMICALLY several dials — a

--- a/src/app/graph.ts
+++ b/src/app/graph.ts
@@ -186,6 +186,12 @@ export function defaultGraph(selection?: SlotSelection, registry?: NodeRegistry)
       // instrument plays a diatonic chord from head/face pose; it emits silent
       // voices unless the mode is 'controls', so the merge is unaffected otherwise.
       { from: { node: 'camFace', port: 'face' }, to: { node: 'faceCtrl', port: 'face' } },
+      // The axis tuning (#76) is a LIVE input, not a build-time param: the `faceControls`
+      // dial reaches the node here, so a gain / deadzone / neutral-zero edit takes effect
+      // on the next tick. Without this edge the dial would exist and do nothing — exactly
+      // the #137 failure mode (a shipped node with an unconnected enable input), which is
+      // why `app_graph.test.ts` asserts this edge structurally.
+      { from: { node: 'ui', port: 'faceControls' }, to: { node: 'faceCtrl', port: 'config' } },
       { from: { node: 'faceCtrl', port: 'controls' }, to: { node: 'poseChord', port: 'controls' } },
       // #75: pose chords also read the decoupled chord-source spec (unblocks pose mode
       // on a non-seven-note melody, exactly like the emotion chord).

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -36,10 +36,20 @@ import {
   type MidiSettings,
 } from '@/settings/schema';
 import { DEFAULT_HAND_MAP, type HandMap } from '@/nodes/mapping/hand_map';
+import {
+  FaceControlsDialSchema,
+  DEFAULT_FACE_CONTROLS_DIAL,
+  type FaceControlsDialParams,
+} from '@/nodes/features/face_controls';
 
 /** A fresh deep copy of the default hand map (nested fingers/routes), so the store's
  *  initializer and healers never share mutable sub-objects with the constant. */
 const defaultHandMap = (): HandMap => structuredClone(DEFAULT_HAND_MAP);
+
+/** A fresh copy of the shipped face-control axis tuning (#76), for the same reason as
+ *  {@link defaultHandMap}: the initializer and the healers must never hand out the
+ *  module-level constant itself, or an edit in one instrument would mutate the default. */
+const defaultFaceControls = (): FaceControlsDialParams => ({ ...DEFAULT_FACE_CONTROLS_DIAL });
 
 /** The preset keys (derived from the schema — the SSOT). Add a field to
  *  SettingsSchema (+ the store) and it is snapshotted, persisted, and restored
@@ -125,6 +135,16 @@ export interface ControlState {
    *  field (in {@link SETTINGS_KEYS}); read live by the `midi-out` node via
    *  `store-controls` → its `enabled`/`port` inputs. */
   midi: MidiSettings;
+  /**
+   * The head/face CONTROL axis tuning (#76): per-axis gain (negative flips a
+   * direction), deadzone, neutral zero and shared smoothing for the `face-controls`
+   * node. A preset field (in {@link SETTINGS_KEYS}) — unlike {@link faceCalibration},
+   * which is a per-DEVICE property, an axis tuning is part of how an instrument plays,
+   * so it rides the instrument. Read live by `face-controls` via `store-controls` →
+   * its `config` input port, so a change takes effect on the next tick without a graph
+   * rebuild or a face-model reload.
+   */
+  faceControls: FaceControlsDialParams;
   /** Per-DEVICE expression calibration: a per-emotion firing-sensitivity override
    *  produced by the calibration wizard, applied OVER `faceExpr.sensitivity` for every
    *  instrument (so calibration is global). Persisted to localStorage, NOT part of a
@@ -333,6 +353,26 @@ export function mergeControls(persisted: unknown, current: ControlState): Contro
       midi = current.midi;
     }
   }
+  // Heal the face-control axes (#76): a pre-#76-dials blob has none → the shipped tuning;
+  // a partial one is completed; a corrupt one falls back whole rather than leaving the
+  // panel to dereference an undefined into a NaN slider.
+  //
+  // Parsed RAW, unlike the `midi`/`faceChord` healers above which pre-spread their
+  // defaults. That is not an inconsistency to tidy up later: EVERY field of this schema
+  // carries a `.default(...)`, so `parse` already completes a partial blob, and the spread
+  // would be dead code that a reader would mistake for load-bearing. The invariant it
+  // relies on is enforced at import time, not by convention — `DEFAULT_FACE_CONTROLS_DIAL`
+  // is built by `FaceControlsDialSchema.parse({})`, which throws on the day someone adds a
+  // field without a default. (A mutation test caught the spread: removing it left the
+  // suite fully green, which is the definition of a guard that guards nothing.)
+  let faceControls = current.faceControls;
+  if (p.faceControls) {
+    try {
+      faceControls = FaceControlsDialSchema.parse(p.faceControls);
+    } catch {
+      faceControls = current.faceControls;
+    }
+  }
   // Heal the gesture prefs (#129) the same way as the other tooling prefs: complete
   // a partial blob from the current (default) prefs, then validate — a pre-#129 blob
   // has none → the defaults; a corrupt blob falls back rather than crashing a newer
@@ -346,7 +386,7 @@ export function mergeControls(persisted: unknown, current: ControlState): Contro
       gestures = current.gestures;
     }
   }
-  return { ...current, ...p, overlay, featureLab, faceMapping, faceChord, faceExpr, handMap, midi, gestures };
+  return { ...current, ...p, overlay, featureLab, faceMapping, faceChord, faceExpr, handMap, midi, faceControls, gestures };
 }
 
 // localStorage in the browser; a no-op elsewhere (Node test runtime) so the
@@ -379,6 +419,7 @@ export const useControls = create<ControlState>()(
       featureLab: defaultFeatureLab(),
       handMap: defaultHandMap(),
       midi: { ...DEFAULT_MIDI },
+      faceControls: defaultFaceControls(),
       faceCalibration: null,
       gestures: defaultGesturePrefs(),
       setVoice: (side, patch) =>
@@ -448,7 +489,13 @@ export const useControls = create<ControlState>()(
       // (disabled; fist → silence, pinch → restore volume, open unbound), healed by
       // mergeControls like featureLab, so no data transform is needed — the bump is
       // the version marker for the schema growth.
-      version: 9,
+      // Version 10: #76 added the `faceControls` preset field (per-axis gain / deadzone /
+      // neutral zero / smoothing for the head-pose control mode). ADDITIVE with the
+      // shipped tuning as its default — which is byte-identical to the build-time params
+      // the node used before the dial existed, so a returning player's `controls` mode
+      // sounds and feels exactly as it did. Healed by mergeControls, so no data transform
+      // is needed; the bump is the version marker for the schema growth.
+      version: 10,
       migrate: migrateControls,
       merge: mergeControls,
       storage: createJSONStorage(controlsStorage),

--- a/src/nodes/features/face_controls.ts
+++ b/src/nodes/features/face_controls.ts
@@ -22,6 +22,16 @@
  * control eases rather than jumps. Head axes additionally take a per-session
  * neutral *zero* (degrees) — the seam a future "look at the camera" calibration
  * fills — and a full-scale *range* (the degrees of rotation that reach ±1).
+ *
+ * Those knobs are **reachable** (#76): {@link FaceControlsDialSchema} re-exports this
+ * node's params as the `faceControls` dial, and the `config` input port lets the dial
+ * override the build-time params LIVE, per tick. So the axis gains — including the
+ * negative ones that flip a direction — are tuned from the settings panel while the
+ * camera is running, rather than by editing this file and rebuilding. That matters
+ * beyond convenience: the yaw/pitch/roll SIGN conventions still cannot be asserted
+ * headlessly (no fixture can tell us which way a real camera calls "left"), so the
+ * remaining check is a human looking at a screen — and a live-tunable gain is what
+ * makes that check a ten-second flip instead of a build cycle.
  */
 import { z } from 'zod';
 import { defineNode } from '@/dag';
@@ -60,6 +70,25 @@ const Params = z.object({
   smileGain: z.number().min(0).default(1),
 });
 type Params = z.infer<typeof Params>;
+
+/**
+ * The node's params, re-exported as the SSOT for the `faceControls` **dial** (#76).
+ *
+ * Lifted 1:1 rather than restated, for the reason `OverlayDialSchema` exists in
+ * `canvas_overlay.ts`: a dial that re-declares a node's params is a second shape that
+ * drifts silently the first time one side gains a field. Because the dial IS this
+ * schema, `commands/paths.ts` derives a `dial.setIn` leaf for every axis knob here with
+ * no hand-maintenance — add a param below and it becomes settable from the panel, the
+ * Cmd/Ctrl-K palette, the AI assistant and a keybinding at once.
+ *
+ * (Unlike `OverlayDialSchema` there is nothing to `.omit()`: every param here is a
+ * per-instrument musical parameter, not a per-device tooling pref.)
+ */
+export const FaceControlsDialSchema = Params;
+export type FaceControlsDialParams = Params;
+
+/** The shipped defaults, as a plain value — the dial/store/schema default. */
+export const DEFAULT_FACE_CONTROLS_DIAL: FaceControlsDialParams = FaceControlsDialSchema.parse({});
 
 const clampSigned = (v: number): number => (v < -1 ? -1 : v > 1 ? 1 : v);
 
@@ -108,24 +137,40 @@ export const faceControlsNode = defineNode<Params>({
   title: 'Face Controls',
   description:
     'Face frame → deliberate control axes (head yaw/pitch/roll, jaw-open, smile↔frown, brow-raise, lip-pucker), each with gain/deadzone/smoothing.',
-  inputs: [{ name: 'face', kind: 'face-frame' }],
+  inputs: [
+    { name: 'face', kind: 'face-frame' },
+    // LIVE override of the build-time params (#76), the same pattern the chord
+    // instruments use for `chordConfig`: the `faceControls` dial flows in here through
+    // `store-controls`, so re-tuning a gain or a deadzone takes effect on the next tick
+    // without rebuilding the graph or reloading the MediaPipe face model. This is what
+    // turns the still-open axis-sign check into "flip a number while looking at the
+    // camera" instead of "edit source, rebuild, re-grant camera permission".
+    { name: 'config', kind: 'face-controls-config' },
+  ],
   outputs: [{ name: 'controls', kind: 'face-controls' }],
   params: Params,
   make(p) {
     const prev = zeroAxes();
     const keys = Object.keys(prev) as (keyof AxisState)[];
 
-    /** EMA `prev` toward `target` (target 0 = decay toward rest). */
-    const ease = (target: AxisState) => {
-      for (const k of keys) prev[k] = prev[k] + (1 - p.smoothing) * (target[k] - prev[k]);
+    /** EMA `prev` toward `target` (target 0 = decay toward rest). `smoothing` is passed
+     *  per-tick rather than closed over, so the live `config` port can change it. */
+    const ease = (target: AxisState, smoothing: number) => {
+      for (const k of keys) prev[k] = prev[k] + (1 - smoothing) * (target[k] - prev[k]);
     };
 
     return {
       process(inputs) {
+        // The live config wins field-by-field over the build-time params, so a PARTIAL
+        // override (or none at all, in the headless fixtures) still resolves to a
+        // complete param set.
+        const live = inputs.config as Partial<Params> | undefined;
+        const q: Params = live ? { ...p, ...live } : p;
+
         const face = inputs.face as FaceFrame | undefined;
         if (!face || !face.present) {
           // Decay toward rest so a lost face relaxes the axes rather than freezing them.
-          ease(zeroAxes());
+          ease(zeroAxes(), q.smoothing);
           return { controls: { ...ABSENT_FACE_CONTROLS } };
         }
 
@@ -136,25 +181,25 @@ export const faceControlsNode = defineNode<Params>({
         // blendshape-only fixture has none, so they rest at 0 (present stays true).
         const pose = face.headPose;
         const target: AxisState = {
-          headYaw: pose ? headAxis(pose.yaw, p.yawZeroDeg, p.headRangeDeg, p.headDeadzoneDeg, p.yawGain) : 0,
-          headPitch: pose ? headAxis(pose.pitch, p.pitchZeroDeg, p.headRangeDeg, p.headDeadzoneDeg, p.pitchGain) : 0,
-          headRoll: pose ? headAxis(pose.roll, p.rollZeroDeg, p.headRangeDeg, p.headDeadzoneDeg, p.rollGain) : 0,
-          mouthOpen: unipolar(bs('jawOpen'), p.mouthDeadzone, p.mouthGain),
+          headYaw: pose ? headAxis(pose.yaw, q.yawZeroDeg, q.headRangeDeg, q.headDeadzoneDeg, q.yawGain) : 0,
+          headPitch: pose ? headAxis(pose.pitch, q.pitchZeroDeg, q.headRangeDeg, q.headDeadzoneDeg, q.pitchGain) : 0,
+          headRoll: pose ? headAxis(pose.roll, q.rollZeroDeg, q.headRangeDeg, q.headDeadzoneDeg, q.rollGain) : 0,
+          mouthOpen: unipolar(bs('jawOpen'), q.mouthDeadzone, q.mouthGain),
           smileFrown: clampSigned(
             bipolar(
               avg(bs('mouthSmileLeft'), bs('mouthSmileRight')) - avg(bs('mouthFrownLeft'), bs('mouthFrownRight')),
-              p.smileDeadzone,
-            ) * p.smileGain,
+              q.smileDeadzone,
+            ) * q.smileGain,
           ),
           browRaise: unipolar(
             avg(bs('browInnerUp'), bs('browOuterUpLeft'), bs('browOuterUpRight')),
-            p.browDeadzone,
-            p.browGain,
+            q.browDeadzone,
+            q.browGain,
           ),
-          lipPucker: unipolar(avg(bs('mouthPucker'), bs('mouthFunnel')), p.puckerDeadzone, p.puckerGain),
+          lipPucker: unipolar(avg(bs('mouthPucker'), bs('mouthFunnel')), q.puckerDeadzone, q.puckerGain),
         };
 
-        ease(target);
+        ease(target, q.smoothing);
         return { controls: { present: true, ...prev } as FaceControls };
       },
     };

--- a/src/nodes/sources/store_controls.ts
+++ b/src/nodes/sources/store_controls.ts
@@ -15,6 +15,7 @@ import type { SoundId } from '@/music/sounds';
 import { legacyFaceToMapping, type FaceMapping } from '@/nodes/domain';
 import type { FaceChord, FaceExpr } from '@/settings/schema';
 import type { OverlayDialParams } from '@/nodes/output/canvas_overlay';
+import type { FaceControlsDialParams } from '@/nodes/features/face_controls';
 import { defaultFeatureLab, type FeatureLabConfig } from '@/features/labConfig';
 
 export interface VoiceControlSnapshot {
@@ -66,6 +67,10 @@ export interface ControlSnapshot {
   /** MIDI output (#137): on/off + target port name ('' = first available). Fed to
    *  the `midi-out` node's `enabled`/`port` inputs as live ports. */
   midi?: { enabled: boolean; port: string };
+  /** The head/face CONTROL axis tuning (#76): per-axis gain / deadzone / neutral zero
+   *  / smoothing. Fed to the `face-controls` node's `config` input as a live override
+   *  of its build-time params, so re-tuning an axis needs no graph rebuild. */
+  faceControls?: FaceControlsDialParams;
 }
 
 const Params = z.object({});
@@ -107,6 +112,9 @@ export const storeControlsNode = defineNode<Record<string, never>>({
     // so the settings panel / palette / AI can turn MIDI on without a graph rebuild.
     { name: 'midiEnabled', kind: 'boolean' },
     { name: 'midiPort', kind: 'string' },
+    // The head/face control axis tuning (#76) → `face-controls`' `config` input, so
+    // the panel / palette / AI can re-tune an axis (including flipping a sign) live.
+    { name: 'faceControls', kind: 'face-controls-config' },
   ],
   params: Params,
   make() {
@@ -150,6 +158,10 @@ export const storeControlsNode = defineNode<Record<string, never>>({
           chordScale: generateScale(chordSpec),
           faceMapping: c.faceMapping ?? legacyFaceToMapping(c.faceEnabled),
         };
+        // Only emitted when the host actually has a tuning: an absent value must leave
+        // the node on its build-time params, and an explicitly-emitted `undefined` would
+        // be indistinguishable from that anyway — so skip the key entirely.
+        if (c.faceControls) out.faceControls = c.faceControls;
         if (c.faceChord) {
           out.chordConfig = {
             sound: c.faceChord.sound,

--- a/src/settings/dials.ts
+++ b/src/settings/dials.ts
@@ -20,6 +20,7 @@ import { VOICINGS, RENDERINGS, type VoicingId, type RenderingId } from '@/music/
 import { FACE_MAPPINGS, type FaceMapping } from '@/nodes/domain';
 import { DEFAULT_EXPRESSION_SENSITIVITY, DEFAULT_EXPRESSION_TO_DEGREE } from '@/music/expression';
 import { OverlayDialSchema } from '@/nodes/output/canvas_overlay';
+import { FaceControlsDialSchema, DEFAULT_FACE_CONTROLS_DIAL } from '@/nodes/features/face_controls';
 import { DEFAULT_HAND_MAP } from '@/nodes/mapping/hand_map';
 import { SettingsSchema, HandMapSchema, DEFAULT_FACE_CHORD, type Settings } from './schema';
 
@@ -109,6 +110,16 @@ export const thoreminDials = defineDials(
     // The hand→sound mapping (note source + finger routing + knobs) — a whole-object
     // dial rendered by the bespoke Hand widget, like `overlay` / the expression maps.
     handMap: HandMapSchema.default(DEFAULT_HAND_MAP).meta({ facets: ['Hand'], title: 'Hand mapping' }),
+    // The head/face CONTROL axes (#76) — a whole-object dial like `overlay` / `handMap`,
+    // rendered by a bespoke widget in the Face panel and reachable leaf-by-leaf through
+    // `dial.setIn` (paths.ts derives `faceControls.yawGain`, `faceControls.headRangeDeg`,
+    // … straight from this schema). Facet 'Face' so it files with the mapping chooser it
+    // belongs to; the panel only shows it in the `controls` mode that uses it.
+    faceControls: FaceControlsDialSchema.default(DEFAULT_FACE_CONTROLS_DIAL).meta({
+      facets: ['Face', 'advanced'],
+      title: 'Face control axes',
+      description: 'Per-axis gain / deadzone / neutral zero / smoothing for the head-pose control mode',
+    }),
   }),
   // No cross-field constraints: since #75 the chord/head-pose modes no longer require
   // a seven-note melody scale — the chord SOURCE (auto-derived or custom) is what a
@@ -159,6 +170,7 @@ export function settingsToLayer(s: Settings): Layer {
     'midi.port': s.midi.port,
     overlay: s.overlay,
     handMap: s.handMap,
+    faceControls: s.faceControls,
   });
 }
 
@@ -191,5 +203,6 @@ export function layerToSettings(v: Record<string, unknown>): Settings {
     midi: { enabled: v['midi.enabled'], port: v['midi.port'] },
     overlay: v.overlay,
     handMap: v.handMap,
+    faceControls: v.faceControls,
   });
 }

--- a/src/settings/schema.ts
+++ b/src/settings/schema.ts
@@ -15,6 +15,7 @@ import { SOUND_IDS, type SoundId } from '@/music/sounds';
 import { VOICINGS, RENDERINGS, type VoicingId, type RenderingId } from '@/music/voicing';
 import { FACE_MAPPINGS, legacyFaceToMapping, type FaceMapping } from '@/nodes/domain';
 import { OverlayDialSchema } from '@/nodes/output/canvas_overlay';
+import { FaceControlsDialSchema, DEFAULT_FACE_CONTROLS_DIAL } from '@/nodes/features/face_controls';
 import { DEFAULT_EXPRESSION_SENSITIVITY, DEFAULT_EXPRESSION_TO_DEGREE } from '@/music/expression';
 import {
   EFFECTS,
@@ -191,6 +192,12 @@ export const SettingsSchema = z.object({
   handMap: HandMapSchema,
   // MIDI output (#137). `.default(...)` keeps pre-MIDI presets valid (off).
   midi: MidiSettingsSchema.default(DEFAULT_MIDI),
+  // The head/face CONTROL axes (#76): per-axis gain / deadzone / zero / smoothing for
+  // the `face-controls` node. The schema is the node's own params, imported rather
+  // than restated (see FaceControlsDialSchema) so the two can never drift.
+  // `.default(...)` keeps presets saved before #76's dials valid — they get the shipped
+  // axis tuning, which is byte-identical to the build-time params they were played with.
+  faceControls: FaceControlsDialSchema.default(DEFAULT_FACE_CONTROLS_DIAL),
 });
 export type Settings = z.infer<typeof SettingsSchema>;
 

--- a/test/app_graph.test.ts
+++ b/test/app_graph.test.ts
@@ -88,6 +88,22 @@ describe('production app graph', () => {
     expect(inbound).toContain('params');
   });
 
+  it('wires the face CONTROL axis tuning live from the store — the #76 regression guard', () => {
+    const edges = defaultGraph().edges;
+    const has = (fn: string, fp: string, tn: string, tp: string) =>
+      edges.some((e) => e.from.node === fn && e.from.port === fp && e.to.node === tn && e.to.port === tp);
+    // The exact wiring: the `faceControls` dial flows from the store into the node's
+    // live `config` input, so a gain / deadzone / neutral-zero edit lands next tick.
+    expect(has('ui', 'faceControls', 'faceCtrl', 'config')).toBe(true);
+    // The same structural guard #137 earned, applied to #76's axes. A dial whose port is
+    // left unconnected is a dial that silently does nothing — the panel would look alive,
+    // every unit test would pass, and turning a knob would change no sound. That is
+    // precisely how MIDI out shipped (PR #120) and how the Feature Lab shipped (#119).
+    const inbound = edges.filter((e) => e.to.node === 'faceCtrl').map((e) => e.to.port);
+    expect(inbound).toContain('face');
+    expect(inbound).toContain('config');
+  });
+
   it('wires the Feature Lab vector taps additively off the existing sources (#119)', () => {
     const edges = defaultGraph().edges;
     const has = (fn: string, fp: string, tn: string, tp: string) =>

--- a/test/app_store.test.ts
+++ b/test/app_store.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { useControls, toSettings, migrateControls, mergeControls } from '@/app/store';
 import { defaultGesturePrefs } from '@/app/gesturePrefs';
 import { DEFAULT_FACE_CHORD, SettingsSchema } from '@/settings/schema';
+import { DEFAULT_FACE_CONTROLS_DIAL } from '@/nodes/features/face_controls';
 import { storeControlsNode } from '@/nodes/browser';
 import { generateScale } from '@/music/theory';
 import { DEFAULT_SOUND_RIGHT, DEFAULT_SOUND_LEFT } from '@/music/sounds';
@@ -278,6 +279,26 @@ describe('persist migration (v1 → v2, returning users)', () => {
     });
   });
 
+  it('mergeControls heals the face-control axes (#76): absent → shipped tuning, partial → completed, corrupt → default', () => {
+    const initial = useControls.getInitialState();
+    // A pre-#76-dials blob has no faceControls key at all → the shipped tuning, which is
+    // byte-identical to the build-time params the node ran on before the dial existed, so
+    // a returning player's `controls` mode feels exactly as it did.
+    expect(mergeControls({ masterVolume: 0.5 }, initial).faceControls).toEqual(DEFAULT_FACE_CONTROLS_DIAL);
+    // A PARTIAL blob keeps what the player tuned and completes the rest from the schema's
+    // own declared defaults — which is exactly why the heal can parse it raw rather than
+    // pre-spreading a default object over it (see the note in mergeControls).
+    const partial = mergeControls({ faceControls: { yawGain: -1 } as never }, initial).faceControls;
+    expect(partial.yawGain).toBe(-1);
+    expect(partial.pitchGain).toBe(DEFAULT_FACE_CONTROLS_DIAL.pitchGain);
+    expect(partial.headRangeDeg).toBe(DEFAULT_FACE_CONTROLS_DIAL.headRangeDeg);
+    // A corrupt value falls back whole — never a crash, never an undefined the panel
+    // would dereference into a NaN slider.
+    expect(
+      mergeControls({ faceControls: { yawGain: 'left', smoothing: 9 } as never }, initial).faceControls,
+    ).toEqual(DEFAULT_FACE_CONTROLS_DIAL);
+  });
+
   it('mergeControls heals the gesture prefs (#129): absent → defaults, partial → completed, corrupt → default', () => {
     const initial = useControls.getInitialState();
     // A pre-#129 blob has no gestures key at all → the defaults (disabled; fist +
@@ -407,6 +428,17 @@ describe('store-controls node reads the store', () => {
     out = node.process({}, ctxWith({ controls: () => useControls.getState() }));
     expect(out.midiEnabled).toBe(true);
     expect(out.midiPort).toBe('IAC Driver Bus 1');
+  });
+
+  it('emits the face-control axis tuning as a live port (#76)', () => {
+    const node = storeControlsNode.make(storeControlsNode.params.parse({}));
+    let out = node.process({}, ctxWith({ controls: () => useControls.getState() }));
+    expect(out.faceControls).toEqual(DEFAULT_FACE_CONTROLS_DIAL);
+    // Flipping an axis sign flows straight through — no rebuild, next tick. This is the
+    // whole point of #76's dial lap: the axis-sign check becomes a knob, not a build.
+    useControls.setState({ faceControls: { ...DEFAULT_FACE_CONTROLS_DIAL, yawGain: -1 } });
+    out = node.process({}, ctxWith({ controls: () => useControls.getState() }));
+    expect((out.faceControls as { yawGain: number }).yawGain).toBe(-1);
   });
 
   it('a wider octave range widens scaleRight through store-controls (#63 replay)', () => {

--- a/test/commands_paths.test.ts
+++ b/test/commands_paths.test.ts
@@ -104,7 +104,9 @@ describe('structured-dial leaf paths (#126)', () => {
     expect(paths).toEqual([...paths].sort((a, b) => a.localeCompare(b)));
     expect(new Set(paths).size).toBe(paths.length);
     const owners = new Set(structuredDialLeaves().map((l) => l.key));
-    expect(owners).toEqual(new Set(['overlay', 'handMap', 'faceExpr.degrees', 'faceExpr.sensitivity']));
+    expect(owners).toEqual(
+      new Set(['overlay', 'handMap', 'faceControls', 'faceExpr.degrees', 'faceExpr.sensitivity']),
+    );
     // Every declared structured dial has at least one settable leaf — otherwise it would
     // be silently unreachable by BOTH `dial.set` (skipped: not a scalar) and `dial.setIn`.
     expect(owners.size).toBeGreaterThan(0);

--- a/test/face_axes_panel.test.tsx
+++ b/test/face_axes_panel.test.tsx
@@ -85,3 +85,59 @@ describe('the Flip control writes through the command registry (#126 write path)
     expect(axes().headRangeDeg).toBe(DEFAULT_FACE_CONTROLS_DIAL.headRangeDeg);
   });
 });
+
+/**
+ * The sliders must SURVIVE their own writes.
+ *
+ * A component declared inside another component's body is a new function IDENTITY on
+ * every render, so React's reconciler sees a different element TYPE and unmounts the
+ * whole subtree instead of updating it. For a `<select>` that is merely wasteful; for an
+ * `<input type="range">` it is fatal, because the DOM node under the pointer is replaced
+ * mid-drag and the native drag gesture ends after a single step. Keyboard is hit just as
+ * hard: focus lands on a detached node, so the second arrow key goes nowhere.
+ *
+ * That failure would also nullify Decision B itself — the panel writes directly, skipping
+ * the command registry, *purely* to keep a drag responsive. A drag that cannot last more
+ * than one frame has paid the auditability cost and bought nothing.
+ *
+ * The existing tests above miss it because they only click the Flip buttons, which are
+ * rendered directly by `FaceAxisControls` rather than through the row helper. So this
+ * asserts the property the panel actually depends on: NODE IDENTITY across a write.
+ */
+describe('the axis sliders survive their own writes (no remount on every keystroke)', () => {
+  const ranges = (c: HTMLElement) =>
+    Array.from(c.querySelectorAll<HTMLInputElement>('input[type="range"]'));
+
+  it('keeps the same DOM node for a slider after it writes', () => {
+    setDial('face.mapping' as never, 'controls');
+    const { container } = render(<FaceControls />);
+
+    const before = ranges(container);
+    expect(before.length).toBeGreaterThanOrEqual(15); // 3 head axes x2 + 4 face axes x2 + 4
+    const yawGain = before[0];
+
+    fireEvent.change(yawGain, { target: { value: '0.5' } });
+    expect(axes().yawGain).toBe(0.5);
+
+    const after = ranges(container);
+    expect(after.length).toBe(before.length);
+    // The identity check IS the assertion: a remount replaces the node the pointer holds.
+    expect(after[0]).toBe(yawGain);
+    for (let i = 0; i < before.length; i += 1) expect(after[i]).toBe(before[i]);
+  });
+
+  it('keeps keyboard focus on the slider being adjusted', () => {
+    setDial('face.mapping' as never, 'controls');
+    const { container } = render(<FaceControls />);
+
+    const slider = ranges(container)[0];
+    slider.focus();
+    expect(document.activeElement).toBe(slider);
+
+    fireEvent.change(slider, { target: { value: '0.7' } });
+    // A remount detaches the focused node and focus falls back to <body>, so a second
+    // arrow press would do nothing at all.
+    expect(document.activeElement).toBe(ranges(container)[0]);
+    expect(document.activeElement).not.toBe(document.body);
+  });
+});

--- a/test/face_axes_panel.test.tsx
+++ b/test/face_axes_panel.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+/**
+ * Face control-axis panel reachability (#76) — the UI half of the guard, mirroring
+ * `midi_panel.test.tsx` for #137.
+ *
+ * The DAG-edge test (`app_graph.test.ts`) proves the axis tuning CAN reach the node.
+ * The node test (`face_controls.test.ts`) proves the node honours it. Neither says a
+ * player can FIND it, and that is exactly the gap #119 and #120 fell into: shipped,
+ * deployed, fully tested, unreachable. So this file asserts the reachability itself —
+ * that the axis editor is mounted by the Face panel in the mode that uses it, that the
+ * Flip control exists, and that it is NOT shown in the modes where it would be noise.
+ *
+ * It also pins the write-path split (`test/dials_write_path.test.ts` enforces it
+ * statically, this exercises it dynamically): the Flip button DISPATCHES a command
+ * rather than writing the store directly.
+ */
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { FaceControls } from '@/app/dials/panels/face';
+import { dialsStore, setDial } from '@/app/dials/settingsStore';
+import { DEFAULT_FACE_CONTROLS_DIAL } from '@/nodes/features/face_controls';
+import type { FaceControlsDialParams } from '@/nodes/features/face_controls';
+
+const axes = () => dialsStore.getState().effective['faceControls'] as FaceControlsDialParams;
+
+beforeEach(() => {
+  setDial('face.mapping' as never, 'none');
+  setDial('faceControls' as never, { ...DEFAULT_FACE_CONTROLS_DIAL });
+});
+afterEach(cleanup);
+
+describe('the Face panel mounts the axis editor in `controls` mode (#76 reachability)', () => {
+  it('renders the Control axes section when the head-pose mode is selected', () => {
+    setDial('face.mapping' as never, 'controls');
+    render(<FaceControls />);
+    expect(screen.getByText('Control axes')).toBeTruthy();
+    // The three head axes, each with the Flip affordance that answers the sign question.
+    expect(screen.getByText('Turn (yaw)')).toBeTruthy();
+    expect(screen.getByText('Nod (pitch)')).toBeTruthy();
+    expect(screen.getByText('Tilt (roll)')).toBeTruthy();
+    expect(screen.getAllByTitle('Reverse this axis (negate its gain)').length).toBe(3);
+  });
+
+  it('does NOT render it in the modes that do not use the axes', () => {
+    for (const mode of ['none', 'timbre', 'chord'] as const) {
+      cleanup();
+      setDial('face.mapping' as never, mode);
+      render(<FaceControls />);
+      expect(screen.queryByText('Control axes')).toBeNull();
+    }
+  });
+});
+
+describe('the Flip control writes through the command registry (#126 write path)', () => {
+  it('negates the axis gain, so the sign check is one click rather than a rebuild', async () => {
+    setDial('face.mapping' as never, 'controls');
+    render(<FaceControls />);
+    expect(axes().yawGain).toBe(1);
+
+    const [yawFlip] = screen.getAllByTitle('Reverse this axis (negate its gain)');
+    fireEvent.click(yawFlip);
+    // The dispatch is async (a command returns a promise); let the microtask queue drain.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(axes().yawGain).toBe(-1);
+
+    // …and it is an involution: clicking again restores the original direction, so a
+    // maintainer probing a sign can never get stranded in a state they can't undo.
+    fireEvent.click(screen.getAllByTitle('Reverse this axis (negate its gain)')[0]);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(axes().yawGain).toBe(1);
+  });
+
+  it('flips ONE axis, leaving its siblings alone (a deep-set, not a replace)', async () => {
+    setDial('face.mapping' as never, 'controls');
+    render(<FaceControls />);
+    const flips = screen.getAllByTitle('Reverse this axis (negate its gain)');
+    fireEvent.click(flips[1]); // pitch
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(axes().pitchGain).toBe(-1);
+    expect(axes().yawGain).toBe(1);
+    expect(axes().rollGain).toBe(1);
+    expect(axes().headRangeDeg).toBe(DEFAULT_FACE_CONTROLS_DIAL.headRangeDeg);
+  });
+});

--- a/test/face_controls.test.ts
+++ b/test/face_controls.test.ts
@@ -7,6 +7,11 @@
 import { describe, it, expect } from 'vitest';
 import { replayNode } from '@/dag';
 import { faceControlsNode } from '@/nodes';
+import {
+  FaceControlsDialSchema,
+  DEFAULT_FACE_CONTROLS_DIAL,
+} from '@/nodes/features/face_controls';
+import { structuredLeafPaths } from '@/app/commands/paths';
 import { ABSENT_FACE_CONTROLS, type FaceControls, type FaceFrame, type HeadPose } from '@/nodes/domain';
 
 const frame = (blendshapes: Record<string, number>, headPose?: HeadPose): FaceFrame => ({
@@ -107,5 +112,114 @@ describe('face-controls node (unit)', () => {
     expect(seq[0]).toBeCloseTo(0.5, 5);
     expect(seq[2]).toBeGreaterThan(seq[0]);
     expect(seq[2]).toBeLessThan(1);
+  });
+});
+
+/**
+ * The LIVE `config` input (#76) — the dial's override of the node's build-time params.
+ *
+ * Why this block exists at all: the axes shipped in PR #86 with their gains, deadzones and
+ * neutral zeros settable only by editing the node's source. That made the one check this
+ * repo genuinely cannot do headlessly — whether a real camera's yaw/pitch/roll signs match
+ * the intended felt direction — cost a source edit and a rebuild. These cases pin the
+ * mechanism that turns it into a knob.
+ */
+describe('face-controls live config override (#76)', () => {
+  /** Replay one frame with an explicit build-time param set AND a live config. */
+  async function runLive(
+    input: FaceFrame,
+    params: Record<string, unknown>,
+    config: Record<string, unknown> | undefined,
+  ): Promise<FaceControls> {
+    const p = faceControlsNode.params.parse({ smoothing: 0, ...params });
+    const [out] = await replayNode(faceControlsNode.make(p), {
+      face: [input],
+      ...(config ? { config: [config] } : {}),
+    });
+    return out.controls as FaceControls;
+  }
+
+  const pose = (yaw: number): HeadPose => ({ yaw, pitch: 0, roll: 0 });
+
+  it('a live gain OVERRIDES the build-time param', async () => {
+    const built = await runLive(frame({}, pose(15)), { yawGain: 1 }, undefined);
+    const live = await runLive(frame({}, pose(15)), { yawGain: 1 }, { yawGain: 0.5 });
+    expect(built.headYaw).toBeGreaterThan(0);
+    expect(live.headYaw).toBeCloseTo(built.headYaw * 0.5, 6);
+  });
+
+  it('a NEGATIVE live gain flips the felt direction — the axis-sign fix, without a rebuild', async () => {
+    const fwd = await runLive(frame({}, pose(15)), { yawGain: 1 }, undefined);
+    const flipped = await runLive(frame({}, pose(15)), { yawGain: 1 }, { yawGain: -1 });
+    expect(fwd.headYaw).toBeGreaterThan(0);
+    expect(flipped.headYaw).toBeCloseTo(-fwd.headYaw, 6);
+  });
+
+  it('overrides a BLENDSHAPE axis too, not only the head axes', async () => {
+    const built = await runLive(frame({ jawOpen: 0.5 }), {}, undefined);
+    const live = await runLive(frame({ jawOpen: 0.5 }), {}, { mouthGain: 0.5 });
+    expect(live.mouthOpen).toBeCloseTo(built.mouthOpen * 0.5, 6);
+  });
+
+  it('is PARTIAL — an override of one field leaves the others on their build-time values', async () => {
+    const c = await runLive(frame({ jawOpen: 0.5 }, pose(15)), { yawGain: 2 }, { mouthGain: 0.5 });
+    const baseline = await runLive(frame({ jawOpen: 0.5 }, pose(15)), { yawGain: 2 }, undefined);
+    // mouthGain was overridden…
+    expect(c.mouthOpen).toBeCloseTo(baseline.mouthOpen * 0.5, 6);
+    // …and yawGain: 2 survived it. (A `{...live}` that replaced rather than merged, or a
+    // `q` that read the live object alone, would silently reset yaw to the schema default.)
+    expect(c.headYaw).toBeCloseTo(baseline.headYaw, 6);
+  });
+
+  it('with NO config wired, the build-time params still rule (the headless fixture path)', async () => {
+    const c = await runLive(frame({}, pose(15)), { yawGain: -1 }, undefined);
+    expect(c.headYaw).toBeLessThan(0);
+  });
+
+  it('smoothing is read per-tick, so the live config can change the easing', async () => {
+    // Two ticks of a held pose. With smoothing 0 the first tick already lands on target;
+    // with the live 0.9 it must still be easing well short of it. If `smoothing` were
+    // closed over at make() time (the pre-#76 shape), the override would be ignored.
+    const p = faceControlsNode.params.parse({ smoothing: 0 });
+    const f = frame({}, pose(20));
+    const [, slow] = await replayNode(faceControlsNode.make(p), {
+      face: [f, f],
+      config: [{ smoothing: 0.9 }, { smoothing: 0.9 }],
+    });
+    const [, fast] = await replayNode(faceControlsNode.make(p), { face: [f, f] });
+    expect((slow.controls as FaceControls).headYaw).toBeLessThan((fast.controls as FaceControls).headYaw);
+  });
+});
+
+/** The dial SSOT (#76): the `faceControls` dial IS the node's params schema. */
+describe('faceControls dial is the node schema, not a copy (#76)', () => {
+  it('the dial schema is literally the node params schema', () => {
+    expect(FaceControlsDialSchema).toBe(faceControlsNode.params);
+  });
+
+  it('every node param is an addressable `dial.setIn` leaf — no knob is unreachable', () => {
+    const paths = new Set(structuredLeafPaths());
+    for (const key of Object.keys(DEFAULT_FACE_CONTROLS_DIAL)) {
+      expect(paths.has(`faceControls.${key}`)).toBe(true);
+    }
+  });
+
+  it('the shipped default is what the schema parses from nothing (no drifted second copy)', () => {
+    expect(DEFAULT_FACE_CONTROLS_DIAL).toEqual(FaceControlsDialSchema.parse({}));
+  });
+
+  it('EVERY field carries a default — the invariant the store heal parses raw on', () => {
+    // `mergeControls` heals a partial saved blob with a bare `.parse(blob)`, which only
+    // completes the missing knobs because each one declares a default. If a field is ever
+    // added without one, `parse({})` throws — and that throw is at MODULE LOAD, because
+    // DEFAULT_FACE_CONTROLS_DIAL is built from it. This pins the property explicitly so
+    // the reason survives even if that construction is refactored.
+    for (const key of Object.keys(FaceControlsDialSchema.shape)) {
+      expect(FaceControlsDialSchema.parse({})).toHaveProperty(key);
+    }
+    // …and a partial parse really does fill the rest rather than rejecting it.
+    const partial = FaceControlsDialSchema.parse({ yawGain: -1 });
+    expect(partial.yawGain).toBe(-1);
+    expect(partial.headRangeDeg).toBe(DEFAULT_FACE_CONTROLS_DIAL.headRangeDeg);
   });
 });


### PR DESCRIPTION
Advances #76. It does **not** close it — see "What remains" at the bottom.

## Scope, honestly stated

PR #86 shipped Phases 0–2 of #76 and a sliver of Phase 3. The issue's own narrowed scope — **per-axis live-tuning UI**, **per-user calibration**, **demoting the emotion classifier to opt-in** — was 0 of 3 done. This PR does the first.

## Why the dials lap comes FIRST, reversing the order the status comment proposes

That comment says do the live sign check first, because it may invalidate the shipped defaults. I deliberately did the opposite, and the reasoning is worth stating because it generalises:

**A dial exposing `yawGain` is correct whichever way the sign turns out.** Its value is not contingent on the answer. Meanwhile the ordering it replaces is strictly worse in both directions:

- Check first → the fix is a hardcoded constant in `face_controls.ts` that nobody can retune, on a machine-and-camera-specific finding. The next person with a different webcam is back where we started.
- Dial first → the check itself becomes *cheaper*. It goes from "edit source, `npm run build`, reload, re-grant camera permission, re-pose" to **"click Flip while looking at the camera"** — and whatever the maintainer discovers is then a saved instrument parameter rather than a commit.

Put differently: the check is blocked on a human with a webcam (#146), which no amount of my work unblocks. What I *can* do is make the ten seconds that human spends actually decisive.

## The shape — the #137/#147 precedent, followed exactly

**1. One schema, not two.** `face_controls.ts` now exports its `Params` as `FaceControlsDialSchema` — lifted 1:1, the same move `OverlayDialSchema` makes in `canvas_overlay.ts`. A dial that re-declares a node's params is a second shape that drifts silently the first time one side gains a field. Because the dial *is* the schema, `commands/paths.ts` derives a `dial.setIn` leaf for **every** knob with zero hand-maintenance — so each axis is settable from the panel, the Cmd/Ctrl-K palette, a keybinding and the AI assistant at once.

**2. A live input port, so the dial actually does something.** A `config` input overrides the build-time params per tick (the `chordConfig` pattern the chord instruments already use), merged **field-by-field** so a partial override is safe and the headless fixtures — which wire no config — keep running on the build-time params. `smoothing` is now read per-tick rather than captured in the `make()` closure, which it had to be for a live change to reach the easing.

**3. Persistence.** `SettingsSchema.faceControls`, defaulted — a pre-#76 preset stays valid and, because the default is byte-identical to the params the node already ran on, sounds and feels exactly as it did. Persist version 9 → 10 with a `mergeControls` heal.

**4. Wiring.** `store-controls` emits a `faceControls` port; `graph.ts` connects it to `faceCtrl.config`, beside the existing `ui → faceCtrl` edges. `app_graph.test.ts` asserts that edge structurally — the guard #137 earned, because a dial whose port is unconnected is a panel that looks alive and changes no sound, with every unit test green. That is precisely how MIDI out (#120) and the Feature Lab (#119) shipped.

**5. The panel.** Under the existing `PoseMovesHelp`, in `controls` mode only: a **Flip** button per head axis, gain / neutral-zero / deadzone sliders, shared smoothing, and Reset. Discrete controls **dispatch** (`dispatchDialSetIn`, plus a new `dispatchDialReset` symmetric with the existing three); sliders stay a direct `setDial` per **Decision B**.

**6.** `npm run catalog` run and committed (`docs/CATALOG.md`, `public/manual.html`, `public/catalog.json`).

### One thing the write-path guard taught me mid-build

My first panel factored the sliders into a `<Slider>` component. `test/dials_write_path.test.ts` rejected all seven — correctly. It sanctions a direct write by the source range of the **literal `<input type="range">` element**, so wrapping the input in a component hides the exception from the AST; as the guard's own comment says, sanctioning a render helper's body would sanctify the whole panel. I rewrote it with the inputs inline. Decision B stays auditable instead of laundered.

## Mutation testing — 9 mutations, each reverted

| # | Mutation | Result |
|---|---|---|
| M1 | drop the `ui.faceControls → faceCtrl.config` edge | `app_graph` **RED** (1) |
| M2 | node ignores the live config (`q = p`) | `face_controls` **RED** (5) |
| M3 | live config REPLACES instead of merging | `face_controls` **RED** (5) |
| M4 | heal parses raw instead of default-completing | **GREEN** — see below |
| M4b | heal skips validation entirely | `app_store` **RED** (1) |
| M4c | heal dropped from the merge return | `app_store` **RED** (1) |
| M5 | `store-controls` stops emitting the port | `app_store` **RED** (1) |
| M6 | panel drops `<FaceAxisControls/>` | `face_axes_panel` **RED** (3) |
| M7 | a schema field loses its `.default()` | module **throws at import** |
| M8 | Flip writes the store directly | `dials_write_path` **RED** (1) |
| M9 | the `controls` mode gate is removed | `face_axes_panel` **RED** (1) |

### M4 surviving is a real finding, and I am reporting it as one

I wrote the heal as `.parse({ ...DEFAULT_FACE_CONTROLS_DIAL, ...blob })`, copying the `midi`/`faceChord` healers, and wrote a test comment asserting that a bare `.parse(blob)` "would throw on the missing keys and silently revert the axes the player DID tune."

**That was false.** Every field of this schema declares a default, so `parse` already completes a partial blob. The spread was dead code, and the comment justifying it was wrong — the exact species of confidently-worded, never-checked claim that PR #155 in this same batch exists to clean up.

Both are fixed rather than papered over: the heal now parses raw with a note explaining *why* that is safe, and a new test pins the all-defaults invariant it depends on. M7 demonstrates that invariant does not fail silently — `DEFAULT_FACE_CONTROLS_DIAL` is built by `FaceControlsDialSchema.parse({})`, so adding a field without a default throws at **module load**, not at some user's next reload.

A guard that stays green under mutation is worthless. This one did, and it is why the code is different now.

## Gates

```
$ npm test
 Test Files  88 passed (88)
      Tests  927 passed (927)

$ npm run typecheck
> tsc -p tsconfig.dag.json --noEmit
(clean)

$ npm run build
✓ built in 5.30s

$ npm run catalog
catalog: 31 nodes -> docs/CATALOG.md, public/manual.html, public/catalog.json
```

## What remains on #76 — it stays open

1. **The axis-sign live check.** Still unresolved, and structurally unresolvable here: no fixture can tell us which way a real camera calls "left". Tracked in #146. This PR makes it a one-click check instead of a build cycle.
2. **Per-user calibration.** The `*ZeroDeg` seam exists and is now a dial, but there is no "look at the camera to zero" flow.
3. **Demoting the emotion classifier to opt-in**, once `controls` proves out.

#76 stays open for those three.

https://claude.ai/code/session_01GPpn5ixPgqGqk7uJH7cC6o
