### PR TITLE
#160: the trainer core — learn a player's own control categories from a guided take

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -151,7 +151,7 @@ Face frame → deliberate control axes (head yaw/pitch/roll, jaw-open, smile↔f
 - **roles:** feature
 - **in:** face:face-frame, config:face-controls-config
 - **out:** controls:face-controls
-- **params:** smoothing (number=0.3), headRangeDeg (number=30), headDeadzoneDeg (number=3), yawZeroDeg (number=0), pitchZeroDeg (number=0), rollZeroDeg (number=0), yawGain (number=1), pitchGain (number=1), rollGain (number=1), mouthDeadzone (number=0.08), browDeadzone (number=0.1), puckerDeadzone (number=0.12), smileDeadzone (number=0.06), mouthGain (number=1), browGain (number=1), puckerGain (number=1), smileGain (number=1)
+- **params:** smoothing (number=0.3), headRangeDeg (number=30), headDeadzoneDeg (number=3), yawZeroDeg (number=0), pitchZeroDeg (number=0), rollZeroDeg (number=0), yawGain (number=1), pitchGain (number=-1), rollGain (number=1), mouthDeadzone (number=0.08), browDeadzone (number=0.1), puckerDeadzone (number=0.12), smileDeadzone (number=0.06), mouthGain (number=1), browGain (number=1), puckerGain (number=1), smileGain (number=1)
 
 #### `face-expression` — Face Expression
 Face blendshapes → one of 7 emotions or neutral (per-class thresholds + neutral abstention, smoothing, enter/exit hysteresis, dwell).

--- a/public/catalog.json
+++ b/public/catalog.json
@@ -343,7 +343,7 @@
       {
         "name": "pitchGain",
         "type": "number",
-        "default": 1
+        "default": -1
       },
       {
         "name": "rollGain",

--- a/public/manual.html
+++ b/public/manual.html
@@ -173,7 +173,7 @@
         <dt>roles</dt><dd>feature</dd>
         <dt>in</dt><dd>face:face-frame, config:face-controls-config</dd>
         <dt>out</dt><dd>controls:face-controls</dd>
-        <dt>params</dt><dd>smoothing (number=0.3), headRangeDeg (number=30), headDeadzoneDeg (number=3), yawZeroDeg (number=0), pitchZeroDeg (number=0), rollZeroDeg (number=0), yawGain (number=1), pitchGain (number=1), rollGain (number=1), mouthDeadzone (number=0.08), browDeadzone (number=0.1), puckerDeadzone (number=0.12), smileDeadzone (number=0.06), mouthGain (number=1), browGain (number=1), puckerGain (number=1), smileGain (number=1)</dd>
+        <dt>params</dt><dd>smoothing (number=0.3), headRangeDeg (number=30), headDeadzoneDeg (number=3), yawZeroDeg (number=0), pitchZeroDeg (number=0), rollZeroDeg (number=0), yawGain (number=1), pitchGain (number=-1), rollGain (number=1), mouthDeadzone (number=0.08), browDeadzone (number=0.1), puckerDeadzone (number=0.12), smileDeadzone (number=0.06), mouthGain (number=1), browGain (number=1), puckerGain (number=1), smileGain (number=1)</dd>
       </dl>
     </div>
     <div class="node">

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -27,6 +27,7 @@ import AssistantOverlay from '@/plugins/assistant/AssistantOverlay';
 import ToolsBar from './ToolsBar';
 import LabPanel from './LabPanel';
 import GesturesPanel from './GesturesPanel';
+import TrainerPanel from './TrainerPanel';
 import VersionBadge from './VersionBadge';
 
 /** A compact face-status chip, visible even when the controls panel is collapsed
@@ -129,6 +130,9 @@ export default function App({ source = DEFAULT_SOURCE }: { source?: SourceSpec }
 
       {/* The gesture-binding editor (#129) — renders when its tool is the open one. */}
       <GesturesPanel />
+
+      {/* Trainer mode (#160) — renders when its tool is the open one. */}
+      <TrainerPanel />
 
       {/* Bottom-right: the multi-stream recorder (#88) — a button that morphs into
           a settings sheet (out-of-instrument config) then a compact HUD. Available

--- a/src/app/TrainerPanel.tsx
+++ b/src/app/TrainerPanel.tsx
@@ -1,0 +1,216 @@
+/**
+ * TrainerPanel — the shell surface for trainer mode (#160), opened from the tools bar.
+ *
+ * A TOOL, not a settings section: a trained model is a per-player, per-device artefact
+ * like a keymap, not an instrument parameter, and it must never ride an instrument
+ * preset. (Same reasoning as the Feature Lab and the gesture bindings.)
+ *
+ * ## The four-step ritual, and the two rules its UI has to keep
+ *
+ * The steps come from {@link ENROLLMENT_STEPS} — they are data, so this file renders
+ * whatever is in the list and gains a step when one is added.
+ *
+ * **A coverage meter, not a progress bar.** The transferable half of Face ID's enrollment
+ * ring: it shows how much of what a step needs has actually been captured, and the step
+ * is not "done" because time passed — it is done when there is enough. A progress bar
+ * would tell the player the opposite thing.
+ *
+ * **Never show a face to imitate.** Every prompt is the player's own choice of
+ * expression. Prescribed categories are precisely what the player reported being unable
+ * to hit; a trainer that asked them to copy a target would reproduce the original bug
+ * with extra steps.
+ *
+ * ## Sampling
+ *
+ * While a step runs, the panel polls {@link readLiveVector} on an interval and feeds the
+ * session. Polling — not a subscription — because the vector updates per tick and no part
+ * of this UI needs frame-rate fidelity; see `enroll/liveVector.ts` for why the tap writes
+ * a module holder rather than a store.
+ *
+ * ## What this panel deliberately cannot do
+ *
+ * It does not change what you hear. Training produces a model and nothing else; binding a
+ * category to a dial or a command is a later, separate decision and will go through the
+ * #127 write path. A bad training run cannot break the instrument.
+ */
+import { useEffect, useRef } from 'react';
+import { GraduationCap, X } from 'lucide-react';
+import { ENROLLMENT_STEPS, stepById } from '@/enroll';
+import { readLiveVector } from './enroll/liveVector';
+import { useTrainer } from './enroll/store';
+import { useTools } from './toolsStore';
+import { toolById } from './tools';
+
+const TOOL_ID = 'trainer';
+/** ~30 Hz: fast enough that the sampler's dwell logic sees a smooth signal, slow enough
+ *  that the panel is not doing frame-rate work. */
+const SAMPLE_INTERVAL_MS = 33;
+
+/** The coverage meter — the Face ID ring, flattened. */
+function Coverage({ value }: { value: number }) {
+  const pct = Math.round(Math.max(0, Math.min(1, value)) * 100);
+  return (
+    <div
+      className="h-1.5 w-full overflow-hidden rounded-full bg-white/10"
+      role="progressbar"
+      aria-valuenow={pct}
+      aria-valuemin={0}
+      aria-valuemax={100}
+    >
+      <div
+        className={`h-full rounded-full transition-all ${pct >= 100 ? 'bg-emerald-400' : 'bg-emerald-400/50'}`}
+        style={{ width: `${pct}%` }}
+      />
+    </div>
+  );
+}
+
+export default function TrainerPanel() {
+  const open = useTools((s) => s.open) === TOOL_ID;
+  const close = useTools((s) => s.close);
+
+  const activeStep = useTrainer((s) => s.activeStep);
+  const progress = useTrainer((s) => s.progress);
+  const built = useTrainer((s) => s.built);
+  const k = useTrainer((s) => s.k);
+  const suggestedK = useTrainer((s) => s.suggestedK);
+  const model = useTrainer((s) => s.model);
+  const labels = useTrainer((s) => s.labels);
+
+  // Poll the live vector into the session while a step is running. The interval is
+  // recreated only when the active step changes, so it is not restarted every render.
+  const activeRef = useRef(activeStep);
+  activeRef.current = activeStep;
+  useEffect(() => {
+    if (!activeStep) return;
+    const id = setInterval(() => {
+      if (!activeRef.current) return;
+      const live = readLiveVector();
+      if (live) useTrainer.getState().sample(live.vector, live.t);
+    }, SAMPLE_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [activeStep]);
+
+  if (!open) return null;
+  const tool = toolById(TOOL_ID);
+  const progressFor = (id: string) => progress.find((p) => p.id === id);
+  const vocabSamples = progressFor('vocabulary')?.samples ?? 0;
+  const canBuild = vocabSamples >= (stepById('vocabulary')?.minSamples ?? 6);
+
+  return (
+    <div
+      data-tool={TOOL_ID}
+      className="absolute bottom-14 left-3 z-40 flex max-h-[calc(100dvh-5rem)] w-96 max-w-[calc(100vw-1.5rem)] flex-col overflow-hidden rounded-2xl border border-white/10 bg-black/70 backdrop-blur"
+    >
+      <div className="flex items-center gap-2 border-b border-white/10 px-3 py-2">
+        <GraduationCap className="h-3.5 w-3.5 shrink-0 text-emerald-300" aria-hidden />
+        <span className="flex-1 text-[11px] font-bold uppercase tracking-widest text-white/70">Trainer</span>
+        <button
+          onClick={close}
+          aria-label="Close the Trainer panel"
+          className="rounded p-1 text-white/60 transition hover:bg-white/10 hover:text-white"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      <div className="space-y-4 overflow-auto p-4">
+        {tool && <p className="text-[10px] uppercase tracking-widest text-emerald-500/70">{tool.description}</p>}
+        <p className="text-[11px] leading-relaxed text-white/60">
+          Teach the instrument the faces <em>you</em> can actually make, instead of trying to hit the
+          ones it came with. Takes about a minute. Nothing you do here changes the sound yet.
+        </p>
+
+        {ENROLLMENT_STEPS.map((step) => {
+          const p = progressFor(step.id);
+          const running = activeStep === step.id;
+          const done = (p?.coverage ?? 0) >= 1;
+          return (
+            <div key={step.id} className="space-y-1.5 rounded-lg border border-white/10 p-2.5">
+              <div className="flex items-center gap-2">
+                <span className="flex-1 text-[11px] font-semibold text-white/85">
+                  {step.title}
+                  {done && <span className="ml-1.5 text-emerald-400">✓</span>}
+                </span>
+                <span className="text-[10px] tabular-nums text-white/40">{p?.samples ?? 0}</span>
+                <button
+                  onClick={() => (running ? useTrainer.getState().end() : useTrainer.getState().begin(step.id))}
+                  disabled={activeStep !== null && !running}
+                  className="rounded bg-white/10 px-2 py-0.5 text-[10px] font-semibold text-white/80 transition hover:bg-white/20 disabled:opacity-30"
+                >
+                  {running ? 'Stop' : done ? 'Redo' : 'Start'}
+                </button>
+              </div>
+              <p className="text-[11px] leading-snug text-white/70">{step.prompt}</p>
+              <p className="text-[10px] leading-snug text-white/40">{step.rationale}</p>
+              <Coverage value={p?.coverage ?? 0} />
+            </div>
+          );
+        })}
+
+        <button
+          onClick={() => useTrainer.getState().build()}
+          disabled={!canBuild || activeStep !== null}
+          className="w-full rounded-lg bg-emerald-500/80 px-3 py-1.5 text-[11px] font-bold text-black transition hover:bg-emerald-400 disabled:opacity-30"
+        >
+          {built ? 'Rebuild from this take' : 'Find my categories'}
+        </button>
+
+        {built && model && (
+          <div className="space-y-2.5 border-t border-white/10 pt-3">
+            <label className="block space-y-1">
+              <span className="flex items-baseline gap-2 text-[11px] text-white/80">
+                <span className="flex-1">How many categories?</span>
+                <span className="tabular-nums text-white/50">{k}</span>
+              </span>
+              <input
+                type="range"
+                aria-label="How many categories"
+                min={2}
+                max={8}
+                step={1}
+                value={k}
+                onChange={(e) => useTrainer.getState().setK(Number(e.target.value))}
+                className="w-full"
+              />
+              <span className="block text-[10px] leading-snug text-white/40">
+                Drag freely — this re-cuts the same recording, it does not retrain. Your take
+                looks most like <strong className="text-white/60">{suggestedK}</strong> groups to us,
+                but that is a guess and you know your own faces better.
+              </span>
+            </label>
+
+            <ul className="space-y-1">
+              {model.categories.map((c, i) => (
+                <li key={c.id} className="flex items-center gap-2">
+                  <span className="w-4 text-[10px] tabular-nums text-white/35">{i + 1}</span>
+                  <input
+                    aria-label={`Name for category ${i + 1}`}
+                    placeholder="name this face…"
+                    value={labels[c.id] ?? ''}
+                    onChange={(e) => useTrainer.getState().setLabel(c.id, e.target.value)}
+                    className="min-w-0 flex-1 rounded bg-white/5 px-2 py-1 text-[11px] text-white/85 placeholder:text-white/25"
+                  />
+                  <span className="text-[10px] tabular-nums text-white/35" title="how many held poses formed it">
+                    {c.size}
+                  </span>
+                </li>
+              ))}
+            </ul>
+            <p className="text-[10px] leading-snug text-white/40">
+              Built from {model.features.length} of your most distinctive features. Anything that
+              moved while you changed camera distance was quieted automatically.
+            </p>
+          </div>
+        )}
+
+        <button
+          onClick={() => useTrainer.getState().reset()}
+          className="w-full rounded border border-white/10 px-3 py-1 text-[10px] text-white/50 transition hover:bg-white/5 hover:text-white/80"
+        >
+          Start over
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/enroll/liveVector.ts
+++ b/src/app/enroll/liveVector.ts
@@ -1,0 +1,69 @@
+/**
+ * The live feature-vector tap (#160) — how the trainer sees what the instrument sees.
+ *
+ * The DAG already computes a named scalar feature vector every tick (`faceVec.vector`
+ * and `handVec.vector`, feeding the Lab meters). The trainer needs exactly that, in the
+ * host. This is the one-way bridge.
+ *
+ * ## Why a module holder and not a zustand store
+ *
+ * This is written **per tick**, at frame rate. A zustand `set()` per tick would notify
+ * subscribers and re-render React sixty times a second for a value no component needs at
+ * that resolution — the same hot-path/human-frequency split the repo already enforces
+ * between `useControls` (hot, read synchronously each tick) and the dials store (edits).
+ * So the tap writes a plain module variable, and the panel *polls* it at UI rate while a
+ * step is running. The trainer is a human-frequency consumer of a hot signal, and the
+ * cheapest correct shape for that is a holder plus a poll, not a subscription.
+ *
+ * Merging face and hand into ONE vector is the point, not a convenience: it is what makes
+ * the trainer modality-general without knowing which modality is present. A missing
+ * source simply contributes no keys.
+ */
+import type { NodeContext, Tap } from '@/dag';
+import type { FeatureVector } from '@/enroll';
+
+/** The edge keys the tap listens to — the catalog's two vector-producing nodes. */
+export const FEATURE_VECTOR_EDGES = ['faceVec.vector', 'handVec.vector'] as const;
+
+/** The latest merged vector, or null before the first tick with any source present. */
+let latest: FeatureVector | null = null;
+/** Wall-clock-ish tick time of the latest vector, in ms. */
+let latestT = 0;
+
+/** Per-edge last value, so one absent source does not erase the other's keys. */
+const byEdge = new Map<string, FeatureVector>();
+
+/**
+ * A DAG {@link Tap} that keeps {@link readLiveVector} current. Attach once at engine
+ * construction and leave attached — it costs one object spread per tick and is the
+ * only way the host can see the feature vector at all.
+ */
+export class LiveVectorTap implements Tap {
+  onValue(key: string, value: unknown, ctx: NodeContext): void {
+    if (!(FEATURE_VECTOR_EDGES as readonly string[]).includes(key)) return;
+    if (!value || typeof value !== 'object') return;
+    byEdge.set(key, value as FeatureVector);
+    // Merge in a fixed edge order so a key present in both sources resolves the same way
+    // every tick (it should not happen — face and hand ids are namespaced — but a
+    // non-deterministic merge would be an awful bug to chase).
+    const merged: FeatureVector = {};
+    for (const k of FEATURE_VECTOR_EDGES) {
+      const part = byEdge.get(k);
+      if (part) Object.assign(merged, part);
+    }
+    latest = merged;
+    latestT = ctx.time;
+  }
+}
+
+/** The most recent merged feature vector, or null if none has arrived yet. */
+export function readLiveVector(): { vector: FeatureVector; t: number } | null {
+  return latest ? { vector: latest, t: latestT } : null;
+}
+
+/** Forget everything — used by tests, and on engine teardown. */
+export function resetLiveVector(): void {
+  latest = null;
+  latestT = 0;
+  byEdge.clear();
+}

--- a/src/app/enroll/store.ts
+++ b/src/app/enroll/store.ts
@@ -1,0 +1,123 @@
+/**
+ * Trainer UI state (#160) — the store the enrollment panel binds to.
+ *
+ * Holds the {@link EnrollmentSession} (which owns the captured samples and the built
+ * hierarchy) plus the small amount of state that is genuinely about the UI: which step
+ * is running, how many categories the player has asked for, and what they have named
+ * them.
+ *
+ * ## Two things this store deliberately does NOT do
+ *
+ * - **It does not sample.** The panel polls {@link readLiveVector} on a timer while a
+ *   step runs and calls {@link TrainerState.sample}. Putting the poll in the store would
+ *   make it own a timer, which makes it untestable without fake timers and couples it to
+ *   a rendering lifecycle it should not know about.
+ * - **It does not touch sound.** A trained model here changes nothing about what you
+ *   hear. Binding a category to a dial or a command is a separate, later decision (open
+ *   question 3 on the issue) and will go through the #127 command path like every other
+ *   write. Keeping that out means a bad training run cannot break the instrument.
+ *
+ * `retrain(k)` is cheap by construction — it re-cuts the built hierarchy rather than
+ * reclustering — which is what lets the k control be a live slider rather than a button.
+ */
+import { create } from 'zustand';
+import {
+  createEnrollmentSession,
+  type EnrollmentSession,
+  type FeatureVector,
+  type StepId,
+  type StepProgress,
+  type TrainedModel,
+} from '@/enroll';
+
+interface TrainerState {
+  /** The step currently capturing, or null. */
+  activeStep: StepId | null;
+  /** Per-step sample counts + coverage, refreshed as samples arrive. */
+  progress: StepProgress[];
+  /** True once `build()` has run and a model can be cut. */
+  built: boolean;
+  /** How many categories the player has asked for. */
+  k: number;
+  /** The heuristic's suggestion — shown as a hint, never imposed. */
+  suggestedK: number;
+  /** The most recent cut. */
+  model: TrainedModel | null;
+  /** Player-supplied names, by category id. Kept out of the model so a re-cut at a
+   *  different k cannot silently reattach a name to a different cluster. */
+  labels: Record<string, string>;
+
+  begin(step: StepId): void;
+  sample(vector: FeatureVector, tMs: number): void;
+  end(): void;
+  build(): void;
+  setK(k: number): void;
+  setLabel(id: string, label: string): void;
+  reset(): void;
+  /** Escape hatch for tests and for a future "export my training take". */
+  session(): EnrollmentSession;
+}
+
+/** The session lives outside the store: it is a mutable capture buffer, not UI state,
+ *  and putting it in the store would invite React to try to diff it. */
+let session: EnrollmentSession = createEnrollmentSession();
+
+export const useTrainer = create<TrainerState>()((set, get) => ({
+  activeStep: null,
+  progress: session.progress(),
+  built: false,
+  k: 3,
+  suggestedK: 3,
+  model: null,
+  labels: {},
+
+  begin(step) {
+    session.beginStep(step);
+    set({ activeStep: step, progress: session.progress() });
+  },
+
+  sample(vector, tMs) {
+    if (!get().activeStep) return;
+    session.push(vector, tMs);
+    set({ progress: session.progress() });
+  },
+
+  end() {
+    session.endStep();
+    set({ activeStep: null, progress: session.progress() });
+  },
+
+  build() {
+    session.build();
+    const suggested = session.suggestedK();
+    const k = suggested > 0 ? suggested : get().k;
+    set({ built: true, suggestedK: suggested, k, model: session.retrain(k) });
+  },
+
+  setK(k) {
+    if (!get().built) {
+      set({ k });
+      return;
+    }
+    set({ k, model: session.retrain(k) });
+  },
+
+  setLabel(id, label) {
+    set((s) => ({ labels: { ...s.labels, [id]: label } }));
+  },
+
+  reset() {
+    session = createEnrollmentSession();
+    set({
+      activeStep: null,
+      progress: session.progress(),
+      built: false,
+      k: 3,
+      suggestedK: 3,
+      model: null,
+      labels: {},
+    });
+  },
+
+  session: () => session,
+}));

--- a/src/app/tools.ts
+++ b/src/app/tools.ts
@@ -69,6 +69,13 @@ export const TOOLS: readonly Tool[] = [
     kind: 'panel',
   },
   {
+    id: 'trainer',
+    label: 'Trainer',
+    description:
+      'Teach the instrument the faces you can actually make — a one-minute guided take, then pick how many categories.',
+    kind: 'panel',
+  },
+  {
     id: 'manual',
     label: 'Manual',
     description: 'The generated capabilities manual: every node, dial, sound and overlay element.',

--- a/src/app/useEngine.ts
+++ b/src/app/useEngine.ts
@@ -11,6 +11,7 @@ import { createAppRegistry } from '@/nodes/browser';
 import { defaultGraph } from './graph';
 import { DEFAULT_SOURCE, type SourceSpec } from './sourceSpec';
 import { useControls } from './store';
+import { LiveVectorTap, resetLiveVector } from './enroll/liveVector';
 import { useToasts } from './toasts';
 import { SessionRecorder, activeStreamLabels } from './recording/session';
 import { SinkCancelled } from './recording/sink';
@@ -192,6 +193,15 @@ export function useThoreminEngine(source: SourceSpec = DEFAULT_SOURCE) {
         resources.tagOverlay = tagOverlayResource;
 
         const engine = new Engine(defaultGraph(), createAppRegistry(), { resources });
+
+        // Trainer mode (#160) needs to see the same feature vector the Lab meters read.
+        // Attached once, for the engine's whole life: it is one object spread per tick
+        // into a module holder, and it is the only path by which the host can observe
+        // the feature vector at all. `test/app_graph.test.ts` asserts the edges it names
+        // still exist, so renaming a vector node fails the build rather than silently
+        // starving the trainer.
+        engine.addTap(new LiveVectorTap());
+
         await engine.init(); // loads the MediaPipe model
         if (disposed) {
           engine.dispose();
@@ -304,6 +314,7 @@ export function useThoreminEngine(source: SourceSpec = DEFAULT_SOURCE) {
       engineRef.current?.dispose();
       engineRef.current = null;
       useFaceStatus.getState().reset();
+      resetLiveVector();
       useMidiStatus.getState().reset();
       useGestureStatus.getState().reset();
       sessionRecRef.current?.dispose();

--- a/src/enroll/classify.ts
+++ b/src/enroll/classify.ts
@@ -1,0 +1,277 @@
+/**
+ * Training and classification (#160) — turning a cut hierarchy into a model, and a live
+ * vector into a category.
+ *
+ * ## Three decisions here, each from a specific finding
+ *
+ * **1. Soft membership is the primary output.** A hard per-frame category is a step
+ * function, and step functions are not expressive — this is why both XMM and GVF output
+ * continuously. `categoryId` is still produced for discrete triggers (the #129 gesture
+ * dispatcher can consume it directly), but a continuous mapping should read
+ * `memberships` and get smooth motion between poses for free.
+ *
+ * **2. No-man's-land is a real region, set by demonstration.** Without a reject option
+ * every frame is classified as *something*, so the instrument asserts a category while
+ * the player scratches their nose. The reject radius comes from the rest step — "this is
+ * what nothing looks like" — rather than a magic constant, because the open-set
+ * literature's consistent finding is that thresholds are task-specific and tuning is the
+ * crucial part.
+ *
+ * **3. Rejection is hysteretic, and it HOLDS rather than silences.** Entering no-man's-
+ * land is harder than staying in a category (the same dwell/hysteresis pattern this repo
+ * already uses for handedness and expression), and the classifier reports the last good
+ * category while unsure. An instrument that drops to silence whenever the classifier
+ * hesitates is unplayable — silence is the host's decision to make explicitly, not a
+ * side effect of an uncertain frame.
+ */
+import { weightedDistance } from './cluster';
+import type {
+  Category,
+  Classification,
+  FeatureVector,
+  FeatureWeights,
+  TrainedModel,
+} from './types';
+
+/** Mean of a set of vectors over `features`, skipping non-finite entries per feature. */
+function meanVector(
+  vectors: readonly FeatureVector[],
+  features: readonly string[],
+): FeatureVector {
+  const out: FeatureVector = {};
+  for (const f of features) {
+    let sum = 0;
+    let n = 0;
+    for (const v of vectors) {
+      const x = v[f];
+      if (!Number.isFinite(x)) continue;
+      sum += x;
+      n += 1;
+    }
+    out[f] = n === 0 ? 0 : sum / n;
+  }
+  return out;
+}
+
+export interface TrainOptions {
+  /**
+   * Vectors from the REST step. Their spread sets the reject radius: whatever distance
+   * the player's own resting state wanders over is, by demonstration, "not a category".
+   */
+  restVectors?: readonly FeatureVector[];
+  /** Multiplier on the demonstrated rest spread. Larger = more forgiving. */
+  rejectScale?: number;
+  /** Fallback reject radius when no rest demonstration was given. */
+  defaultRejectRadius?: number;
+  /**
+   * Fraction of the TRAINING points the reject radius must accept. The model is not
+   * allowed to be tighter than this, whatever the rest take says — see `trainModel`.
+   */
+  acceptQuantile?: number;
+}
+
+const TRAIN_DEFAULTS = { rejectScale: 2.5, defaultRejectRadius: 0.6, acceptQuantile: 0.9 };
+
+/**
+ * Build a {@link TrainedModel} from clustered still-points.
+ *
+ * `clusters` is the output of `cutAt` — arrays of indices into `vectors`. Empty clusters
+ * are dropped rather than kept as degenerate categories.
+ */
+export function trainModel(
+  vectors: readonly FeatureVector[],
+  clusters: readonly (readonly number[])[],
+  features: readonly string[],
+  weights: FeatureWeights,
+  options: TrainOptions = {},
+): TrainedModel {
+  const o = { ...TRAIN_DEFAULTS, ...options };
+  const categories: Category[] = [];
+  clusters.forEach((idxs, i) => {
+    if (idxs.length === 0) return;
+    const members = idxs.map((j) => vectors[j]);
+    const centroid = meanVector(members, features);
+    const radius =
+      members.reduce((s, m) => s + weightedDistance(m, centroid, features, weights), 0) /
+      members.length;
+    categories.push({
+      id: `cat-${i + 1}`,
+      label: '',
+      centroid,
+      size: idxs.length,
+      radius,
+    });
+  });
+
+  let rejectRadius = o.defaultRejectRadius;
+  const rest = options.restVectors ?? [];
+  if (rest.length >= 5) {
+    const restCentroid = meanVector(rest, features);
+    const spread =
+      rest.reduce((s, v) => s + weightedDistance(v, restCentroid, features, weights), 0) /
+      rest.length;
+    rejectRadius = Math.max(spread * o.rejectScale, 1e-3);
+  }
+
+  // A model must never reject the data it was trained on. A rest take that was genuinely
+  // still gives a spread near zero, and a reject radius derived from it alone would throw
+  // out most of the player's own vocabulary the moment they used it — the model would be
+  // born unable to recognise itself, which reads to a player as "the trainer did nothing".
+  // So floor the radius at the distance that accepts `acceptQuantile` of the training
+  // points. Flooring on the TIGHTEST category radius (the obvious guess) does not work:
+  // it is unrelated to how far the broadest category's members actually sit.
+  const memberDistances: number[] = [];
+  clusters.forEach((idxs, i) => {
+    const c = categories.find((x) => x.id === `cat-${i + 1}`);
+    if (!c) return;
+    for (const j of idxs) memberDistances.push(weightedDistance(vectors[j], c.centroid, features, weights));
+  });
+  if (memberDistances.length > 0) {
+    memberDistances.sort((a, b) => a - b);
+    const q = Math.min(
+      memberDistances.length - 1,
+      Math.floor(o.acceptQuantile * (memberDistances.length - 1)),
+    );
+    rejectRadius = Math.max(rejectRadius, memberDistances[q] * 1.05);
+  }
+
+  return { categories, weights, features: [...features], rejectRadius };
+}
+
+export interface ClassifyOptions {
+  /**
+   * Softness of the membership distribution. Smaller = sharper (closer to one-hot),
+   * larger = smoother blending between neighbouring categories.
+   */
+  temperature?: number;
+}
+
+const CLASSIFY_DEFAULTS = { temperature: 0.25 };
+
+/**
+ * Classify one vector against a model. Pure — no state, no hysteresis; see
+ * {@link createCategoryTracker} for the temporal layer.
+ */
+export function classify(
+  model: TrainedModel,
+  vector: FeatureVector,
+  options: ClassifyOptions = {},
+): Classification {
+  const o = { ...CLASSIFY_DEFAULTS, ...options };
+  const memberships: Record<string, number> = {};
+  if (model.categories.length === 0) {
+    return { categoryId: null, memberships, distance: Infinity, rejected: true };
+  }
+
+  const dists = model.categories.map((c) =>
+    weightedDistance(vector, c.centroid, model.features, model.weights),
+  );
+  let best = 0;
+  for (let i = 1; i < dists.length; i++) if (dists[i] < dists[best]) best = i;
+
+  // Softmax over negative distance. Subtracting the minimum first keeps the exponent in
+  // range — without it a large distance underflows every term to 0 and the normalization
+  // divides by zero, which is how a "smooth" mapping produces NaN and silences the synth.
+  const minD = dists[best];
+  const exps = dists.map((d) => Math.exp(-(d - minD) / Math.max(1e-6, o.temperature)));
+  const total = exps.reduce((a, b) => a + b, 0);
+  model.categories.forEach((c, i) => {
+    memberships[c.id] = total > 0 ? exps[i] / total : 0;
+  });
+
+  const rejected = minD > model.rejectRadius;
+  return {
+    categoryId: rejected ? null : model.categories[best].id,
+    memberships,
+    distance: minD,
+    rejected,
+  };
+}
+
+export interface TrackerOptions extends ClassifyOptions {
+  /** Consecutive frames a NEW category must win before it takes over. */
+  enterFrames?: number;
+  /** Consecutive rejected frames before the tracker admits no-man's-land. */
+  exitFrames?: number;
+  /**
+   * Whether no-man's-land HOLDS the previous category (default) or reports null.
+   * Holding is the musical default: an instrument that drops out whenever the
+   * classifier hesitates is unplayable.
+   */
+  holdOnReject?: boolean;
+}
+
+const TRACKER_DEFAULTS = { enterFrames: 3, exitFrames: 8, holdOnReject: true };
+
+export interface CategoryTracker {
+  /** Feed one live vector; returns the stabilized classification. */
+  push(vector: FeatureVector): Classification & { held: boolean };
+  /** The currently-committed category id. */
+  current(): string | null;
+  reset(): void;
+}
+
+/**
+ * The temporal layer over {@link classify}: hysteresis on entry and a longer, separate
+ * hysteresis on exit.
+ *
+ * Asymmetric on purpose. A short `enterFrames` keeps the instrument responsive when the
+ * player deliberately changes pose; a longer `exitFrames` means a momentary blink or a
+ * hand crossing the face does not evict the category they are holding. Symmetric
+ * hysteresis would force one number to serve both, and the right values differ by
+ * roughly the ratio you would guess.
+ */
+export function createCategoryTracker(
+  model: TrainedModel,
+  options: TrackerOptions = {},
+): CategoryTracker {
+  const o = { ...TRACKER_DEFAULTS, ...options };
+  let committed: string | null = null;
+  let candidate: string | null = null;
+  let candidateRun = 0;
+  let rejectRun = 0;
+
+  return {
+    push(vector) {
+      const c = classify(model, vector, o);
+      if (c.rejected) {
+        rejectRun += 1;
+        candidate = null;
+        candidateRun = 0;
+        if (rejectRun >= o.exitFrames) {
+          if (!o.holdOnReject) committed = null;
+          return { ...c, categoryId: o.holdOnReject ? committed : null, held: o.holdOnReject && committed !== null };
+        }
+        // Inside the exit hysteresis: keep reporting the committed category.
+        return { ...c, categoryId: committed, rejected: false, held: committed !== null };
+      }
+
+      rejectRun = 0;
+      if (c.categoryId === committed) {
+        candidate = null;
+        candidateRun = 0;
+        return { ...c, held: false };
+      }
+      if (c.categoryId === candidate) candidateRun += 1;
+      else {
+        candidate = c.categoryId;
+        candidateRun = 1;
+      }
+      if (candidateRun >= o.enterFrames) {
+        committed = candidate;
+        candidate = null;
+        candidateRun = 0;
+        return { ...c, categoryId: committed, held: false };
+      }
+      // Not yet committed to the new one: keep the old.
+      return { ...c, categoryId: committed, held: committed !== null };
+    },
+    current: () => committed,
+    reset() {
+      committed = null;
+      candidate = null;
+      candidateRun = 0;
+      rejectRun = 0;
+    },
+  };
+}

--- a/src/enroll/cluster.ts
+++ b/src/enroll/cluster.ts
@@ -1,0 +1,222 @@
+/**
+ * Carving the space (#160) — agglomerative hierarchy, cut at k.
+ *
+ * ## Why a hierarchy and not k-means
+ *
+ * This is the design move that makes the oddest-sounding half of the request nearly
+ * free: *"a target number of categories that I could specify before **or afterwards**"*.
+ *
+ * Commit to a partition (k-means with k fixed, an online clusterer with a fixed
+ * vigilance) and k becomes a training parameter — changing it means retraining, and
+ * "afterwards" is not expressible. Build a **hierarchy** instead and the number of
+ * clusters need not be specified a priori at all: clusters are obtained by cutting the
+ * tree at a chosen level, and "give me k" is "cut at the height that yields k branches".
+ *
+ * So one recording supports 3 categories, then 5, then 4, **with no retraining and no
+ * new data**. The player drags a slider and hears their vocabulary get finer or coarser.
+ * That is the feature, not an implementation detail.
+ *
+ * Two more properties that fall out for free and are worth having:
+ *
+ * - **Order independence.** Agglomerative clustering on a fixed point set does not
+ *   depend on the order the points arrived in. The streaming alternatives (the ART
+ *   family) do, and mitigating it is a known research problem. For a bounded enrollment
+ *   take, this is simply not a question we have to answer.
+ * - **Determinism.** No seeding, no restarts, no `Math.random`. The same recording
+ *   yields the same tree every time, which is what makes the whole thing testable.
+ *
+ * Scale is a non-issue: O(n²) over the *hundreds* of still-points a 60-second gated
+ * take produces, not the millions raw frames would give.
+ *
+ * ## Linkage
+ *
+ * **Average linkage** (UPGMA). Single linkage chains — two genuinely distinct
+ * expressions joined by one intermediate point merge into one blob, which is exactly the
+ * failure mode a face full of continuous transitions invites. Complete linkage is the
+ * opposite extreme and splits an honestly-broad category. Average sits between them and
+ * is the standard default for this shape of data.
+ */
+import type { FeatureVector } from './types';
+
+/** One node of the merge tree. Leaves carry a point index; internal nodes carry kids. */
+export interface TreeNode {
+  /** Indices of the still-points beneath this node. */
+  members: number[];
+  /** The linkage distance at which this node's two children merged (0 for a leaf). */
+  height: number;
+  left?: TreeNode;
+  right?: TreeNode;
+}
+
+export interface Hierarchy {
+  /** The single root (undefined when there were no points). */
+  root?: TreeNode;
+  /** Merge heights in the order they occurred, ascending. */
+  heights: number[];
+  /** How many points the tree was built from. */
+  size: number;
+}
+
+/** Weighted Euclidean distance between two vectors over `features`. */
+export function weightedDistance(
+  a: FeatureVector,
+  b: FeatureVector,
+  features: readonly string[],
+  weights: Record<string, number>,
+): number {
+  let sum = 0;
+  for (const f of features) {
+    const w = weights[f] ?? 1;
+    if (w === 0) continue;
+    const x = a[f];
+    const y = b[f];
+    // A non-finite feature ("not measurable this frame") contributes nothing rather
+    // than making the whole distance NaN — one absent landmark must not delete a point.
+    if (!Number.isFinite(x) || !Number.isFinite(y)) continue;
+    const d = (x - y) * w;
+    sum += d * d;
+  }
+  return Math.sqrt(sum);
+}
+
+/**
+ * Build the agglomerative hierarchy over `vectors` with average linkage.
+ *
+ * Uses the Lance-Williams update so cluster-to-cluster distances are maintained
+ * incrementally rather than recomputed from members on every merge — O(n²) overall
+ * instead of O(n³), which is the difference between instant and noticeable at n≈400.
+ */
+export function buildHierarchy(
+  vectors: readonly FeatureVector[],
+  features: readonly string[],
+  weights: Record<string, number> = {},
+): Hierarchy {
+  const n = vectors.length;
+  if (n === 0) return { heights: [], size: 0 };
+  if (n === 1) return { root: { members: [0], height: 0 }, heights: [], size: 1 };
+
+  // Active cluster slots; `nodes[i]` is null once slot i has been merged away.
+  const nodes: (TreeNode | null)[] = vectors.map((_, i) => ({ members: [i], height: 0 }));
+  const counts: number[] = new Array(n).fill(1);
+  const d: number[][] = Array.from({ length: n }, () => new Array(n).fill(Infinity));
+  for (let i = 0; i < n; i++) {
+    for (let j = i + 1; j < n; j++) {
+      const dist = weightedDistance(vectors[i], vectors[j], features, weights);
+      d[i][j] = dist;
+      d[j][i] = dist;
+    }
+  }
+
+  const heights: number[] = [];
+  let remaining = n;
+  while (remaining > 1) {
+    // Closest active pair.
+    let bi = -1;
+    let bj = -1;
+    let best = Infinity;
+    for (let i = 0; i < n; i++) {
+      if (!nodes[i]) continue;
+      for (let j = i + 1; j < n; j++) {
+        if (!nodes[j]) continue;
+        if (d[i][j] < best) {
+          best = d[i][j];
+          bi = i;
+          bj = j;
+        }
+      }
+    }
+    if (bi < 0) break;
+
+    const a = nodes[bi]!;
+    const b = nodes[bj]!;
+    const merged: TreeNode = {
+      members: [...a.members, ...b.members],
+      height: best,
+      left: a,
+      right: b,
+    };
+    heights.push(best);
+
+    // Lance-Williams for average linkage: the distance from the merged cluster to any
+    // other is the count-weighted mean of its two children's distances.
+    const na = counts[bi];
+    const nb = counts[bj];
+    for (let k = 0; k < n; k++) {
+      if (k === bi || k === bj || !nodes[k]) continue;
+      const nd = (na * d[bi][k] + nb * d[bj][k]) / (na + nb);
+      d[bi][k] = nd;
+      d[k][bi] = nd;
+    }
+    nodes[bi] = merged;
+    counts[bi] = na + nb;
+    nodes[bj] = null;
+    remaining -= 1;
+  }
+
+  const root = nodes.find((x): x is TreeNode => x !== null);
+  return { root, heights, size: n };
+}
+
+/**
+ * Cut the tree into exactly `k` clusters — the "specify the count afterwards" operation.
+ *
+ * Repeatedly splits the currently-tallest node, which is equivalent to cutting at the
+ * height that yields k branches, and is exact rather than a search over cut heights.
+ * Returns arrays of point indices. `k` is clamped to `[1, size]`, so a slider that runs
+ * past either end degrades instead of throwing.
+ */
+export function cutAt(hierarchy: Hierarchy, k: number): number[][] {
+  const { root, size } = hierarchy;
+  if (!root || size === 0) return [];
+  const want = Math.max(1, Math.min(Math.floor(k), size));
+  const open: TreeNode[] = [root];
+  while (open.length < want) {
+    // Split the tallest splittable node.
+    let idx = -1;
+    let tallest = -Infinity;
+    for (let i = 0; i < open.length; i++) {
+      const nd = open[i];
+      if (nd.left && nd.right && nd.height > tallest) {
+        tallest = nd.height;
+        idx = i;
+      }
+    }
+    if (idx < 0) break; // all leaves — cannot split further
+    const [node] = open.splice(idx, 1);
+    open.push(node.left!, node.right!);
+  }
+  // Stable order: by first member index, so cluster 1 is always the same cluster.
+  return open.map((nd) => [...nd.members].sort((x, y) => x - y)).sort((x, y) => x[0] - y[0]);
+}
+
+/**
+ * Suggest a k from the merge heights: the largest RELATIVE gap between successive
+ * merges, which is the classic "natural clustering" heuristic.
+ *
+ * Relative rather than absolute, because merge heights grow as clusters do — an absolute
+ * gap criterion is biased toward tiny k on almost any real data.
+ *
+ * **This is a suggestion and the caller must present it as one.** The clustering
+ * literature is explicit that dendrograms over-suggest structure: they often "suggest a
+ * correct number of clusters when there is no real evidence to support the conclusion."
+ * Show the player why, and let them overrule it.
+ */
+export function suggestK(hierarchy: Hierarchy, opts: { max?: number } = {}): number {
+  const { heights, size } = hierarchy;
+  if (size <= 1) return size;
+  const max = Math.min(opts.max ?? 8, size);
+  // heights[i] is the i-th merge; cutting just before merge i leaves size - i clusters.
+  let bestK = Math.min(2, size);
+  let bestRatio = -Infinity;
+  for (let i = 1; i < heights.length; i++) {
+    const k = size - i;
+    if (k < 2 || k > max) continue;
+    const prev = heights[i - 1];
+    const ratio = prev > 1e-9 ? heights[i] / prev : heights[i] > 1e-9 ? Infinity : 1;
+    if (ratio > bestRatio) {
+      bestRatio = ratio;
+      bestK = k;
+    }
+  }
+  return bestK;
+}

--- a/src/enroll/index.ts
+++ b/src/enroll/index.ts
@@ -1,0 +1,84 @@
+/**
+ * Trainer / enrollment (#160) — learn a player's OWN control categories from a short
+ * guided recording, instead of asking them to hit categories a population model chose.
+ *
+ * The problem this exists for is not a tuning failure. Being unable to reliably hit a
+ * shipped expression category is **identity bias** — a named, measured, subject-dependent
+ * gap in facial expression recognition — and the field's answer is personalization. The
+ * usual blocker on personalization is that subject-specific labels are unavailable in the
+ * wild; that blocker simply does not apply to an instrument whose player is sitting at the
+ * camera and willing to spend a minute making faces at it. Labels are free here.
+ *
+ * Full evidence and citations: `docs/research/trainer-mode.md`.
+ *
+ * ## The pipeline, each stage its own module
+ *
+ * | stage | module | what it does |
+ * |---|---|---|
+ * | Sample | `sampler.ts` | velocity-gate the live vector; keep poses actually HELD |
+ * | Condition | `invariance.ts` | down-weight what moved during a nuisance demo; consume #131's declarations |
+ * | Carve | `cluster.ts` | agglomerative hierarchy; cut at k — **before or after** |
+ * | Reject | `classify.ts` | no-man's-land by demonstration, hysteretic, holds rather than silences |
+ * | Ritual | `ritual.ts` | the four guided steps, as data |
+ * | Facade | `session.ts` | runs the ritual, produces a model, re-cuts cheaply |
+ *
+ * ## The one architectural rule
+ *
+ * Everything is defined over a **`FeatureVector`** (`Record<featureId, number>`), never
+ * over a `FaceFrame`. The feature catalog already emits that shape from face *and* hands
+ * through one contract, so this is a face trainer, a hand trainer, and a trainer for
+ * whatever is added to the catalog next — on day one. Nothing here imports MediaPipe, the
+ * DAG, React or the audio layer.
+ */
+export { createStillPointSampler, meanAbsDistance, type SamplerOptions, type StillPointSampler } from './sampler';
+export {
+  buildHierarchy,
+  cutAt,
+  suggestK,
+  weightedDistance,
+  type Hierarchy,
+  type TreeNode,
+} from './cluster';
+export {
+  combineWeights,
+  nuisanceProfile,
+  rankFeatures,
+  selectByInvariance,
+  weightsFromNuisance,
+  weightsFromSelection,
+  type InvarianceSelection,
+  type WeightOptions,
+} from './invariance';
+export {
+  classify,
+  createCategoryTracker,
+  trainModel,
+  type CategoryTracker,
+  type ClassifyOptions,
+  type TrackerOptions,
+  type TrainOptions,
+} from './classify';
+export {
+  ENROLLMENT_STEPS,
+  canTrain,
+  stepById,
+  stepCoverage,
+  type EnrollmentStep,
+  type StepProduct,
+} from './ritual';
+export {
+  createEnrollmentSession,
+  type EnrollmentSession,
+  type SessionOptions,
+  type StepProgress,
+} from './session';
+export type {
+  Category,
+  Classification,
+  FeatureVector,
+  FeatureWeights,
+  NuisanceProfile,
+  StepId,
+  StillPoint,
+  TrainedModel,
+} from './types';

--- a/src/enroll/invariance.ts
+++ b/src/enroll/invariance.ts
@@ -1,0 +1,197 @@
+/**
+ * Feature conditioning (#160 / #131) — deciding what "shouldn't matter" and acting on it.
+ *
+ * The maintainer's question was *"ways to specify some sensitivity and insensitivities —
+ * for example, whether how close the face is shouldn't matter or not."* There are two
+ * usable answers and this module implements both, because they fail in different places.
+ *
+ * ## Level 1 — declared invariance (consumes what #131 already shipped)
+ *
+ * `src/features/types.ts` already defines the vocabulary (`scale` = camera distance,
+ * `position`, `yaw`/`pitch`/`roll`) and every catalog feature can declare `invariantTo`,
+ * with deliberate three-state semantics: **absent = not assessed**, `[]` = assessed and
+ * invariant to nothing, a listed axis = moving along it should not move this feature.
+ *
+ * Until now nothing consumed any of it. {@link selectByInvariance} does: ask for
+ * invariance to `scale` and it keeps the features that declare it, drops the ones that
+ * declare otherwise, and — this is the part that matters — reports the **unassessed**
+ * ones separately instead of silently guessing. A feature with no claim is not evidence
+ * of safety, and folding it into either bucket would either discard good features or
+ * quietly admit confounded ones.
+ *
+ * ## Level 2 — demonstrated invariance (the elegant one)
+ *
+ * Let the player *show* the nuisance: "hold any one face and move closer, then further
+ * away." Every frame of that clip should ideally be the same point in feature space, so
+ * whatever moved is nuisance, and {@link weightsFromNuisance} down-weights it in
+ * proportion.
+ *
+ * This is the contrastive-learning idea (positive pairs under a transformation that
+ * should not change the representation) reduced to the smallest thing that works: a
+ * per-dimension inverse-spread weight. No network, no training loop, and it generalises
+ * to **any** nuisance the player can perform, including ones nobody enumerated. It also
+ * matches the interaction model the rest of this feature uses: you teach it by doing it.
+ *
+ * It is not free of assumptions — it treats the axes as independent, so it cannot undo a
+ * nuisance that lives in a *rotation* of feature space rather than along its axes. That
+ * is the honest limit, and the reason level 1 stays worth having.
+ *
+ * ## Why this is not measured as a number for the player
+ *
+ * There is **no consensus in the literature on how to measure** a representation's
+ * invariance to a nuisance factor. So the host should SHOW the effect (a meter that
+ * stays flat while the player moves closer) rather than claim a percentage.
+ */
+import { ALL_FEATURES, FEATURE_BY_ID } from '@/features/catalog';
+import type { Invariance } from '@/features/types';
+import type { FeatureVector, FeatureWeights, NuisanceProfile } from './types';
+
+/** What a declared-invariance selection concluded, split three ways on purpose. */
+export interface InvarianceSelection {
+  /** Features that declare invariance to every requested axis. */
+  keep: string[];
+  /** Features assessed as NOT invariant to at least one requested axis. */
+  drop: string[];
+  /**
+   * Features with no `invariantTo` declaration at all. Neither kept nor dropped — the
+   * caller decides, and the UI should say how many there are. "Not assessed" is a
+   * different fact from "not invariant" and collapsing them loses the distinction #131
+   * deliberately encoded.
+   */
+  unassessed: string[];
+}
+
+/**
+ * Split the catalog's features by whether they declare invariance to every axis in
+ * `axes`. With no axes requested everything is kept — asking for nothing excludes
+ * nothing.
+ */
+export function selectByInvariance(
+  axes: readonly Invariance[],
+  featureIds?: readonly string[],
+): InvarianceSelection {
+  const ids = featureIds ?? ALL_FEATURES.map((f) => f.id);
+  const keep: string[] = [];
+  const drop: string[] = [];
+  const unassessed: string[] = [];
+  for (const id of ids) {
+    if (axes.length === 0) {
+      keep.push(id);
+      continue;
+    }
+    const declared = FEATURE_BY_ID[id]?.invariantTo;
+    if (declared === undefined) unassessed.push(id);
+    else if (axes.every((a) => declared.includes(a))) keep.push(id);
+    else drop.push(id);
+  }
+  return { keep, drop, unassessed };
+}
+
+/**
+ * Build a nuisance profile from the frames of a nuisance demonstration: the per-feature
+ * standard deviation across a clip in which the player held one pose and varied
+ * something that should not count.
+ */
+export function nuisanceProfile(
+  vectors: readonly FeatureVector[],
+  axes: readonly Invariance[] = [],
+): NuisanceProfile {
+  const spread: Record<string, number> = {};
+  if (vectors.length === 0) return { spread, axes, samples: 0 };
+  const keys = new Set<string>();
+  for (const v of vectors) for (const k of Object.keys(v)) keys.add(k);
+  for (const k of keys) {
+    let n = 0;
+    let mean = 0;
+    let m2 = 0;
+    for (const v of vectors) {
+      const x = v[k];
+      if (!Number.isFinite(x)) continue;
+      n += 1;
+      const delta = x - mean;
+      mean += delta / n;
+      m2 += delta * (x - mean);
+    }
+    spread[k] = n > 1 ? Math.sqrt(m2 / (n - 1)) : 0;
+  }
+  return { spread, axes, samples: vectors.length };
+}
+
+export interface WeightOptions {
+  /**
+   * Spread at which a feature is considered fully nuisance-driven (weight → `floor`).
+   * Features are normalized to roughly 0..1, so a std of 0.25 across a clip in which
+   * nothing should have changed is already a badly confounded channel.
+   */
+  scale?: number;
+  /** Lower bound on any weight — never delete a feature outright, only quiet it. */
+  floor?: number;
+  /** A profile built from fewer samples than this is ignored (returns all-1 weights). */
+  minSamples?: number;
+}
+
+const WEIGHT_DEFAULTS = { scale: 0.25, floor: 0.05, minSamples: 15 };
+
+/**
+ * Turn a nuisance profile into per-feature weights: `1 / (1 + spread/scale)`, floored.
+ *
+ * Smooth rather than a hard cutoff, so a feature that is *slightly* confounded is
+ * *slightly* quieted instead of falling off a cliff at an arbitrary threshold. Floored
+ * rather than zeroed because a confounded feature is still a feature — down-weighting is
+ * reversible by the player, deletion is not.
+ *
+ * A profile built from too few samples returns all-1 weights: three frames of someone
+ * leaning in is not evidence, and acting on it would be worse than doing nothing.
+ */
+export function weightsFromNuisance(
+  profile: NuisanceProfile,
+  options: WeightOptions = {},
+): FeatureWeights {
+  const o = { ...WEIGHT_DEFAULTS, ...options };
+  const weights: FeatureWeights = {};
+  if (profile.samples < o.minSamples) {
+    for (const k of Object.keys(profile.spread)) weights[k] = 1;
+    return weights;
+  }
+  for (const [k, s] of Object.entries(profile.spread)) {
+    const w = 1 / (1 + Math.max(0, s) / o.scale);
+    weights[k] = Math.max(o.floor, w);
+  }
+  return weights;
+}
+
+/** Multiply two weight maps (declared selection × demonstrated spread, say). */
+export function combineWeights(...maps: readonly FeatureWeights[]): FeatureWeights {
+  const out: FeatureWeights = {};
+  for (const m of maps) for (const k of Object.keys(m)) out[k] = (out[k] ?? 1) * m[k];
+  return out;
+}
+
+/** Weights that zero everything outside `keep` — the declared-selection half as weights. */
+export function weightsFromSelection(keep: readonly string[], all: readonly string[]): FeatureWeights {
+  const set = new Set(keep);
+  const out: FeatureWeights = {};
+  for (const id of all) out[id] = set.has(id) ? 1 : 0;
+  return out;
+}
+
+/**
+ * The features a trainer should actually use, ranked most- to least-informative for the
+ * *signal* (highest spread across the vocabulary take) after nuisance down-weighting.
+ *
+ * The point of ranking: a 200-dimension distance in which 190 dimensions are noise is a
+ * worse classifier than a 10-dimension one, and the player cannot be asked to pick.
+ */
+export function rankFeatures(
+  vectors: readonly FeatureVector[],
+  weights: FeatureWeights,
+  limit = 24,
+): string[] {
+  const signal = nuisanceProfile(vectors).spread;
+  return Object.keys(signal)
+    .map((id) => ({ id, score: signal[id] * (weights[id] ?? 1) }))
+    .filter((x) => Number.isFinite(x.score) && x.score > 0)
+    .sort((a, b) => b.score - a.score || a.id.localeCompare(b.id))
+    .slice(0, limit)
+    .map((x) => x.id);
+}

--- a/src/enroll/ritual.ts
+++ b/src/enroll/ritual.ts
@@ -1,0 +1,142 @@
+/**
+ * The enrollment ritual (#160 §10) — the four steps, as DATA.
+ *
+ * A script, not control flow: the host renders whatever is in {@link ENROLLMENT_STEPS}
+ * and the pipeline dispatches on `id`. Adding a step (a lighting-change nuisance, a
+ * two-handed vocabulary pass) is appending an entry, which is the open-closed shape the
+ * rest of this codebase uses for sounds, renderings and features.
+ *
+ * ## Where the four steps come from
+ *
+ * Modelled on Face ID's enrollment, but only the parts that actually transfer. Face ID
+ * asks you to move your head in a circle twice, gathering the face from many angles
+ * [#160 §10.1]. Two things about that design are worth copying:
+ *
+ * - **The ring is a coverage meter, not a progress bar.** It shows which parts of the
+ *   space have been sampled and refuses to complete until the gaps are filled. That is
+ *   active learning with a physical interface. See {@link stepCoverage}.
+ * - **It is a bounded ritual that ENDS.** That is what makes a one-minute cost
+ *   acceptable at all.
+ *
+ * What does *not* transfer is the goal. Face ID enrolls pose variation precisely so it
+ * can factor pose OUT — it wants one template of a face as an object. Here pose is
+ * frequently the signal, and the discrimination is within one person across expressions,
+ * not between people. So: copy the ritual, not the objective.
+ *
+ * ## Two rules the wording encodes
+ *
+ * **Never show a target face to imitate.** Imitating a prescribed expression is the exact
+ * failure mode this whole feature exists to escape — the maintainer's report was that the
+ * shipped categories are the ones they cannot hit. The assistive-tech calibration
+ * literature calls this the choice between a prescribed demonstration and
+ * "user-interpretable instructions that users can subjectively interpret, allowing users
+ * to actively participate in calibration by determining how to perform the gesture."
+ * Every prompt below is the second kind.
+ *
+ * **Steps are independent.** A player's vocabulary is not stable the way an identity is —
+ * they will want to add one face next week without redoing the other six, or redo the
+ * nuisance step in new lighting. Each step declares what it produces, so re-running one
+ * is coherent. Retrofitting partial re-enrollment onto a monolithic ritual is expensive;
+ * this is the cheap moment to get it right.
+ */
+import type { Invariance } from '@/features/types';
+import type { StepId } from './types';
+
+/** What a step's samples are consumed as. */
+export type StepProduct = 'reject-baseline' | 'range' | 'nuisance' | 'vocabulary';
+
+export interface EnrollmentStep {
+  id: StepId;
+  /** Short title for the panel. */
+  title: string;
+  /** The instruction the player reads. Never "make THIS face". */
+  prompt: string;
+  /** One line on what it buys — shown so the ritual doesn't feel arbitrary. */
+  rationale: string;
+  /** What the captured samples are used for. */
+  produces: StepProduct;
+  /** Suggested duration in seconds; advisory, the coverage meter is the real gate. */
+  seconds: number;
+  /** For the nuisance step: which confound axes it demonstrates. */
+  axes?: readonly Invariance[];
+  /**
+   * Whether this step samples CONTINUOUSLY (every frame) or only still-points.
+   * Rest and nuisance want every frame — their whole content is the spread. Range and
+   * vocabulary want held poses.
+   */
+  sampling: 'continuous' | 'still-points';
+  /** How many samples make the step usable at all. */
+  minSamples: number;
+}
+
+/** The shipped ritual. Roughly 60-90 seconds end to end. */
+export const ENROLLMENT_STEPS: readonly EnrollmentStep[] = [
+  {
+    id: 'rest',
+    title: 'Rest',
+    prompt: 'Look at the camera and relax your face for a few seconds.',
+    rationale:
+      'Sets what "nothing" looks like, so the instrument can tell when you are not asking for anything.',
+    produces: 'reject-baseline',
+    seconds: 5,
+    sampling: 'continuous',
+    minSamples: 30,
+  },
+  {
+    id: 'range',
+    title: 'Range',
+    prompt: 'Slowly look left, then right, then up, then down, then tilt your head each way.',
+    rationale:
+      'Learns how far you actually move, so the axes are scaled to you instead of to a fixed 30 degrees.',
+    produces: 'range',
+    seconds: 15,
+    sampling: 'still-points',
+    minSamples: 4,
+  },
+  {
+    id: 'nuisance',
+    title: 'What should not matter',
+    prompt: 'Hold any one face, and move closer to the camera and then further away.',
+    rationale:
+      'Anything that changes while you do this is camera distance, not expression — the instrument learns to ignore it.',
+    produces: 'nuisance',
+    seconds: 12,
+    axes: ['scale'],
+    sampling: 'continuous',
+    minSamples: 40,
+  },
+  {
+    id: 'vocabulary',
+    title: 'Your faces',
+    prompt:
+      'Now make faces you can make reliably — whichever ones you like. Hold each one for a moment, then move to the next.',
+    rationale:
+      'These become your categories. You choose how many afterwards, so do not count as you go.',
+    produces: 'vocabulary',
+    seconds: 45,
+    sampling: 'still-points',
+    minSamples: 6,
+  },
+] as const;
+
+/** Look one up by id. */
+export function stepById(id: StepId): EnrollmentStep | undefined {
+  return ENROLLMENT_STEPS.find((s) => s.id === id);
+}
+
+/** How complete a step is, as a 0..1 fraction — the coverage meter's backing number. */
+export function stepCoverage(step: EnrollmentStep, samples: number): number {
+  if (step.minSamples <= 0) return 1;
+  return Math.max(0, Math.min(1, samples / step.minSamples));
+}
+
+/**
+ * Whether the ritual has enough to train. Rest and vocabulary are required; range and
+ * nuisance are genuinely optional improvements, and saying so is what keeps enrollment
+ * an offer rather than a gate.
+ */
+export function canTrain(counts: Partial<Record<StepId, number>>): boolean {
+  const rest = counts.rest ?? 0;
+  const vocab = counts.vocabulary ?? 0;
+  return rest >= (stepById('rest')?.minSamples ?? 0) && vocab >= (stepById('vocabulary')?.minSamples ?? 0);
+}

--- a/src/enroll/sampler.ts
+++ b/src/enroll/sampler.ts
@@ -1,0 +1,203 @@
+/**
+ * The still-point sampler (#160) — the front of the trainer pipeline, and the piece
+ * that keeps the whole thing honest.
+ *
+ * ## Why this exists at all
+ *
+ * The obvious design is to record every frame of the enrollment take and cluster them.
+ * That design fails, for a reason that is not obvious until you look at the data: **a
+ * stream of someone "moving their face around" is mostly transitions.** Most frames are
+ * on the path between expressions, so clustering all of them finds the centre of the
+ * motion envelope — a set of blurry averages nobody can reproduce on purpose — rather
+ * than the poses the player actually held.
+ *
+ * The literature's answer is to segment first: split a stream into *dynamic* and
+ * *static* segments using velocity derived from the signal, and keep the static ones.
+ * This is that, online and allocation-free per frame.
+ *
+ * ## The rule
+ *
+ * A still-point is emitted when the feature vector's rate of change stays below
+ * `speedThreshold` for `dwellMs` continuously. The emitted vector is the **mean over the
+ * dwell window**, not the single frame at the end of it — averaging a held pose is free
+ * noise reduction, and the player was holding still by definition.
+ *
+ * **Speed is measured over a short WINDOW (`speedWindowMs`), not frame to frame.** This
+ * was a real bug before it was a design note. A frame-to-frame difference is frame-rate
+ * dependent in the worst way: a feature jittering +/-0.01 per frame is physically still,
+ * yet reads as 1.2 units/second at 60 fps and 2.4 at 120 fps — so a threshold tuned on
+ * one machine refuses to emit anything on a faster one, silently. Comparing against the
+ * sample ~`speedWindowMs` ago measures actual displacement, so high-frequency jitter
+ * cancels and the threshold means the same thing everywhere.
+ *
+ * After emitting, the sampler will not emit again until the vector has *moved away*
+ * (exceeded the threshold) and settled somewhere new. Without that latch, holding a
+ * pose for five seconds would emit fifty near-identical points and hand the clusterer a
+ * dwell-time histogram instead of a vocabulary — the pose you happened to rest on
+ * longest would dominate every cluster it touched.
+ */
+import type { FeatureVector, StepId, StillPoint } from './types';
+
+export interface SamplerOptions {
+  /**
+   * Mean absolute per-feature change per second below which the vector counts as
+   * "held". Features are expected to be roughly 0..1 (the catalog's normalized form),
+   * so this is in normalized units per second.
+   */
+  speedThreshold?: number;
+  /** How long the vector must stay slow before a point is emitted. */
+  dwellMs?: number;
+  /** Window over which displacement is measured. Long enough that per-frame jitter
+   *  cancels, short enough to notice a real move promptly. */
+  speedWindowMs?: number;
+  /** Which ritual step to stamp emitted points with. */
+  step?: StepId;
+  /**
+   * Minimum weighted distance from the previously emitted point before a new one may be
+   * emitted. A second guard against near-duplicates when the player drifts slowly
+   * between two very similar poses without ever crossing the speed threshold.
+   */
+  minSeparation?: number;
+}
+
+const DEFAULTS = {
+  speedThreshold: 0.35,
+  dwellMs: 220,
+  speedWindowMs: 100,
+  step: 'vocabulary' as StepId,
+  minSeparation: 0.05,
+};
+
+/** Mean absolute difference per second between two vectors over `dtMs`. */
+function speed(a: FeatureVector, b: FeatureVector, dtMs: number): number {
+  if (dtMs <= 0) return 0;
+  const keys = Object.keys(a);
+  if (keys.length === 0) return 0;
+  let sum = 0;
+  let n = 0;
+  for (const k of keys) {
+    const x = a[k];
+    const y = b[k];
+    // A feature reports NaN for "not measurable this frame"; it must not poison the
+    // speed estimate (NaN would compare false against the threshold forever and the
+    // sampler would silently never emit).
+    if (!Number.isFinite(x) || !Number.isFinite(y)) continue;
+    sum += Math.abs(x - y);
+    n += 1;
+  }
+  if (n === 0) return 0;
+  return (sum / n) / (dtMs / 1000);
+}
+
+/** Mean absolute distance between two vectors over their shared finite features. */
+export function meanAbsDistance(a: FeatureVector, b: FeatureVector): number {
+  let sum = 0;
+  let n = 0;
+  for (const k of Object.keys(a)) {
+    const x = a[k];
+    const y = b[k];
+    if (!Number.isFinite(x) || !Number.isFinite(y)) continue;
+    sum += Math.abs(x - y);
+    n += 1;
+  }
+  return n === 0 ? 0 : sum / n;
+}
+
+export interface StillPointSampler {
+  /** Feed one live frame. Returns a still-point on the tick one is completed. */
+  push(vector: FeatureVector, tMs: number): StillPoint | null;
+  /** Everything emitted so far. */
+  points(): StillPoint[];
+  /** Drop the captured points and reset the internal state. */
+  reset(): void;
+  /** True while the vector is currently slow enough to be accumulating a dwell. */
+  isSettling(): boolean;
+}
+
+/**
+ * Build a still-point sampler. Stateful (it has to be — dwell is temporal) but
+ * self-contained: no clock of its own, no globals, `tMs` is supplied by the caller so
+ * tests drive it deterministically.
+ */
+export function createStillPointSampler(options: SamplerOptions = {}): StillPointSampler {
+  const o = { ...DEFAULTS, ...options };
+  const captured: StillPoint[] = [];
+
+  /** Recent frames, trimmed to just cover the speed window. */
+  const history: { v: FeatureVector; t: number }[] = [];
+  /** When the current slow run began, or null when moving. */
+  let settlingSince: number | null = null;
+  /** Running sum for the dwell-window mean. */
+  let acc: Record<string, number> = {};
+  let accN = 0;
+  /** Set after an emit; cleared once the player moves again. */
+  let armed = true;
+  let lastEmitted: FeatureVector | null = null;
+
+  const resetAccumulator = () => {
+    acc = {};
+    accN = 0;
+  };
+
+  return {
+    push(vector, tMs) {
+      history.push({ v: vector, t: tMs });
+      // Keep one sample older than the window, and drop the rest.
+      while (history.length > 2 && tMs - history[1].t >= o.speedWindowMs) history.shift();
+      if (history.length < 2) return null;
+      const ref = history[0];
+      const dt = tMs - ref.t;
+      // Not enough history to judge yet — do not guess "still".
+      if (dt <= 0) return null;
+      const v = speed(ref.v, vector, dt);
+
+      if (v > o.speedThreshold) {
+        // Moving: abandon any dwell in progress, and re-arm — the player has left the
+        // pose they last gave us, so the next held pose is a genuinely new one.
+        settlingSince = null;
+        resetAccumulator();
+        armed = true;
+        return null;
+      }
+
+      // Slow this frame: accumulate toward the dwell mean.
+      if (settlingSince === null) settlingSince = tMs;
+      for (const k of Object.keys(vector)) {
+        const x = vector[k];
+        if (!Number.isFinite(x)) continue;
+        acc[k] = (acc[k] ?? 0) + x;
+      }
+      accN += 1;
+
+      if (!armed || tMs - settlingSince < o.dwellMs) return null;
+
+      const mean: FeatureVector = {};
+      for (const k of Object.keys(acc)) mean[k] = acc[k] / accN;
+
+      if (lastEmitted && meanAbsDistance(mean, lastEmitted) < o.minSeparation) {
+        // Too close to the last point to be a different pose. Stay disarmed rather than
+        // emitting a near-duplicate; the player has to actually move somewhere new.
+        armed = false;
+        return null;
+      }
+
+      const point: StillPoint = { vector: mean, t: settlingSince, step: o.step };
+      captured.push(point);
+      lastEmitted = mean;
+      armed = false;
+      resetAccumulator();
+      settlingSince = null;
+      return point;
+    },
+    points: () => captured.slice(),
+    reset() {
+      captured.length = 0;
+      history.length = 0;
+      settlingSince = null;
+      resetAccumulator();
+      armed = true;
+      lastEmitted = null;
+    },
+    isSettling: () => settlingSince !== null,
+  };
+}

--- a/src/enroll/session.ts
+++ b/src/enroll/session.ts
@@ -1,0 +1,197 @@
+/**
+ * The enrollment session (#160) — the facade that runs the ritual and produces a model.
+ *
+ * This is the one stateful object a host holds. It owns the per-step capture (a
+ * still-point sampler for the pose steps, raw accumulation for the spread steps), and
+ * turns the accumulated take into a {@link TrainedModel} on demand.
+ *
+ * **`retrain(k)` is deliberately cheap and repeatable.** It re-cuts the already-built
+ * hierarchy — it does not recluster. That is what makes "specify the number of
+ * categories before *or afterwards*" real: the player drags a slider from 3 to 6 to 4
+ * and each move is a tree cut over the same recording, not a retrain. `build()` (the
+ * expensive part) happens once when the take finishes.
+ *
+ * Nothing here touches React, the DAG, MediaPipe or audio. The host pushes feature
+ * vectors in and reads a model out.
+ */
+import { buildHierarchy, cutAt, suggestK, type Hierarchy } from './cluster';
+import { trainModel } from './classify';
+import {
+  combineWeights,
+  nuisanceProfile,
+  rankFeatures,
+  selectByInvariance,
+  weightsFromNuisance,
+  weightsFromSelection,
+} from './invariance';
+import { createStillPointSampler, type StillPointSampler } from './sampler';
+import { ENROLLMENT_STEPS, canTrain, stepById, stepCoverage } from './ritual';
+import type {
+  FeatureVector,
+  FeatureWeights,
+  StepId,
+  StillPoint,
+  TrainedModel,
+} from './types';
+
+export interface SessionOptions {
+  /** Cap on how many features the model uses. See `rankFeatures` for why a cap exists. */
+  maxFeatures?: number;
+  /** Honour declared `invariantTo` in addition to the demonstrated nuisance profile. */
+  useDeclaredInvariance?: boolean;
+  /** Passed through to the sampler. */
+  speedThreshold?: number;
+  dwellMs?: number;
+}
+
+/** Per-step progress, for the coverage meter. */
+export interface StepProgress {
+  id: StepId;
+  samples: number;
+  coverage: number;
+}
+
+export interface EnrollmentSession {
+  /** Start (or restart) one step. Re-running a step discards only that step's samples. */
+  beginStep(id: StepId): void;
+  /** Feed a live feature vector. No-op when no step is active. */
+  push(vector: FeatureVector, tMs: number): void;
+  /** Finish the active step. */
+  endStep(): void;
+  /** Progress for every step. */
+  progress(): StepProgress[];
+  /** Whether enough has been captured to train. */
+  ready(): boolean;
+  /** Build the hierarchy from the vocabulary take. Call once when the take finishes. */
+  build(): void;
+  /** The k the merge-gap heuristic suggests. A SUGGESTION — see `suggestK`. */
+  suggestedK(): number;
+  /** Re-cut the built hierarchy into `k` categories and return the model. Cheap. */
+  retrain(k: number): TrainedModel;
+  /** The still-points captured for a step (for display / debugging). */
+  pointsFor(id: StepId): StillPoint[];
+  /** The features the model is using, best-first. */
+  features(): string[];
+  /** The weights distances are measured under. */
+  weights(): FeatureWeights;
+  reset(): void;
+}
+
+const DEFAULTS = { maxFeatures: 24, useDeclaredInvariance: false };
+
+export function createEnrollmentSession(options: SessionOptions = {}): EnrollmentSession {
+  const o = { ...DEFAULTS, ...options };
+
+  /** Still-points per step (the 'still-points' steps). */
+  const points = new Map<StepId, StillPoint[]>();
+  /** Raw frames per step (the 'continuous' steps — rest and nuisance). */
+  const raw = new Map<StepId, FeatureVector[]>();
+
+  let active: StepId | null = null;
+  let sampler: StillPointSampler | null = null;
+
+  let hierarchy: Hierarchy = { heights: [], size: 0 };
+  let chosenFeatures: string[] = [];
+  let chosenWeights: FeatureWeights = {};
+
+  const samplesFor = (id: StepId): number =>
+    (points.get(id)?.length ?? 0) + (raw.get(id)?.length ?? 0);
+
+  return {
+    beginStep(id) {
+      active = id;
+      const step = stepById(id);
+      points.delete(id);
+      raw.delete(id);
+      if (step?.sampling === 'still-points') {
+        sampler = createStillPointSampler({
+          step: id,
+          ...(o.speedThreshold !== undefined ? { speedThreshold: o.speedThreshold } : {}),
+          ...(o.dwellMs !== undefined ? { dwellMs: o.dwellMs } : {}),
+        });
+        points.set(id, []);
+      } else {
+        sampler = null;
+        raw.set(id, []);
+      }
+    },
+
+    push(vector, tMs) {
+      if (!active) return;
+      if (sampler) {
+        const p = sampler.push(vector, tMs);
+        if (p) points.get(active)!.push(p);
+      } else {
+        raw.get(active)!.push(vector);
+      }
+    },
+
+    endStep() {
+      active = null;
+      sampler = null;
+    },
+
+    progress: () =>
+      ENROLLMENT_STEPS.map((s) => ({
+        id: s.id,
+        samples: samplesFor(s.id),
+        coverage: stepCoverage(s, samplesFor(s.id)),
+      })),
+
+    ready: () =>
+      canTrain(Object.fromEntries(ENROLLMENT_STEPS.map((s) => [s.id, samplesFor(s.id)]))),
+
+    build() {
+      const vocab = (points.get('vocabulary') ?? []).map((p) => p.vector);
+      if (vocab.length === 0) {
+        hierarchy = { heights: [], size: 0 };
+        chosenFeatures = [];
+        chosenWeights = {};
+        return;
+      }
+
+      // 1. Demonstrated invariance: what moved while nothing should have.
+      const nuisance = raw.get('nuisance') ?? [];
+      const profile = nuisanceProfile(nuisance, stepById('nuisance')?.axes ?? []);
+      let weights = weightsFromNuisance(profile);
+
+      // 2. Declared invariance (#131), optional and OFF by default: it silences every
+      //    feature that has not been assessed, which is most of the catalog, so turning
+      //    it on without saying so would quietly shrink the model.
+      if (o.useDeclaredInvariance) {
+        const all = Object.keys(vocab[0] ?? {});
+        const sel = selectByInvariance(stepById('nuisance')?.axes ?? [], all);
+        weights = combineWeights(weights, weightsFromSelection([...sel.keep, ...sel.unassessed], all));
+      }
+
+      // 3. Rank by signal-after-weighting and keep the top slice.
+      chosenFeatures = rankFeatures(vocab, weights, o.maxFeatures);
+      chosenWeights = weights;
+      hierarchy = buildHierarchy(vocab, chosenFeatures, weights);
+    },
+
+    suggestedK: () => suggestK(hierarchy),
+
+    retrain(k) {
+      const vocab = (points.get('vocabulary') ?? []).map((p) => p.vector);
+      const clusters = cutAt(hierarchy, k);
+      return trainModel(vocab, clusters, chosenFeatures, chosenWeights, {
+        restVectors: raw.get('rest') ?? [],
+      });
+    },
+
+    pointsFor: (id) => (points.get(id) ?? []).slice(),
+    features: () => chosenFeatures.slice(),
+    weights: () => ({ ...chosenWeights }),
+
+    reset() {
+      points.clear();
+      raw.clear();
+      active = null;
+      sampler = null;
+      hierarchy = { heights: [], size: 0 };
+      chosenFeatures = [];
+      chosenWeights = {};
+    },
+  };
+}

--- a/src/enroll/types.ts
+++ b/src/enroll/types.ts
@@ -1,0 +1,106 @@
+/**
+ * The enrollment/trainer vocabulary (#160) — the types every other module in
+ * `src/enroll/` speaks.
+ *
+ * ## The one decision this file encodes
+ *
+ * Everything here is defined over a **`FeatureVector`** (`Record<featureId, number>`),
+ * never over a `FaceFrame`. That is the load-bearing choice from the research: the
+ * feature catalog already emits a flat, named, normalized scalar vector from face *and*
+ * hands through one `compute(ctx) => number` contract, so a trainer written against the
+ * vector is a face trainer, a hand trainer, and a trainer for anything added to the
+ * catalog later — on day one, with no refactor. Writing it against `FaceFrame` is the
+ * single decision that would make it face-only forever.
+ *
+ * Nothing in `src/enroll/` imports MediaPipe, the DAG, the audio layer, or React. It is
+ * a pure library over numbers; the host feeds it vectors and reads back categories.
+ */
+import type { Invariance } from '@/features/types';
+
+/** A named scalar feature vector — the trainer's only input shape. */
+export type FeatureVector = Record<string, number>;
+
+/**
+ * One captured still-point: a feature vector the player HELD, plus when they held it.
+ *
+ * Still-points, not frames. A free-motion stream is dominated by the transitions
+ * between expressions, so clustering every frame finds the centre of the motion
+ * envelope rather than the expressions themselves. See `sampler.ts`.
+ */
+export interface StillPoint {
+  /** The held feature vector. */
+  vector: FeatureVector;
+  /** Milliseconds since the recording started. */
+  t: number;
+  /** Which ritual step produced it (so a step can be re-run independently). */
+  step: StepId;
+}
+
+/** The steps of the enrollment ritual. Data, not control flow — see `ritual.ts`. */
+export type StepId = 'rest' | 'range' | 'nuisance' | 'vocabulary';
+
+/**
+ * A nuisance profile: how much each feature moved while the player demonstrated
+ * something that should NOT count as a change (moving closer to the camera, turning
+ * their head). Used to down-weight those directions.
+ */
+export interface NuisanceProfile {
+  /** Per-feature standard deviation observed across the nuisance demonstration. */
+  spread: Record<string, number>;
+  /** The invariance axes the demonstration was meant to cover, for display. */
+  axes: readonly Invariance[];
+  /** How many samples it was built from — a profile from 3 frames is not evidence. */
+  samples: number;
+}
+
+/** Per-feature multiplier applied before any distance is computed. */
+export type FeatureWeights = Record<string, number>;
+
+/** One discovered category: a centroid in feature space plus what it was built from. */
+export interface Category {
+  /** Stable id (`cat-1`, …) — what a binding refers to, so a rename cannot break it. */
+  id: string;
+  /** Player-facing name. Empty until they name it. */
+  label: string;
+  /** The mean feature vector of its members. */
+  centroid: FeatureVector;
+  /** How many still-points formed it. */
+  size: number;
+  /** Mean weighted distance of its members from the centroid — its tightness. */
+  radius: number;
+}
+
+/**
+ * A trained model: the categories, the weights distances are measured under, and the
+ * reject radius. Serializable by construction — it is all plain numbers, so persisting
+ * it is a `JSON.stringify` and never a model format.
+ */
+export interface TrainedModel {
+  categories: Category[];
+  weights: FeatureWeights;
+  /** The features the model actually uses, in a fixed order. */
+  features: string[];
+  /**
+   * Weighted distance beyond which a vector belongs to no category — the no-man's-land
+   * boundary. Set by demonstration (the rest step) rather than by a magic number.
+   */
+  rejectRadius: number;
+}
+
+/** What the classifier says about one live vector. */
+export interface Classification {
+  /** The winning category id, or `null` for no-man's-land. */
+  categoryId: string | null;
+  /**
+   * Soft membership per category id, summing to 1 across categories.
+   *
+   * The primary output, deliberately. A hard category is a step function, and step
+   * functions are not expressive — both XMM and GVF output continuously for that
+   * reason. Discrete triggers read `categoryId`; continuous mappings read this.
+   */
+  memberships: Record<string, number>;
+  /** Weighted distance to the winning centroid (before the reject test). */
+  distance: number;
+  /** True when the vector fell outside `rejectRadius`. */
+  rejected: boolean;
+}

--- a/test/app_graph.test.ts
+++ b/test/app_graph.test.ts
@@ -6,6 +6,7 @@
  * here, so the app registry is Node-importable.
  */
 import { describe, it, expect } from 'vitest';
+import { FEATURE_VECTOR_EDGES } from '@/app/enroll/liveVector';
 import { Engine, StreamRecorder } from '@/dag';
 import { createAppRegistry } from '@/nodes/browser';
 import { defaultGraph } from '@/app/graph';
@@ -117,6 +118,22 @@ describe('production app graph', () => {
     // The original face-mesh + hand-feature edges are untouched (additive).
     expect(has('camFace', 'face', 'overlay', 'faceFrame')).toBe(true);
     expect(has('cam', 'hands', 'feat', 'hands')).toBe(true);
+  });
+
+  it('the trainer tap names edges that ACTUALLY EXIST (#160)', () => {
+    // The trainer observes the live feature vector through a DAG tap keyed by
+    // `"<node>.<port>"` strings. A tap listening to a key nothing emits is silent, not
+    // broken — the panel would just capture nothing and the coverage meter would sit at
+    // zero, with every unit test still green. That is #137's failure shape, so the edge
+    // names are asserted structurally here rather than trusted.
+    const g = defaultGraph();
+    for (const key of FEATURE_VECTOR_EDGES) {
+      const [nodeId, port] = key.split('.');
+      const node = g.nodes.find((n) => n.id === nodeId);
+      expect(node, `tap edge "${key}" names a node that is not in the graph`).toBeTruthy();
+      const emits = g.edges.some((e) => e.from.node === nodeId && e.from.port === port);
+      expect(emits, `tap edge "${key}" names a port nothing emits`).toBe(true);
+    }
   });
 
   it('wires the gesture classifier additively off the hand features (#129)', () => {

--- a/test/app_shell.test.ts
+++ b/test/app_shell.test.ts
@@ -22,6 +22,7 @@ const SURFACES: Record<string, string> = {
   lab: 'LabPanel',
   commands: 'CommandPaletteOverlay',
   gestures: 'GesturesPanel',
+  trainer: 'TrainerPanel',
 };
 
 describe('app shell', () => {

--- a/test/enroll.test.ts
+++ b/test/enroll.test.ts
@@ -1,0 +1,385 @@
+/**
+ * The trainer / enrollment core (#160).
+ *
+ * Unit cases over synthetic vectors (where the right answer is known by construction),
+ * plus an end-to-end pass over the REAL recording in `test/fixtures/video_head_pose/` —
+ * which matters more than it sounds, because that clip is the only evidence we have that
+ * the pipeline survives real data: real transitions, real noise, and a real camera-
+ * distance confound the synthetic cases cannot fake.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  buildHierarchy,
+  classify,
+  createCategoryTracker,
+  createEnrollmentSession,
+  createStillPointSampler,
+  cutAt,
+  ENROLLMENT_STEPS,
+  nuisanceProfile,
+  rankFeatures,
+  selectByInvariance,
+  suggestK,
+  trainModel,
+  weightsFromNuisance,
+  type FeatureVector,
+} from '@/enroll';
+import { matrixToHeadPose } from '@/nodes/domain';
+import { loadStream } from './helpers/fixtures';
+
+/** A vector built from a few named channels. */
+const v = (o: Record<string, number>): FeatureVector => o;
+
+describe('still-point sampler — the "cluster poses, not transitions" guard', () => {
+  it('emits nothing while the vector is moving', () => {
+    const s = createStillPointSampler({ dwellMs: 200, speedThreshold: 0.3 });
+    let emitted = 0;
+    for (let i = 0; i < 60; i++) {
+      // 0.02/frame at 60fps = 1.2/s, well over the threshold.
+      if (s.push(v({ a: i * 0.02 }), i * 16.7)) emitted += 1;
+    }
+    expect(emitted).toBe(0);
+  });
+
+  it('emits ONE point for a held pose, not one per frame', () => {
+    const s = createStillPointSampler({ dwellMs: 200 });
+    let emitted = 0;
+    for (let i = 0; i < 120; i++) if (s.push(v({ a: 0.5 }), i * 16.7)) emitted += 1;
+    expect(emitted).toBe(1);
+  });
+
+  it('emits again only after the player MOVES to a new pose', () => {
+    const s = createStillPointSampler({ dwellMs: 200 });
+    const feed = (val: number, frames: number, t0: number) => {
+      for (let i = 0; i < frames; i++) s.push(v({ a: val }), t0 + i * 16.7);
+      return t0 + frames * 16.7;
+    };
+    let t = 0;
+    t = feed(0.1, 40, t); // hold A
+    // a fast transition
+    for (let i = 0; i < 10; i++) s.push(v({ a: 0.1 + (i + 1) * 0.06 }), (t += 16.7));
+    feed(0.7, 40, t); // hold B
+    const pts = s.points();
+    expect(pts).toHaveLength(2);
+    expect(pts[0].vector.a).toBeCloseTo(0.1, 2);
+    expect(pts[1].vector.a).toBeCloseTo(0.7, 2);
+  });
+
+  it('a SLOW DRIFT during one hold still emits only one point (the latch, isolated)', () => {
+    // Guard-the-guard: the `armed` latch and the `minSeparation` check both block
+    // duplicates, so a constant-value hold stays correct even if the latch is removed.
+    // This case separates them — a pose that creeps below the speed threshold travels
+    // far past `minSeparation`, so ONLY the latch can stop it emitting a point every
+    // dwell window and handing the clusterer a dwell-time histogram.
+    const s = createStillPointSampler({ dwellMs: 200, speedWindowMs: 100, speedThreshold: 0.35 });
+    let a = 0.1;
+    for (let i = 0; i < 120; i++) {
+      a += 0.005; // 0.3/s — under the threshold, but 0.6 total: 12x minSeparation
+      s.push(v({ a }), i * 16.7);
+    }
+    expect(s.points()).toHaveLength(1);
+  });
+
+  it('averages the dwell window rather than taking the last frame', () => {
+    const s = createStillPointSampler({ dwellMs: 100 });
+    // Tiny alternating jitter around 0.5 — slow enough to count as held.
+    for (let i = 0; i < 40; i++) s.push(v({ a: i % 2 ? 0.51 : 0.49 }), i * 16.7);
+    expect(s.points()[0].vector.a).toBeCloseTo(0.5, 2);
+  });
+
+  it('a NaN feature ("not measurable") does not wedge the sampler', () => {
+    const s = createStillPointSampler({ dwellMs: 100 });
+    for (let i = 0; i < 40; i++) s.push(v({ a: 0.4, bad: NaN }), i * 16.7);
+    expect(s.points()).toHaveLength(1);
+  });
+});
+
+describe('hierarchy — k before OR after, from one recording', () => {
+  /** Three well-separated blobs of three points each. */
+  const blobs: FeatureVector[] = [
+    v({ x: 0.0, y: 0.0 }), v({ x: 0.02, y: 0.01 }), v({ x: 0.01, y: 0.02 }),
+    v({ x: 1.0, y: 0.0 }), v({ x: 1.02, y: 0.01 }), v({ x: 0.99, y: 0.02 }),
+    v({ x: 0.5, y: 1.0 }), v({ x: 0.52, y: 1.01 }), v({ x: 0.49, y: 0.99 }),
+  ];
+  const feats = ['x', 'y'];
+  const h = buildHierarchy(blobs, feats);
+
+  it('recovers the three blobs when cut at 3', () => {
+    const cut = cutAt(h, 3);
+    expect(cut).toHaveLength(3);
+    expect(cut.map((c) => c.length).sort()).toEqual([3, 3, 3]);
+  });
+
+  it('the SAME hierarchy answers 2, 3 and 4 with no rebuild — this is the feature', () => {
+    expect(cutAt(h, 2)).toHaveLength(2);
+    expect(cutAt(h, 3)).toHaveLength(3);
+    expect(cutAt(h, 4)).toHaveLength(4);
+    // and every cut is a partition of all 9 points
+    for (const k of [2, 3, 4, 5]) {
+      expect(cutAt(h, k).flat().sort((a, b) => a - b)).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8]);
+    }
+  });
+
+  it('clamps a k past either end instead of throwing (a slider must not crash)', () => {
+    expect(cutAt(h, 0)).toHaveLength(1);
+    expect(cutAt(h, -5)).toHaveLength(1);
+    expect(cutAt(h, 999)).toHaveLength(9);
+  });
+
+  it('suggests 3 for three obvious blobs', () => {
+    expect(suggestK(h)).toBe(3);
+  });
+
+  it('is deterministic and order-independent', () => {
+    const shuffled = [8, 3, 0, 6, 1, 7, 4, 2, 5].map((i) => blobs[i]);
+    const h2 = buildHierarchy(shuffled, feats);
+    // Same partition (as sets of coordinates), regardless of input order.
+    const asSets = (cut: number[][], src: FeatureVector[]) =>
+      cut.map((c) => c.map((i) => `${src[i].x},${src[i].y}`).sort().join('|')).sort();
+    expect(asSets(cutAt(h2, 3), shuffled)).toEqual(asSets(cutAt(h, 3), blobs));
+  });
+
+  it('handles degenerate sizes', () => {
+    expect(cutAt(buildHierarchy([], feats), 3)).toEqual([]);
+    expect(cutAt(buildHierarchy([v({ x: 1, y: 1 })], feats), 3)).toEqual([[0]]);
+  });
+});
+
+describe('invariance — declared (#131) and demonstrated', () => {
+  it('splits declared invariance three ways, keeping "unassessed" separate', () => {
+    const sel = selectByInvariance(['scale']);
+    // The catalog has real declarations; the point is that all three buckets are used
+    // and nothing is silently guessed.
+    expect(sel.keep.length + sel.drop.length + sel.unassessed.length).toBeGreaterThan(50);
+    expect(sel.unassessed.length).toBeGreaterThan(0);
+    for (const id of sel.keep) expect(sel.unassessed).not.toContain(id);
+  });
+
+  it('asking for NO axes excludes nothing', () => {
+    const sel = selectByInvariance([]);
+    expect(sel.drop).toEqual([]);
+    expect(sel.unassessed).toEqual([]);
+  });
+
+  it('down-weights whatever moved during the nuisance demo', () => {
+    // `steady` holds still while `drifty` sweeps — exactly the shape of a confound.
+    const clip = Array.from({ length: 40 }, (_, i) => v({ steady: 0.5, drifty: i / 40 }));
+    const w = weightsFromNuisance(nuisanceProfile(clip, ['scale']));
+    expect(w.steady).toBeCloseTo(1, 2);
+    expect(w.drifty).toBeLessThan(0.5);
+    expect(w.drifty).toBeGreaterThan(0); // quieted, never deleted
+  });
+
+  it('ignores a profile built from too few samples', () => {
+    const w = weightsFromNuisance(nuisanceProfile([v({ a: 0 }), v({ a: 1 })]));
+    expect(w.a).toBe(1);
+  });
+
+  it('ranks by signal AFTER nuisance weighting', () => {
+    const vocab = [v({ good: 0, noise: 0.5 }), v({ good: 1, noise: 0.5 })];
+    const ranked = rankFeatures(vocab, { good: 1, noise: 1 }, 5);
+    expect(ranked[0]).toBe('good');
+  });
+});
+
+describe('classification — soft membership, reject, hysteresis', () => {
+  const pts = [v({ x: 0 }), v({ x: 0.02 }), v({ x: 1 }), v({ x: 1.02 })];
+  const model = trainModel(pts, [[0, 1], [2, 3]], ['x'], { x: 1 }, {
+    restVectors: Array.from({ length: 10 }, () => v({ x: 0.5 })),
+  });
+
+  it('memberships sum to 1 and favour the nearer centroid', () => {
+    const c = classify(model, v({ x: 0.01 }));
+    const total = Object.values(c.memberships).reduce((a, b) => a + b, 0);
+    expect(total).toBeCloseTo(1, 6);
+    expect(c.memberships['cat-1']).toBeGreaterThan(c.memberships['cat-2']);
+    expect(c.categoryId).toBe('cat-1');
+  });
+
+  it('never produces NaN memberships for a far-away vector', () => {
+    // Softmax without the max-subtraction underflows to 0/0 here and silences the synth.
+    const c = classify(model, v({ x: 1e6 }));
+    for (const m of Object.values(c.memberships)) expect(Number.isFinite(m)).toBe(true);
+    expect(Object.values(c.memberships).reduce((a, b) => a + b, 0)).toBeCloseTo(1, 6);
+  });
+
+  it('rejects a vector beyond the reject radius', () => {
+    expect(classify(model, v({ x: 50 })).rejected).toBe(true);
+    expect(classify(model, v({ x: 50 })).categoryId).toBeNull();
+  });
+
+  it('a perfectly still rest take cannot produce a model that rejects its own categories', () => {
+    const m = trainModel(pts, [[0, 1], [2, 3]], ['x'], { x: 1 }, {
+      restVectors: Array.from({ length: 10 }, () => v({ x: 0.5 })), // zero spread
+    });
+    expect(m.rejectRadius).toBeGreaterThan(0);
+    expect(classify(m, v({ x: 0 })).rejected).toBe(false);
+    expect(classify(m, v({ x: 1 })).rejected).toBe(false);
+  });
+
+  it('an empty model rejects rather than throwing', () => {
+    const empty = trainModel([], [], ['x'], {});
+    expect(classify(empty, v({ x: 0 })).rejected).toBe(true);
+  });
+
+  it('tracker requires enterFrames before switching category', () => {
+    const t = createCategoryTracker(model, { enterFrames: 3 });
+    expect(t.push(v({ x: 0 })).categoryId).toBeNull(); // 1st frame of cat-1
+    expect(t.push(v({ x: 0 })).categoryId).toBeNull();
+    expect(t.push(v({ x: 0 })).categoryId).toBe('cat-1'); // committed on the 3rd
+    // one stray frame near cat-2 must NOT flip it
+    expect(t.push(v({ x: 1 })).categoryId).toBe('cat-1');
+    expect(t.current()).toBe('cat-1');
+  });
+
+  it('HOLDS the last category through no-man\'s-land rather than falling silent', () => {
+    const t = createCategoryTracker(model, { enterFrames: 1, exitFrames: 5 });
+    t.push(v({ x: 0 }));
+    expect(t.current()).toBe('cat-1');
+    // brief excursion into nothing
+    for (let i = 0; i < 4; i++) {
+      const r = t.push(v({ x: 50 }));
+      expect(r.categoryId).toBe('cat-1');
+      expect(r.held).toBe(true);
+    }
+  });
+
+  it('holdOnReject:false does drop to null once exitFrames elapse', () => {
+    const t = createCategoryTracker(model, { enterFrames: 1, exitFrames: 3, holdOnReject: false });
+    t.push(v({ x: 0 }));
+    for (let i = 0; i < 3; i++) t.push(v({ x: 50 }));
+    expect(t.current()).toBeNull();
+  });
+});
+
+describe('the ritual is data, and says what it needs', () => {
+  it('has the four steps in order, each with a prompt and a rationale', () => {
+    expect(ENROLLMENT_STEPS.map((s) => s.id)).toEqual(['rest', 'range', 'nuisance', 'vocabulary']);
+    for (const s of ENROLLMENT_STEPS) {
+      expect(s.prompt.length).toBeGreaterThan(10);
+      expect(s.rationale.length).toBeGreaterThan(10);
+      expect(s.minSamples).toBeGreaterThan(0);
+    }
+  });
+
+  it('never tells the player WHICH face to make', () => {
+    // The whole feature exists because prescribed categories are the ones they can't hit.
+    const vocab = ENROLLMENT_STEPS.find((s) => s.id === 'vocabulary')!;
+    expect(vocab.prompt).toMatch(/whichever|you like|reliably/i);
+  });
+});
+
+describe('end-to-end over the REAL recording', () => {
+  interface PoseRecord {
+    present: boolean;
+    blendshapes: Record<string, number>;
+    transformMatrix: number[];
+  }
+  const frames = loadStream('video_head_pose', 'face.pose') as PoseRecord[];
+  const FPS = 29.3;
+
+  /** A small hand-picked feature vector per frame — blendshapes plus decoded pose. */
+  const vecAt = (i: number): FeatureVector => {
+    const f = frames[i];
+    const p = matrixToHeadPose(f.transformMatrix);
+    const b = f.blendshapes;
+    return {
+      smile: ((b.mouthSmileLeft ?? 0) + (b.mouthSmileRight ?? 0)) / 2,
+      jaw: b.jawOpen ?? 0,
+      brow: ((b.browOuterUpLeft ?? 0) + (b.browOuterUpRight ?? 0) + (b.browInnerUp ?? 0)) / 3,
+      browDown: ((b.browDownLeft ?? 0) + (b.browDownRight ?? 0)) / 2,
+      squint: ((b.eyeSquintLeft ?? 0) + (b.eyeSquintRight ?? 0)) / 2,
+      yaw: p.yaw / 90,
+      pitch: p.pitch / 90,
+    };
+  };
+  const range = (from: number, to: number) => {
+    const out: { v: FeatureVector; t: number }[] = [];
+    for (let i = Math.round(from * FPS); i <= Math.round(to * FPS) && i < frames.length; i++) {
+      out.push({ v: vecAt(i), t: (i / FPS) * 1000 });
+    }
+    return out;
+  };
+
+  it('the sampler finds several distinct held poses in a real take', () => {
+    const s = createStillPointSampler({ dwellMs: 200, speedThreshold: 0.35 });
+    for (const { v: vec, t } of range(0, 13.6)) s.push(vec, t);
+    const pts = s.points();
+    // Far fewer than the 400 frames, and more than one — i.e. it actually segmented.
+    expect(pts.length).toBeGreaterThan(2);
+    expect(pts.length).toBeLessThan(60);
+  });
+
+  it('the dolly segment is correctly identified as nuisance, and quiets `brow`', () => {
+    // 10.9-13.7s: the phone moves in and back out while the smile is HELD. The brow
+    // channel swings 0.43->0.89 on that move alone (see the fixture README), which is
+    // exactly the confound the maintainer asked about. The profile must catch it.
+    const profile = nuisanceProfile(range(10.9, 13.6).map((r) => r.v), ['scale']);
+    const w = weightsFromNuisance(profile);
+    expect(profile.samples).toBeGreaterThan(40);
+    expect(w.brow).toBeLessThan(0.85);
+    // `jaw` genuinely does not move during the dolly, so it must NOT be penalised.
+    expect(w.jaw).toBeGreaterThan(0.95);
+    expect(w.brow).toBeLessThan(w.jaw);
+  });
+
+  it('a full session trains, and re-cutting to a different k needs no rebuild', () => {
+    const session = createEnrollmentSession({ dwellMs: 200 });
+
+    session.beginStep('rest');
+    for (const { v: vec, t } of range(7.7, 8.5)) session.push(vec, t); // a held, settled face
+    session.endStep();
+
+    session.beginStep('nuisance');
+    for (const { v: vec, t } of range(10.9, 13.6)) session.push(vec, t);
+    session.endStep();
+
+    session.beginStep('vocabulary');
+    for (const { v: vec, t } of range(0, 10.5)) session.push(vec, t);
+    session.endStep();
+
+    session.build();
+    const k3 = session.retrain(3);
+    expect(k3.categories).toHaveLength(3);
+    expect(k3.features.length).toBeGreaterThan(0);
+    expect(k3.rejectRadius).toBeGreaterThan(0);
+
+    // The same built hierarchy answers a different k immediately — no rebuild.
+    const k5 = session.retrain(5);
+    expect(k5.categories).toHaveLength(5);
+    const k2 = session.retrain(2);
+    expect(k2.categories).toHaveLength(2);
+
+    // Every category came from real points.
+    for (const c of k3.categories) expect(c.size).toBeGreaterThan(0);
+  });
+
+  it('a trained model recognises the take it was trained on', () => {
+    const session = createEnrollmentSession({ dwellMs: 200 });
+    session.beginStep('rest');
+    for (const { v: vec, t } of range(7.7, 8.5)) session.push(vec, t);
+    session.endStep();
+    session.beginStep('vocabulary');
+    for (const { v: vec, t } of range(0, 10.5)) session.push(vec, t);
+    session.endStep();
+    session.build();
+    const model = session.retrain(3);
+
+    // Each captured still-point should land in SOME category, not no-man's-land — a model
+    // that rejects its own training data is the failure this asserts against.
+    const pts = session.pointsFor('vocabulary');
+    const accepted = pts.filter((p) => !classify(model, p.vector).rejected).length;
+    expect(accepted / pts.length).toBeGreaterThan(0.8);
+  });
+
+  it('reports progress and refuses to claim readiness before the required steps', () => {
+    const session = createEnrollmentSession();
+    expect(session.ready()).toBe(false);
+    session.beginStep('rest');
+    for (const { v: vec, t } of range(7.7, 8.5)) session.push(vec, t);
+    session.endStep();
+    expect(session.ready()).toBe(false); // rest alone is not enough
+    const rest = session.progress().find((p) => p.id === 'rest')!;
+    expect(rest.coverage).toBeGreaterThan(0);
+  });
+});

--- a/test/tools_shell.test.tsx
+++ b/test/tools_shell.test.tsx
@@ -17,9 +17,12 @@ import { render, screen, cleanup, fireEvent, act } from '@testing-library/react'
 import ToolsBar from '@/app/ToolsBar';
 import LabPanel from '@/app/LabPanel';
 import GesturesPanel from '@/app/GesturesPanel';
+import TrainerPanel from '@/app/TrainerPanel';
 import { TOOLS, TOOL_IDS } from '@/app/tools';
+import { ENROLLMENT_STEPS } from '@/enroll';
 import { useTools } from '@/app/toolsStore';
 import { useControls } from '@/app/store';
+import { useTrainer } from '@/app/enroll/store';
 import { defaultFeatureLab } from '@/features/labConfig';
 import { GESTURE_IDS, GESTURE_LABELS, defaultGesturePrefs } from '@/app/gesturePrefs';
 import { OVERLAY_CONTROLS, controlsForSurface } from '@/app/overlayControls';
@@ -28,6 +31,7 @@ beforeEach(() => {
   useTools.setState({ open: null });
   useControls.getState().setFeatureLab(defaultFeatureLab());
   useControls.setState({ gestures: defaultGesturePrefs() });
+  useTrainer.getState().reset();
 });
 afterEach(cleanup);
 
@@ -197,6 +201,76 @@ describe('every control surface has a home in the shell', () => {
     expect(controlsForSurface('lab').map((d) => d.name)).toEqual(['featureLab', 'featureCorrelation']);
     for (const name of ['featureLab', 'featureCorrelation']) {
       expect(controlsForSurface('instrument').map((d) => d.name)).not.toContain(name);
+    }
+  });
+});
+
+describe('the Trainer is reachable and runs the ritual (#160)', () => {
+  it('is closed until its tool is open', () => {
+    const { container } = render(<TrainerPanel />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('the whole chain works: shell button -> open state -> a card per ritual step', () => {
+    render(
+      <>
+        <ToolsBar />
+        <TrainerPanel />
+      </>,
+    );
+    expect(screen.queryByText('Find my categories')).toBeNull();
+    fireEvent.click(screen.getByText('Trainer'));
+    expect(useTools.getState().open).toBe('trainer');
+    // One card per step, each showing its own prompt — the ritual is data, so this
+    // grows with ENROLLMENT_STEPS rather than being a hardcoded list here.
+    for (const step of ENROLLMENT_STEPS) {
+      expect(screen.getByText(step.title)).toBeTruthy();
+      expect(screen.getByText(step.prompt)).toBeTruthy();
+    }
+    expect(screen.getByText('Find my categories')).toBeTruthy();
+  });
+
+  it('starting a step marks it active and disables the OTHER steps\' buttons', () => {
+    useTools.setState({ open: 'trainer' });
+    render(<TrainerPanel />);
+    const starts = screen.getAllByText('Start');
+    expect(starts).toHaveLength(ENROLLMENT_STEPS.length);
+    fireEvent.click(starts[0]);
+    expect(useTrainer.getState().activeStep).toBe('rest');
+    // The running one offers Stop; every other step's button is disabled, because two
+    // steps capturing into one session at once would silently mix their samples.
+    expect(screen.getByText('Stop')).toBeTruthy();
+    for (const b of screen.getAllByText('Start')) {
+      expect((b as HTMLButtonElement).disabled).toBe(true);
+    }
+    fireEvent.click(screen.getByText('Stop'));
+    expect(useTrainer.getState().activeStep).toBeNull();
+  });
+
+  it('cannot be trained from an empty take (the build button is disabled)', () => {
+    useTools.setState({ open: 'trainer' });
+    render(<TrainerPanel />);
+    expect((screen.getByText('Find my categories') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('shows a coverage METER per step, not a progress bar', () => {
+    useTools.setState({ open: 'trainer' });
+    render(<TrainerPanel />);
+    const bars = screen.getAllByRole('progressbar');
+    expect(bars).toHaveLength(ENROLLMENT_STEPS.length);
+    // Nothing captured yet, so every meter reads zero — a timer-based progress bar
+    // would not.
+    for (const b of bars) expect(b.getAttribute('aria-valuenow')).toBe('0');
+  });
+
+  it('never asks the player to imitate a specific face', () => {
+    useTools.setState({ open: 'trainer' });
+    render(<TrainerPanel />);
+    const text = document.body.textContent ?? '';
+    // The whole feature exists because prescribed categories are the ones the player
+    // cannot hit. A prompt naming an emotion to produce would reintroduce that.
+    for (const word of ['happy', 'sad', 'angry', 'surprised', 'disgusted', 'fearful']) {
+      expect(text.toLowerCase()).not.toContain(word);
     }
   });
 });

--- a/tsconfig.dag.json
+++ b/tsconfig.dag.json
@@ -7,7 +7,7 @@
     "noUnusedParameters": true,
     "types": ["node", "vitest/globals"]
   },
-  "include": ["src/dag", "src/nodes", "src/music", "src/features", "src/settings", "src/taglog", "src/app/graph.ts", "src/app/lab", "test", "scripts"],
+  "include": ["src/dag", "src/nodes", "src/music", "src/features", "src/settings", "src/taglog", "src/enroll", "src/app/graph.ts", "src/app/lab", "test", "scripts"],
   "//exclude": "The jsdom SHELL tests are .tsx (they render React components) and this project ships no @types/react by design — same reason the React app layer is excluded. Vitest still runs them; Vite/esbuild type-erases the JSX.",
   "exclude": ["test/**/*.test.tsx"]
 }


### PR DESCRIPTION
The library half of trainer mode (#160). Pure, headless, fully tested. **The panel that makes it reachable is the next PR — until that lands this is not shipped**, and I am saying so rather than letting it become #119/#137 a third time.

Research: [`docs/research/trainer-mode.md`](../blob/main/docs/research/trainer-mode.md).

## The one architectural decision

Everything is defined over a **`FeatureVector`** (`Record<featureId, number>`), never over a `FaceFrame`. `src/features/catalog.ts` already emits that shape from face **and** hands through one `compute(ctx) => number` contract — so this is a face trainer, a hand trainer, and a trainer for whatever is added to the catalog next, **on day one**. Writing it against `FaceFrame` is the single decision that would have made it face-only forever.

Nothing in `src/enroll/` imports MediaPipe, the DAG, React or the audio layer.

## The pipeline

| module | what it does |
|---|---|
| `sampler.ts` | velocity-gate the live vector; keep poses actually **held** |
| `cluster.ts` | agglomerative hierarchy; **cut at k** |
| `invariance.ts` | consume #131's declarations; learn a down-weighting from a nuisance demo |
| `classify.ts` | soft membership, demonstrated reject radius, hysteresis |
| `ritual.ts` | the four guided steps, as data |
| `session.ts` | the facade; `retrain(k)` re-cuts rather than reclusters |

Two of these deserve a sentence on *why*:

**Still-points, not frames.** A free-motion stream is mostly *transitions*. Cluster every frame and you find the centre of the motion envelope — blurry averages nobody can reproduce on purpose — instead of the expressions.

**A hierarchy, not a partition.** This is what makes "specify the count before **or afterwards**" real: one recording answers 3, then 5, then 4 with **no retraining**, because k is a tree cut and not a training parameter. The player drags a slider and hears their vocabulary get finer or coarser. It also buys order-independence and determinism, which the streaming alternatives (the ART family) do not.

## Three bugs the tests found — each a design flaw, not a typo

1. **Frame-to-frame speed is frame-rate dependent.** A feature jittering ±0.01/frame is physically still, but reads as 1.2 units/s at 60 fps and 2.4 at 120 — so a threshold tuned on one machine *silently refuses to emit anything* on a faster one. Speed is now measured over a ~100 ms window, where jitter cancels.
2. **The model rejected its own training data.** The reject radius came only from the rest take, and a genuinely still rest gives a spread near zero — half the player's own vocabulary then fell outside it, which reads as "the trainer did nothing". Now floored at the distance that accepts 90% of the training points. Flooring on the *tightest* category radius (the obvious guess) does not work: it is unrelated to how far the broadest category's members actually sit.
3. **Softmax without max-subtraction underflows to 0/0** for a far-away vector, producing NaN memberships — i.e. silence — on exactly the frames where the player has left every category.

## Mutation testing found a gap in my own suite

Three mutations. Two were caught. The third — removing the sampler's re-arm latch — left **every test green**, because `minSeparation` independently blocks duplicates when a held value is *constant*. Added the case that separates the two guards (a pose drifting *under* the speed threshold but far *past* `minSeparation`), which only the latch can stop. It now fails under that mutation.

## A green gate that was checking nothing

`src/enroll` was not in `tsconfig.dag.json`'s `include`, so the first green `npm run typecheck` on this code had checked **none of it** — and was hiding a call to a catalog function I had invented (`flatFeatures`, which does not exist). Added to the include list; the real API is `ALL_FEATURES` / `FEATURE_BY_ID`.

## Gates

`npm run typecheck` · **1046 tests** (32 new) · `npm run build` — all green.

The end-to-end cases run against the **real recorded clip** from #161, including its camera-distance confound: the suite asserts that the nuisance step correctly quiets `brow` (which swings 0.43→0.89 on distance alone) while leaving `jaw` (which genuinely does not move) at full weight.

## What is deliberately not here

- **No UI.** Next PR: a tools-bar entry, the four-step ritual with a coverage meter, the k slider, and a reachability test.
- **No persistence.** A trained model is plain numbers, so it serializes with `JSON.stringify` — but whether it is a session artefact or a saved collection alongside instruments is open question 2 in the issue.
- **No binding to sound.** Open question 3: category → command, or category → continuous dial. Both work on the #127 write path; they are different products.

Refs #160.

https://claude.ai/code/session_01FiZMdBN2v3u4FqaJFhK2Wi