### PR TITLE
#163 prep: the trainer actually sees the feature stream (feature demand, ms clock, face-model gate)

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -17,7 +17,8 @@ import { installKeyboardShortcuts } from './keyboardShortcuts';
 import { installTaggingKeymap } from './tagging/keymap';
 import { useControls } from './store';
 import { useFaceStatus } from './faceStatus';
-import { labWantsFace } from '@/features/labConfig';
+import { demandWantsFace, labWantsFace } from '@/features/labConfig';
+import { useDemandedGroups } from './useDemandedGroups';
 import InstrumentsPanel from './dials/InstrumentsPanel';
 import RecordButton from './RecordButton';
 import TaggingControls from './tagging/TaggingControls';
@@ -38,9 +39,10 @@ import VersionBadge from './VersionBadge';
 function FaceChip() {
   const faceMapping = useControls((s) => s.faceMapping);
   const featureLab = useControls((s) => s.featureLab);
+  const demanded = useDemandedGroups();
   const status = useFaceStatus((s) => s.status);
   const label = useFaceStatus((s) => s.label);
-  if (faceMapping === 'none' && !labWantsFace(featureLab)) return null;
+  if (faceMapping === 'none' && !labWantsFace(featureLab) && !demandWantsFace(demanded)) return null;
 
   let dot = 'bg-white/40';
   let text = 'face starting…';

--- a/src/app/TrainerPanel.tsx
+++ b/src/app/TrainerPanel.tsx
@@ -91,6 +91,13 @@ export default function TrainerPanel() {
     return () => clearInterval(id);
   }, [activeStep]);
 
+  // Closing the panel (the X, or switching tools) must end a running step: otherwise the
+  // poll keeps sampling and the feature-demand claim (#163) keeps the whole catalog
+  // computing every tick, with nothing on screen to say so.
+  useEffect(() => {
+    if (!open && activeStep) useTrainer.getState().end();
+  }, [open, activeStep]);
+
   if (!open) return null;
   const tool = toolById(TOOL_ID);
   const progressFor = (id: string) => progress.find((p) => p.id === id);

--- a/src/app/enroll/liveVector.ts
+++ b/src/app/enroll/liveVector.ts
@@ -27,7 +27,11 @@ export const FEATURE_VECTOR_EDGES = ['faceVec.vector', 'handVec.vector'] as cons
 
 /** The latest merged vector, or null before the first tick with any source present. */
 let latest: FeatureVector | null = null;
-/** Wall-clock-ish tick time of the latest vector, in ms. */
+/** Tick time of the latest vector, in MILLISECONDS. The DAG clock (`ctx.time`) is in
+ *  seconds; the trainer's sampler (`dwellMs`, `speedWindowMs`) is in ms, and v1
+ *  passed the seconds through unconverted — a 220 ms dwell became 220 s, and the
+ *  speed estimate (displacement / dt) was a thousand times too large, so nothing
+ *  ever read as "held". Convert HERE, at the boundary, once. */
 let latestT = 0;
 
 /** Per-edge last value, so one absent source does not erase the other's keys. */
@@ -52,11 +56,12 @@ export class LiveVectorTap implements Tap {
       if (part) Object.assign(merged, part);
     }
     latest = merged;
-    latestT = ctx.time;
+    latestT = ctx.time * 1000;
   }
 }
 
-/** The most recent merged feature vector, or null if none has arrived yet. */
+/** The most recent merged feature vector (and its tick time in ms), or null if none
+ *  has arrived yet. */
 export function readLiveVector(): { vector: FeatureVector; t: number } | null {
   return latest ? { vector: latest, t: latestT } : null;
 }

--- a/src/app/enroll/store.ts
+++ b/src/app/enroll/store.ts
@@ -21,6 +21,8 @@
  * reclustering — which is what lets the k control be a live slider rather than a button.
  */
 import { create } from 'zustand';
