### PR TITLE
#51: the engine graph lifecycle — re-wire a running engine without rebuilding it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,10 +41,18 @@ Discussion #3. Key rules from it:
   element to a node only when something *outside* the node must consume/tap it.
 - **A role earns a settings swap-dropdown only when ≥2 real implementations
   exist.** Don't build slot machinery for hypothetical swaps.
-- Two known prerequisites before "node swapping is a config flip" is true: the
-  interchangeable mapping nodes don't yet share an **input/params contract**
-  (only the output contract), and the registry is a **hand-listed array** with no
-  discovery seam. See the design doc's "Two corrections" section.
+- Of the prerequisites before "node swapping is a config flip" is true, one
+  remains: the registry is a **hand-listed array** with no discovery seam (the
+  design doc's "Two corrections", #2). The other two are done — the mapping nodes
+  share an **input/params contract** (`src/nodes/mapping/mapping_contract.ts`),
+  and the engine can now re-wire itself while running (next bullet).
+- **The running graph is not frozen.** `Engine.applyGraph(spec, registry?)`
+  reconciles a live engine onto a new `GraphSpec`, keeping every node whose id +
+  type + *validated* params are unchanged — so a swap does not reload the
+  MediaPipe models or rebuild the audio graph. It plans synchronously (a bad spec
+  is a no-op), inits the new nodes **while the old graph keeps ticking**, then
+  commits atomically. Never construct a second `Engine` to change wiring. See
+  `docs/design/component-model.md` → "Swapping at runtime: the engine lifecycle".
 
 ## Persistence & collections → **zodal** (project rule)
 

--- a/docs/design/component-model.md
+++ b/docs/design/component-model.md
@@ -113,6 +113,13 @@ exported `PortSpec[]`/schema the alternatives spread). Fixing that contract is
 the real load-bearing work that makes node-swapping safe — and it must come
 *before* any slot machinery.
 
+> **Resolved.** `src/nodes/mapping/mapping_contract.ts` is that named contract
+> (`MAPPING_SLOT_INPUTS` / `MAPPING_SLOT_OUTPUT` / `MAPPING_SLOT_CONTRACT`), and
+> `SLOTS` + `resolveSlot` in `src/app/graph.ts` validate a candidate against it
+> before the engine ever sees the spec. `test/slots.test.ts` pins the
+> edge-stability guarantee. What remained after that was the *runtime* half —
+> see the next section.
+
 ### 2. The registry is a hand-listed array, not a discovery seam
 
 `CORE_NODES` (`src/nodes/index.ts`) and `BROWSER_NODES` (`src/nodes/browser.ts`)
@@ -121,6 +128,40 @@ node with a role and it auto-appears in settings" assumes a discovery mechanism
 that does not exist. True open-closed/third-party extensibility needs a
 registration seam added first. (We don't need third-party plugins yet — but the
 docs must not *claim* open-closed before the seam exists.)
