### PR TITLE
#127: one dispatch middleware seam — undo/redo, telemetry, command export/replay

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,6 +193,7 @@ So, when you add a user-facing capability:
 | Music theory + **sounds** (timbre presets) | `src/music/` (`theory.ts`, `sounds.ts`, `voicing.ts`, `expression.ts`) |
 | Overlay (compose elements here) | `src/nodes/output/canvas_overlay.ts` |
 | **Command registry** (#87) — the single write path, guarded by `test/dials_write_path.test.ts` | `src/app/commands/` (`registry.ts`, `dials.ts`, `perDial.ts`, `paths.ts`, `instruments.ts`, `confirmation.ts`) + the panel dispatchers in `src/app/dispatchDial.ts` |
+| **Dispatch middleware** (#127) — one seam on `registry.dispatch`; undo/redo, telemetry and export/replay are three readings of it. Order is stated as data in `registry.ts` (gate outermost) | `src/app/commands/` (`middleware.ts`, `history.ts`, `journal.ts`) + the ⌘Z/⌘⇧Z bindings in `src/app/keyboardShortcuts.ts` |
 | **Dials** — settings schema store + named **instruments** (saved profiles) | `src/app/dials/` (`settingsStore.ts`, `instruments.ts`, panels) |
 | Dials schema / presets SSOT | `src/settings/` (`schema.ts`, `dials.ts`, `presets.ts`) |
 | **Feature catalog** (#119) — data-driven features, safe formula compiler, online normalizer | `src/features/` (`catalog.ts`, `formula.ts`, `normalizer.ts`) |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -156,14 +156,53 @@ such — a bracketed `#n` in this list always means an issue.
   (the `*ZeroDeg` seam exists), and **demoting the emotion classifier to opt-in** once
   `controls` proves out. The **axis-sign live check** is the #146 item.
 
+- **[#160] Trainer mode — learn the player's OWN categories from a live stream.**
+  Research: [`docs/research/trainer-mode.md`](research/trainer-mode.md) (26 refs).
+  Reframes the face-mapping problem: the difficulty hitting the shipped expression
+  categories is **identity bias** — a named, measured gap — and the field's answer is
+  personalization, whose usual blocker (subject-specific labels are unavailable) simply
+  does not apply to an instrument whose player is sitting at the camera. So: stop tuning
+  a population model, let each player carve their own space.
+
+  Four things the research settles, each load-bearing:
+
+  1. **Train on the FEATURE VECTOR, not the face.** `src/features/catalog.ts` already
+     emits a flat named scalar vector from face *and* hands through one contract, so
+     `Record<featureId, number>` makes this modality-general on day one. Building it
+     against `FaceFrame` is the one decision that would make it face-only forever.
+  2. **Build a hierarchy, cut it at k.** That is what makes "specify the count before
+     *or afterwards*" nearly free — one recording supports 3 then 5 then 4 categories
+     with no retraining. The player drags a slider; the vocabulary gets finer or coarser.
+  3. **Cluster the still points, not the frames.** A free-motion stream is mostly
+     transitions; clustering every frame finds the centre of the motion envelope rather
+     than the expressions. Velocity-gate to poses actually held.
+  4. **No-man's-land is a reject region, hysteretic, and NOT silent** — it should hold
+     the last category, not drop out. An instrument that goes quiet whenever the
+     classifier is unsure is unplayable.
+
+  The invariance half ("camera distance shouldn't matter") is **~70% already shipped**:
+  #131's `invariantTo` vocabulary already names `scale` as camera distance and ships
+  `residual()`/`deconfound()`. Nothing consumes it — level 1 is a selection policy, not
+  new mathematics. Level 2 (learn the nuisance from a demonstration clip) is the elegant
+  target; level 3 (adversarial invariance) is knowingly declined.
+
+  Four maintainer questions are open in the issue (discrete vs continuous; persistence;
+  command vs dial; acceptable recording length).
+
 ### Command dispatch
 
-- **[#127] #87 Phase 4 (opt-in)** — undo via `acture-undo`, telemetry, command
-  export/replay: one middleware seam on `registry.dispatch`, viewed three ways. Written
-  as blocked on #126; **that blocker is cleared** (#126 merged 2026-07-13), as is its
-  "not worth building while only two call sites dispatch" reasoning — there are now
-  fifteen dispatch call sites across the panels plus four independent dispatchers
-  (panels, keyboard, AI assistant, gestures). Still deliberately opt-in and unscheduled.
+- **[#127] #87 Phase 4 — DONE (PR #159).** One middleware seam on `registry.dispatch`
+  (`src/app/commands/middleware.ts`), read three ways: undo/redo, the telemetry journal,
+  and command export/replay. Order is stated as data, gate outermost, because a blocked
+  command did not run and must not be journaled or undoable. Undo is hand-written, not
+  `acture-undo`: that package observes `setStateWithPatches` on a `PatchCapableAdapter`,
+  and this registry deliberately holds no adapter while zodal's settings store emits no
+  patches. History snapshots the whole editable layer per dispatch rather than
+  registering per-command inverses, so a command added later gets undo for free and
+  `dial.patch` cannot be half-undone. Bound to ⌘/Ctrl-Z + both redo spellings — an undo
+  history reachable only from a module export is the #137 trap. Two properties to know:
+  slider drags bypass the registry (Decision B) so they appear in neither surface, and
+  the journal has **no egress and no persistence**.
 
 ### Generative
 

--- a/docs/research/trainer-mode.md
+++ b/docs/research/trainer-mode.md
@@ -1,0 +1,438 @@
+# Research: trainer mode — learning a player's own control categories from a live stream
+
+**Status:** research (evidence), not design (commitment). Point-in-time, 2026-08-22.
+Re-verify library versions and claims before relying on them.
+**Question it answers:** the player cannot reliably hit the expression categories the
+shipped model recognises. Instead of tuning the model's categories, let the player
+*carve their own* — move around in front of the camera, say how many categories they
+want (before **or** after), and have the system find them. Generalise to any input
+stream, not just the face.
+
+---
+
+## 0. The short version
+
+1. **The complaint is a known, named, measured phenomenon**, not a tuning failure.
+   It is *identity bias* / the subject-dependent accuracy gap in facial expression
+   recognition, and the literature's answer is personalization — which is exactly what
+   is being asked for [1][2][3].
+2. **The dominant prior art is supervised and it is from this exact field.** Wekinator
+   (Fiebrink) [4][5] and Mapping-by-Demonstration (Françoise/Bevilacqua, IRCAM) [7][8][9]
+   are two decades of "the performer demonstrates, the system learns the mapping." The
+   default answer to "how do I get categories that fit me" is *record a few seconds per
+   category*, not *cluster an unlabelled stream*.
+3. **But the unlabelled version — the one actually described — is also well-founded**,
+   and it has one design move that makes "specify the count before *or afterwards*" fall
+   out for free: **build a hierarchy once, cut it at whatever k is asked for** [16][17].
+   The count stops being a training parameter and becomes a view.
+4. **The "no man's land" is a first-class, well-studied thing**: the reject option /
+   open-set recognition [12][13], and in the streaming-clustering family it is literally
+   a tunable parameter — ART's *vigilance* [10][11].
+5. **The invariance request is ~70% already built in this repo.** #131 shipped a declared
+   `invariantTo` vocabulary (`scale` = camera distance, `position`, `yaw`/`pitch`/`roll`)
+   on every catalog feature, plus `residual()`/`deconfound()` helpers in the Lab formula
+   compiler. What is missing is a *consumer* that selects or down-weights features by
+   that declaration — not new mathematics.
+6. **The single highest-value recommendation:** build the trainer over the **feature
+   vector**, not over the face. `src/features/catalog.ts` already emits a flat, named,
+   normalized scalar vector from face *and* hands through one interface. Train on that
+   and "generalizable to any input" is not a future refactor — it is the starting state.
+
+---
+
+## 1. Diagnosing the actual complaint first
+
+It is worth being precise about *why* the current expression mapping is hard to hit,
+because two different diagnoses imply two different products.
+
+The current pipeline scores MediaPipe's 52 blendshapes against FACS-grounded emotion
+prototypes. Issue #76 already established two independent reasons this is a poor control
+surface: posed (volitional) and felt (spontaneous) facial movement are driven by
+different neural pathways, so a player can only *pose a face they hope the classifier
+reads as X*; and the channels the harder emotions lean on (`noseSneer`, `eyeWide`) are
+under-reported by the model itself.
+
+The research adds a third, and it is the decisive one for *this* request:
+
+> Identity bias has always been a challenge for facial expression analysis, as
+> expressions and identities are inherently entangled [1][3].
+
+Expression recognisers trained on posed corpora carry a measurable **subject-dependent
+accuracy gap**. The mitigation the field converges on is *personalization* — adapting to
+the individual rather than normalising the individual away [1][2]. Some approaches
+normalise identity out ("Norface" maps every face to a common identity before analysis
+[3]); others fine-tune per subject, and note that this "depends on subject-specific
+labels, which are often unavailable in real-world applications" [1].
+
+**That caveat is the whole opportunity.** In a musical instrument, the player is present,
+motivated, and holding the camera. Subject-specific labels are not unavailable — they are
+*free*. The player will happily spend sixty seconds making faces at their own instrument.
+This is a domain where personalization is unusually cheap, which is why the music-IML
+tradition got here first.
+
+**Conclusion:** the complaint is not that the model is badly tuned. It is that a
+population model is the wrong object. The fix is a per-player model, and the reason to
+build it is that acquiring one is cheap here.
+
+---
+
+## 2. What this is called, and the prior art that matters
+
+### 2.1 Interactive Machine Learning (IML) — the tradition
+
+The framing "user supplies examples in a tight loop and steers the model by demonstration
+rather than by parameters" is **Interactive Machine Learning**. In music its canonical
+artefact is **Wekinator** (Rebecca Fiebrink, 2008) [4][5]: a standalone tool that applies
+supervised learning to real-time sensor→sound mapping, supporting classification
+(category labels), regression (continuous values) and temporal modelling. It has been the
+default answer for gesturally-controlled instruments for fifteen years.
+
+The load-bearing observation from that tradition, and the one most relevant here: the
+value is not the algorithm. It is that **the training loop is fast enough to be part of
+playing**. Fiebrink's systems let a performer add examples, retrain, and immediately hear
+the result — the model is an instrument you *play into shape*.
+
+### 2.2 Mapping-by-Demonstration — the continuous cousin
+
+IRCAM's ISMM team formalised **Mapping-by-Demonstration**: "crafting sonic interactions
+from demonstrations of embodied associations between motion and sound" [7][8]. The
+software artefact is **XMM**, a C++ library of Gaussian Mixture Models and Hierarchical
+Hidden Markov Models for recognition *and regression* [6][9].
+
+Two ideas worth stealing regardless of which algorithm ships:
+
+- **Demonstrate the pairing, not the category.** The performer moves *while the sound
+  plays*, and the system learns the joint motion↔sound relationship. The label never has
+  to be named.
+- **Recognition and continuous output from one model.** XMM's regression mode outputs
+  synthesis parameters continuously, not a discrete class per frame. For an instrument
+  this matters enormously — a hard classification into N categories is a *step function*,
+  and step functions are not expressive.
+
+### 2.3 Gesture Variation Follower — recognition *and* how you did it
+
+**GVF** (Caramiaux, Montecchio, Tanaka, Bevilacqua) [14][15] uses sequential Monte Carlo
+inference to simultaneously (a) recognise which template a gesture matches and (b)
+estimate its *variation* — scale, orientation, speed — continuously, as the gesture is
+still being performed.
+
+This is directly relevant to the invariance question in §5. GVF does not throw away
+camera distance or orientation; it **estimates them as separate outputs**. "Distance
+shouldn't matter" and "distance is a usable control axis" become the same mechanism
+looked at from two ends.
+
+### 2.4 Teachable Machine — the UX benchmark
+
+Google's Teachable Machine [18] is the interaction design to beat: pick a number of
+classes, hold a button to record webcam samples for each, press train, use it. No
+expertise, no code. Reported practice ranges from ~10 samples per class for a toy to
+~250–300 for something robust [18].
+
+Its relevant limitation: **the classes are named up front**. The request here explicitly
+wants the count specifiable *afterwards*, which Teachable Machine cannot do — and which
+§4 shows is cheap if the representation is chosen correctly.
+
+---
+
+## 3. Where do the examples come from? Two regimes, and a recommended hybrid
+
+### 3.1 Regime A — supervised by demonstration (Wekinator / Teachable Machine)
+
+Player says "this is category 1", holds a pose, records N frames. Repeat.
+
+- **Pros:** the categories mean what the player intends. Trivially explainable. Robust
+  with tiny data. This is what fifteen years of practice actually uses.
+- **Cons:** requires the player to know their vocabulary up front, and to hold poses —
+  which is the *very thing* they report struggling with.
+
+### 3.2 Regime B — unsupervised carving (what was described)
+
+Player moves freely for a minute. The system clusters the trajectory in feature space and
+carves out k regions.
+
+- **Pros:** zero organisation demanded. The categories are *discovered from what the
+  player can actually reliably produce*, which is the exact failure mode being fixed.
+- **Cons:** the clusters are unnamed and may not correspond to anything meaningful. A
+  cluster can capture a *transition* rather than a *pose*, since a free-motion stream is
+  mostly transitions. And k-means-style methods are sensitive to the dwell-time
+  distribution — you get clusters where the player happened to pause.
+
+**That last point is the real risk and deserves emphasis.** A continuous stream of
+someone "moving their face around" is dominated by the paths between expressions, not the
+expressions. Naive clustering of every frame finds the *centre of the motion envelope*,
+not the extremes. The literature's answer is to segment first: unsupervised threshold
+methods split a stream into *dynamic* and *static* segments using velocity/acceleration
+derived from position, and cluster only the static ones [19][20].
+
+> **Design consequence:** cluster the **still points**, not the frames. A velocity-gated
+> sampler — "record a candidate only when the feature vector's rate of change drops below
+> a threshold for ~200 ms" — turns a free-motion stream into a set of *poses the player
+> actually held*, which is both a better clustering input and a much better match for
+> "categories I can hit on purpose."
+
+### 3.3 Recommended: B for discovery, A for confirmation
+
+Run the unsupervised pass to *propose* categories, then let the player accept, merge,
+split, or discard them — and optionally add a demonstration or two for one that is
+wrong. The player never has to organise anything up front, and never has to accept a
+category they cannot hit. This is the "minimum effort, minimum organisation" the request
+asks for, without inheriting Regime B's failure mode.
+
+---
+
+## 4. "Specify k before **or afterwards**" — the design move that makes this free
+
+This is the most useful single finding in this document.
+
+If the trainer commits to a *partition* (k-means with k fixed, or an online clusterer with
+a fixed vigilance), then k is a training parameter and changing it means retraining.
+
+If instead the trainer produces a **hierarchy** — an agglomerative tree over the collected
+still-points — then:
+
+- the number of clusters need not be specified a priori; clusters are obtained by
+  **cutting the dendrogram at a chosen level** [16][17];
+- specifying k *after* the fact is exactly "choose the cut height that yields k branches"
+  [16];
+- and the *same recording* supports 3 categories, then 5, then 4, with no retraining and
+  no new data — the player drags a slider and hears the vocabulary get finer or coarser.
+
+That last property is not a technical convenience; it is the feature. "Carve the space I
+just made into however many categories I want" **is** cutting a dendrogram, and it is a
+slider.
+
+Useful cut heuristics to *offer as suggestions* (never as the only option): the largest
+gap between successive merge heights, which arguably indicates a natural clustering [17];
+and the silhouette score [16]. Both are cheap over a few hundred points.
+
+**One honest caveat from the same sources**, worth carrying into the UI: "it is generally
+a mistake to use dendrograms as a tool for determining the number of clusters… dendrograms
+often suggest a correct number of clusters when there is no real evidence to support the
+conclusion" [16]. So: suggest a k, show the player *why*, and let them overrule it. Do not
+present a discovered k as a fact.
+
+### The scale question
+
+Agglomerative clustering is O(n²) in memory. That is a non-issue here: a 60-second
+recording gated to still-points yields *hundreds* of points, not millions. If unbounded
+streaming ever becomes a requirement, the ART family (§5.2) is the streaming answer and
+can be a second strategy behind the same interface.
+
+---
+
+## 5. The "no man's land" — a first-class concept, two ways to get it
+
+The request's "maybe with an extra no-man's-land one" is not an afterthought; it is the
+difference between an instrument that is playable and one that is possessed. Without a
+reject region, **every frame is classified as something**, so the instrument is always
+asserting a category — including while the player is between expressions, scratching
+their nose, or talking.
+
+### 5.1 As a threshold — open-set recognition
+
+The literature calls this the **reject option** or **open-set recognition**: rather than
+misclassifying an input as the most similar known class, reject it as "none of the above"
+[12][13]. It is usually framed as a thresholding problem — accept a prediction only when
+its confidence or distance score passes a bar, otherwise treat it as unknown [12].
+
+The literature's warning is also the practical one: **threshold-tuning is crucial, and
+different tasks need very different thresholds** [12]. So the bar must be a dial the
+player can move, and — better — one they can set *by demonstration*: "hold your neutral
+face; everything that looks like this is no-man's-land."
+
+### 5.2 As a parameter of the clusterer — ART's vigilance
+
+The Adaptive Resonance Theory family builds the reject region into the clustering itself.
+ART clusters unlabelled data online with an unknown number of clusters, governed by a
+**vigilance parameter ρ** which "controls when resonance happens" — i.e. how close an
+input must be to an existing category to join it, versus spawning a new one [10][11]. It
+is explicitly designed for streaming: samples are processed and discarded, with low
+computational complexity and low noise sensitivity [10]. Later variants use *dual*
+vigilance to separate cluster similarity from data quantization and so retrieve
+arbitrarily-shaped clusters [11].
+
+ART is the better fit if the trainer ever becomes *continuous* (always learning while you
+play). It has a known weakness worth recording: **order dependence** — the result depends
+on the sequence the data arrived in, which is addressed by pre/post-processing such as a
+Merge-ART module [11]. For a fixed recording that is cut into a hierarchy (§4), order
+dependence does not arise, which is one more argument for the agglomerative route first.
+
+### 5.3 Recommendation
+
+Ship the threshold form (§5.1) because it composes with the hierarchy: after cutting at k,
+a point further than τ from every centroid is no-man's-land. Expose τ as a dial *and* as a
+"hold your resting state" calibration. Keep ART on the shelf for a continuous-learning
+mode.
+
+**The musical detail that matters more than the algorithm:** no-man's-land should almost
+certainly be *hysteretic* and *not silent*. Entering it should be harder than staying in a
+category (the repo already uses dwell/hysteresis for handedness and expression), and it
+probably means "hold the last category" rather than "stop making sound" — an instrument
+that drops to silence whenever the classifier is unsure is unplayable.
+
+---
+
+## 6. Invariance — mostly already built here
+
+The request: *"ways to specify some sensitivity and insensitivities… for example, whether
+how close the face is shouldn't matter or not."*
+
+There are three levels at which this can be answered, and this repo is already at level 1.
+
+### Level 1 — invariance by construction (SHIPPED, #131)
+
+`src/features/types.ts` already defines the vocabulary:
+
+```ts
+export type Invariance = 'scale' | 'position' | 'yaw' | 'pitch' | 'roll';
+```
+
+with `scale` documented as *camera distance* — the exact example asked about. Every
+catalog feature can declare `invariantTo`, with deliberate three-state semantics: absent
+= not assessed, `[]` = assessed and invariant to nothing, a listed axis = moving only
+along that axis should not move this feature. The Lab formula compiler already ships
+`residual(x, z)` and `deconfound(x, z1, z2, …)` to correct a feature for a confound it is
+*not* invariant to.
+
+**So the mechanism exists; nothing consumes it.** A trainer that lets the player tick
+"camera distance shouldn't matter" needs to (a) prefer features declaring
+`invariantTo: ['scale']`, (b) apply `residual()` against the scale proxy for those that
+don't, and (c) *say* which features it dropped and why. That is a selection policy over
+existing data, not new mathematics — by far the cheapest of the three levels.
+
+A blunt but effective complement: normalise the landmark mesh itself (Procrustes-style —
+translate, scale by inter-ocular distance, optionally rotate out head pose) before any
+feature is computed. The catalog already computes `iod` as its face-scale reference.
+
+### Level 2 — invariance by demonstration (the elegant answer)
+
+The contrastive-learning literature's core mechanism: two transformed views of the same
+thing form a *positive pair*, and the representation is trained so "the same sample after
+different transformations should be consistent in the feature space", letting the network
+"ignore some details" [21][22]. Standard practice bakes in invariance to a *pre-defined*
+set of augmentations — but recent work introduces an explicit **invariance descriptor**
+denoting whether a feature extractor should be invariant or *sensitive* to each factor of
+variation [23], precisely because treating every augmentation equally "limits flexibility"
+[24].
+
+The translation to this instrument is direct and rather beautiful:
+
+> **Let the player demonstrate the nuisance.** "Hold the same expression and move closer
+> and further away." Every frame of that clip is a positive pair with every other. Learn
+> a metric (or simply down-weight the feature directions with the highest variance across
+> that clip) in which they are all the same point.
+
+This needs no deep network — a linear whitening or a per-dimension variance down-weight
+over the nuisance clip captures most of it, and it generalises to *any* nuisance the
+player can perform, including ones nobody enumerated. It also matches the interaction
+model already established: you teach it by doing it.
+
+Note the honest caveat from the same literature: **there is no consensus on how to measure
+invariance** of a learned representation to a nuisance factor [21]. So whatever ships must
+show the player the effect (a meter that should stay flat while they move closer) rather
+than claim a number.
+
+### Level 3 — adversarial / disentangled invariance
+
+Full nuisance-invariant representation learning [25][26]. Real, well-studied, and
+comprehensively out of budget for a browser instrument. Recorded so it is knowingly
+declined.
+
+---
+
+## 7. A sketch of what this could be in thoremin
+
+Not a commitment — the design lives in the issue. But the substrate is unusually ready,
+and the shape follows from §§3–6.
+
+**Train on the feature vector, and modality-generality is free.** `src/features/catalog.ts`
+already assembles face and hand features into "a flat, ordered registry of every scalar
+feature id + its group" with a uniform `compute(ctx) → number` contract, an online
+normalizer, and per-feature `invariantTo` / `controllability` declarations. A trainer that
+takes `Record<featureId, number>` is, on day one, a *face* trainer, a *hand* trainer, and a
+trainer for anything added to the catalog later — which is what "start with face but make
+it generalizable to any inputs" asks for. Building it against `FaceFrame` instead would be
+the single decision that makes it face-only forever.
+
+Sketch of the pipeline, each stage a named seam:
+
+| Stage | What it does | Prior art |
+|---|---|---|
+| **Sample** | velocity-gate the live feature vector; keep still-points | [19][20] |
+| **Condition** | drop / `residual()` features against declared nuisance axes; optionally learn a down-weighting from a nuisance clip | #131, [21][23] |
+| **Carve** | agglomerative hierarchy over still-points; cut at k (before or after) | [16][17] |
+| **Reject** | distance threshold τ → no-man's-land, hysteretic | [12][13] |
+| **Bind** | assign each category to a command / dial write | the #127 registry |
+
+Two existing pieces make the last row nearly free. `#129` already ships discrete hand
+poses → command dispatch with edge-triggering, hold and cooldown; a trained category is
+just another discrete event feeding the same adapter. And `#127` (this session) makes
+every param write a recorded, replayable, undoable command — so "bind category 3 to this"
+is a command, and a mis-trained model's damage is one ⌘Z.
+
+**And the honest warning, from #137 and #119:** a trainer buried in a settings panel is
+not shipped. It needs an entry in `src/app/tools.ts` and a reachability test.
+
+---
+
+## 8. What NOT to do
+
+- **Do not classify per frame into a hard category and drive sound from that.** Both XMM
+  and GVF output continuously for a reason [9][14]. A step function is not expressive.
+  Prefer per-category *membership weights* (soft assignment) as the mapping output, with
+  the hard category available for discrete triggers.
+- **Do not cluster raw frames.** The stream is mostly transitions; you will find the
+  middle of the motion envelope (§3.2).
+- **Do not train on the 52 raw blendshapes directly.** The catalog exists, is normalized,
+  and carries the invariance metadata. Bypassing it forfeits §6 Level 1 entirely.
+- **Do not present a discovered k as correct.** The dendrogram literature is explicit that
+  it over-suggests structure [16].
+- **Do not make no-man's-land silent** (§5.3).
+- **Do not build Level 3 invariance** (§6).
+
+---
+
+## 9. Open questions for the maintainer
+
+1. **Is the target a category set (discrete) or a continuous space (regression)?** The
+   request says categories, but the whole IRCAM line argues that continuous is more
+   musical and the Wekinator line supports both. Soft membership may be the answer that
+   avoids choosing.
+2. **Is training a session act or a persistent artefact?** A trained model is a per-player
+   thing that should presumably persist alongside instruments — which makes it a zodal
+   collection question, and would inherit the #82 fragment/composition thinking.
+3. **Does a trained category map to a command, or to a continuous dial?** Both are
+   possible on the #127 write path; they are different products.
+4. **How much recording is acceptable?** 30 s, 60 s, 5 min? This bounds the algorithm
+   choice more than anything else in this document.
+
+---
+
+## REFERENCES
+
+1. [Progressive Multi-Source Domain Adaptation for Personalized Facial Expression Recognition](https://arxiv.org/pdf/2504.04252) — personalization depends on subject-specific labels usually unavailable in the wild.
+2. [Personalized two-stage comparison-based framework for low-to-mid-intensity facial expression recognition in real-world scenarios](https://www.sciencedirect.com/science/article/pii/S2667305326000025)
+3. [Norface: Improving Facial Expression Analysis by Identity Normalization](https://arxiv.org/pdf/2407.15617) — expressions and identities are inherently entangled.
+4. [The Wekinator: A System for Real-time, Interactive Machine Learning in Music](https://archives.ismir.net/ismir2010/latebreaking/000012.pdf) — Fiebrink, ISMIR 2010 late-breaking.
+5. [Wekinator — software for real-time, interactive machine learning](https://doc.gold.ac.uk/~mas01rf/Wekinator/) — classification, regression, temporal modelling.
+6. [XMM — Probabilistic Models for Motion Recognition and Mapping](https://ismm.ircam.fr/software/xmm-probabilistic-models-for-motion-recognition-and-mapping/) — IRCAM ISMM.
+7. [Motion-Sound Mapping through Interaction](https://hal.science/hal-02409300/file/TiiS_HCML___Mapping_through_Interaction.pdf) — Françoise & Bevilacqua.
+8. [Motion-Sound Mapping by Demonstration](https://theses.hal.science/tel-01206009v2/file/2015PA066105.pdf) — Françoise PhD thesis, 2015.
+9. [Gesture–Sound Mapping by Demonstration in Interactive Music Systems](https://hal.science/hal-01061221/document) — hierarchical HMM, user-authorable structure.
+10. [Fractional Adaptive Resonance Theory (FRA-ART): an extension for a stream clustering method](https://doi.org/10.3390/math12132049) — ART for streams; vigilance; low complexity.
+11. [Distributed dual vigilance fuzzy adaptive resonance theory learns online, retrieves arbitrarily-shaped clusters, and mitigates order dependence](https://arxiv.org/pdf/1901.00794) — dual vigilance; the order-dependence problem.
+12. [Open Set Recognition — overview](https://www.sciencedirect.com/topics/computer-science/open-set-recognition) — thresholding formulation; threshold-tuning is crucial.
+13. [Toward Open-Set Face Recognition](https://arxiv.org/pdf/1705.01567) — the "none of the above" option.
+14. [Adaptive Gesture Recognition with Variation Estimation for Interactive Systems](https://research.gold.ac.uk/10541/1/gvf_tiis_si.pdf) — Caramiaux et al., ACM TiiS 4(4), 2014.
+15. [ofxGVF — Gesture Variation Follower](https://github.com/bcaramiaux/ofxGVF) — reference implementation.
+16. [Hierarchical clustering: cutting the dendrogram](https://www.displayr.com/what-is-dendrogram/) — cut at height h or specify k; and the caution against reading k off a dendrogram.
+17. [Hierarchical agglomerative clustering](https://nlp.stanford.edu/IR-book/html/htmledition/hierarchical-agglomerative-clustering-1.html) — Manning, Raghavan & Schütze; the largest-gap cut heuristic.
+18. [Teachable Machine](https://teachablemachine.withgoogle.com/) — the interaction benchmark; webcam samples per class.
+19. [Unsupervised Gesture Segmentation by Motion Detection of a Real-Time Data Stream](https://ieeexplore.ieee.org/document/7576613/) — dynamic vs static segments from velocity/acceleration.
+20. [Segmenting Continuous Motions with Hidden Semi-Markov Models and Gaussian Processes](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5742615/) — unsupervised segmentation of continuous time series.
+21. [Weakly Supervised Invariant Representation Learning via Disentangling Known and Unknown Nuisance Factors](https://arxiv.org/pdf/2209.06827) — nuisance factors; no consensus on measuring invariance.
+22. [Improving Transformation Invariance in Contrastive Representation Learning](https://arxiv.org/pdf/2010.09515)
+23. [Amortised Invariance Learning for Contrastive Self-Supervision](https://arxiv.org/pdf/2302.12712) — the *invariance descriptor*: be invariant or sensitive, per factor.
+24. [Rethinking the Augmentation Module in Contrastive Learning](https://arxiv.org/abs/2206.00227) — treating augmentations equally limits flexibility.
+25. [Unsupervised Adversarial Invariance](https://arxiv.org/pdf/1809.10083)
+26. [Unified Adversarial Invariance](https://arxiv.org/pdf/1905.03629)

--- a/src/app/commands/confirmation.ts
+++ b/src/app/commands/confirmation.ts
@@ -12,7 +12,8 @@
  * self-approve. Human dispatches (palette / hotkeys — no assistant channel) pass
  * through ungated, so this is invisible to every non-AI surface.
  */
-import { err, type Registry, type Result } from 'acture';
+import { err, type Registry } from 'acture';
+import { installMiddleware, type Middleware } from './middleware';
 
 /** A rough risk class for a command; only `destructive` gates by default. */
 export type SideEffect = 'query' | 'additive' | 'destructive';
@@ -76,10 +77,6 @@ export interface AssistantDispatchContext {
   [k: string]: unknown;
 }
 
-/** The shape of `registry.dispatch` the gate wraps (a local alias, not an acture export).
- *  Trailing args (acture's `options`, e.g. an internal token) are forwarded untouched. */
-type Dispatch = (command: string, params?: unknown, context?: unknown, ...rest: unknown[]) => Promise<Result<unknown>>;
-
 /**
  * Build a dispatch middleware that gates destructive commands on the assistant surface.
  * A gated call without a valid one-use token returns a `confirmation_required` Result
@@ -89,7 +86,7 @@ type Dispatch = (command: string, params?: unknown, context?: unknown, ...rest: 
 export function confirmationGate(
   getRisk: (id: string) => RiskMeta,
   approvals: ApprovalStore,
-): (next: Dispatch) => Dispatch {
+): Middleware {
   return (next) => async (command, params, context, ...rest) => {
     const risk = getRisk(command);
     const needs = risk.requiresConfirmation ?? risk.sideEffect === 'destructive';
@@ -114,7 +111,6 @@ export function installConfirmationGate(
 ): { approvals: ApprovalStore } {
   const getRisk = options.getRisk ?? defaultGetRisk;
   const approvals = options.approvals ?? createApprovalStore();
-  const original = registry.dispatch.bind(registry) as Dispatch;
-  registry.dispatch = confirmationGate(getRisk, approvals)(original) as typeof registry.dispatch;
+  installMiddleware(registry, confirmationGate(getRisk, approvals));
   return { approvals };
 }

--- a/src/app/commands/history.ts
+++ b/src/app/commands/history.ts
@@ -1,0 +1,187 @@
+/**
+ * Undo/redo over the dials layer (#127) — the third reading of the one dispatch seam.
+ *
+ * ## Why this is hand-written and not `acture-undo`
+ *
+ * #127 proposes `acture-undo`, and it does not fit — for a structural reason worth
+ * recording rather than rediscovering. `acture-undo` builds its history by observing
+ * `adapter.setStateWithPatches` on a `PatchCapableAdapter`. thoremin's registry
+ * **holds no acture adapter at all**: by deliberate design (see `registry.ts`) handlers
+ * reach state by closure-capturing the dials store, so the registry stays a pure command
+ * index. The store itself is `@zodal/dials-ui`'s `createSettingsStore`, which exposes
+ * `set`/`reset`/`setLayer` and emits no patches. Adopting `acture-undo` would mean
+ * writing a patch-capable adapter over a store we do not own, to reconstruct information
+ * we can read directly. `acture-undo`'s own README names the alternative — "an agent can
+ * hand-write this integration into your project instead" — and this is it.
+ *
+ * ## Why a whole-layer snapshot, not per-command inverses
+ *
+ * The obvious design is an inverse per command (`dial.set` ⇄ the previous value). It is
+ * also the fragile one: every new mutating command must remember to supply an inverse,
+ * and the day one forgets, undo silently skips a write instead of failing loudly. The
+ * dials layer is a small sparse map, so we snapshot it whole, before and after, and push
+ * an entry only when it ACTUALLY CHANGED (deep-compared). That buys three things:
+ *
+ * - **Command-agnostic.** A command added tomorrow gets undo for free, including
+ *   `instrument.load`, which replaces the entire layer in one go.
+ * - **`dial.patch` is atomic in the history too.** A synced-hands voice edit writes the
+ *   primary field and its mirror; one dispatch is one entry, so one undo takes back the
+ *   whole thing rather than half a mirrored pair.
+ * - **A failed or no-op command leaves no entry.** Nothing to special-case: if the layer
+ *   is unchanged there is nothing to undo, which is also the right answer for a query.
+ *
+ * ## Two properties to know
+ *
+ * - **Slider drags are invisible here** (Decision B: continuous `type="range"` writes
+ *   bypass the registry for latency). Undo therefore steps through discrete choices and
+ *   skips drags entirely. That is arguably the correct coalescing — you rarely want to
+ *   undo one pointer-move frame — but it is a consequence, not a decision anyone made,
+ *   so it is stated rather than discovered.
+ * - **Undo/redo apply via `setLayer`, outside dispatch.** So the middleware never sees
+ *   its own writes and cannot record an undo of an undo. `redo` is what re-applies.
+ */
+import { isOk } from 'acture';
+import type { Layer, SettingKey } from '@zodal/dials-core';
+import type { Middleware } from './middleware';
+
+/** The slice of the dials store the history needs — narrowed so tests can pass a fake. */
+export interface LayerStoreLike {
+  getState(): { layer: Layer };
+  setLayer(layer: Layer): void;
+}
+
+/** One undoable step: the editable layer either side of a dispatch that changed it. */
+export interface HistoryEntry {
+  /** The command id that produced the change (the label an undo UI would show). */
+  command: string;
+  /** The editable layer before the dispatch. */
+  before: Layer;
+  /** The editable layer after the dispatch. */
+  after: Layer;
+}
+
+export interface DialsHistory {
+  /** The middleware to install on the registry. */
+  middleware: Middleware;
+  canUndo(): boolean;
+  canRedo(): boolean;
+  /** Revert the most recent change. Returns false if there was nothing to undo. */
+  undo(): boolean;
+  /** Re-apply the most recently undone change. Returns false if there was nothing to redo. */
+  redo(): boolean;
+  /** Forget all history (both stacks). */
+  clear(): void;
+  /** The command id undo would revert, for a menu label / tooltip. */
+  undoLabel(): string | undefined;
+  /** The command id redo would re-apply. */
+  redoLabel(): string | undefined;
+  /** How many undoable entries are held. */
+  size(): number;
+}
+
+/** Bounded so a long session cannot grow the history without limit. */
+const DEFAULT_LIMIT = 100;
+
+/**
+ * Deep clone a layer value. NOT `structuredClone`: a `Layer` value may be the dials-core
+ * `UNSET` sentinel, which is a **symbol** — `structuredClone` throws on symbols, so a
+ * single explicitly-unset dial would break the whole history. Symbols (and every other
+ * primitive) pass through by identity here, which is exactly right for a sentinel.
+ */
+function cloneValue(value: unknown): unknown {
+  if (typeof value !== 'object' || value === null) return value;
+  if (Array.isArray(value)) return value.map(cloneValue);
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(value)) out[k] = cloneValue(v);
+  return out;
+}
+
+/** Snapshot the editable layer, detached from the store's own object graph. */
+function cloneLayer(layer: Layer): Layer {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(layer)) out[k] = cloneValue(v);
+  return out as Layer;
+}
+
+/**
+ * Structural equality, symbol-safe and key-order-independent. A hand-rolled walk rather
+ * than `JSON.stringify` comparison: stringify drops the `UNSET` symbol (so an unset dial
+ * would compare equal to an absent one) and is key-order sensitive (so an object rebuilt
+ * by `setIn`'s spread could compare unequal to an identical one).
+ */
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (typeof a !== 'object' || typeof b !== 'object' || a === null || b === null) return false;
+  if (Array.isArray(a) !== Array.isArray(b)) return false;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return a.length === b.length && a.every((x, i) => deepEqual(x, b[i]));
+  }
+  const ak = Object.keys(a as object);
+  const bk = Object.keys(b as object);
+  if (ak.length !== bk.length) return false;
+  return ak.every(
+    (k) =>
+      Object.prototype.hasOwnProperty.call(b, k) &&
+      deepEqual((a as Record<string, unknown>)[k], (b as Record<string, unknown>)[k]),
+  );
+}
+
+/** True when two editable layers hold the same keys and the same values. */
+export function layersEqual(a: Layer, b: Layer): boolean {
+  return deepEqual(a, b);
+}
+
+/**
+ * Build an undo history over a dials-like store. `limit` bounds the undo stack; the
+ * oldest entry is dropped when it is exceeded.
+ */
+export function createDialsHistory(
+  store: LayerStoreLike,
+  options: { limit?: number } = {},
+): DialsHistory {
+  const limit = options.limit ?? DEFAULT_LIMIT;
+  const undoStack: HistoryEntry[] = [];
+  const redoStack: HistoryEntry[] = [];
+
+  const middleware: Middleware = (next) => async (command, params, context, ...rest) => {
+    const before = cloneLayer(store.getState().layer);
+    const result = await next(command, params, context, ...rest);
+    if (!isOk(result as never)) return result;
+    const after = cloneLayer(store.getState().layer);
+    if (layersEqual(before, after)) return result; // a query, or a write that changed nothing
+    undoStack.push({ command, before, after });
+    if (undoStack.length > limit) undoStack.splice(0, undoStack.length - limit);
+    redoStack.length = 0; // a new branch discards the redo future
+    return result;
+  };
+
+  return {
+    middleware,
+    canUndo: () => undoStack.length > 0,
+    canRedo: () => redoStack.length > 0,
+    undo() {
+      const entry = undoStack.pop();
+      if (!entry) return false;
+      store.setLayer(cloneLayer(entry.before));
+      redoStack.push(entry);
+      return true;
+    },
+    redo() {
+      const entry = redoStack.pop();
+      if (!entry) return false;
+      store.setLayer(cloneLayer(entry.after));
+      undoStack.push(entry);
+      return true;
+    },
+    clear() {
+      undoStack.length = 0;
+      redoStack.length = 0;
+    },
+    undoLabel: () => undoStack[undoStack.length - 1]?.command,
+    redoLabel: () => redoStack[redoStack.length - 1]?.command,
+    size: () => undoStack.length,
+  };
+}
+
+/** Re-exported for callers that hold a `SettingKey` — keeps the type import local. */
+export type { SettingKey };

--- a/src/app/commands/index.ts
+++ b/src/app/commands/index.ts
@@ -4,7 +4,7 @@
  * command definitions. See `dials.ts` for the hard command/hot-path boundary and
  * `test/commands_firewall.test.ts` for the import firewall that enforces it.
  */
-export { registry, createThoreminRegistry, approvals } from './registry';
+export { registry, createThoreminRegistry, approvals, history, journal } from './registry';
 export { DIAL_COMMANDS, setDialCmd, setDialInCmd, resetDialCmd, patchDialsCmd, applyDialSet, applyDialSetIn } from './dials';
 export {
   DIAL_LEAVES,
@@ -28,3 +28,24 @@ export {
   type SideEffect,
   type AssistantDispatchContext,
 } from './confirmation';
+export {
+  installMiddleware,
+  composeMiddleware,
+  type Dispatch,
+  type Middleware,
+} from './middleware';
+export {
+  createJournal,
+  replayJournal,
+  type Journal,
+  type JournalEntry,
+  type JournalExport,
+  type ReplayReport,
+} from './journal';
+export {
+  createDialsHistory,
+  layersEqual,
+  type DialsHistory,
+  type HistoryEntry,
+  type LayerStoreLike,
+} from './history';

--- a/src/app/commands/journal.ts
+++ b/src/app/commands/journal.ts
@@ -1,0 +1,145 @@
+/**
+ * The command journal (#127) — telemetry and command export/replay, which are ONE
+ * recorder read two ways.
+ *
+ * Every dispatch that reaches this middleware is appended to a bounded in-memory ring
+ * buffer as `{command, params, t, ok}`. Read as a log it answers *which dials do people
+ * actually touch* across all four dispatchers (panels, keyboard, AI assistant, gestures)
+ * — the two of which (AI, gestures) nobody has data for. Read as a script it is a
+ * replayable session: `replayJournal` re-dispatches it against a registry, which is the
+ * substrate #82 wants for "an instrument as a replayable command sequence", and the
+ * cheapest possible bug report ("here is the exact sequence that broke it").
+ *
+ * ## What it deliberately does NOT do
+ *
+ * - **No egress, no persistence.** The buffer lives in memory and dies with the tab.
+ *   thoremin has no backend and a BYO-key posture; a telemetry feature that quietly
+ *   started shipping a player's session somewhere would be a different product. Export
+ *   is an explicit act by the person holding the tab (`toJSON()`).
+ * - **It does not record failures out.** A rejected dispatch is recorded with `ok:false`
+ *   and its error code, because *the failures are the interesting half* for a bug report.
+ *   `replayable()` is what filters them back out for replay.
+ * - **It cannot see a slider drag.** Continuous `type="range"` drags bypass the registry
+ *   by design (Decision B — a write per pointer-move frame must not pay Zod validation
+ *   and a promise). So the journal is a complete record of DISCRETE writes and an
+ *   incomplete record of continuous ones. Replaying a session reproduces every discrete
+ *   choice and none of the drags; that is a property to know, not a bug to fix here.
+ */
+import { isOk, type Registry } from 'acture';
+import type { Dispatch, Middleware } from './middleware';
+
+/** One recorded dispatch. `t` is epoch ms (injectable, so tests are deterministic). */
+export interface JournalEntry {
+  /** The dispatched command id, e.g. `dial.set`. */
+  command: string;
+  /** The params as dispatched. */
+  params: unknown;
+  /** Epoch ms at the moment the dispatch RESOLVED. */
+  t: number;
+  /** Whether the command succeeded. */
+  ok: boolean;
+  /** The error code when `ok` is false (e.g. `invalid_value`, `confirmation_required`). */
+  code?: string;
+  /** The dispatching surface, when the caller set one (`assistant`, …). */
+  channel?: string;
+}
+
+/** The exported wire shape. Versioned so a later reader can tell eras apart. */
+export interface JournalExport {
+  version: 1;
+  entries: JournalEntry[];
+}
+
+/** What a replay did. `failed` carries the entries that did not apply, with their index. */
+export interface ReplayReport {
+  /** How many entries were dispatched successfully. */
+  applied: number;
+  /** Entries whose re-dispatch failed, with their index in the replayed list. */
+  failed: { index: number; command: string; code: string }[];
+}
+
+export interface Journal {
+  /** The middleware to install on the registry. */
+  middleware: Middleware;
+  /** A snapshot copy of the buffer, oldest first. */
+  entries(): JournalEntry[];
+  /** The successful entries only — what `replayJournal` should be given. */
+  replayable(): JournalEntry[];
+  /** Drop everything recorded so far. */
+  clear(): void;
+  /** The versioned export envelope. */
+  toJSON(): JournalExport;
+}
+
+/** Default ring-buffer size: long enough to cover a play session, small enough to ignore. */
+const DEFAULT_LIMIT = 500;
+
+/** The dispatch-context field the journal reads (the same one the confirmation gate uses). */
+interface ChannelContext {
+  channel?: string;
+}
+
+/**
+ * Create a command journal. `limit` bounds the ring buffer (oldest entries are dropped);
+ * `now` is injectable so tests don't depend on the wall clock.
+ */
+export function createJournal(options: { limit?: number; now?: () => number } = {}): Journal {
+  const limit = options.limit ?? DEFAULT_LIMIT;
+  const now = options.now ?? (() => Date.now());
+  const buffer: JournalEntry[] = [];
+
+  const middleware: Middleware = (next) => async (command, params, context, ...rest) => {
+    const result = await next(command, params, context, ...rest);
+    const channel = (context as ChannelContext | undefined)?.channel;
+    const ok = isOk(result as never);
+    const entry: JournalEntry = { command, params, t: now(), ok };
+    if (!ok) entry.code = (result as unknown as { error?: { code?: string } }).error?.code;
+    if (channel) entry.channel = channel;
+    buffer.push(entry);
+    if (buffer.length > limit) buffer.splice(0, buffer.length - limit);
+    return result;
+  };
+
+  return {
+    middleware,
+    entries: () => buffer.slice(),
+    replayable: () => buffer.filter((e) => e.ok),
+    clear: () => {
+      buffer.length = 0;
+    },
+    toJSON: () => ({ version: 1, entries: buffer.slice() }),
+  };
+}
+
+/**
+ * Re-dispatch a recorded sequence against a registry, in order.
+ *
+ * Sequential on purpose: the recorded order IS the meaning (a `dial.patch` that mirrors a
+ * synced-hands voice edit depends on what the previous write left behind), so entries are
+ * awaited one at a time rather than raced.
+ *
+ * NOTE: replay goes through the normal dispatch chain, so a replayed session is itself
+ * journaled and does create undo entries. That is the honest behaviour — a replay is a
+ * real sequence of real writes — and it is why `entries()` hands out a COPY: appending
+ * to the live buffer while replaying a snapshot of it cannot feed itself.
+ */
+export async function replayJournal(
+  entries: readonly JournalEntry[],
+  registry: Registry,
+  options: { context?: unknown } = {},
+): Promise<ReplayReport> {
+  // The one cast, here rather than at every call site: acture types `dispatch`'s context
+  // as its own `Context`, which is narrower than the `unknown` a middleware forwards.
+  const dispatch = registry.dispatch.bind(registry) as unknown as Dispatch;
+  const report: ReplayReport = { applied: 0, failed: [] };
+  for (const [index, entry] of entries.entries()) {
+    const result = await dispatch(entry.command, entry.params, options.context);
+    if (isOk(result as never)) {
+      report.applied += 1;
+    } else {
+      const code = (result as unknown as { error?: { code?: string } }).error?.code ?? 'unknown';
+      report.failed.push({ index, command: entry.command, code });
+    }
+  }
+  return report;
+}

--- a/src/app/commands/middleware.ts
+++ b/src/app/commands/middleware.ts
@@ -1,0 +1,70 @@
+/**
+ * The dispatch middleware seam (#127) — the ONE place `registry.dispatch` is wrapped.
+ *
+ * #87 Phase 4 asks for three things (undo/redo, telemetry, command export/replay) and
+ * the issue's own note is the design: *they are the same mechanism viewed three ways*,
+ * so the seam is built once and each feature is a `Middleware` over it. The alternative
+ * — three independent monkey-patches of `registry.dispatch` — makes install ORDER an
+ * emergent property of module evaluation order, and dispose order a latent bug (acture's
+ * own `acture-undo` README warns that disposing an outer wrapper while inner wrappers
+ * still hold its captured dispatch leaves dangling wrappers). One composed install makes
+ * the order explicit and reversible.
+ *
+ * Ordering is the load-bearing part, and it is stated as data at the call site in
+ * `registry.ts`: the FIRST middleware is the OUTERMOST. The confirmation gate (#87
+ * Phase 3) must be outermost, because a gated command that returns `confirmation_required`
+ * DID NOT RUN — journaling it as a dispatch or snapshotting an undo entry for it would
+ * record a mutation that never happened.
+ *
+ * This module deliberately knows nothing about dials, undo or telemetry. It is the seam,
+ * not a consumer of it.
+ */
+import type { Registry, Result } from 'acture';
+
+/**
+ * The shape of `registry.dispatch` a middleware wraps — a local alias, not an acture
+ * export. Trailing args (acture's `options`) are forwarded untouched so a middleware
+ * never silently drops a parameter a future acture version adds.
+ */
+export type Dispatch = (
+  command: string,
+  params?: unknown,
+  context?: unknown,
+  ...rest: unknown[]
+) => Promise<Result<unknown>>;
+
+/** A dispatch middleware: given the next link in the chain, return the wrapped dispatch. */
+export type Middleware = (next: Dispatch) => Dispatch;
+
+/**
+ * Compose middlewares into one, FIRST = OUTERMOST.
+ *
+ * `composeMiddleware(a, b, c)(base)` is `a(b(c(base)))`, so a call enters `a` first and
+ * reaches `base` last. Reading the install list top-to-bottom therefore reads outermost-
+ * to-innermost, which is the order the guards actually apply in.
+ */
+export function composeMiddleware(...middlewares: Middleware[]): Middleware {
+  return (next) => middlewares.reduceRight<Dispatch>((acc, mw) => mw(acc), next);
+}
+
+/**
+ * Install middlewares onto a registry by reassigning its `dispatch` in place (the idiom
+ * acture's own instrumenters use). FIRST argument is OUTERMOST.
+ *
+ * Returns a dispose that restores the ORIGINAL dispatch — restoring the captured value
+ * rather than unwrapping one layer, so disposing is correct even if something else
+ * wrapped dispatch afterwards (it drops those too, loudly, rather than leaving a chain
+ * whose middle link points at a function nobody can reach).
+ */
+export function installMiddleware(registry: Registry, ...middlewares: Middleware[]): () => void {
+  // Keep the ORIGINAL property value for restore, and a bound copy for the chain's tail.
+  // Restoring the bound copy instead would leave `registry.dispatch` observably different
+  // from what was there before — enough to defeat an equality check in a test that
+  // installs and disposes between cases.
+  const original = registry.dispatch;
+  const next = original.bind(registry) as Dispatch;
+  registry.dispatch = composeMiddleware(...middlewares)(next) as typeof registry.dispatch;
+  return () => {
+    registry.dispatch = original;
+  };
+}

--- a/src/app/commands/registry.ts
+++ b/src/app/commands/registry.ts
@@ -8,12 +8,28 @@
  *
  * `createThoreminRegistry()` builds a fresh registry (used by tests for isolation);
  * `registry` is the app-wide singleton the consumers bind to.
+ *
+ * ## The middleware stack (#127)
+ *
+ * The singleton's `dispatch` is wrapped ONCE, with the order stated as data below
+ * rather than emerging from module evaluation order. First = outermost:
+ *
+ * 1. **confirmation gate** (#87 Phase 3) — must be outermost. A gated command returns
+ *    `confirmation_required` and DID NOT RUN; journaling it or opening an undo entry
+ *    for it would record a mutation that never happened.
+ * 2. **undo history** (#127) — snapshots the dials layer either side of a dispatch.
+ * 3. **journal** (#127) — telemetry + export/replay, the innermost observer, so what it
+ *    records is what actually reached the handlers.
  */
 import { createRegistry, type Registry } from 'acture';
+import { dialsStore } from '@/app/dials/settingsStore';
 import { DIAL_COMMANDS } from './dials';
 import { DIAL_FIELD_COMMANDS } from './perDial';
 import { INSTRUMENT_COMMANDS } from './instruments';
-import { installConfirmationGate, type ApprovalStore } from './confirmation';
+import { confirmationGate, createApprovalStore, defaultGetRisk, type ApprovalStore } from './confirmation';
+import { createDialsHistory, type DialsHistory } from './history';
+import { createJournal, type Journal } from './journal';
+import { installMiddleware } from './middleware';
 
 /** Build a registry with all thoremin commands registered: the generic dial verbs,
  *  one typed `set` command per dial (generated from the dials SSOT), and the
@@ -30,13 +46,25 @@ export function createThoreminRegistry(): Registry {
 export const registry: Registry = createThoreminRegistry();
 
 /**
- * The human-in-the-loop approval store for the AI assistant (#87 Phase 3). Installing
- * the gate wraps the singleton's `dispatch`: a destructive command (instrument
- * load/save/create) dispatched with `context.channel === 'assistant'` returns a
- * `confirmation_required` Result instead of running, until the runtime re-dispatches
- * it with a one-use token from THIS store (minted only after a human approves). Every
- * other surface — the palette and hotkeys, which never set the assistant channel —
- * dispatches ungated, so the gate is invisible to them. Tests that want an ungated
- * registry use `createThoreminRegistry()` (raw) and install the gate explicitly.
+ * The human-in-the-loop approval store for the AI assistant (#87 Phase 3). A destructive
+ * command (instrument load/save/create) dispatched with `context.channel === 'assistant'`
+ * returns a `confirmation_required` Result instead of running, until the runtime
+ * re-dispatches it with a one-use token from THIS store (minted only after a human
+ * approves). Every other surface — the palette and hotkeys, which never set the assistant
+ * channel — dispatches ungated, so the gate is invisible to them. Tests that want an
+ * ungated registry use `createThoreminRegistry()` (raw) and install what they need.
  */
-export const approvals: ApprovalStore = installConfirmationGate(registry).approvals;
+export const approvals: ApprovalStore = createApprovalStore();
+
+/** Undo/redo over the dials layer (#127). Bound to ⌘/Ctrl-Z and ⌘/Ctrl-Shift-Z. */
+export const history: DialsHistory = createDialsHistory(dialsStore);
+
+/** The in-memory command journal (#127) — telemetry and export/replay. No egress. */
+export const journal: Journal = createJournal();
+
+installMiddleware(
+  registry,
+  confirmationGate(defaultGetRisk, approvals),
+  history.middleware,
+  journal.middleware,
+);

--- a/src/app/keyboardShortcuts.ts
+++ b/src/app/keyboardShortcuts.ts
@@ -15,7 +15,7 @@
  */
 import { tinykeys } from 'tinykeys';
 import { isEditableTarget } from '@/nodes/sources/keyboard';
-import { registry } from './commands/registry';
+import { history, registry } from './commands/registry';
 import { useControls } from './store';
 
 const OCTAVE_MIN = -2;
@@ -44,6 +44,25 @@ export function toggleMute(): void {
   useControls.getState().toggleMuted();
 }
 
+/**
+ * Undo the last discrete param change (#127). A no-op when the history is empty, so the
+ * binding is safe to fire unconditionally.
+ *
+ * This binding is the reason undo counts as SHIPPED rather than merely present: an undo
+ * history reachable only from a module export is exactly the #137 trap this repo now has
+ * a rule about. Note the guard in `installKeyboardShortcuts` — `isEditableTarget` means
+ * Cmd-Z inside the palette's text input still does the browser's own text undo, which is
+ * what a player expects there.
+ */
+export function undoLastChange(): void {
+  history.undo();
+}
+
+/** Re-apply the most recently undone param change (#127). */
+export function redoLastChange(): void {
+  history.redo();
+}
+
 /** A keymap: a tinykeys key-binding string → a zero-arg action. */
 export type Keymap = Record<string, () => void>;
 
@@ -54,6 +73,12 @@ export const DEFAULT_KEYMAP: Keymap = {
   ArrowRight: () => adjustMagnetism(MAGNETISM_STEP),
   ArrowLeft: () => adjustMagnetism(-MAGNETISM_STEP),
   m: toggleMute,
+  // `$mod` is Cmd on macOS, Ctrl elsewhere. Both redo spellings are bound: Shift-Cmd-Z is
+  // the macOS convention, Ctrl-Y the Windows one, and a player should not have to know
+  // which platform the binding table was written on.
+  '$mod+z': undoLastChange,
+  '$mod+Shift+z': redoLastChange,
+  '$mod+y': redoLastChange,
 };
 
 /**

--- a/test/commands_middleware.test.ts
+++ b/test/commands_middleware.test.ts
@@ -1,0 +1,297 @@
+/**
+ * The dispatch middleware seam and its three consumers (#127) — undo/redo, the
+ * telemetry journal, and command export/replay.
+ *
+ * The load-bearing assertions here are the ones that would go quietly wrong:
+ *
+ *  - **Order.** The confirmation gate must be OUTERMOST, so a command that was blocked
+ *    (and therefore never ran) leaves no journal entry and no undo step. Get that
+ *    backwards and undo starts "reverting" writes that never happened.
+ *  - **`UNSET` is a symbol.** A `Layer` value can be the dials-core UNSET sentinel.
+ *    `structuredClone` throws on symbols and `JSON.stringify` silently DROPS them — so
+ *    the naive implementations of both clone and compare fail on exactly the case
+ *    (an explicitly-unset dial) that is hardest to notice.
+ *  - **The round trip.** The proof #127 asks for: dispatch a scripted sequence,
+ *    serialize it, replay against a reset layer, assert the resulting `Layer` is
+ *    deep-equal.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { UNSET } from '@zodal/dials-core';
+import type { Layer } from '@zodal/dials-core';
+import { dialsStore } from '@/app/dials/settingsStore';
+import {
+  composeMiddleware,
+  installMiddleware,
+  createJournal,
+  replayJournal,
+  createDialsHistory,
+  layersEqual,
+  createThoreminRegistry,
+  confirmationGate,
+  createApprovalStore,
+  defaultGetRisk,
+  type Dispatch,
+  type Middleware,
+} from '@/app/commands';
+
+/** A registry wired exactly like the app singleton: gate → history → journal. */
+function wiredRegistry() {
+  const registry = createThoreminRegistry();
+  const approvals = createApprovalStore();
+  const history = createDialsHistory(dialsStore);
+  const journal = createJournal({ now: () => 0 });
+  const dispose = installMiddleware(
+    registry,
+    confirmationGate(defaultGetRisk, approvals),
+    history.middleware,
+    journal.middleware,
+  );
+  return { registry, approvals, history, journal, dispose };
+}
+
+beforeEach(() => {
+  dialsStore.setLayer({});
+});
+
+describe('composeMiddleware / installMiddleware', () => {
+  it('runs the FIRST middleware outermost', async () => {
+    const order: string[] = [];
+    const tag = (name: string): Middleware => (next) => async (c, p, ctx, ...rest) => {
+      order.push(`${name}:in`);
+      const r = await next(c, p, ctx, ...rest);
+      order.push(`${name}:out`);
+      return r;
+    };
+    const base: Dispatch = async () => ({ ok: true, value: null }) as never;
+    await composeMiddleware(tag('a'), tag('b'), tag('c'))(base)('x');
+    expect(order).toEqual(['a:in', 'b:in', 'c:in', 'c:out', 'b:out', 'a:out']);
+  });
+
+  it('dispose restores the original dispatch', async () => {
+    const registry = createThoreminRegistry();
+    const before = registry.dispatch;
+    const seen: string[] = [];
+    const dispose = installMiddleware(registry, (next) => async (c, p, ctx, ...rest) => {
+      seen.push(c);
+      return next(c, p, ctx, ...rest);
+    });
+    await registry.dispatch('dial.set', { key: 'right.root', value: 5 });
+    expect(seen).toEqual(['dial.set']);
+    dispose();
+    expect(registry.dispatch).toBe(before);
+    await registry.dispatch('dial.set', { key: 'right.root', value: 7 });
+    expect(seen).toEqual(['dial.set']); // not recorded again
+  });
+});
+
+describe('the journal (#127 telemetry + export)', () => {
+  it('records successful and failed dispatches, with the error code and the channel', async () => {
+    const { registry, journal } = wiredRegistry();
+    await registry.dispatch('dial.set', { key: 'right.root', value: 5 });
+    await registry.dispatch('dial.set', { key: 'nope.nope', value: 1 });
+    await registry.dispatch('dial.set', { key: 'right.root', value: 3 }, { channel: 'assistant' });
+
+    const entries = journal.entries();
+    expect(entries.map((e) => e.command)).toEqual(['dial.set', 'dial.set', 'dial.set']);
+    expect(entries.map((e) => e.ok)).toEqual([true, false, true]);
+    expect(entries[1].code).toBe('unknown_dial');
+    expect(entries[2].channel).toBe('assistant');
+    // The failures are the interesting half for a bug report, but not for a replay.
+    expect(journal.replayable().map((e) => e.ok)).toEqual([true, true]);
+  });
+
+  it('is a bounded ring buffer — the oldest entries fall off', async () => {
+    const journal = createJournal({ limit: 3, now: () => 0 });
+    const base: Dispatch = async () => ({ ok: true, value: null }) as never;
+    const d = journal.middleware(base);
+    for (const v of [1, 2, 3, 4, 5]) await d('dial.set', { value: v });
+    expect(journal.entries()).toHaveLength(3);
+    expect(journal.entries().map((e) => (e.params as { value: number }).value)).toEqual([3, 4, 5]);
+  });
+
+  it('exports a versioned envelope and clears', async () => {
+    const { registry, journal } = wiredRegistry();
+    await registry.dispatch('dial.set', { key: 'right.root', value: 5 });
+    expect(journal.toJSON().version).toBe(1);
+    expect(journal.toJSON().entries).toHaveLength(1);
+    journal.clear();
+    expect(journal.entries()).toEqual([]);
+  });
+});
+
+describe('command export → replay round trip (the #127 proof)', () => {
+  it('replaying a serialized session reproduces the exact same Layer', async () => {
+    const { registry, journal } = wiredRegistry();
+
+    // A scripted session touching all four write verbs.
+    await registry.dispatch('dial.set', { key: 'right.root', value: 5 });
+    await registry.dispatch('dial.setIn', { path: 'overlay.landmarks.show', value: false });
+    await registry.dispatch('dial.patch', {
+      writes: [
+        { key: 'left.root', value: 7 },
+        { key: 'left.octaves', value: 3 },
+      ],
+    });
+    await registry.dispatch('dial.set', { key: 'master.volume', value: 0.42 });
+    await registry.dispatch('dial.reset', { key: 'right.root' });
+
+    const expected: Layer = JSON.parse(JSON.stringify(dialsStore.getState().layer));
+    const wire = JSON.parse(JSON.stringify(journal.toJSON())) as ReturnType<typeof journal.toJSON>;
+
+    // Replay against a FRESH layer, through a separate registry.
+    dialsStore.setLayer({});
+    expect(dialsStore.getState().layer).not.toEqual(expected);
+
+    const { registry: replayRegistry } = wiredRegistry();
+    const report = await replayJournal(wire.entries, replayRegistry);
+
+    expect(report.failed).toEqual([]);
+    expect(report.applied).toBe(wire.entries.length);
+    expect(dialsStore.getState().layer).toEqual(expected);
+  });
+});
+
+describe('undo/redo over the dials layer (#127)', () => {
+  it('undoes and redoes a single dial write', async () => {
+    const { registry, history } = wiredRegistry();
+    await registry.dispatch('dial.set', { key: 'right.root', value: 5 });
+    expect(dialsStore.getState().effective['right.root']).toBe(5);
+
+    expect(history.canUndo()).toBe(true);
+    expect(history.undoLabel()).toBe('dial.set');
+    expect(history.undo()).toBe(true);
+    expect(dialsStore.getState().layer['right.root']).toBeUndefined();
+
+    expect(history.canRedo()).toBe(true);
+    expect(history.redo()).toBe(true);
+    expect(dialsStore.getState().effective['right.root']).toBe(5);
+  });
+
+  it('treats an atomic dial.patch as ONE undo entry', async () => {
+    const { registry, history } = wiredRegistry();
+    await registry.dispatch('dial.patch', {
+      writes: [
+        { key: 'left.root', value: 7 },
+        { key: 'left.octaves', value: 3 },
+      ],
+    });
+    expect(history.size()).toBe(1);
+    history.undo();
+    // Both halves of the mirrored write come back, not one.
+    expect(dialsStore.getState().layer['left.root']).toBeUndefined();
+    expect(dialsStore.getState().layer['left.octaves']).toBeUndefined();
+  });
+
+  it('undoes a structured-dial leaf write (dial.setIn)', async () => {
+    const { registry, history } = wiredRegistry();
+    const before = dialsStore.getState().effective['overlay'];
+    await registry.dispatch('dial.setIn', { path: 'overlay.landmarks.show', value: false });
+    expect((dialsStore.getState().effective['overlay'] as { landmarks: { show: boolean } }).landmarks.show).toBe(false);
+    history.undo();
+    expect(dialsStore.getState().effective['overlay']).toEqual(before);
+  });
+
+  it('opens no entry for a FAILED command', async () => {
+    const { registry, history } = wiredRegistry();
+    await registry.dispatch('dial.set', { key: 'right.root', value: 5 });
+    await registry.dispatch('dial.set', { key: 'right.octaves', value: 999 }); // out of range
+    expect(history.size()).toBe(1);
+    expect(history.undoLabel()).toBe('dial.set');
+    history.undo();
+    expect(dialsStore.getState().layer['right.root']).toBeUndefined();
+  });
+
+  it('opens no entry for a write that changed nothing', async () => {
+    const { registry, history } = wiredRegistry();
+    await registry.dispatch('dial.set', { key: 'right.root', value: 5 });
+    expect(history.size()).toBe(1);
+    await registry.dispatch('dial.set', { key: 'right.root', value: 5 }); // same value
+    expect(history.size()).toBe(1);
+  });
+
+  it('a new change discards the redo future', async () => {
+    const { registry, history } = wiredRegistry();
+    await registry.dispatch('dial.set', { key: 'right.root', value: 5 });
+    history.undo();
+    expect(history.canRedo()).toBe(true);
+    await registry.dispatch('dial.set', { key: 'left.root', value: 2 });
+    expect(history.canRedo()).toBe(false);
+  });
+
+  it('is bounded by its limit', async () => {
+    const { registry } = wiredRegistry();
+    const history = createDialsHistory(dialsStore, { limit: 2 });
+    const dispose = installMiddleware(registry, history.middleware);
+    for (const v of [1, 2, 3, 4]) {
+      await registry.dispatch('dial.set', { key: 'right.root', value: v });
+    }
+    expect(history.size()).toBe(2);
+    dispose();
+  });
+
+  it('undo/redo are no-ops (not throws) on empty stacks', () => {
+    const history = createDialsHistory(dialsStore);
+    expect(history.undo()).toBe(false);
+    expect(history.redo()).toBe(false);
+    expect(history.canUndo()).toBe(false);
+  });
+});
+
+describe('order: the confirmation gate is outermost', () => {
+  it('a BLOCKED assistant command is neither journaled nor undoable', async () => {
+    const { registry, journal, history } = wiredRegistry();
+    const blocked = await registry.dispatch(
+      'instrument.save',
+      { name: 'X' },
+      { channel: 'assistant' },
+    );
+    expect(blocked.ok).toBe(false);
+    // It never ran, so neither observer saw it.
+    expect(journal.entries()).toEqual([]);
+    expect(history.size()).toBe(0);
+  });
+});
+
+describe('layersEqual is symbol-safe (guard the guard)', () => {
+  it('does NOT treat an explicitly-UNSET dial as equal to an absent one', () => {
+    // JSON.stringify drops a symbol value, so a stringify-based compare would call these
+    // equal and undo would silently skip the write that unset the dial.
+    expect(layersEqual({ 'right.root': UNSET } as Layer, {} as Layer)).toBe(false);
+    expect(layersEqual({ 'right.root': UNSET } as Layer, { 'right.root': UNSET } as Layer)).toBe(true);
+  });
+
+  it('ignores key ORDER but not key SET', () => {
+    expect(layersEqual({ a: 1, b: 2 } as unknown as Layer, { b: 2, a: 1 } as unknown as Layer)).toBe(true);
+    expect(layersEqual({ a: 1 } as unknown as Layer, { a: 1, b: 2 } as unknown as Layer)).toBe(false);
+  });
+
+  it('compares nested structured values deeply', () => {
+    const a = { overlay: { landmarks: { show: true }, video: { alpha: 0.5 } } } as unknown as Layer;
+    const b = { overlay: { video: { alpha: 0.5 }, landmarks: { show: true } } } as unknown as Layer;
+    const c = { overlay: { landmarks: { show: false }, video: { alpha: 0.5 } } } as unknown as Layer;
+    expect(layersEqual(a, b)).toBe(true);
+    expect(layersEqual(a, c)).toBe(false);
+  });
+
+  it('survives an UNSET dial through a full snapshot/undo cycle', async () => {
+    const { registry, history } = wiredRegistry();
+    dialsStore.setLayer({ 'right.root': UNSET } as Layer);
+    // A clone that used structuredClone would THROW here rather than fail an assertion.
+    await expect(registry.dispatch('dial.set', { key: 'left.root', value: 4 })).resolves.toMatchObject({ ok: true });
+    expect(history.undo()).toBe(true);
+    expect(dialsStore.getState().layer['right.root']).toBe(UNSET);
+  });
+});
+
+describe('the keyboard entry point', () => {
+  it('binds undo and redo in the default keymap', async () => {
+    const { DEFAULT_KEYMAP } = await import('@/app/keyboardShortcuts');
+    expect(Object.keys(DEFAULT_KEYMAP)).toEqual(
+      expect.arrayContaining(['$mod+z', '$mod+Shift+z', '$mod+y']),
+    );
+    const undoSpy = vi.spyOn((await import('@/app/commands/registry')).history, 'undo');
+    DEFAULT_KEYMAP['$mod+z']();
+    expect(undoSpy).toHaveBeenCalled();
+    undoSpy.mockRestore();
+  });
+});

--- a/test/keyboard_shortcuts.test.ts
+++ b/test/keyboard_shortcuts.test.ts
@@ -58,6 +58,18 @@ describe('keyboard shortcuts (#90)', () => {
   });
 
   it('DEFAULT_KEYMAP binds the expected keys', () => {
-    expect(Object.keys(DEFAULT_KEYMAP).sort()).toEqual(['ArrowDown', 'ArrowLeft', 'ArrowRight', 'ArrowUp', 'm']);
+    // Exhaustive on purpose: a new binding must be a deliberate edit here, not a
+    // silent addition. `$mod` is Cmd on macOS / Ctrl elsewhere; the undo family
+    // (#127) carries both redo spellings so the binding works on either platform.
+    expect(Object.keys(DEFAULT_KEYMAP).sort()).toEqual([
+      '$mod+Shift+z',
+      '$mod+y',
+      '$mod+z',
+      'ArrowDown',
+      'ArrowLeft',
+      'ArrowRight',
+      'ArrowUp',
+      'm',
+    ]);
   });
 });


### PR DESCRIPTION
Closes #127.

#127's own note is the design: undo, telemetry and command export/replay are **the same mechanism viewed three ways**, so the seam is built once (`src/app/commands/middleware.ts`) and each feature is a `Middleware` over it. Three independent monkey-patches of `registry.dispatch` would have made install order an emergent property of module evaluation order — and dispose order a latent bug that `acture-undo`'s own README warns about.

## Order is the load-bearing part, and it is now data

Stated at the call site in `registry.ts`, first = outermost:

1. **confirmation gate** (#87 Phase 3)
2. **undo history**
3. **journal**

The gate *must* be outermost: a command that returned `confirmation_required` **did not run**. Journaling it, or opening an undo entry for it, records a mutation that never happened. There is a test for exactly that, and it fails when the order is swapped (mutation-checked).

## Why undo is hand-written and not `acture-undo`

Structural, and worth recording so it isn't rediscovered. `acture-undo` builds history by observing `adapter.setStateWithPatches` on a `PatchCapableAdapter`. This registry **deliberately holds no acture adapter at all** — handlers closure-capture the dials store so the registry stays a pure command index — and the store is zodal's `createSettingsStore`, which emits no patches. Adopting it would mean writing a patch-capable adapter over a store we don't own, to reconstruct information we can read directly. acture-undo's README names hand-writing as the intended alternative.

## Whole-layer snapshot, not per-command inverses

History snapshots the editable layer either side of a dispatch and pushes an entry only when it **actually changed** (deep-compared). That buys:

- **Command-agnostic** — a command added tomorrow gets undo for free, including `instrument.load`, which replaces the layer wholesale.
- **`dial.patch` is one entry** — a synced-hands voice mirror cannot be half-undone.
- **No special cases** — a failed or no-op command leaves no entry, which is also the right answer for a query.

## Two traps found while building (both guarded, both mutation-checked)

- **`UNSET` is a symbol.** A `Layer` value can be the dials-core `UNSET` sentinel. `structuredClone` **throws** on symbols and `JSON.stringify` silently **drops** them — so the naive clone and the naive compare each fail on the case that is hardest to notice: an explicitly-unset dial comparing equal to an absent one, and undo skipping the write that unset it. Swapping `layersEqual` to a stringify compare reddens 3 tests.
- **`installMiddleware` restores the original property value on dispose**, not a bound copy, so install/dispose between test cases is observably clean.

## Reachability (the #137 rule)

Undo is bound to **⌘/Ctrl-Z**, redo to **⌘⇧Z** and **Ctrl-Y** (both spellings — a player shouldn't need to know which platform the binding table was written on). An undo history reachable only from a module export is exactly the trap this repo now has a rule about. The `isEditableTarget` guard means ⌘Z inside a text input still does the browser's own text undo.

The existing exhaustive keymap assertion in `test/keyboard_shortcuts.test.ts` was updated deliberately (with a comment saying a new binding must be a deliberate edit), not loosened.

## Two properties stated rather than left to be discovered

- **Slider drags are invisible to both.** Continuous `type="range"` writes bypass the registry by design (Decision B), so they appear in neither the journal nor the history. Arguably the correct coalescing — you rarely want to undo one pointer-move frame — but it was a consequence, not a decision anyone had made.
- **The journal has no egress and no persistence.** In-memory ring buffer (500), dies with the tab, exported only by an explicit `toJSON()`. thoremin has no backend and a BYO-key posture; telemetry that quietly shipped a session somewhere would be a different product.

## Gates

- `npm run typecheck` — green
- `npm test` — **1001 passed** (90 files), 20 new
- `npm run build` — green

Includes the round-trip proof the issue asks for: dispatch a scripted session across all four write verbs → serialize → reset the layer → replay → the resulting `Layer` is deep-equal.

https://claude.ai/code/session_01FiZMdBN2v3u4FqaJFhK2Wi