+import { FEATURE_GROUP_IDS } from '@/features/catalog';
+import { appFeatureDemand } from '../featureDemand';
 import {
   createEnrollmentSession,
   type EnrollmentSession,
@@ -62,6 +64,9 @@ interface TrainerState {
  *  and putting it in the store would invite React to try to diff it. */
 let session: EnrollmentSession = createEnrollmentSession();
 
+/** The trainer's claim on the feature-demand registry while a step runs. */
+const DEMAND_OWNER = 'trainer';
+
 export const useTrainer = create<TrainerState>()((set, get) => ({
   activeStep: null,
   progress: session.progress(),
@@ -73,6 +78,9 @@ export const useTrainer = create<TrainerState>()((set, get) => ({
 
   begin(step) {
     session.beginStep(step);
+    // Ask the engine to compute the catalog while the step runs (#163): with the Lab
+    // closed the vector nodes otherwise emit `{}`, and the step captures nothing.
+    appFeatureDemand.claim(DEMAND_OWNER, FEATURE_GROUP_IDS);
     set({ activeStep: step, progress: session.progress() });
   },
 
@@ -84,6 +92,7 @@ export const useTrainer = create<TrainerState>()((set, get) => ({
 
   end() {
     session.endStep();
+    appFeatureDemand.release(DEMAND_OWNER);
     set({ activeStep: null, progress: session.progress() });
   },
 
@@ -108,6 +117,7 @@ export const useTrainer = create<TrainerState>()((set, get) => ({
 
   reset() {
     session = createEnrollmentSession();
+    appFeatureDemand.release(DEMAND_OWNER);
     set({
       activeStep: null,
       progress: session.progress(),

--- a/src/app/featureDemand.ts
+++ b/src/app/featureDemand.ts
@@ -1,0 +1,19 @@
+/**
+ * The app's feature-demand registry (#163) — the one instance the engine serves.
+ *
+ * `useEngine` installs {@link featureDemandResource} as `ctx.resources.featureDemand`,
+ * and any host-side consumer that needs feature groups computed while the Lab is
+ * closed claims them here (the trainer, while a cue runs). See `@/features/demand` for
+ * the contract and the bug it closes.
+ *
+ * A module-level instance rather than a store: it is read synchronously per tick, and
+ * written a handful of times per session.
+ */
+import { createFeatureDemand, type DemandedGroups } from '@/features/demand';
+
+export const appFeatureDemand = createFeatureDemand();
+
+/** The per-tick read the vector nodes perform — installed on the engine's resources. */
+export function featureDemandResource(): DemandedGroups {
+  return appFeatureDemand.groups();
+}

--- a/src/app/useDemandedGroups.ts
+++ b/src/app/useDemandedGroups.ts
@@ -1,0 +1,14 @@
+/**
+ * `useDemandedGroups` — the live feature demand (#163) as a React value.
+ *
+ * Kept apart from `featureDemand.ts` so that module stays React-free (it is in the
+ * strict DAG typecheck, and the repo ships no `@types/react`). The FaceChip uses this
+ * to report the face model running for a trainer cue the same way it does for the Lab.
+ */
+import { useSyncExternalStore } from 'react';
+import type { DemandedGroups } from '@/features/demand';
+import { appFeatureDemand, featureDemandResource } from './featureDemand';
+
+export function useDemandedGroups(): DemandedGroups {
+  return useSyncExternalStore(appFeatureDemand.subscribe, featureDemandResource, featureDemandResource);
+}

--- a/src/app/useEngine.ts
+++ b/src/app/useEngine.ts
@@ -12,6 +12,7 @@ import { defaultGraph } from './graph';
 import { DEFAULT_SOURCE, type SourceSpec } from './sourceSpec';
 import { useControls } from './store';
 import { LiveVectorTap, resetLiveVector } from './enroll/liveVector';
+import { featureDemandResource } from './featureDemand';
 import { useToasts } from './toasts';
 import { SessionRecorder, activeStreamLabels } from './recording/session';
 import { SinkCancelled } from './recording/sink';
@@ -191,6 +192,9 @@ export function useThoreminEngine(source: SourceSpec = DEFAULT_SOURCE) {
         // Live tagging (#92): the burned-in corner HUD reads this each tick (null
         // unless a take is recording). Same synchronous-read pattern as `controls`.
         resources.tagOverlay = tagOverlayResource;
+        // Feature demand (#163): the vector nodes compute whatever a host consumer
+        // (the trainer, while a cue runs) has claimed, even with the Lab closed.
+        resources.featureDemand = featureDemandResource;
 
         const engine = new Engine(defaultGraph(), createAppRegistry(), { resources });
 

--- a/src/features/demand.ts
+++ b/src/features/demand.ts
@@ -45,6 +45,8 @@ export interface FeatureDemand {
   owners(): string[];
   /** Forget every claim. */
   reset(): void;
+  /** Be told after any change (claim / release / reset). Returns the unsubscribe. */
+  subscribe(listener: () => void): () => void;
 }
 
 /**
@@ -54,6 +56,10 @@ export interface FeatureDemand {
 export function createFeatureDemand(): FeatureDemand {
   const claims = new Map<string, ReadonlySet<string>>();
   let union: DemandedGroups = null;
+  const listeners = new Set<() => void>();
+  const notify = () => {
+    for (const l of listeners) l();
+  };
 
   const recompute = () => {
     if (claims.size === 0) {
@@ -73,15 +79,26 @@ export function createFeatureDemand(): FeatureDemand {
         claims.set(owner, new Set(groups));
       }
       recompute();
+      notify();
     },
     release(owner) {
-      if (claims.delete(owner)) recompute();
+      if (claims.delete(owner)) {
+        recompute();
+        notify();
+      }
     },
     groups: () => union,
     owners: () => [...claims.keys()],
     reset() {
       claims.clear();
       union = null;
+      notify();
+    },
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
     },
   };
 }

--- a/src/features/demand.ts
+++ b/src/features/demand.ts
@@ -1,0 +1,87 @@
+/**
+ * Feature demand (#163) — how a consumer other than the Lab asks for feature groups to
+ * be COMPUTED.
+ *
+ * ## The bug this closes
+ *
+ * The two feature-vector nodes are gated on the Feature Lab: with the meters hidden
+ * (the default) they emit an empty vector, so the catalog costs nothing while nobody
+ * is looking at it (#136). That is the right default for a display — and it silently
+ * starved the trainer. Trainer v1 (#160) tapped `faceVec.vector` / `handVec.vector`
+ * and polled them while a step ran, but never asked for anything to be computed, so
+ * with the Lab closed every sample it took was `{}`. Every test stayed green: the tap
+ * named real edges, the sampler handled empty vectors without complaint, and the
+ * coverage meter filled up with nothing. Nobody had run it with a webcam.
+ *
+ * ## The seam
+ *
+ * A demand is a CLAIM: "`owner` needs these groups computed while this claim stands."
+ * The registry holds one claim per owner (re-claiming replaces), and the nodes read
+ * the union of all live claims through `ctx.resources.featureDemand` each tick. The
+ * gate ({@link resolveLabGate}) then computes the Lab's groups when the Lab is shown,
+ * PLUS whatever is demanded — so a demand never turns the meters on, and the meters
+ * never have to be on for a demand to be served.
+ *
+ * A consumer declares groups, never feature ids: groups are the catalog's unit of
+ * enablement (the Lab picker, the node params), and a cue that says "I need
+ * `face.head`" should not have to know which eight features that currently is.
+ *
+ * Written at human frequency (a cue starting or ending), read per tick — the same
+ * holder-plus-synchronous-read shape as `ctx.resources.controls`, for the same reason:
+ * nothing on the tick path may await or subscribe.
+ */
+
+/** A live set of demanded feature groups, or `null` when nothing is demanded. */
+export type DemandedGroups = ReadonlySet<string> | null;
+
+export interface FeatureDemand {
+  /** Replace `owner`'s claim with `groups`. An empty list is the same as releasing. */
+  claim(owner: string, groups: readonly string[]): void;
+  /** Drop `owner`'s claim. Unknown owners are a no-op. */
+  release(owner: string): void;
+  /** The union of every live claim, or `null` when there are none. */
+  groups(): DemandedGroups;
+  /** The owners with a live claim (for display / debugging). */
+  owners(): string[];
+  /** Forget every claim. */
+  reset(): void;
+}
+
+/**
+ * Build a demand registry. The union is recomputed on write, not on read, so the
+ * per-tick `groups()` is a field read.
+ */
+export function createFeatureDemand(): FeatureDemand {
+  const claims = new Map<string, ReadonlySet<string>>();
+  let union: DemandedGroups = null;
+
+  const recompute = () => {
+    if (claims.size === 0) {
+      union = null;
+      return;
+    }
+    const all = new Set<string>();
+    for (const groups of claims.values()) for (const g of groups) all.add(g);
+    union = all.size > 0 ? all : null;
+  };
+
+  return {
+    claim(owner, groups) {
+      if (groups.length === 0) {
+        claims.delete(owner);
+      } else {
+        claims.set(owner, new Set(groups));
+      }
+      recompute();
+    },
+    release(owner) {
+      if (claims.delete(owner)) recompute();
+    },
+    groups: () => union,
+    owners: () => [...claims.keys()],
+    reset() {
+      claims.clear();
+      union = null;
+    },
+  };
+}

--- a/src/features/demand.ts
+++ b/src/features/demand.ts
@@ -31,6 +31,10 @@
  * nothing on the tick path may await or subscribe.
  */
 
+/** The formula-only group id (mirrors `DERIVED_GROUP` in the catalog; kept as a literal
+ *  here so this module has no import edge into the catalog). */
+const DERIVED_GROUP = 'derived';
+
 /** A live set of demanded feature groups, or `null` when nothing is demanded. */
 export type DemandedGroups = ReadonlySet<string> | null;
 
@@ -73,10 +77,13 @@ export function createFeatureDemand(): FeatureDemand {
 
   return {
     claim(owner, groups) {
-      if (groups.length === 0) {
+      // `derived` (Lab formulas) has no catalog features: demanding it would open the
+      // gate for an empty result. Drop it here so every claim is a claim on real work.
+      const real = groups.filter((g) => g !== DERIVED_GROUP);
+      if (real.length === 0) {
         claims.delete(owner);
       } else {
-        claims.set(owner, new Set(groups));
+        claims.set(owner, new Set(real));
       }
       recompute();
       notify();

--- a/src/features/labConfig.ts
+++ b/src/features/labConfig.ts
@@ -15,6 +15,7 @@
  *  - the app's hot control store, which owns the value and persists it per-device.
  */
 import { z } from 'zod';
+import type { DemandedGroups } from './demand';
 import { DEFAULT_LAB_GROUPS, DERIVED_GROUP, FEATURE_GROUPS } from './catalog';
 
 /**
@@ -127,15 +128,26 @@ export function readLiveLab(controls: LabControlsSnapshot | undefined): LiveLabC
  * One copy, in the module that owns the config.
  *
  * `undefined` live config (a headless test / a host that wires no controls) → active with
- * the params' groups. A live config → active only when the meters are shown.
+ * the params' groups. A live config → active only when the meters are shown — OR when
+ * some other consumer has a live feature DEMAND (#163, `@/features/demand`): the trainer
+ * claims the groups its running cue needs, and those compute whether or not the Lab is
+ * open. The Lab's own groups still compute only while it is shown, so a demand never
+ * turns the meters on and never widens what they measure.
  */
 export function resolveLabGate(
   params: { groups?: string[] },
   controls: LabControlsSnapshot | undefined,
+  demanded: DemandedGroups = null,
 ): { active: boolean; enabled: (group: string) => boolean } {
   const live = readLiveLab(controls);
-  const active = live ? live.show === true : true;
+  const labActive = live ? live.show === true : true;
   const groups = live?.groups ?? params.groups;
-  const set = groups ? new Set(groups) : null;
-  return { active, enabled: (group: string) => (set ? set.has(group) : true) };
+  const labSet = groups ? new Set(groups) : null;
+  const demand = demanded && demanded.size > 0 ? demanded : null;
+  const active = labActive || demand !== null;
+  return {
+    active,
+    enabled: (group: string) =>
+      (labActive && (labSet ? labSet.has(group) : true)) || (demand !== null && demand.has(group)),
+  };
 }

--- a/src/features/labConfig.ts
+++ b/src/features/labConfig.ts
@@ -92,6 +92,18 @@ export function labWantsFace(cfg: FeatureLabConfig | undefined): boolean {
   return cfg.groups.some((g) => FACE_GROUP_IDS.includes(g));
 }
 
+/**
+ * Does a live feature DEMAND (#163) need the face model loaded? The trainer claims
+ * face groups while a cue runs; without this the vector node would be computing from a
+ * face frame that is never produced, because the model gate only knew about the Lab
+ * and the sound mapping.
+ */
+export function demandWantsFace(demanded: DemandedGroups): boolean {
+  if (!demanded) return false;
+  for (const g of demanded) if (FACE_GROUP_IDS.includes(g)) return true;
+  return false;
+}
+
 // ---- The compute gate the feature-vector nodes share ------------------------------
 
 /** The slice of the lab config the feature-vector nodes need off a control snapshot. */

--- a/src/features/labMeters.ts
+++ b/src/features/labMeters.ts
@@ -161,8 +161,15 @@ export function createLabMeterComputer(): LabMeterComputer {
       compiled = compileDerived(cfg.derived);
     }
     if (compiled.length && enabled.has(DERIVED_GROUP)) {
+      // Scope = the Lab's ENABLED groups only. The vector may carry more than that while
+      // a feature demand (#163) is live — the trainer computing `face.head` with it
+      // unchecked here — and a formula must not see a feature the meters do not show.
       const scope: Record<string, number> = {};
-      for (const k of Object.keys(raw)) scope[safeName(k)] = raw[k];
+      for (const feat of ALL_FEATURES) {
+        if (!enabled.has(feat.group)) continue;
+        const v = raw[feat.id];
+        if (v !== undefined) scope[safeName(feat.id)] = v;
+      }
       for (const d of compiled) {
         const val = d.fn.eval(scope);
         if (Number.isFinite(val)) raw[`derived.${d.id}`] = val;

--- a/src/nodes/features/face_feature_vector.ts
+++ b/src/nodes/features/face_feature_vector.ts
@@ -25,6 +25,7 @@ import { defineNode } from '@/dag';
 import type { NodeContext } from '@/dag';
 import type { FaceFrame } from '../domain';
 import { buildFaceCtx, FACE_FEATURES, type FeatureVector } from '@/features/catalog';
+import type { DemandedGroups } from '@/features/demand';
 import { resolveLabGate, type LabControlsSnapshot } from '@/features/labConfig';
 
 const Params = z.object({
@@ -35,12 +36,18 @@ const Params = z.object({
 type Params = z.infer<typeof Params>;
 
 type ControlsGetter = () => LabControlsSnapshot | undefined;
+/** The live feature demand (#163): groups some non-Lab consumer needs computed. */
+type DemandGetter = () => DemandedGroups;
 
 /** Resolve the active flag + enabled-group predicate. The rule itself lives in
  *  `@/features/labConfig` — it is shared with the hand/face twin, and keeping two copies
  *  of it is how #136 silently un-gated the whole catalog. */
 function resolveGroups(p: Params, ctx: NodeContext): { active: boolean; enabled: (group: string) => boolean } {
-  return resolveLabGate(p, (ctx.resources.controls as ControlsGetter | undefined)?.());
+  return resolveLabGate(
+    p,
+    (ctx.resources.controls as ControlsGetter | undefined)?.(),
+    (ctx.resources.featureDemand as DemandGetter | undefined)?.() ?? null,
+  );
 }
 
 export const faceFeatureVectorNode = defineNode<Params>({

--- a/src/nodes/features/hand_feature_vector.ts
+++ b/src/nodes/features/hand_feature_vector.ts
@@ -53,6 +53,7 @@ import {
   type HandCtx,
   type HandSide,
 } from '@/features/catalog';
+import type { DemandedGroups } from '@/features/demand';
 import { resolveLabGate, type LabControlsSnapshot } from '@/features/labConfig';
 
 const Params = z.object({
@@ -74,12 +75,18 @@ const Params = z.object({
 type Params = z.infer<typeof Params>;
 
 type ControlsGetter = () => LabControlsSnapshot | undefined;
+/** The live feature demand (#163): groups some non-Lab consumer needs computed. */
+type DemandGetter = () => DemandedGroups;
 
 /** Resolve the active flag + enabled-group predicate. The rule itself lives in
  *  `@/features/labConfig` — it is shared with the hand/face twin, and keeping two copies
  *  of it is how #136 silently un-gated the whole catalog. */
 function resolveGroups(p: Params, ctx: NodeContext): { active: boolean; enabled: (group: string) => boolean } {
-  return resolveLabGate(p, (ctx.resources.controls as ControlsGetter | undefined)?.());
+  return resolveLabGate(
+    p,
+    (ctx.resources.controls as ControlsGetter | undefined)?.(),
+    (ctx.resources.featureDemand as DemandGetter | undefined)?.() ?? null,
+  );
 }
 
 export const handFeatureVectorNode = defineNode<Params>({

--- a/src/nodes/sources/webcam_face.ts
+++ b/src/nodes/sources/webcam_face.ts
@@ -26,7 +26,8 @@ import { z } from 'zod';
 import { defineNode } from '@/dag';
 import type { NodeContext } from '@/dag';
 import { matrixToHeadPose, type FaceFrame, type FaceMapping, type FaceStatus } from '../domain';
-import { labWantsFace, type FeatureLabConfig } from '@/features/labConfig';
+import type { DemandedGroups } from '@/features/demand';
+import { demandWantsFace, labWantsFace, type FeatureLabConfig } from '@/features/labConfig';
 
 // MediaPipe FaceLandmarker assets, loaded from a CDN on demand (mirrors how
 // `webcam-hands` resolves its MediaPipe solution from jsDelivr). The wasm
@@ -115,19 +116,27 @@ type FaceControlsGetter = () => {
 /**
  * Should the face model be loaded and run?
  *
- * Two independent consumers can want the face, and either is sufficient:
+ * Three independent consumers can want the face, and any one is sufficient:
  *  - the MAPPING wants it — the face drives sound (`faceMapping !== 'none'`), falling
  *    back to the legacy `faceEnabled` flag when the newer field is absent (older
  *    callers / tests);
  *  - the LAB wants it — the Feature Instrumentation Lab is measuring face groups
  *    ({@link labWantsFace}). Before #136 only the mapping could turn the model on, so
  *    you could not look at a face meter without also handing the face control of the
- *    sound: a measuring instrument that cannot observe without altering.
+ *    sound: a measuring instrument that cannot observe without altering;
+ *  - a feature DEMAND wants it (#163, {@link demandWantsFace}) — the trainer has
+ *    claimed face groups for a running cue. Trainer v1 asked the vector node for
+ *    features without asking this gate for the model, and with the Lab closed and the
+ *    mapping off (both defaults) it sampled an absent face.
  *
- * Exported so the app shell can tell the player the face camera is running for either
- * reason (the FaceChip), and so the rule is directly testable.
+ * Exported so the app shell can tell the player the face camera is running for any of
+ * these reasons (the FaceChip), and so the rule is directly testable.
  */
-export function faceActive(controls: ReturnType<FaceControlsGetter> | undefined): boolean {
+export function faceActive(
+  controls: ReturnType<FaceControlsGetter> | undefined,
+  demanded: DemandedGroups = null,
+): boolean {
+  if (demandWantsFace(demanded)) return true;
   if (!controls) return false;
   if (labWantsFace(controls.featureLab)) return true;
   if (controls.faceMapping !== undefined) return controls.faceMapping !== 'none';
@@ -272,7 +281,8 @@ export const webcamFaceNode = defineNode<Params>({
       process(_inputs, ctx: NodeContext) {
         video = (ctx.resources.video as HTMLVideoElement | undefined) ?? video;
         const getControls = ctx.resources.controls as FaceControlsGetter | undefined;
-        const enabled = faceActive(getControls?.());
+        const getDemand = ctx.resources.featureDemand as (() => DemandedGroups) | undefined;
+        const enabled = faceActive(getControls?.(), getDemand?.() ?? null);
         if (!enabled) {
           // Release the model if one is loaded/loading; also clear a prior
           // failure latch so a deliberate re-enable retries the load.

--- a/test/feature_demand.test.ts
+++ b/test/feature_demand.test.ts
@@ -19,6 +19,16 @@ import { useTrainer } from '@/app/enroll/store';
 const ctx = (resources: Record<string, unknown> = {}): NodeContext => ({ tick: 0, time: 0, dt: 1 / 30, resources });
 
 describe('the demand registry', () => {
+  it('ignores groups that have no features (the formula-only `derived` group)', () => {
+    // Claiming `derived` alone would open the gate for nothing: no catalog feature
+    // carries that group, and the vector nodes would run for an empty result.
+    const d = createFeatureDemand();
+    d.claim('a', ['derived']);
+    expect(d.groups()).toBeNull();
+    d.claim('a', ['derived', 'face.head']);
+    expect([...d.groups()!]).toEqual(['face.head']);
+  });
+
   it('is empty (null) until someone claims, and unions claims across owners', () => {
     const d = createFeatureDemand();
     expect(d.groups()).toBeNull();
@@ -125,7 +135,10 @@ describe('the vector nodes serve a demand with the Lab CLOSED (the v1 trainer bu
       ctx({ controls: labHidden, featureDemand: () => new Set(['hand.finger.flexion']) }),
     ) as { vector: FeatureVector };
     const keys = Object.keys(demanded.vector);
-    expect(keys.length).toBeGreaterThan(0);
+    // Per-GROUP gating, observed: a flexion feature is there, a spread feature is not.
+    // (The side label is the DISPLAY side after the selfie mirror, so match either.)
+    expect(keys.some((k) => /^hand\.(left|right)\..*\.(mcp|pip)Angle$/.test(k))).toBe(true);
+    expect(keys.some((k) => /^hand\.(left|right)\.spread\./.test(k))).toBe(false);
     expect(keys.every((k) => k.startsWith('hand.'))).toBe(true);
   });
 });
@@ -227,5 +240,14 @@ describe('the production wiring (source guard — useEngine is outside the stric
     ]) {
       expect(read(file), `${file} does not read ctx.resources.featureDemand`).toMatch(/ctx\.resources\.featureDemand/);
     }
+  });
+});
+
+describe('the registry\'s `derived` literal matches the catalog\'s DERIVED_GROUP', () => {
+  it('(no import edge demand -> catalog, so the two are tied here)', async () => {
+    const { DERIVED_GROUP } = await import('@/features/catalog');
+    const d = createFeatureDemand();
+    d.claim('a', [DERIVED_GROUP]);
+    expect(d.groups()).toBeNull();
   });
 });

--- a/test/feature_demand.test.ts
+++ b/test/feature_demand.test.ts
@@ -163,3 +163,69 @@ describe('the live-vector tap stamps samples in MILLISECONDS (the sampler\'s uni
     resetLiveVector();
   });
 });
+
+describe('the face MODEL gate honours a demand (the second half of the v1 bug)', () => {
+  it('faceActive: mapping off + Lab hidden + no demand → off; a face-group demand → on', async () => {
+    const { faceActive } = await import('@/nodes/sources/webcam_face');
+    const { defaultFeatureLab } = await import('@/features/labConfig');
+    const controls = { faceMapping: 'none' as const, featureLab: defaultFeatureLab() };
+    expect(faceActive(controls)).toBe(false);
+    expect(faceActive(controls, null)).toBe(false);
+    // A hand-only demand must NOT load the face model.
+    expect(faceActive(controls, new Set(['hand.finger.flexion']))).toBe(false);
+    expect(faceActive(controls, new Set(['face.head']))).toBe(true);
+    // The demand is sufficient on its own, even with no controls snapshot at all.
+    expect(faceActive(undefined, new Set(['face.geom.mouth']))).toBe(true);
+  });
+
+  it('the webcam-face node reads the demand off ctx.resources and reports the model active', async () => {
+    const { webcamFaceNode } = await import('@/nodes/sources/webcam_face');
+    const { defaultFeatureLab } = await import('@/features/labConfig');
+    const h = webcamFaceNode.make(webcamFaceNode.params.parse({}));
+    const controls = () => ({ faceMapping: 'none' as const, featureLab: defaultFeatureLab() });
+    // No <video> resource, so the model is never loaded headlessly — but the STATUS says
+    // whether the node considers itself enabled, which is the gate under test.
+    const off = h.process({}, ctx({ controls })) as { status: { phase: string } };
+    const on = h.process({}, ctx({ controls, featureDemand: () => new Set(['face.head']) })) as { status: { phase: string } };
+    // 'idle' = the gate said no; anything else ('loading' here, with no landmarker yet)
+    // = the gate said yes and the node is on its way to a model.
+    expect(off.status.phase).toBe('idle');
+    expect(on.status.phase).toBe('loading');
+  });
+
+  it('the registry notifies subscribers on claim / release / reset (for the FaceChip)', () => {
+    const d = createFeatureDemand();
+    let n = 0;
+    const off = d.subscribe(() => {
+      n += 1;
+    });
+    d.claim('a', ['face.head']);
+    d.release('a');
+    d.release('a'); // nothing to release: no notification
+    d.reset();
+    expect(n).toBe(3);
+    off();
+    d.claim('b', ['face.au']);
+    expect(n).toBe(3);
+  });
+});
+
+describe('the production wiring (source guard — useEngine is outside the strict typecheck)', () => {
+  it('useEngine installs the demand resource under the key the nodes read', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const read = (p: string) => readFileSync(resolve(process.cwd(), p), 'utf8');
+    const engine = read('src/app/useEngine.ts');
+    // The install. Deleting this line leaves every unit test green (the nodes are always
+    // handed a hand-built getter in tests) — which is exactly how v1 shipped blind.
+    expect(engine).toMatch(/resources\.featureDemand\s*=\s*featureDemandResource/);
+    // And the three readers use the SAME resource key (uncorrelated string literals).
+    for (const file of [
+      'src/nodes/features/face_feature_vector.ts',
+      'src/nodes/features/hand_feature_vector.ts',
+      'src/nodes/sources/webcam_face.ts',
+    ]) {
+      expect(read(file), `${file} does not read ctx.resources.featureDemand`).toMatch(/ctx\.resources\.featureDemand/);
+    }
+  });
+});

--- a/test/feature_demand.test.ts
+++ b/test/feature_demand.test.ts
@@ -147,3 +147,19 @@ describe('the trainer claims the catalog while a step runs, and lets go after', 
     expect(featureDemandResource()).toBeNull();
   });
 });
+
+describe('the live-vector tap stamps samples in MILLISECONDS (the sampler\'s unit)', () => {
+  it('converts the DAG clock (seconds) at the boundary', async () => {
+    const { LiveVectorTap, readLiveVector, resetLiveVector } = await import('@/app/enroll/liveVector');
+    resetLiveVector();
+    const tap = new LiveVectorTap();
+    tap.onValue('faceVec.vector', { 'face.head.yaw': 3 }, ctx());
+    tap.onValue('faceVec.vector', { 'face.head.yaw': 4 }, { ...ctx(), time: 1.5 });
+    const live = readLiveVector();
+    expect(live?.vector['face.head.yaw']).toBe(4);
+    // 1.5 s of engine time is 1500 ms to the sampler. Passing seconds through would make
+    // a 220 ms dwell a 220 s one, and nothing would ever be sampled.
+    expect(live?.t).toBe(1500);
+    resetLiveVector();
+  });
+});

--- a/test/feature_demand.test.ts
+++ b/test/feature_demand.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Feature demand (#163) — a non-Lab consumer can have feature groups computed.
+ *
+ * The regression this guards: trainer v1 polled the feature vector with the Lab closed,
+ * and the vector nodes — gated on the Lab being SHOWN — handed it `{}` every tick. Every
+ * unit test stayed green because nothing asserted that a demanded group actually reaches
+ * the emitted vector. The node-level cases below do exactly that, with the production
+ * control shape (`featureLab.show === false`).
+ */
+import { describe, it, expect } from 'vitest';
+import type { NodeContext } from '@/dag';
+import { createFeatureDemand } from '@/features/demand';
+import { resolveLabGate } from '@/features/labConfig';
+import { faceFeatureVectorNode, handFeatureVectorNode } from '@/nodes';
+import { makeHandKeypoints, type FaceFrame, type FeatureVector, type HandsFrame } from '@/nodes';
+import { appFeatureDemand, featureDemandResource } from '@/app/featureDemand';
+import { useTrainer } from '@/app/enroll/store';
+
+const ctx = (resources: Record<string, unknown> = {}): NodeContext => ({ tick: 0, time: 0, dt: 1 / 30, resources });
+
+describe('the demand registry', () => {
+  it('is empty (null) until someone claims, and unions claims across owners', () => {
+    const d = createFeatureDemand();
+    expect(d.groups()).toBeNull();
+    d.claim('a', ['face.head']);
+    d.claim('b', ['face.geom.mouth', 'face.head']);
+    expect([...d.groups()!].sort()).toEqual(['face.geom.mouth', 'face.head']);
+    expect(d.owners().sort()).toEqual(['a', 'b']);
+  });
+
+  it('re-claiming REPLACES an owner\'s claim rather than accumulating it', () => {
+    const d = createFeatureDemand();
+    d.claim('a', ['face.head']);
+    d.claim('a', ['face.au']);
+    expect([...d.groups()!]).toEqual(['face.au']);
+  });
+
+  it('releasing the last owner returns to null; an empty claim is a release', () => {
+    const d = createFeatureDemand();
+    d.claim('a', ['face.head']);
+    d.release('a');
+    expect(d.groups()).toBeNull();
+    d.claim('a', ['face.head']);
+    d.claim('a', []);
+    expect(d.groups()).toBeNull();
+    d.release('never-claimed'); // no throw
+    expect(d.groups()).toBeNull();
+  });
+});
+
+describe('resolveLabGate with a demand', () => {
+  const hidden = { featureLab: { show: false, groups: ['face.blendshape.jaw'] } };
+  const shown = { featureLab: { show: true, groups: ['face.blendshape.jaw'] } };
+
+  it('Lab hidden + no demand → inactive (the #136 default, unchanged)', () => {
+    expect(resolveLabGate({}, hidden).active).toBe(false);
+    expect(resolveLabGate({}, hidden, null).active).toBe(false);
+    expect(resolveLabGate({}, hidden, new Set()).active).toBe(false);
+  });
+
+  it('Lab hidden + demand → active for the DEMANDED groups only (the Lab\'s stay off)', () => {
+    const g = resolveLabGate({}, hidden, new Set(['face.head']));
+    expect(g.active).toBe(true);
+    expect(g.enabled('face.head')).toBe(true);
+    expect(g.enabled('face.blendshape.jaw')).toBe(false);
+    expect(g.enabled('face.au')).toBe(false);
+  });
+
+  it('Lab shown + demand → the union', () => {
+    const g = resolveLabGate({}, shown, new Set(['face.head']));
+    expect(g.active).toBe(true);
+    expect(g.enabled('face.head')).toBe(true);
+    expect(g.enabled('face.blendshape.jaw')).toBe(true);
+    expect(g.enabled('face.au')).toBe(false);
+  });
+
+  it('headless (no controls) + demand → params groups plus the demand', () => {
+    const g = resolveLabGate({ groups: ['face.au'] }, undefined, new Set(['face.head']));
+    expect(g.enabled('face.au')).toBe(true);
+    expect(g.enabled('face.head')).toBe(true);
+    expect(g.enabled('face.blendshape.jaw')).toBe(false);
+    // and with no params either, everything (unchanged headless behaviour)
+    expect(resolveLabGate({}, undefined, new Set(['face.head'])).enabled('face.au')).toBe(true);
+  });
+});
+
+describe('the vector nodes serve a demand with the Lab CLOSED (the v1 trainer bug)', () => {
+  const face: FaceFrame = {
+    present: true,
+    blendshapes: { jawOpen: 0.7, mouthSmileLeft: 0.3, mouthSmileRight: 0.5, browInnerUp: 0.2 },
+  };
+  const labHidden = () => ({ featureLab: { show: false, groups: ['face.blendshape.brow'] } });
+
+  it('face: without a demand the hidden Lab yields {} — with one, the demanded group arrives', () => {
+    const h = faceFeatureVectorNode.make(faceFeatureVectorNode.params.parse({}));
+    const none = h.process({ face }, ctx({ controls: labHidden })) as { vector: FeatureVector };
+    expect(Object.keys(none.vector)).toHaveLength(0);
+
+    const demanded = h.process(
+      { face },
+      ctx({ controls: labHidden, featureDemand: () => new Set(['face.blendshape.jaw']) }),
+    ) as { vector: FeatureVector };
+    expect(demanded.vector['face.blendshape.jaw.open']).toBeCloseTo(0.7);
+    // The Lab's own group (brow) is NOT computed: the meters are off, and a demand must
+    // not widen what they measure behind their back.
+    expect(Object.keys(demanded.vector).some((k) => k.startsWith('face.blendshape.brow'))).toBe(false);
+  });
+
+  it('hand: the same, through the shared gate', () => {
+    const hands: HandsFrame = {
+      width: 640,
+      height: 480,
+      hands: [
+        {
+          handedness: 'Right',
+          keypoints: makeHandKeypoints({ cx: 320, cy: 240, scale: 70, spread: 0.5, pinch: 0.2, handedness: 'Right' }),
+        },
+      ],
+    };
+    const h = handFeatureVectorNode.make(handFeatureVectorNode.params.parse({}));
+    const none = h.process({ hands }, ctx({ controls: labHidden })) as { vector: FeatureVector };
+    expect(Object.keys(none.vector)).toHaveLength(0);
+    const demanded = h.process(
+      { hands },
+      ctx({ controls: labHidden, featureDemand: () => new Set(['hand.finger.flexion']) }),
+    ) as { vector: FeatureVector };
+    const keys = Object.keys(demanded.vector);
+    expect(keys.length).toBeGreaterThan(0);
+    expect(keys.every((k) => k.startsWith('hand.'))).toBe(true);
+  });
+});
+
+describe('the trainer claims the catalog while a step runs, and lets go after', () => {
+  it('begin → claim; end → release; reset → release', () => {
+    appFeatureDemand.reset();
+    useTrainer.getState().reset();
+    expect(featureDemandResource()).toBeNull();
+    useTrainer.getState().begin('rest');
+    const during = featureDemandResource();
+    expect(during).not.toBeNull();
+    expect(during!.has('face.head')).toBe(true);
+    expect(during!.has('hand.finger.flexion')).toBe(true);
+    useTrainer.getState().end();
+    expect(featureDemandResource()).toBeNull();
+    useTrainer.getState().begin('vocabulary');
+    useTrainer.getState().reset();
+    expect(featureDemandResource()).toBeNull();
+  });
+});

--- a/test/tools_shell.test.tsx
+++ b/test/tools_shell.test.tsx
@@ -247,6 +247,20 @@ describe('the Trainer is reachable and runs the ritual (#160)', () => {
     expect(useTrainer.getState().activeStep).toBeNull();
   });
 
+  it('closing the panel mid-step ENDS the step (and releases the feature demand)', async () => {
+    const { appFeatureDemand } = await import('@/app/featureDemand');
+    useTools.setState({ open: 'trainer' });
+    render(<TrainerPanel />);
+    fireEvent.click(screen.getAllByText('Start')[0]);
+    expect(useTrainer.getState().activeStep).toBe('rest');
+    expect(appFeatureDemand.groups()).not.toBeNull();
+    // The X button only writes useTools.open; the panel itself must notice.
+    fireEvent.click(screen.getByLabelText('Close the Trainer panel'));
+    expect(useTools.getState().open).toBeNull();
+    expect(useTrainer.getState().activeStep).toBeNull();
+    expect(appFeatureDemand.groups()).toBeNull();
+  });
+
   it('cannot be trained from an empty take (the build button is disabled)', () => {
     useTools.setState({ open: 'trainer' });
     render(<TrainerPanel />);

--- a/tsconfig.dag.json
+++ b/tsconfig.dag.json
@@ -7,7 +7,7 @@
     "noUnusedParameters": true,
     "types": ["node", "vitest/globals"]
   },
-  "include": ["src/dag", "src/nodes", "src/music", "src/features", "src/settings", "src/taglog", "src/enroll", "src/app/graph.ts", "src/app/lab", "test", "scripts"],
+  "include": ["src/dag", "src/nodes", "src/music", "src/features", "src/settings", "src/taglog", "src/enroll", "src/app/graph.ts", "src/app/featureDemand.ts", "src/app/enroll", "src/app/lab", "test", "scripts"],
   "//exclude": "The jsdom SHELL tests are .tsx (they render React components) and this project ships no @types/react by design — same reason the React app layer is excluded. Vitest still runs them; Vite/esbuild type-erases the JSX.",
   "exclude": ["test/**/*.test.tsx"]
 }


### PR DESCRIPTION
Prerequisite for #163 (trainer v2). Three v1 (#160) bugs that every unit test passed over and that a webcam run would have hit first — all found and fixed headlessly:

1. **The vector nodes emit `{}` with the Lab hidden** (the #136 gate), and the trainer never asked for anything to be computed. New **feature-demand seam** (`src/features/demand.ts`): a consumer claims feature *groups*; `resolveLabGate` serves the union of the Lab's groups (when shown) and every live claim. A demand never turns the meters on and never widens what they measure. Installed on the engine as `ctx.resources.featureDemand`.
2. **`ctx.time` is seconds; the tap stamped it as ms.** The sampler's 220 ms dwell was 220 s and the speed estimate was ×1000, so nothing ever read as held. Converted once at the boundary.
3. **The face MODEL gate ignored the demand** (found by the adversarial review): with the defaults (`face.mapping: none`, Lab hidden) MediaPipe never loaded, so demanded face groups were computed from an absent frame. `faceActive(controls, demanded)` now honours `demandWantsFace` (the sibling of `labWantsFace`); the registry is subscribable so the FaceChip reports the model running for a trainer cue as it does for the Lab.

Plus, from the review: closing the Trainer panel mid-step now ends the step (the claim and the 30 Hz poll outlived the panel); `derived` is dropped from claims; the Lab's formula scope stays within the Lab's own groups while a demand is live.

**Guards:** `test/feature_demand.test.ts` (registry, gate, node-level face+hand with the production control shape, face-model gate, ms boundary, a source-level guard on the `useEngine` install) — mutation-tested: ignoring the demand in the gate fails 5 cases; deleting the `useEngine` line fails the source guard. `src/app/enroll` + `src/app/featureDemand.ts` are now in the strict typecheck.

The v1 trainer still needs #163's unit fix (raw degrees vs blendshapes) to be useful on a real face — that is PR 1 of the v2 series, next.

Refs #163, #160, #146.

https://claude.ai/code/session_01X3jUdZKZNcW4QzuBrAEwpj