+
+## Swapping at runtime: the engine lifecycle
+
+A validated, edge-stable swap is only half of "node swapping is a config flip".
+The other half is that the engine must be able to *adopt* the new graph while it
+is running. Until #51's third bullet was built, changing one node type meant
+constructing a new `Engine` — which re-runs **every** node's `init()`, which
+reloads the MediaPipe hand and face models and rebuilds the audio graph. Paying
+several seconds of black screen and silence to change one mapping node is not a
+config flip; it is a restart.
+
+**`Engine.applyGraph(spec, registry?)`** (`src/dag/engine.ts`) reconciles a
+running engine onto a new `GraphSpec` in place and returns a `GraphChange`
+(`added` / `removed` / `replaced` / `kept` / `rewired`).
+
+- **Identity is `id` + `type` + *validated* params.** Matching on the validated
+  (Zod-parsed) params, not the raw spec, is what makes `{}` and `{ offset: 0 }`
+  the same node — otherwise every re-apply would rebuild the world.
+- **Kept means kept**: the same live instance, `init()` not re-run, internal
+  state (loaded model, smoothing history, sounding voices) intact, and its last
+  outputs still standing so downstream sees no one-tick hole.
+- **Three phases, because `init()` is async.** *Plan* compiles the whole next
+  graph synchronously and throws before touching anything, so a bad spec is a
+  no-op. *Prepare* awaits `init()` on the new instances only — **the old graph
+  keeps ticking for this entire phase**, which is precisely what "without
+  freezing the tick loop" means. *Commit* swaps node map, order, outputs and
+  spec in one synchronous block; `tick()` is synchronous, so no tick can observe
+  a half-swapped graph. If any `init` rejects, the half-built graph is torn down
+  and the running one plays on.
+
+This is the mechanism a settings swap-dropdown, the React Flow patcher (#14) and
+the Stream Applier's source selection all sit on top of; none of them needs to
+know about node instances. Edges are re-wired unconditionally on every apply,
+which is free — they are just a map on each node.
 
 ## Sub-components are functions inside a node — **not** DAG nodes
 

--- a/docs/design/stream-applier.md
+++ b/docs/design/stream-applier.md
@@ -216,10 +216,18 @@ boundaries allow.
 - **M-D — The Applier (R4 complete, R5 orthogonality). ⚠ untested live surface.**
   `runHeadless` delegates (BatchClock + bounded recorder tap, no audio sink);
   `useEngine`'s effect becomes a thin Applier config — **this is where the live
-  rAF loop adopts `RealtimeClock(1)`** (deferred from M-B). Also validate
-  `speed > 0` on adoption (a non-positive speed collapses to a frozen clock).
+  rAF loop adopts `RealtimeClock(1)`** (deferred from M-B).
   **Gate on a browser smoke test** — the effect (StrictMode guards, face bridge,
   mute mirror, AudioContext lifecycle) has no headless coverage.
+  - ✅ **`speed > 0` validation done** — `RealtimeClock` now throws a `RangeError`
+    on a non-finite or non-positive speed rather than shipping a frozen clock
+    (a speed of 0 pins engine time to `base`, so every tick gets `dt === 0` while
+    frames keep coming: smoothing filters and note envelopes stop advancing and
+    the instrument looks hung).
+  - ✅ **The engine-lifecycle prerequisite is done** — `Engine.applyGraph()`
+    reconciles a *running* engine onto a new `GraphSpec`, keeping every unchanged
+    node (see below). The Applier can therefore change its source/graph without
+    reconstructing the engine and reloading the ML models.
 - **M-E — Composition + timestamp-aware replay (R2).** `defineMergeNode`; event
   sources buffer→list; a **separate** time-based `replay-source-timed` reading
   `StreamRecord.t` (index-by-tick stays canonical for CI goldens).
@@ -275,6 +283,35 @@ clock. M-C's value is the *contract* — open-closed source plugging and port co
 which pays off when the Applier (M-D) lands and when a second non-webcam origin actually
 appears. Neither is currently blocking anything, so the design is banked and the build is
 not scheduled.
+
+## Changing the graph while it runs (the lifecycle prerequisite)
+
+An Applier that can only pick its sources *once*, at construction, is not
+open-closed in any useful sense — switching source mid-session would mean a new
+`Engine`, and therefore a full `init()` sweep: the MediaPipe hand and face models
+reload, the audio graph is rebuilt. So the Applier rests on a prior guarantee:
+
+**`Engine.applyGraph(spec, registry?)`** reconciles a running engine onto a new
+`GraphSpec` in place, keeping every node whose id, type and *validated* params are
+unchanged, and returns a `GraphChange` (`added`/`removed`/`replaced`/`kept`/`rewired`).
+It plans synchronously (a bad spec throws before anything is touched), then awaits
+`init()` on the new instances **while the old graph keeps ticking**, then commits in
+one synchronous block. A rejected `init` tears down the half-built graph and leaves
+the running one playing.
+
+Consequences for this design:
+
+- **M-C's `source` slot** becomes a live selection, not a startup-only one: swapping
+  `webcam-hands` → `replay-source` is an `applyGraph` with one changed node.
+- **M-D's Applier** owns *which* graph and *which* clock; it does not need to own
+  engine construction. `useEngine` and `runHeadless` can both hand it a live engine.
+- **Boundary A is unaffected** — the batch path still swaps in a finished-frame node
+  rather than decoding video in Node; `applyGraph` is only how that swap is applied.
+
+The mechanism is documented in `docs/design/component-model.md`
+("Swapping at runtime: the engine lifecycle") and tested in
+`test/engine_lifecycle.test.ts`; it was built for #51's "engine lifecycle on swap"
+bullet, which #14 (the React Flow patcher) and this document's M-C/M-D both need.
 
 ## Relationship to existing work
 

--- a/src/dag/clock.ts
+++ b/src/dag/clock.ts
@@ -71,6 +71,20 @@ export class RealtimeClock implements Clock {
 
   constructor(opts: RealtimeClockOptions = {}) {
     this.speed = opts.speed ?? 1;
+    // Reject a non-positive / non-finite speed rather than silently freezing the
+    // instrument. `t = base + (real - base) * speed` at speed 0 pins engine time
+    // to `base` forever: every tick gets `dt === 0`, so smoothing filters, note
+    // envelopes and anything else integrating over dt stop advancing while the
+    // frames keep coming — a wedged instrument that looks like a hang, not a
+    // setting. A negative speed runs time backwards, which the engine clamps to
+    // `dt = 0` anyway. The design doc (stream-applier.md, M-D) calls for this
+    // check at the point the clock is adopted by the app; this is that check.
+    if (!Number.isFinite(this.speed) || this.speed <= 0) {
+      throw new RangeError(
+        `RealtimeClock: speed must be a finite number > 0 (got ${String(opts.speed)}). ` +
+          `Use a stop condition to pause; a zero/negative speed would freeze ctx.dt.`,
+      );
+    }
     this.now = opts.now ?? (() => performance.now() / 1000);
     // Referenced lazily inside run(), so importing this module in Node (where
     // requestAnimationFrame is absent but only BatchClock is used) is safe.

--- a/src/dag/engine.ts
+++ b/src/dag/engine.ts
@@ -9,6 +9,16 @@
  * matches how the existing Thoremin loop works — features and synth params are
  * recomputed every animation frame — while making the data path explicit and
  * tap-able.
+ *
+ * **Graph lifecycle.** The graph a running engine evaluates is not frozen at
+ * construction: {@link Engine.applyGraph} reconciles the live engine onto a new
+ * {@link GraphSpec} *in place*, keeping every node whose type and params are
+ * unchanged. That is the load-bearing half of node-swap slots (#51's "engine
+ * lifecycle on swap" bullet) — without it, changing one node type means a new
+ * `Engine`, which means re-running every `init()`, which means reloading the
+ * MediaPipe model and rebuilding the audio voices for a swap that touched one
+ * node. See {@link Engine.applyGraph} for the prepare-then-commit protocol that
+ * makes the swap glitch-free.
  */
 import type {
   EdgeSpec,
@@ -23,6 +33,13 @@ import type { NodeRegistry } from './registry';
 interface BuiltNode {
   id: string;
   type: string;
+  /**
+   * The node's *validated* params (Zod output, so defaults are filled in). Kept
+   * on the instance so {@link Engine.applyGraph} can tell "the same node, respecified"
+   * from "a genuinely different node" — comparing raw specs would treat `{}` and
+   * `undefined` as different when both parse to the same defaults.
+   */
+  params: unknown;
   handlers: NodeHandlers;
   /** Declared output port names (for tap emission and validation). */
   outputPorts: string[];
@@ -42,6 +59,69 @@ export interface EngineOptions {
   log?: (msg: string) => void;
 }
 
+/**
+ * What one {@link Engine.applyGraph} reconcile actually did. Every node id in the
+ * new graph appears in exactly one of `added` / `replaced` / `kept`; `removed`
+ * lists ids that were in the old graph and are not in the new one.
+ *
+ * The distinction that matters to a caller is **`kept` vs the rest**: a kept node
+ * is the *same live instance* — its `init()` was not re-run, its internal state
+ * (loaded model, smoothing history, sounding voices) is intact, and its last
+ * outputs still stand. Anything else was torn down and rebuilt.
+ */
+export interface GraphChange {
+  /** Node ids in the new graph that had no counterpart in the old one. */
+  added: string[];
+  /** Node ids that were in the old graph and are not in the new one (disposed). */
+  removed: string[];
+  /** Node ids present in both, but whose type or params differ (rebuilt + re-init'd). */
+  replaced: string[];
+  /** Node ids carried over as live instances — same type, same validated params. */
+  kept: string[];
+  /** True when the edge set differs from the previous spec's. */
+  rewired: boolean;
+}
+
+/**
+ * Structural equality for validated node params. Params are plain data by
+ * construction (a {@link GraphSpec} is "a complete, serializable description"),
+ * so this walks arrays and plain objects and falls back to `Object.is` — which
+ * makes any exotic value (a function, a class instance from a `.transform()`)
+ * compare by identity. Erring toward "not equal" is the safe direction: the
+ * worst case is rebuilding a node that could have been kept.
+ */
+function paramsEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+  if (typeof a !== 'object' || typeof b !== 'object' || a === null || b === null) return false;
+  if (Array.isArray(a) !== Array.isArray(b)) return false;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return a.length === b.length && a.every((x, i) => paramsEqual(x, b[i]));
+  }
+  // Plain-object walk. A non-plain object (Date, Map, class instance) has already
+  // failed Object.is above and its prototype differs from Object.prototype, so
+  // treating it as unequal here is the intended conservative answer.
+  if (Object.getPrototypeOf(a) !== Object.prototype || Object.getPrototypeOf(b) !== Object.prototype) {
+    return false;
+  }
+  const ak = Object.keys(a as Record<string, unknown>);
+  const bk = Object.keys(b as Record<string, unknown>);
+  if (ak.length !== bk.length) return false;
+  return ak.every(
+    (k) =>
+      Object.prototype.hasOwnProperty.call(b, k) &&
+      paramsEqual((a as Record<string, unknown>)[k], (b as Record<string, unknown>)[k]),
+  );
+}
+
+/** Order-insensitive edge-set comparison, for the `rewired` flag. */
+function sameEdges(a: readonly EdgeSpec[], b: readonly EdgeSpec[]): boolean {
+  if (a.length !== b.length) return false;
+  const key = (e: EdgeSpec) => `${e.from.node}.${e.from.port}>${e.to.node}.${e.to.port}`;
+  const as = a.map(key).sort();
+  const bs = b.map(key).sort();
+  return as.every((k, i) => k === bs[i]);
+}
+
 export class Engine {
   private nodes = new Map<string, BuiltNode>();
   private order: string[] = [];
@@ -52,16 +132,37 @@ export class Engine {
   private nominalDt: number;
   private log?: (msg: string) => void;
 
+  /** Kept so {@link applyGraph} can re-resolve node types without the caller re-supplying it. */
+  private registry: NodeRegistry;
+  /** The spec currently being evaluated (for {@link currentGraph} and edge diffing). */
+  private spec: GraphSpec;
+  /** Bumped on every committed {@link applyGraph} — a cheap identity for "the wiring changed". */
+  private version = 0;
+  /**
+   * Serializes overlapping {@link applyGraph} calls. Two applies interleaving
+   * would each plan against the same old graph and the second commit would
+   * dispose instances the first had just adopted.
+   */
+  private applyQueue: Promise<unknown> = Promise.resolve();
+  /** In-flight {@link init}, so an apply cannot swap `order` out from under it. */
+  private initPromise: Promise<void> | null = null;
+
   private tickIndex = -1;
   private lastTime = 0;
   private started = false;
+  private disposed = false;
 
   constructor(spec: GraphSpec, registry: NodeRegistry, opts: EngineOptions = {}) {
     this.taps = opts.taps ?? [];
     this.resources = opts.resources ?? {};
     this.nominalDt = opts.nominalDt ?? 1 / 60;
     this.log = opts.log;
-    this.build(spec, registry);
+    this.registry = registry;
+    this.spec = spec;
+    const { nodes, order } = compile(spec, registry, new Map());
+    this.nodes = nodes;
+    this.order = order;
+    for (const id of nodes.keys()) this.outputs.set(id, {});
   }
 
   /**
@@ -84,108 +185,128 @@ export class Engine {
     if (i >= 0) this.taps.splice(i, 1);
   }
 
-  // ---- build ------------------------------------------------------------
+  // ---- graph lifecycle ---------------------------------------------------
 
-  private build(spec: GraphSpec, registry: NodeRegistry): void {
-    const ids = new Set<string>();
-    for (const n of spec.nodes) {
-      if (ids.has(n.id)) throw new Error(`Engine: duplicate node id "${n.id}"`);
-      ids.add(n.id);
-    }
+  /**
+   * Reconcile this **running** engine onto `next`, keeping every node the new
+   * spec leaves unchanged. Returns a {@link GraphChange} describing what moved.
+   *
+   * A node is **kept** — the same live instance, `init()` not re-run, state and
+   * last outputs intact — when its id, type and *validated* params all match.
+   * Otherwise it is disposed and rebuilt. Edges are always re-wired from `next`,
+   * which is free (they are just a map on each node).
+   *
+   * Three phases, in this order, because the middle one is async:
+   *
+   *  1. **Plan** (sync) — compile the whole next graph: resolve types, validate
+   *     params, validate every edge, topo-sort. Anything invalid throws *here*,
+   *     before a single live instance has been touched, so a bad spec leaves the
+   *     running graph exactly as it was.
+   *  2. **Prepare** (async) — `init()` only the new instances, in the new
+   *     topological order. The **old graph keeps ticking throughout**: this is
+   *     the whole point of splitting prepare from commit, and it is what #51 means
+   *     by "handle async `init()` without freezing the tick loop". If any `init`
+   *     rejects, the half-built graph is torn down and the running one is kept.
+   *  3. **Commit** (sync) — swap the node map, order, outputs and spec in one
+   *     synchronous block, then dispose whatever the new graph no longer runs.
+   *     `tick()` is synchronous and JS is single-threaded, so no tick can observe
+   *     a half-swapped graph.
+   *
+   * Calling this before {@link init} is fine: the new nodes are not init'd here
+   * (there is nothing running to keep alive), and the later `init()` covers the
+   * whole graph as usual.
+   *
+   * @param next the graph to run from now on.
+   * @param registry the registry to resolve `next`'s node types against; defaults
+   *   to the one this engine was built with.
+   */
+  async applyGraph(next: GraphSpec, registry: NodeRegistry = this.registry): Promise<GraphChange> {
+    const run = this.applyQueue.then(
+      () => this.applyGraphNow(next, registry),
+      () => this.applyGraphNow(next, registry),
+    );
+    // A rejected apply must not poison the queue for the next caller.
+    this.applyQueue = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
 
-    // Instantiate nodes (validate params via Zod).
-    for (const n of spec.nodes) {
-      const def = registry.get(n.type);
-      let params: unknown;
+  private async applyGraphNow(next: GraphSpec, registry: NodeRegistry): Promise<GraphChange> {
+    if (this.disposed) throw new Error('Engine: applyGraph called on a disposed engine');
+    // An init() in flight is iterating the CURRENT order; let it finish before
+    // swapping the graph out from under it.
+    if (this.initPromise) await this.initPromise.then(undefined, () => undefined);
+    if (this.disposed) throw new Error('Engine: applyGraph called on a disposed engine');
+
+    const previous = this.nodes;
+    const previousSpec = this.spec;
+
+    // 1. PLAN — throws before anything is mutated.
+    const { nodes, order, fresh, kept } = compile(next, registry, previous);
+
+    // 2. PREPARE — init the new instances while the old graph keeps ticking.
+    if (this.started) {
+      const freshSet = new Set(fresh);
+      const ctx = this.makeContext(this.lastTime, 0);
       try {
-        params = def.params.parse(n.params ?? {});
+        for (const id of order) {
+          if (!freshSet.has(id)) continue;
+          await nodes.get(id)!.handlers.init?.(ctx);
+        }
       } catch (err) {
-        throw new Error(`Engine: invalid params for node "${n.id}" (${n.type}): ${String(err)}`);
+        // Tear down only what we just built; the running graph is untouched.
+        for (const id of fresh) disposeQuietly(nodes.get(id)!, this.log);
+        throw err;
       }
-      const handlers = def.make(params as never);
-      const inputDefaults = new Map<string, unknown>();
-      for (const p of def.inputs) {
-        if (p.default !== undefined) inputDefaults.set(p.name, p.default);
-      }
-      this.nodes.set(n.id, {
-        id: n.id,
-        type: n.type,
-        handlers,
-        outputPorts: def.outputs.map((p) => p.name),
-        inputDefaults,
-        incoming: new Map(),
-      });
-      this.outputs.set(n.id, {});
     }
 
-    // Wire edges (validate endpoints; reject duplicate fan-in to one input port).
-    for (const e of spec.edges) {
-      this.validateEdge(e, registry);
-      const target = this.nodes.get(e.to.node)!;
-      if (target.incoming.has(e.to.port)) {
-        throw new Error(
-          `Engine: input port "${e.to.node}.${e.to.port}" already has an edge; ` +
-            `fan-in to one input is not allowed (use a merge node).`,
-        );
-      }
-      target.incoming.set(e.to.port, { node: e.from.node, port: e.from.port });
+    // 3. COMMIT — one synchronous block, so no tick sees a half-swapped graph.
+    const keptSet = new Set(kept);
+    const outputs = new Map<string, PortValues>();
+    for (const id of nodes.keys()) {
+      // A kept node's last outputs stand, so downstream readers see no one-tick hole.
+      outputs.set(id, (keptSet.has(id) ? this.outputs.get(id) : undefined) ?? {});
+    }
+    this.nodes = nodes;
+    this.order = order;
+    this.outputs = outputs;
+    this.spec = next;
+    this.registry = registry;
+    this.version += 1;
+
+    // Dispose whatever the new graph no longer runs. Identity on `handlers` is
+    // the exact test: it covers removed nodes AND the old instances of replaced
+    // ones, and can never catch a kept node (whose handlers are in `nodes`).
+    const surviving = new Set<NodeHandlers>();
+    for (const n of nodes.values()) surviving.add(n.handlers);
+    for (const n of previous.values()) {
+      if (!surviving.has(n.handlers)) disposeQuietly(n, this.log);
     }
 
-    this.order = this.topoSort(spec.edges);
+    const previousIds = new Set(previous.keys());
+    return {
+      added: fresh.filter((id) => !previousIds.has(id)),
+      removed: [...previousIds].filter((id) => !nodes.has(id)),
+      replaced: fresh.filter((id) => previousIds.has(id)),
+      kept,
+      rewired: !sameEdges(previousSpec.edges, next.edges),
+    };
   }
 
-  private validateEdge(e: EdgeSpec, registry: NodeRegistry): void {
-    const from = this.nodes.get(e.from.node);
-    const to = this.nodes.get(e.to.node);
-    if (!from) throw new Error(`Engine: edge from unknown node "${e.from.node}"`);
-    if (!to) throw new Error(`Engine: edge to unknown node "${e.to.node}"`);
-    const fromDef = registry.get(from.type);
-    const toDef = registry.get(to.type);
-    if (!fromDef.outputs.some((p) => p.name === e.from.port)) {
-      throw new Error(`Engine: node "${from.id}" (${from.type}) has no output port "${e.from.port}"`);
-    }
-    if (!toDef.inputs.some((p) => p.name === e.to.port)) {
-      throw new Error(`Engine: node "${to.id}" (${to.type}) has no input port "${e.to.port}"`);
-    }
+  /**
+   * The spec this engine is currently evaluating. A fresh container holding the
+   * *same* node/edge objects — safe to read and to spread into a modified spec
+   * for {@link applyGraph}, not a deep clone.
+   */
+  currentGraph(): GraphSpec {
+    return { nodes: [...this.spec.nodes], edges: [...this.spec.edges] };
   }
 
-  /** Kahn's algorithm; throws on cycles. */
-  private topoSort(edges: EdgeSpec[]): string[] {
-    const indeg = new Map<string, number>();
-    const adj = new Map<string, Set<string>>();
-    for (const id of this.nodes.keys()) {
-      indeg.set(id, 0);
-      adj.set(id, new Set());
-    }
-    for (const e of edges) {
-      if (e.from.node === e.to.node) {
-        throw new Error(`Engine: self-loop on node "${e.from.node}" not allowed in v0`);
-      }
-      // Count a dependency once even if multiple ports connect the same pair.
-      if (!adj.get(e.from.node)!.has(e.to.node)) {
-        adj.get(e.from.node)!.add(e.to.node);
-        indeg.set(e.to.node, (indeg.get(e.to.node) ?? 0) + 1);
-      }
-    }
-    const queue: string[] = [];
-    for (const [id, d] of indeg) if (d === 0) queue.push(id);
-    queue.sort(); // deterministic ordering among independents
-    const order: string[] = [];
-    while (queue.length) {
-      const id = queue.shift()!;
-      order.push(id);
-      const next: string[] = [];
-      for (const m of adj.get(id)!) {
-        indeg.set(m, indeg.get(m)! - 1);
-        if (indeg.get(m) === 0) next.push(m);
-      }
-      next.sort();
-      queue.push(...next);
-    }
-    if (order.length !== this.nodes.size) {
-      throw new Error('Engine: graph has a cycle (not allowed in v0; use explicit delay nodes for feedback)');
-    }
-    return order;
+  /** How many times {@link applyGraph} has committed — 0 for a never-rewired engine. */
+  graphVersion(): number {
+    return this.version;
   }
 
   // ---- run --------------------------------------------------------------
@@ -193,10 +314,22 @@ export class Engine {
   /** Call each node's async `init` once, in dependency order. */
   async init(): Promise<void> {
     if (this.started) return;
+    if (!this.initPromise) {
+      this.initPromise = this.initAll().finally(() => {
+        this.initPromise = null;
+      });
+    }
+    await this.initPromise;
+  }
+
+  private async initAll(): Promise<void> {
     const ctx = this.makeContext(this.lastTime, 0);
-    for (const id of this.order) {
-      const node = this.nodes.get(id)!;
-      if (node.handlers.init) await node.handlers.init(ctx);
+    // Snapshot the order: an applyGraph awaits `initPromise` before committing,
+    // but iterating a snapshot means a future change to that ordering cannot
+    // turn into a mid-loop `undefined` node.
+    for (const id of [...this.order]) {
+      const node = this.nodes.get(id);
+      if (node?.handlers.init) await node.handlers.init(ctx);
     }
     this.started = true;
   }
@@ -257,9 +390,154 @@ export class Engine {
   }
 
   dispose(): void {
+    this.disposed = true;
     for (const id of this.order) {
       const node = this.nodes.get(id);
       node?.handlers.dispose?.();
     }
   }
+}
+
+// ---- compilation (shared by the constructor and applyGraph) ---------------
+
+/** Dispose a node without letting its teardown abort the caller's own cleanup. */
+function disposeQuietly(node: BuiltNode, log?: (msg: string) => void): void {
+  try {
+    node.handlers.dispose?.();
+  } catch (err) {
+    log?.(`Engine: dispose of node "${node.id}" (${node.type}) threw: ${String(err)}`);
+  }
+}
+
+/**
+ * Turn a {@link GraphSpec} into an executable node map + evaluation order,
+ * **reusing** any instance in `reusable` whose id, type and validated params all
+ * match. Pure with respect to engine state: it never touches the live graph, so
+ * a throw here leaves a running engine exactly as it was.
+ *
+ * `fresh` lists the ids this call instantiated (the ones that still need
+ * `init()`); `kept` lists the ids carried over from `reusable`. Together they
+ * cover every node in `spec`.
+ */
+function compile(
+  spec: GraphSpec,
+  registry: NodeRegistry,
+  reusable: ReadonlyMap<string, BuiltNode>,
+): { nodes: Map<string, BuiltNode>; order: string[]; fresh: string[]; kept: string[] } {
+  const nodes = new Map<string, BuiltNode>();
+  const fresh: string[] = [];
+  const kept: string[] = [];
+
+  try {
+    for (const n of spec.nodes) {
+      if (nodes.has(n.id)) throw new Error(`Engine: duplicate node id "${n.id}"`);
+      const def = registry.get(n.type);
+      let params: unknown;
+      try {
+        params = def.params.parse(n.params ?? {});
+      } catch (err) {
+        throw new Error(`Engine: invalid params for node "${n.id}" (${n.type}): ${String(err)}`);
+      }
+
+      const prev = reusable.get(n.id);
+      if (prev && prev.type === n.type && paramsEqual(prev.params, params)) {
+        // Carry the LIVE instance over — same type, same params means same
+        // behaviour, and (the point of all this) the same already-init'd state:
+        // the loaded ML model, the smoothing history, the sounding voices.
+        // `incoming` is rebuilt from the new edges below.
+        nodes.set(n.id, { ...prev, incoming: new Map() });
+        kept.push(n.id);
+        continue;
+      }
+
+      const inputDefaults = new Map<string, unknown>();
+      for (const p of def.inputs) {
+        if (p.default !== undefined) inputDefaults.set(p.name, p.default);
+      }
+      nodes.set(n.id, {
+        id: n.id,
+        type: n.type,
+        params,
+        handlers: def.make(params as never),
+        outputPorts: def.outputs.map((p) => p.name),
+        inputDefaults,
+        incoming: new Map(),
+      });
+      fresh.push(n.id);
+    }
+
+    // Wire edges (validate endpoints; reject duplicate fan-in to one input port).
+    for (const e of spec.edges) {
+      validateEdge(e, nodes, registry);
+      const target = nodes.get(e.to.node)!;
+      if (target.incoming.has(e.to.port)) {
+        throw new Error(
+          `Engine: input port "${e.to.node}.${e.to.port}" already has an edge; ` +
+            `fan-in to one input is not allowed (use a merge node).`,
+        );
+      }
+      target.incoming.set(e.to.port, { node: e.from.node, port: e.from.port });
+    }
+
+    return { nodes, order: topoSort(nodes, spec.edges), fresh, kept };
+  } catch (err) {
+    // Release anything this failed compile constructed. Reused instances belong
+    // to the live graph and are deliberately left alone.
+    for (const id of fresh) disposeQuietly(nodes.get(id)!);
+    throw err;
+  }
+}
+
+function validateEdge(e: EdgeSpec, nodes: ReadonlyMap<string, BuiltNode>, registry: NodeRegistry): void {
+  const from = nodes.get(e.from.node);
+  const to = nodes.get(e.to.node);
+  if (!from) throw new Error(`Engine: edge from unknown node "${e.from.node}"`);
+  if (!to) throw new Error(`Engine: edge to unknown node "${e.to.node}"`);
+  const fromDef = registry.get(from.type);
+  const toDef = registry.get(to.type);
+  if (!fromDef.outputs.some((p) => p.name === e.from.port)) {
+    throw new Error(`Engine: node "${from.id}" (${from.type}) has no output port "${e.from.port}"`);
+  }
+  if (!toDef.inputs.some((p) => p.name === e.to.port)) {
+    throw new Error(`Engine: node "${to.id}" (${to.type}) has no input port "${e.to.port}"`);
+  }
+}
+
+/** Kahn's algorithm; throws on cycles. */
+function topoSort(nodes: ReadonlyMap<string, BuiltNode>, edges: readonly EdgeSpec[]): string[] {
+  const indeg = new Map<string, number>();
+  const adj = new Map<string, Set<string>>();
+  for (const id of nodes.keys()) {
+    indeg.set(id, 0);
+    adj.set(id, new Set());
+  }
+  for (const e of edges) {
+    if (e.from.node === e.to.node) {
+      throw new Error(`Engine: self-loop on node "${e.from.node}" not allowed in v0`);
+    }
+    // Count a dependency once even if multiple ports connect the same pair.
+    if (!adj.get(e.from.node)!.has(e.to.node)) {
+      adj.get(e.from.node)!.add(e.to.node);
+      indeg.set(e.to.node, (indeg.get(e.to.node) ?? 0) + 1);
+    }
+  }
+  const queue: string[] = [];
+  for (const [id, d] of indeg) if (d === 0) queue.push(id);
+  queue.sort(); // deterministic ordering among independents
+  const order: string[] = [];
+  while (queue.length) {
+    const id = queue.shift()!;
+    order.push(id);
+    const next: string[] = [];
+    for (const m of adj.get(id)!) {
+      indeg.set(m, indeg.get(m)! - 1);
+      if (indeg.get(m) === 0) next.push(m);
+    }
+    next.sort();
+    queue.push(...next);
+  }
+  if (order.length !== nodes.size) {
+    throw new Error('Engine: graph has a cycle (not allowed in v0; use explicit delay nodes for feedback)');
+  }
+  return order;
 }

--- a/src/dag/engine.ts
+++ b/src/dag/engine.ts
@@ -262,6 +262,18 @@ export class Engine {
       }
     }
 
+    // The engine may have been disposed while PREPARE was awaiting an `init()`
+    // — in the browser that is a React unmount landing on top of a swap that is
+    // still loading a model. Committing anyway would adopt the instances we just
+    // built into a dead engine, where nothing can ever reach them again (every
+    // later applyGraph throws), and would re-dispose the old ones that `dispose()`
+    // has already torn down. Treat it exactly like a rejected `init`: release
+    // what PREPARE built, change nothing, and say why.
+    if (this.disposed) {
+      for (const id of fresh) disposeQuietly(nodes.get(id)!, this.log);
+      throw new Error('Engine: disposed while applyGraph was preparing');
+    }
+
     // 3. COMMIT — one synchronous block, so no tick sees a half-swapped graph.
     const keptSet = new Set(kept);
     const outputs = new Map<string, PortValues>();
@@ -328,6 +340,10 @@ export class Engine {
     // but iterating a snapshot means a future change to that ordering cannot
     // turn into a mid-loop `undefined` node.
     for (const id of [...this.order]) {
+      // `dispose()` tears down every node in the map, including ones this loop
+      // has not reached yet. Continuing would init a node that has already been
+      // disposed, and nothing would ever dispose it again.
+      if (this.disposed) return;
       const node = this.nodes.get(id);
       if (node?.handlers.init) await node.handlers.init(ctx);
     }
@@ -343,6 +359,11 @@ export class Engine {
    * advances by `nominalDt` for deterministic headless runs.
    */
   tick(time?: number): void {
+    // A frame already scheduled when the host tore the engine down would
+    // otherwise run `process()` against released handles (a closed MediaPipe
+    // landmarker, disconnected audio nodes). Ticking a disposed engine is a
+    // caller bug; doing nothing is the safe reading of it.
+    if (this.disposed) return;
     this.tickIndex += 1;
     const t = time ?? (this.tickIndex * this.nominalDt);
     const dt = this.tickIndex === 0 ? 0 : Math.max(0, t - this.lastTime);
@@ -389,11 +410,21 @@ export class Engine {
     return this.order;
   }
 
+  /**
+   * Tear the whole graph down. Idempotent, and **best-effort per node**: one
+   * node's `dispose` throwing must not strand the ones after it. The sinks sort
+   * last in topological order, so an abort here is the worst case there is — the
+   * synth's oscillators keep sounding, `midi-out` never fires its all-notes-off
+   * and holds the port, and a camera node keeps its inference loop running. It
+   * also runs inside the host's own cleanup (`useEngine`), where an escaping
+   * throw would skip stopping the camera tracks.
+   */
   dispose(): void {
+    if (this.disposed) return;
     this.disposed = true;
     for (const id of this.order) {
       const node = this.nodes.get(id);
-      node?.handlers.dispose?.();
+      if (node) disposeQuietly(node, this.log);
     }
   }
 }

--- a/src/dag/index.ts
+++ b/src/dag/index.ts
@@ -9,7 +9,7 @@ export * from './types';
 export { defineNode } from './node';
 export { NodeRegistry, createRegistry } from './registry';
 export { Engine } from './engine';
-export type { EngineOptions } from './engine';
+export type { EngineOptions, GraphChange } from './engine';
 export {
   StreamRecorder,
   serializeRecords,

--- a/test/clock.test.ts
+++ b/test/clock.test.ts
@@ -89,6 +89,22 @@ describe('RealtimeClock', () => {
     expect(captured[3]).toBeCloseTo(100.6, 10);
   });
 
+  // Adoption guard (stream-applier.md, M-D): a non-positive speed pins engine
+  // time to `base` forever, so every tick gets dt === 0 while frames keep coming
+  // — smoothing filters and note envelopes stop advancing and the instrument
+  // looks hung. Refuse it at construction rather than shipping a frozen clock.
+  it.each([0, -1, -0.5, NaN, Infinity, -Infinity])('rejects a speed of %s', (speed) => {
+    expect(() => new RealtimeClock({ speed })).toThrow(RangeError);
+    expect(() => new RealtimeClock({ speed })).toThrow(/finite number > 0/);
+  });
+
+  it('accepts the speeds the design calls for (1, accelerated, slowed)', () => {
+    for (const speed of [1, 2, 0.5, 0.001, 1000]) {
+      expect(() => new RealtimeClock({ speed })).not.toThrow();
+    }
+    expect(() => new RealtimeClock()).not.toThrow(); // defaults to 1
+  });
+
   it('resolves without ticking if shouldStop is already true', async () => {
     const sched = fakeScheduler();
     const spy = vi.fn();

--- a/test/engine_lifecycle.test.ts
+++ b/test/engine_lifecycle.test.ts
@@ -1,0 +1,771 @@
+/**
+ * Tests the engine graph lifecycle (#51's "engine lifecycle on swap" bullet):
+ * `Engine.applyGraph` reconciles a RUNNING engine onto a new GraphSpec in place,
+ * keeping every node the new spec leaves unchanged.
+ *
+ * The guarantees under test, in the order they matter:
+ *
+ *  1. **Keep means keep.** A node whose id, type and validated params are
+ *     unchanged is the same live instance: `init()` is not re-run, its internal
+ *     state survives, and its last outputs still stand. This is the whole point —
+ *     swapping one mapping node must not reload the MediaPipe model.
+ *  2. **The tick loop never freezes.** `init()` is async (model loads, audio
+ *     graph setup); the old graph keeps evaluating for the whole prepare phase
+ *     and the swap lands atomically between two ticks.
+ *  3. **A bad apply changes nothing.** An invalid spec, or a new node whose
+ *     `init` rejects, leaves the running graph bit-for-bit as it was — and it
+ *     keeps ticking.
+ *
+ * Everything here is headless: the mechanism is proved on synthetic nodes where
+ * init/dispose/process calls can be counted exactly, and the classification is
+ * then checked against the REAL production graph (`defaultGraph`) so the mapping
+ * slot swap is verified on the wiring the browser actually runs.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { z } from 'zod';
+import {
+  Engine,
+  createRegistry,
+  defineNode,
+  type GraphSpec,
+  type NodeRegistry,
+  type Tap,
+} from '../src/dag';
+import { createAppRegistry, BROWSER_NODES } from '@/nodes/browser';
+import { CORE_NODES } from '@/nodes';
+import { defaultGraph } from '@/app/graph';
+import { MAPPING_SLOT_INPUTS, MAPPING_SLOT_OUTPUT } from '@/nodes/mapping/mapping_contract';
+
+// ---- instrumented node types ---------------------------------------------
+
+/** Per-node-type call counters, so "was this instance rebuilt?" is a hard fact. */
+interface Calls {
+  init: string[];
+  dispose: string[];
+  process: string[];
+}
+
+/**
+ * A stateful counter node: emits how many times THIS INSTANCE has processed, so
+ * a surviving instance is distinguishable from a freshly built one by its output
+ * alone (a rebuilt node restarts at 1). `offset` is a param, so changing it is
+ * how a test asks for a replace.
+ */
+function counterNode(calls: Calls, type = 'counter') {
+  return defineNode({
+    type,
+    inputs: [{ name: 'in', kind: 'number' }],
+    outputs: [{ name: 'n', kind: 'number' }],
+    params: z.object({ offset: z.number().default(0) }),
+    make(p) {
+      let n = 0;
+      const id = `${type}:${p.offset}`;
+      return {
+        init: () => {
+          calls.init.push(id);
+        },
+        process: () => {
+          n += 1;
+          calls.process.push(id);
+          return { n: n + p.offset };
+        },
+        dispose: () => {
+          calls.dispose.push(id);
+        },
+      };
+    },
+  });
+}
+
+/** A zero-input source emitting a constant, for wiring tests. */
+const constNode = defineNode({
+  type: 'const',
+  inputs: [],
+  outputs: [{ name: 'v', kind: 'number' }],
+  params: z.object({ value: z.number().default(1) }),
+  process: (_i, p) => ({ v: p.value }),
+});
+
+/** Passes its input through, tagged, so edge rewiring is observable downstream. */
+const passNode = defineNode({
+  type: 'pass',
+  inputs: [{ name: 'in', kind: 'number', default: -1 }],
+  outputs: [{ name: 'out', kind: 'number' }],
+  params: z.object({}),
+  process: (i) => ({ out: i.in }),
+});
+
+const freshCalls = (): Calls => ({ init: [], dispose: [], process: [] });
+
+function registryFor(calls: Calls, extra: ReturnType<typeof defineNode>[] = []): NodeRegistry {
+  return createRegistry([counterNode(calls), counterNode(calls, 'counter-b'), constNode, passNode, ...extra]);
+}
+
+/** Two counters in a chain: a -> b. */
+const chain = (aOffset = 0, bOffset = 0): GraphSpec => ({
+  nodes: [
+    { id: 'a', type: 'counter', params: { offset: aOffset } },
+    { id: 'b', type: 'counter', params: { offset: bOffset } },
+  ],
+  edges: [{ from: { node: 'a', port: 'n' }, to: { node: 'b', port: 'in' } }],
+});
+
+async function startedEngine(spec: GraphSpec, registry: NodeRegistry): Promise<Engine> {
+  const engine = new Engine(spec, registry);
+  await engine.init();
+  return engine;
+}
+
+// ---- 1. keep means keep ---------------------------------------------------
+
+describe('applyGraph — keeping unchanged nodes', () => {
+  it('re-applying the identical spec keeps every node: no init, no dispose, no rebuild', async () => {
+    const calls = freshCalls();
+    const engine = await startedEngine(chain(), registryFor(calls));
+    engine.tick();
+    engine.tick();
+    expect(calls.init).toEqual(['counter:0', 'counter:0']);
+
+    const change = await engine.applyGraph(chain());
+
+    expect(change.kept.sort()).toEqual(['a', 'b']);
+    expect(change.added).toEqual([]);
+    expect(change.replaced).toEqual([]);
+    expect(change.removed).toEqual([]);
+    expect(change.rewired).toBe(false);
+    // Nothing was re-init'd and nothing was torn down.
+    expect(calls.init).toHaveLength(2);
+    expect(calls.dispose).toEqual([]);
+  });
+
+  it('a kept node keeps its internal state; a replaced one starts over', async () => {
+    const calls = freshCalls();
+    const engine = await startedEngine(chain(), registryFor(calls));
+    engine.tick();
+    engine.tick();
+    engine.tick();
+    expect(engine.getOutput('a', 'n')).toBe(3); // three processes on this instance
+    expect(engine.getOutput('b', 'n')).toBe(3);
+
+    // Change ONLY b's params.
+    const change = await engine.applyGraph(chain(0, 100));
+    expect(change.kept).toEqual(['a']);
+    expect(change.replaced).toEqual(['b']);
+    expect(calls.dispose).toEqual(['counter:0']); // b's old instance only
+    expect(calls.init).toEqual(['counter:0', 'counter:0', 'counter:100']);
+
+    engine.tick();
+    expect(engine.getOutput('a', 'n')).toBe(4); // a carried on: 4th process
+    expect(engine.getOutput('b', 'n')).toBe(101); // b restarted: 1st process + offset
+  });
+
+  it('a kept node keeps its last outputs, so downstream sees no one-tick hole', async () => {
+    const calls = freshCalls();
+    const spec: GraphSpec = {
+      nodes: [
+        { id: 'a', type: 'counter', params: { offset: 0 } },
+        { id: 'p', type: 'pass' },
+      ],
+      edges: [{ from: { node: 'a', port: 'n' }, to: { node: 'p', port: 'in' } }],
+    };
+    const engine = await startedEngine(spec, registryFor(calls));
+    engine.tick();
+    engine.tick();
+    expect(engine.getOutput('a', 'n')).toBe(2);
+
+    // Replace only `p`; `a`'s stored output must survive the commit.
+    await engine.applyGraph({
+      ...spec,
+      nodes: [spec.nodes[0], { id: 'p', type: 'pass', params: {} }],
+    });
+    expect(engine.getOutput('a', 'n')).toBe(2);
+  });
+
+  it('distinguishes a real params change from a re-specified default', async () => {
+    const calls = freshCalls();
+    // `offset` defaults to 0, so omitting it and passing 0 must compare EQUAL —
+    // otherwise every re-apply would needlessly rebuild the world.
+    const withDefault: GraphSpec = { nodes: [{ id: 'a', type: 'counter' }], edges: [] };
+    const withExplicitZero: GraphSpec = {
+      nodes: [{ id: 'a', type: 'counter', params: { offset: 0 } }],
+      edges: [],
+    };
+    const engine = await startedEngine(withDefault, registryFor(calls));
+    expect((await engine.applyGraph(withExplicitZero)).kept).toEqual(['a']);
+    expect((await engine.applyGraph(withDefault)).kept).toEqual(['a']);
+    expect(calls.dispose).toEqual([]);
+  });
+
+  it('a type change on the same id is a replace, not a keep', async () => {
+    const calls = freshCalls();
+    const engine = await startedEngine(chain(), registryFor(calls));
+    const change = await engine.applyGraph({
+      nodes: [
+        { id: 'a', type: 'counter' },
+        { id: 'b', type: 'counter-b' },
+      ],
+      edges: [{ from: { node: 'a', port: 'n' }, to: { node: 'b', port: 'in' } }],
+    });
+    expect(change.kept).toEqual(['a']);
+    expect(change.replaced).toEqual(['b']);
+    expect(calls.init).toContain('counter-b:0');
+  });
+});
+
+// ---- 2. structural changes ------------------------------------------------
+
+describe('applyGraph — structural changes', () => {
+  it('adds a node: it is init\'d, the rest are kept', async () => {
+    const calls = freshCalls();
+    const engine = await startedEngine(chain(), registryFor(calls));
+    const change = await engine.applyGraph({
+      nodes: [...chain().nodes, { id: 'c', type: 'pass' }],
+      edges: [
+        ...chain().edges,
+        { from: { node: 'b', port: 'n' }, to: { node: 'c', port: 'in' } },
+      ],
+    });
+    expect(change.added).toEqual(['c']);
+    expect(change.kept.sort()).toEqual(['a', 'b']);
+    expect(change.rewired).toBe(true);
+    expect(engine.evaluationOrder()).toEqual(['a', 'b', 'c']);
+    engine.tick();
+    expect(engine.getOutput('c', 'out')).toBe(1);
+  });
+
+  it('removes a node: it is disposed and its outputs are dropped', async () => {
+    const calls = freshCalls();
+    const engine = await startedEngine(chain(), registryFor(calls));
+    engine.tick();
+    expect(engine.getOutput('b', 'n')).toBe(1);
+
+    const change = await engine.applyGraph({ nodes: [{ id: 'a', type: 'counter' }], edges: [] });
+    expect(change.removed).toEqual(['b']);
+    expect(change.kept).toEqual(['a']);
+    expect(calls.dispose).toEqual(['counter:0']);
+    expect(engine.getOutput('b', 'n')).toBeUndefined();
+    expect(engine.evaluationOrder()).toEqual(['a']);
+  });
+
+  it('rewires edges with every node kept, and recomputes the evaluation order', async () => {
+    const calls = freshCalls();
+    const spec: GraphSpec = {
+      nodes: [
+        { id: 'src', type: 'const', params: { value: 7 } },
+        { id: 'x', type: 'pass' },
+        { id: 'y', type: 'pass' },
+      ],
+      // src -> x -> y
+      edges: [
+        { from: { node: 'src', port: 'v' }, to: { node: 'x', port: 'in' } },
+        { from: { node: 'x', port: 'out' }, to: { node: 'y', port: 'in' } },
+      ],
+    };
+    const engine = await startedEngine(spec, registryFor(calls));
+    engine.tick();
+    expect(engine.getOutput('y', 'out')).toBe(7);
+
+    // src -> y -> x (reversed downstream half)
+    const change = await engine.applyGraph({
+      nodes: spec.nodes,
+      edges: [
+        { from: { node: 'src', port: 'v' }, to: { node: 'y', port: 'in' } },
+        { from: { node: 'y', port: 'out' }, to: { node: 'x', port: 'in' } },
+      ],
+    });
+    expect(change.kept.sort()).toEqual(['src', 'x', 'y']);
+    expect(change.rewired).toBe(true);
+    expect(calls.dispose).toEqual([]);
+    expect(engine.evaluationOrder()).toEqual(['src', 'y', 'x']);
+    engine.tick();
+    expect(engine.getOutput('x', 'out')).toBe(7);
+  });
+
+  it('reports rewired=false when the same edges arrive in a different order', async () => {
+    const calls = freshCalls();
+    const spec: GraphSpec = {
+      nodes: [
+        { id: 'src', type: 'const' },
+        { id: 'x', type: 'pass' },
+        { id: 'y', type: 'pass' },
+      ],
+      edges: [
+        { from: { node: 'src', port: 'v' }, to: { node: 'x', port: 'in' } },
+        { from: { node: 'src', port: 'v' }, to: { node: 'y', port: 'in' } },
+      ],
+    };
+    const engine = await startedEngine(spec, registryFor(calls));
+    const change = await engine.applyGraph({ nodes: spec.nodes, edges: [spec.edges[1], spec.edges[0]] });
+    expect(change.rewired).toBe(false);
+  });
+
+  it('keeps taps attached across a swap', async () => {
+    const calls = freshCalls();
+    const seen: string[] = [];
+    const tap: Tap = { onValue: (key) => void seen.push(key) };
+    const engine = new Engine(chain(), registryFor(calls), { taps: [tap] });
+    await engine.init();
+    engine.tick();
+    seen.length = 0;
+    await engine.applyGraph(chain(0, 5));
+    engine.tick();
+    expect(seen.sort()).toEqual(['a.n', 'b.n']);
+  });
+
+  it('preserves tick/time continuity across a swap (dt does not jump)', async () => {
+    const calls = freshCalls();
+    const dts: number[] = [];
+    const probe = defineNode({
+      type: 'dt-probe',
+      inputs: [],
+      outputs: [{ name: 'dt', kind: 'number' }],
+      params: z.object({}),
+      process: (_i, _p, ctx) => {
+        dts.push(ctx.dt);
+        return { dt: ctx.dt };
+      },
+    });
+    const spec: GraphSpec = { nodes: [{ id: 'd', type: 'dt-probe' }], edges: [] };
+    const engine = await startedEngine(spec, registryFor(calls, [probe]));
+    engine.tick(10);
+    engine.tick(10.5);
+    await engine.applyGraph({ nodes: [...spec.nodes, { id: 'c', type: 'const' }], edges: [] });
+    engine.tick(11);
+    expect(dts).toEqual([0, 0.5, 0.5]); // the swap did not reset lastTime
+  });
+});
+
+// ---- 3. the tick loop never freezes --------------------------------------
+
+describe('applyGraph — the old graph keeps ticking through a slow async init', () => {
+  it('evaluates the OLD graph for the whole prepare phase, then swaps atomically', async () => {
+    const calls = freshCalls();
+    let beginInit!: () => void;
+    let releaseInit!: () => void;
+    const initBegan = new Promise<void>((r) => {
+      beginInit = r;
+    });
+    const gate = new Promise<void>((r) => {
+      releaseInit = r;
+    });
+    const slow = defineNode({
+      type: 'slow-init',
+      inputs: [],
+      outputs: [{ name: 'v', kind: 'number' }],
+      params: z.object({}),
+      make() {
+        return {
+          init: async () => {
+            beginInit();
+            await gate;
+          },
+          process: () => ({ v: 42 }),
+        };
+      },
+    });
+
+    const engine = await startedEngine(chain(), registryFor(calls, [slow]));
+    engine.tick();
+    expect(calls.process).toHaveLength(2);
+
+    const pending = engine.applyGraph({
+      nodes: [...chain().nodes, { id: 's', type: 'slow-init' }],
+      edges: chain().edges,
+    });
+
+    await initBegan; // the new node's init is running; nothing has committed yet
+    expect(engine.evaluationOrder()).toEqual(['a', 'b']); // still the old graph
+    expect(engine.getOutput('s', 'v')).toBeUndefined();
+
+    // The instrument keeps playing while the model loads.
+    engine.tick();
+    engine.tick();
+    expect(calls.process).toHaveLength(6);
+    expect(engine.getOutput('a', 'n')).toBe(3);
+
+    releaseInit();
+    const change = await pending;
+
+    expect(change.added).toEqual(['s']);
+    expect(change.kept.sort()).toEqual(['a', 'b']);
+    // Independents sort alphabetically in the topo order, so the new source
+    // lands between a and b — the point is that all three are now in it.
+    expect(engine.evaluationOrder()).toEqual(['a', 's', 'b']);
+    engine.tick();
+    expect(engine.getOutput('s', 'v')).toBe(42);
+    expect(engine.getOutput('a', 'n')).toBe(4); // a never restarted
+  });
+
+  it('serializes overlapping applies; the last one wins and nothing leaks', async () => {
+    const calls = freshCalls();
+    const engine = await startedEngine(chain(), registryFor(calls));
+    const [first, second] = await Promise.all([
+      engine.applyGraph(chain(0, 10)),
+      engine.applyGraph(chain(0, 20)),
+    ]);
+    expect(first.replaced).toEqual(['b']);
+    expect(second.replaced).toEqual(['b']);
+    // b was built twice and the intermediate instance was disposed, not orphaned.
+    expect(calls.init).toEqual(['counter:0', 'counter:0', 'counter:10', 'counter:20']);
+    expect(calls.dispose).toEqual(['counter:0', 'counter:10']);
+    engine.tick();
+    expect(engine.getOutput('b', 'n')).toBe(21);
+  });
+});
+
+// ---- 4. a bad apply changes nothing --------------------------------------
+
+describe('applyGraph — failure leaves the running graph untouched', () => {
+  // [label, spec, expected error, instances the failed compile builds then discards].
+  // Only a spec that introduces a NEW node id constructs anything before failing;
+  // those instances must be disposed, and the LIVE ones never touched.
+  const badSpecs: Array<[string, GraphSpec, RegExp, number]> = [
+    [
+      'unknown node type',
+      { nodes: [{ id: 'a', type: 'counter' }, { id: 'z', type: 'ghost' }], edges: [] },
+      /unknown node type/,
+      0,
+    ],
+    [
+      'invalid params',
+      { nodes: [{ id: 'a', type: 'counter', params: { offset: 'nope' } }], edges: [] },
+      /invalid params/,
+      0,
+    ],
+    [
+      'edge to an unknown node',
+      {
+        nodes: [{ id: 'a', type: 'counter' }],
+        edges: [{ from: { node: 'a', port: 'n' }, to: { node: 'nope', port: 'in' } }],
+      },
+      /edge to unknown node/,
+      0,
+    ],
+    [
+      'edge to an undeclared port',
+      {
+        nodes: [
+          { id: 'a', type: 'counter' },
+          { id: 'b', type: 'counter' },
+        ],
+        edges: [{ from: { node: 'a', port: 'n' }, to: { node: 'b', port: 'nope' } }],
+      },
+      /has no input port/,
+      0,
+    ],
+    [
+      'fan-in to one input port',
+      {
+        nodes: [
+          { id: 'a', type: 'counter' },
+          { id: 'b', type: 'counter' },
+          { id: 'c', type: 'counter' },
+        ],
+        edges: [
+          { from: { node: 'a', port: 'n' }, to: { node: 'c', port: 'in' } },
+          { from: { node: 'b', port: 'n' }, to: { node: 'c', port: 'in' } },
+        ],
+      },
+      /fan-in/,
+      1, // `c` is new: built, then discarded when the fan-in is rejected
+    ],
+    [
+      'a cycle',
+      {
+        nodes: [
+          { id: 'a', type: 'counter' },
+          { id: 'b', type: 'counter' },
+        ],
+        edges: [
+          { from: { node: 'a', port: 'n' }, to: { node: 'b', port: 'in' } },
+          { from: { node: 'b', port: 'n' }, to: { node: 'a', port: 'in' } },
+        ],
+      },
+      /cycle/,
+      0,
+    ],
+    [
+      'duplicate node ids',
+      {
+        nodes: [
+          { id: 'a', type: 'counter' },
+          { id: 'a', type: 'counter-b' },
+        ],
+        edges: [],
+      },
+      /duplicate node id/,
+      0,
+    ],
+  ];
+
+  for (const [label, bad, pattern, discarded] of badSpecs) {
+    it(`rejects ${label} and keeps the running graph evaluating`, async () => {
+      const calls = freshCalls();
+      const engine = await startedEngine(chain(), registryFor(calls));
+      engine.tick();
+
+      await expect(engine.applyGraph(bad)).rejects.toThrow(pattern);
+
+      // Untouched: same order, same live instances, still ticking. Any dispose
+      // seen here belongs to a node the failed compile itself built.
+      expect(engine.evaluationOrder()).toEqual(['a', 'b']);
+      expect(calls.dispose).toHaveLength(discarded);
+      expect(engine.graphVersion()).toBe(0);
+      engine.tick();
+      expect(engine.getOutput('a', 'n')).toBe(2);
+      expect(engine.getOutput('b', 'n')).toBe(2);
+    });
+  }
+
+  it('disposes instances built by a failed compile instead of leaking them', async () => {
+    const calls = freshCalls();
+    const engine = await startedEngine(chain(), registryFor(calls));
+    // `c` compiles fine, then the cycle check fails — `c` must be torn down.
+    await expect(
+      engine.applyGraph({
+        nodes: [
+          { id: 'a', type: 'counter' },
+          { id: 'b', type: 'counter' },
+          { id: 'c', type: 'counter', params: { offset: 9 } },
+        ],
+        edges: [
+          { from: { node: 'b', port: 'n' }, to: { node: 'c', port: 'in' } },
+          { from: { node: 'c', port: 'n' }, to: { node: 'b', port: 'in' } },
+        ],
+      }),
+    ).rejects.toThrow(/cycle/);
+    expect(calls.dispose).toEqual(['counter:9']); // only the newly-built one
+    expect(calls.init).toHaveLength(2); // a + b, from the original init()
+  });
+
+  it('rolls back when a new node\'s init rejects, and the old graph plays on', async () => {
+    const calls = freshCalls();
+    const disposed: string[] = [];
+    const boom = defineNode({
+      type: 'boom-init',
+      inputs: [],
+      outputs: [{ name: 'v', kind: 'number' }],
+      params: z.object({}),
+      make() {
+        return {
+          init: async () => {
+            throw new Error('model failed to load');
+          },
+          process: () => ({ v: 1 }),
+          dispose: () => void disposed.push('boom'),
+        };
+      },
+    });
+    const engine = await startedEngine(chain(), registryFor(calls, [boom]));
+    engine.tick();
+
+    await expect(
+      engine.applyGraph({
+        nodes: [...chain().nodes, { id: 'x', type: 'boom-init' }],
+        edges: chain().edges,
+      }),
+    ).rejects.toThrow(/model failed to load/);
+
+    expect(disposed).toEqual(['boom']); // the half-built node was torn down
+    expect(calls.dispose).toEqual([]); // the running nodes were not
+    expect(engine.evaluationOrder()).toEqual(['a', 'b']);
+    expect(engine.graphVersion()).toBe(0);
+    engine.tick();
+    expect(engine.getOutput('a', 'n')).toBe(2);
+  });
+
+  it('a failed apply does not poison the queue for the next one', async () => {
+    const calls = freshCalls();
+    const engine = await startedEngine(chain(), registryFor(calls));
+    await expect(engine.applyGraph({ nodes: [{ id: 'a', type: 'ghost' }], edges: [] })).rejects.toThrow();
+    const change = await engine.applyGraph(chain(0, 3));
+    expect(change.replaced).toEqual(['b']);
+    expect(engine.graphVersion()).toBe(1);
+  });
+
+  it('refuses to apply to a disposed engine', async () => {
+    const calls = freshCalls();
+    const engine = await startedEngine(chain(), registryFor(calls));
+    engine.dispose();
+    await expect(engine.applyGraph(chain(1))).rejects.toThrow(/disposed/);
+  });
+});
+
+// ---- 5. lifecycle bookkeeping --------------------------------------------
+
+describe('applyGraph — bookkeeping', () => {
+  it('does not init new nodes before the engine itself has been init\'d', async () => {
+    const calls = freshCalls();
+    const engine = new Engine(chain(), registryFor(calls)); // no init() yet
+    await engine.applyGraph({
+      nodes: [...chain().nodes, { id: 'c', type: 'counter', params: { offset: 5 } }],
+      edges: chain().edges,
+    });
+    expect(calls.init).toEqual([]); // nothing running, nothing to keep alive
+
+    await engine.init(); // the deferred init covers the WHOLE graph, including 'c'
+    expect(calls.init.sort()).toEqual(['counter:0', 'counter:0', 'counter:5']);
+  });
+
+  it('waits for an in-flight init() before swapping the graph out from under it', async () => {
+    const calls = freshCalls();
+    let releaseInit!: () => void;
+    const gate = new Promise<void>((r) => {
+      releaseInit = r;
+    });
+    const slow = defineNode({
+      type: 'slow-boot',
+      inputs: [],
+      outputs: [{ name: 'v', kind: 'number' }],
+      params: z.object({}),
+      make: () => ({ init: () => gate, process: () => ({ v: 1 }) }),
+    });
+    const engine = new Engine(
+      { nodes: [{ id: 's', type: 'slow-boot' }, { id: 'a', type: 'counter' }], edges: [] },
+      registryFor(calls, [slow]),
+    );
+    const booting = engine.init();
+    // Ask for a rewire — removing one node and ADDING another — while init() is
+    // still walking the CURRENT order. The added node is the sharp case: if the
+    // apply committed mid-init it would see `started === false`, skip its own
+    // prepare phase, and the in-flight init() (already past that point in its
+    // own iteration) would never reach it, leaving `c` permanently un-init'd.
+    const applying = engine.applyGraph({
+      nodes: [
+        { id: 'a', type: 'counter' },
+        { id: 'c', type: 'counter', params: { offset: 7 } },
+      ],
+      edges: [],
+    });
+    releaseInit();
+    await booting;
+    const change = await applying;
+    expect(change.removed).toEqual(['s']);
+    expect(change.kept).toEqual(['a']);
+    expect(change.added).toEqual(['c']);
+    // init() completed on the full OLD graph first, then the apply init'd the new node.
+    expect(calls.init).toEqual(['counter:0', 'counter:7']);
+  });
+
+  it('bumps graphVersion on every committed apply and exposes the live spec', async () => {
+    const calls = freshCalls();
+    const engine = await startedEngine(chain(), registryFor(calls));
+    expect(engine.graphVersion()).toBe(0);
+    expect(engine.currentGraph().nodes.map((n) => n.id)).toEqual(['a', 'b']);
+
+    await engine.applyGraph(chain(0, 1));
+    expect(engine.graphVersion()).toBe(1);
+    await engine.applyGraph(chain(0, 1)); // a no-op apply still commits a version
+    expect(engine.graphVersion()).toBe(2);
+    expect(engine.currentGraph().nodes[1].params).toEqual({ offset: 1 });
+  });
+
+  it('currentGraph returns a fresh container that callers can safely modify', async () => {
+    const calls = freshCalls();
+    const engine = await startedEngine(chain(), registryFor(calls));
+    const snapshot = engine.currentGraph();
+    snapshot.nodes.push({ id: 'intruder', type: 'counter' });
+    expect(engine.currentGraph().nodes).toHaveLength(2);
+  });
+
+  it('disposes only the surviving-instance complement (no double dispose)', async () => {
+    const calls = freshCalls();
+    const engine = await startedEngine(chain(), registryFor(calls));
+    await engine.applyGraph({ nodes: [], edges: [] });
+    expect(calls.dispose).toEqual(['counter:0', 'counter:0']);
+    engine.dispose();
+    expect(calls.dispose).toHaveLength(2); // the emptied graph has nothing left to dispose
+  });
+
+  it('survives a node whose dispose throws', async () => {
+    const rude = defineNode({
+      type: 'rude',
+      inputs: [],
+      outputs: [{ name: 'v', kind: 'number' }],
+      params: z.object({}),
+      make: () => ({
+        process: () => ({ v: 1 }),
+        dispose: () => {
+          throw new Error('teardown exploded');
+        },
+      }),
+    });
+    const calls = freshCalls();
+    const logged: string[] = [];
+    const engine = new Engine({ nodes: [{ id: 'r', type: 'rude' }], edges: [] }, registryFor(calls, [rude]), {
+      log: (m) => void logged.push(m),
+    });
+    await engine.init();
+    const change = await engine.applyGraph({ nodes: [{ id: 'a', type: 'counter' }], edges: [] });
+    expect(change.removed).toEqual(['r']);
+    expect(logged.join()).toMatch(/dispose of node "r" \(rude\) threw/);
+    engine.tick();
+    expect(engine.getOutput('a', 'n')).toBe(1);
+  });
+});
+
+// ---- 6. the real production graph ----------------------------------------
+
+describe('applyGraph on the real instrument graph', () => {
+  /** A second, contract-satisfying mapping impl — the thing the `mapping` slot exists for. */
+  const altMapping = defineNode({
+    type: 'alt-mapping',
+    roles: ['mapping'],
+    inputs: [...MAPPING_SLOT_INPUTS],
+    outputs: [MAPPING_SLOT_OUTPUT],
+    process: () => ({ params: { voices: [] } }),
+  });
+
+  it('a mapping-slot swap replaces exactly one node and keeps the camera nodes', async () => {
+    const registry = createRegistry([...CORE_NODES, ...BROWSER_NODES, altMapping]);
+    // NB: no engine.init() — webcam-hands lazy-loads MediaPipe inside init(), which
+    // is exactly the cost this whole mechanism exists to avoid paying on a swap.
+    const engine = new Engine(defaultGraph(), registry);
+    const before = engine.evaluationOrder().length;
+
+    const change = await engine.applyGraph(defaultGraph({ mapping: 'alt-mapping' }, registry), registry);
+
+    expect(change.replaced).toEqual(['map']);
+    expect(change.added).toEqual([]);
+    expect(change.removed).toEqual([]);
+    // Every other production node — including the two MediaPipe sources — is kept.
+    expect(change.kept).toContain('cam');
+    expect(change.kept).toContain('camFace');
+    expect(change.kept).toContain('synth');
+    expect(change.kept).toHaveLength(before - 1);
+    // The swap is edge-stable: the mapping contract guarantees the port names.
+    expect(change.rewired).toBe(false);
+    expect(engine.evaluationOrder()).toHaveLength(before);
+  });
+
+  it('swapping back restores the default mapping, still keeping everything else', async () => {
+    const registry = createRegistry([...CORE_NODES, ...BROWSER_NODES, altMapping]);
+    const engine = new Engine(defaultGraph(), registry);
+    await engine.applyGraph(defaultGraph({ mapping: 'alt-mapping' }, registry), registry);
+    const change = await engine.applyGraph(defaultGraph(), registry);
+    expect(change.replaced).toEqual(['map']);
+    expect(engine.currentGraph().nodes.find((n) => n.id === 'map')?.type).toBe('voice-mapping');
+    expect(engine.graphVersion()).toBe(2);
+  });
+
+  it('re-applying the production graph is a pure no-op (every node kept)', async () => {
+    const engine = new Engine(defaultGraph(), createAppRegistry());
+    const change = await engine.applyGraph(defaultGraph());
+    expect(change.added).toEqual([]);
+    expect(change.removed).toEqual([]);
+    expect(change.replaced).toEqual([]);
+    expect(change.rewired).toBe(false);
+    expect(change.kept).toHaveLength(engine.evaluationOrder().length);
+  });
+
+  it('a non-conforming swap is caught by resolveSlot, so the engine never sees it', async () => {
+    const registry = createAppRegistry();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const engine = new Engine(defaultGraph(), registry);
+    // indirect-map carries role:mapping but emits `steer`, not `params`.
+    const change = await engine.applyGraph(defaultGraph({ mapping: 'indirect-map' }, registry), registry);
+    expect(change.replaced).toEqual([]); // fell back to voice-mapping → nothing changed
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});

--- a/test/engine_lifecycle.test.ts
+++ b/test/engine_lifecycle.test.ts
@@ -704,6 +704,153 @@ describe('applyGraph — bookkeeping', () => {
   });
 });
 
+// ---- 5b. teardown racing a swap ------------------------------------------
+
+describe('applyGraph vs dispose (found by adversarial review)', () => {
+  /** A node whose init blocks on a gate the test controls. */
+  function gatedNode(type: string, calls: Calls, gate: Promise<void>, began?: () => void) {
+    return defineNode({
+      type,
+      inputs: [],
+      outputs: [{ name: 'v', kind: 'number' }],
+      params: z.object({}),
+      make: () => ({
+        init: async () => {
+          calls.init.push(type);
+          began?.();
+          await gate;
+        },
+        process: () => ({ v: 1 }),
+        dispose: () => void calls.dispose.push(type),
+      }),
+    });
+  }
+
+  it('a dispose() landing DURING prepare aborts the commit and releases what it built', async () => {
+    const calls = freshCalls();
+    let beginInit!: () => void;
+    let releaseInit!: () => void;
+    const began = new Promise<void>((r) => {
+      beginInit = r;
+    });
+    const gate = new Promise<void>((r) => {
+      releaseInit = r;
+    });
+    const engine = await startedEngine(
+      chain(1, 2),
+      registryFor(calls, [gatedNode('slow-swap', calls, gate, beginInit)]),
+    );
+
+    const pending = engine.applyGraph({
+      nodes: [...chain(1, 2).nodes, { id: 's', type: 'slow-swap' }],
+      edges: chain(1, 2).edges,
+    });
+    await began; // the new node's init is in flight
+
+    // The React unmount lands on top of the in-flight swap.
+    engine.dispose();
+    expect(calls.dispose).toEqual(['counter:1', 'counter:2']);
+
+    releaseInit();
+    await expect(pending).rejects.toThrow(/disposed while applyGraph was preparing/);
+
+    // The instance PREPARE built was released, not stranded on a dead engine —
+    // in production that is a MediaPipe landmarker with a live inference loop.
+    expect(calls.dispose).toEqual(['counter:1', 'counter:2', 'slow-swap']);
+    // ...and the running nodes were not torn down a second time.
+    expect(calls.dispose.filter((d) => d === 'counter:1')).toHaveLength(1);
+    // Nothing was committed.
+    expect(engine.graphVersion()).toBe(0);
+    expect(engine.evaluationOrder()).toEqual(['a', 'b']);
+  });
+
+  it('a dispose() during init() stops the boot instead of initing already-disposed nodes', async () => {
+    const calls = freshCalls();
+    let beginInit!: () => void;
+    let releaseInit!: () => void;
+    const began = new Promise<void>((r) => {
+      beginInit = r;
+    });
+    const gate = new Promise<void>((r) => {
+      releaseInit = r;
+    });
+    const engine = new Engine(
+      { nodes: [{ id: 'a', type: 'slow-boot' }, { id: 'z', type: 'counter', params: { offset: 4 } }], edges: [] },
+      registryFor(calls, [gatedNode('slow-boot', calls, gate, beginInit)]),
+    );
+    const booting = engine.init();
+    await began;
+    engine.dispose();
+    releaseInit();
+    await booting;
+    // `z` was disposed by dispose(); the boot must not have gone on to init it.
+    expect(calls.init).toEqual(['slow-boot']);
+    expect(calls.dispose).toEqual(['slow-boot', 'counter:4']);
+  });
+});
+
+// ---- 5c. teardown is best-effort and idempotent ---------------------------
+
+describe('dispose', () => {
+  const boom = defineNode({
+    type: 'boom-dispose',
+    inputs: [],
+    outputs: [{ name: 'v', kind: 'number' }],
+    params: z.object({}),
+    make: () => ({
+      process: () => ({ v: 1 }),
+      dispose: () => {
+        throw new Error('teardown exploded');
+      },
+    }),
+  });
+
+  it('does not let one throwing node strand the nodes after it', async () => {
+    // The sinks sort LAST in topological order, so aborting here is the worst
+    // case there is: the synth keeps sounding and midi-out never sends its
+    // all-notes-off. It also runs inside the host's own cleanup, where an
+    // escaping throw would skip stopping the camera tracks.
+    const calls = freshCalls();
+    const logged: string[] = [];
+    const engine = new Engine(
+      {
+        nodes: [
+          { id: 'a', type: 'counter', params: { offset: 1 } },
+          { id: 'b', type: 'boom-dispose' },
+          { id: 'c', type: 'counter', params: { offset: 3 } },
+        ],
+        edges: [],
+      },
+      registryFor(calls, [boom]),
+      { log: (m) => void logged.push(m) },
+    );
+    await engine.init();
+    expect(() => engine.dispose()).not.toThrow();
+    expect(calls.dispose).toEqual(['counter:1', 'counter:3']); // c survived b's throw
+    expect(logged.join()).toMatch(/dispose of node "b" \(boom-dispose\) threw/);
+  });
+
+  it('is idempotent', async () => {
+    const calls = freshCalls();
+    const engine = await startedEngine(chain(1, 2), registryFor(calls));
+    engine.dispose();
+    engine.dispose();
+    engine.dispose();
+    expect(calls.dispose).toEqual(['counter:1', 'counter:2']);
+  });
+
+  it('makes tick() a no-op, so an already-scheduled frame cannot run on freed handles', async () => {
+    const calls = freshCalls();
+    const engine = await startedEngine(chain(1, 2), registryFor(calls));
+    engine.tick();
+    const processes = calls.process.length;
+    engine.dispose();
+    engine.tick(); // the rAF frame that was already queued at unmount
+    engine.tick();
+    expect(calls.process).toHaveLength(processes);
+  });
+});
+
 // ---- 6. the real production graph ----------------------------------------
 
 describe('applyGraph on the real instrument graph', () => {


### PR DESCRIPTION
`useEngine` built `new Engine(defaultGraph(), ...)` once and there was no way back. Changing one node type meant constructing a second `Engine`, which re-runs **every** node's `init()` — which reloads the MediaPipe hand and face models and rebuilds the audio graph. Paying several seconds of black screen and silence to change one mapping node is not a config flip; it is a restart.

That is the unbuilt third bullet of #51:

> Engine lifecycle on swap: dispose old node, build/init new (handle async `init()` — camera/model loads — without freezing the tick loop).

and it is the wall that node-swap slots (#51), the M-C source slot (#104), the Applier (#101 M-D) and the React Flow patcher (#14) all stop at.

## What this adds

`Engine.applyGraph(spec, registry?)` reconciles a **running** engine onto a new `GraphSpec` in place and returns a `GraphChange` (`added` / `removed` / `replaced` / `kept` / `rewired`).

- **Identity is `id` + `type` + *validated* params.** Comparing the Zod-parsed params rather than the raw spec is what makes `{}` and `{ offset: 0 }` the same node — otherwise every re-apply would rebuild the world.
- **Kept means kept**: the same live instance, `init()` not re-run, internal state (loaded model, smoothing history, sounding voices) intact, and its last outputs still standing so downstream sees no one-tick hole.
- **Three phases, because `init()` is async:**
  1. **Plan** (sync) — compile the whole next graph: resolve types, validate params, validate every edge, topo-sort. Anything invalid throws *here*, before a single live instance is touched, so a bad spec is a no-op.
  2. **Prepare** (async) — `init()` only the new instances, in the new topological order. **The old graph keeps ticking for this entire phase.** That is what "without freezing the tick loop" means.
  3. **Commit** (sync) — swap node map / order / outputs / spec in one synchronous block, then dispose exactly the instances the new graph does not run. `tick()` is synchronous and JS is single-threaded, so no tick can observe a half-swapped graph.
- A rejected `init` tears down the half-built graph and the running one plays on. Overlapping applies serialize. An apply waits out an in-flight `init()`.

Also, the adoption guard the Stream Applier design asks for at M-D: **`RealtimeClock` now rejects a non-finite or non-positive speed.** A speed of `0` pins engine time to `base` forever, so every tick gets `dt === 0` while frames keep arriving — smoothing filters and note envelopes stop advancing and the instrument looks *hung*, not paused.

## Internals

The private `build` / `validateEdge` / `topoSort` became module-level `compile` / `validateEdge` / `topoSort`, shared by the constructor and `applyGraph`. `BuiltNode` carries its validated params. `init()` memoizes its promise. No behaviour change on the existing paths — `runHeadless`, the fixture-replay goldens and every existing engine test are untouched and green.

## Verification

- **34 new headless tests** (`test/engine_lifecycle.test.ts`). The mechanism is proved on synthetic nodes where `init`/`dispose`/`process` calls are counted exactly (including a gated slow `init`, to assert the old graph really does keep evaluating for the whole prepare phase); the classification is then checked against the **real** `defaultGraph()` — a mapping-slot swap replaces exactly `map` and keeps `cam`, `camFace` and everything else.
- **A 9-mutant mutation harness** confirms each protection has a test that fails without it: params-equality, commit-before-prepare, init-rollback, apply serialization, kept-outputs, the in-flight-init wait, stale-instance disposal, failed-compile cleanup, and the clock speed guard. 9/9 caught.
- `npm run typecheck` clean, `npm test` 1094 passed, `npm run build` green.

## Reachability

No user-facing surface, deliberately: this is engine machinery. Its first consumer is the follow-up PR (`useEngine` adopting the Clock and a slot selection); a player-facing swap dropdown is still gated on the component-model rule that a role needs >= 2 real implementations.

Refs #51, #101, #104, #14.
