### PR TITLE
#101 M-D (first half): the live loop runs on the Clock, and the graph on a slot selection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,7 +196,8 @@ So, when you add a user-facing capability:
 | DAG engine (framework-agnostic) | `src/dag/` (`engine.ts`, `types.ts`, `registry.ts`, `recorder.ts`, `clock.ts`) |
 | Node library | `src/nodes/{sources,features,mapping,music,output}/` |
 | Default graph wiring | `src/app/graph.ts` |
-| React↔DAG bridge (webcam, AudioContext, rAF, recorder) | `src/app/useEngine.ts` |
+| React↔DAG bridge (webcam, AudioContext, recorder, slot selection) | `src/app/useEngine.ts` |
+| Live frame loop — the app's `Clock` adoption (tick + per-frame reporters + frame-drop guard) | `src/app/engineLoop.ts` |
 | Live control store (zustand+persist) — the hot per-tick mirror | `src/app/store.ts` |
 | Music theory + **sounds** (timbre presets) | `src/music/` (`theory.ts`, `sounds.ts`, `voicing.ts`, `expression.ts`) |
 | Overlay (compose elements here) | `src/nodes/output/canvas_overlay.ts` |

--- a/docs/design/stream-applier.md
+++ b/docs/design/stream-applier.md
@@ -188,8 +188,8 @@ The Applier also injects `resources.stateReader = { get: (n, p) => engine.getOut
 Each milestone is a small shippable PR set, headless-verifiable where the
 boundaries allow.
 
-- **M-A — Camera-free file video (R6). ⭐ Unblocks camera-free overlay/palette
-  verification.** Pure host wiring, **no engine code**: `?source=video&video=<url>`
+- **M-A — Camera-free file video (R6). ✅ shipped. ⭐ Unblocks camera-free
+  overlay/palette verification.** Pure host wiring, **no engine code**: `?source=video&video=<url>`
   → skip `getUserMedia`, feed a `<video src loop muted>` into `resources.video`;
   webcam nodes run unchanged. Real guards: `loop` **required** (the
   `currentTime !== lastVideoTime` gate freezes on a non-advancing clip),
@@ -219,6 +219,13 @@ boundaries allow.
   rAF loop adopts `RealtimeClock(1)`** (deferred from M-B).
   **Gate on a browser smoke test** — the effect (StrictMode guards, face bridge,
   mute mirror, AudioContext lifecycle) has no headless coverage.
+  - ✅ **The live loop now runs on `RealtimeClock(1)`** — `src/app/engineLoop.ts`
+    (`runEngineLoop`) replaced `useEngine`'s hand-rolled rAF recursion. Splitting
+    the loop out of the hook is what let the deferral be lifted early: the tick,
+    the report fan-out, the frame-drop guard and the stop condition are all
+    headlessly tested (`test/engine_loop.test.ts`) with an injected clock, so what
+    remains for the browser smoke test is only the *effect* (StrictMode guards,
+    camera acquisition, AudioContext lifecycle) — not pacing.
   - ✅ **`speed > 0` validation done** — `RealtimeClock` now throws a `RangeError`
     on a non-finite or non-positive speed rather than shipping a frozen clock
     (a speed of 0 pins engine time to `base`, so every tick gets `dt === 0` while

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -13,6 +13,7 @@ import { useEffect } from 'react';
 import { Play, VolumeX } from 'lucide-react';
 import { useThoreminEngine } from './useEngine';
 import { DEFAULT_SOURCE, type SourceSpec } from './sourceSpec';
+import { NO_SLOTS, type SlotSelection } from './graph';
 import { installKeyboardShortcuts } from './keyboardShortcuts';
 import { installTaggingKeymap } from './tagging/keymap';
 import { useControls } from './store';
@@ -83,9 +84,16 @@ function MutedBadge() {
   );
 }
 
-export default function App({ source = DEFAULT_SOURCE }: { source?: SourceSpec }) {
+export default function App({
+  source = DEFAULT_SOURCE,
+  slots = NO_SLOTS,
+}: {
+  source?: SourceSpec;
+  /** Developer-facing node-swap selection (`?slot.<name>=<type>`); see `graph.ts`. */
+  slots?: SlotSelection;
+}) {
   const { videoRef, canvasRef, status, error, audioOn, startAudio, recording } =
-    useThoreminEngine(source);
+    useThoreminEngine(source, slots);
 
   // #90: install the keyboard shortcuts (octave / magnetism / mute) — an app-level
   // tinykeys keymap dispatching dial commands, replacing the retired in-DAG switch.

--- a/src/app/engineLoop.ts
+++ b/src/app/engineLoop.ts
@@ -1,0 +1,70 @@
+/**
+ * The live frame loop — one engine tick per frame, then the React status bridges.
+ *
+ * This is the app side of the Clock seam (Stream Applier M-B, `src/dag/clock.ts`).
+ * `useEngine` used to hand-roll its own `requestAnimationFrame` recursion, which
+ * meant the shipped `RealtimeClock` was exercised only by its own unit tests
+ * while the code players actually run took a different path. Driving the live
+ * loop from a `Clock` makes pacing one thing again: batch and paced runs differ
+ * by which `Clock` they pass, not by which loop they wrote.
+ *
+ * It lives in its own module rather than inside the hook so the loop's real
+ * behaviour — the tick, the report fan-out, the frame-drop guard, the stop
+ * condition — is testable in plain Node with an injected clock, instead of
+ * needing a browser, a camera and a loaded ML model.
+ */
+import { RealtimeClock, type Clock } from '@/dag';
+
+/** Called once per frame with the frame's time in **milliseconds**. */
+export type FrameReporter = (nowMs: number) => void;
+
+export interface EngineLoopOptions {
+  /** Pacing. Defaults to a wall-clock `RealtimeClock` at speed 1 (rAF-driven). */
+  clock?: Clock;
+  /** Where a dropped frame is reported. Defaults to `console.error`. */
+  onError?: (err: unknown) => void;
+  /** Wall-clock reader in **seconds**, used only if the clock omits the tick time. */
+  now?: () => number;
+}
+
+/** The engine surface the loop needs — narrowed so tests can pass a stub. */
+export interface Tickable {
+  tick(time?: number): void;
+}
+
+/**
+ * Drive `engine` from a {@link Clock} until `shouldStop()` returns true, calling
+ * each reporter after every successful tick. Resolves when the loop stops.
+ *
+ * **One bad frame must never stop the instrument.** A node throwing on a single
+ * frame (a degenerate value, a transient DOM/audio state) is caught here, that
+ * frame is dropped, and the loop continues — so audio and video recover instead
+ * of freezing permanently. Reporters run inside the same guard, matching the
+ * previous inline loop: a throwing reporter costs the rest of that frame's
+ * reports, not the session.
+ */
+export function runEngineLoop(
+  engine: Tickable,
+  reporters: readonly FrameReporter[],
+  shouldStop: () => boolean,
+  opts: EngineLoopOptions = {},
+): Promise<void> {
+  const clock = opts.clock ?? new RealtimeClock();
+  const now = opts.now ?? (() => performance.now() / 1000);
+  const onError =
+    opts.onError ?? ((err: unknown) => console.error('[thoremin] engine tick error (frame dropped)', err));
+
+  return clock.run((t) => {
+    try {
+      // A clock may drive the engine on synthesized time (BatchClock passes no
+      // argument); the reporters still need a real millisecond stamp, so fall
+      // back to the wall clock for them rather than inventing one.
+      const seconds = t ?? now();
+      engine.tick(seconds);
+      const ms = seconds * 1000;
+      for (const report of reporters) report(ms);
+    } catch (err) {
+      onError(err);
+    }
+  }, shouldStop);
+}

--- a/src/app/graph.ts
+++ b/src/app/graph.ts
@@ -56,6 +56,45 @@ export const SLOTS: Record<string, SlotDef> = {
 /** Per-slot chosen node types (keys ⊆ SLOTS keys); all optional → defaults used. */
 export type SlotSelection = Partial<Record<keyof typeof SLOTS, string>>;
 
+/** Nothing selected — every slot uses its default. A module constant so passing
+ *  "no selection" does not create a new object identity on every render. */
+export const NO_SLOTS: SlotSelection = Object.freeze({});
+
+/**
+ * Parse a URL query string into a {@link SlotSelection}: `?slot.<slotName>=<nodeType>`,
+ * e.g. `?slot.mapping=voice-mapping`. Unknown `slot.*` keys and blank values are
+ * ignored; an invalid *node type* is not rejected here but by {@link resolveSlot},
+ * which warns and falls back to the slot default.
+ *
+ * This is a **developer-facing** seam, deliberately, and the same shape as M-A's
+ * `?source=video` (`src/app/sourceSpec.ts`): graphs are data, so selecting one
+ * belongs in the URL. Per the component-model governance rule, a slot earns a
+ * player-facing settings dropdown only once its role has >= 2 real
+ * implementations — `mapping` has one today.
+ *
+ * @param search a `location.search` string (leading `?` optional).
+ */
+export function parseSlotSelection(search: string): SlotSelection {
+  const params = new URLSearchParams(search);
+  const selection: SlotSelection = {};
+  for (const key of Object.keys(SLOTS) as (keyof typeof SLOTS)[]) {
+    const chosen = params.get(`slot.${key}`)?.trim();
+    if (chosen) selection[key] = chosen;
+  }
+  return selection;
+}
+
+/**
+ * A stable, order-independent string identity for a selection — so React effects
+ * can depend on *what was selected* rather than on the object's identity (which
+ * changes on every render and would tear the engine down each time).
+ */
+export function slotSelectionKey(selection: SlotSelection = NO_SLOTS): string {
+  return (Object.keys(SLOTS) as (keyof typeof SLOTS)[])
+    .map((k) => `${k}=${selection[k] ?? ''}`)
+    .join('&');
+}
+
 /**
  * Why a node type does NOT satisfy a slot, or `null` if it does. Checks, in order:
  * registered, carries the slot role, emits the slot's output port+kind, and

--- a/src/app/useEngine.ts
+++ b/src/app/useEngine.ts
@@ -1,14 +1,23 @@
 /**
  * useThoreminEngine — the React ↔ DAG bridge. Owns the webcam, the AudioContext
- * (created lazily on a user gesture, as browsers require), builds the default
- * graph against the browser registry, runs `engine.init()` (loads the ML model)
- * and drives `engine.tick()` from a requestAnimationFrame loop. The engine and
- * its nodes do the real work; this hook just supplies host resources and timing.
+ * (created lazily on a user gesture, as browsers require), builds the graph
+ * against the browser registry, runs `engine.init()` (loads the ML model) and
+ * drives `engine.tick()` from a {@link Clock}. The engine and its nodes do the
+ * real work; this hook just supplies host resources and timing.
+ *
+ * Two seams the hook deliberately does NOT own:
+ *  - **Pacing** is a `Clock` (`src/dag/clock.ts`), driven via `runEngineLoop`.
+ *    The hook used to hand-roll its own rAF recursion, which left the shipped
+ *    `RealtimeClock` exercised only by unit tests while players ran other code.
+ *  - **Which graph** comes from a {@link SlotSelection}. A change to it re-wires
+ *    the LIVE engine via `Engine.applyGraph` — it does not rebuild the engine,
+ *    so the camera is not re-acquired and the ML models are not reloaded.
  */
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Engine } from '@/dag';
 import { createAppRegistry } from '@/nodes/browser';
-import { defaultGraph } from './graph';
+import { defaultGraph, slotSelectionKey, NO_SLOTS, type SlotSelection } from './graph';
+import { runEngineLoop } from './engineLoop';
 import { DEFAULT_SOURCE, type SourceSpec } from './sourceSpec';
 import { useControls } from './store';
 import { LiveVectorTap, resetLiveVector } from './enroll/liveVector';
@@ -65,7 +74,21 @@ function loadRecordingSession(): RecordingSession {
  * active take (HUD), or the brief save/convert step after Stop. */
 export type RecordingPhase = 'idle' | 'settings' | 'recording' | 'saving';
 
-export function useThoreminEngine(source: SourceSpec = DEFAULT_SOURCE) {
+/**
+ * Report a failed re-wire — unless the engine was torn down while the swap was
+ * still preparing. `applyGraph` rejects that case by design (it releases what it
+ * built rather than committing onto a dead engine), and it is the ordinary
+ * unmount / StrictMode remount path, so logging it would cry wolf on every
+ * teardown that happens to overlap a swap. `live` is the hook's engine ref: it is
+ * nulled by the same cleanup that disposes, so a mismatch means "we were torn
+ * down", which is exactly the case to stay quiet about.
+ */
+function reportApplyFailure(engine: Engine, live: Engine | null, err: unknown): void {
+  if (live !== engine) return;
+  console.error('[thoremin] could not apply the slot selection', err);
+}
+
+export function useThoreminEngine(source: SourceSpec = DEFAULT_SOURCE, slots: SlotSelection = NO_SLOTS) {
   const videoRef = useRef<HTMLVideoElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const engineRef = useRef<Engine | null>(null);
@@ -77,7 +100,10 @@ export function useThoreminEngine(source: SourceSpec = DEFAULT_SOURCE) {
   const sessionRecRef = useRef<SessionRecorder | null>(null);
   const recInstrumentRef = useRef<string>('thoremin');
   const recBusyRef = useRef(false);
-  const rafRef = useRef<number | null>(null);
+  // The registry the live engine was built against — `applyGraph` must resolve
+  // node types against the SAME one, or a swap would compare against a different
+  // set of definitions than the running graph was validated with.
+  const registryRef = useRef<ReturnType<typeof createAppRegistry> | null>(null);
 
   const [status, setStatus] = useState<EngineStatus>('idle');
   const [error, setError] = useState<string | null>(null);
@@ -88,6 +114,13 @@ export function useThoreminEngine(source: SourceSpec = DEFAULT_SOURCE) {
 
   const masterVolume = useControls((s) => s.masterVolume);
   const muted = useControls((s) => s.muted);
+
+  // The slot selection is read through a ref inside the (source-keyed) build
+  // effect, so a selection that changes while the engine is still booting is
+  // still the one it gets built with; `slotsKey` drives the live re-wire below.
+  const slotsRef = useRef(slots);
+  slotsRef.current = slots;
+  const slotsKey = slotSelectionKey(slots);
 
   useEffect(() => {
     let disposed = false;
@@ -196,7 +229,13 @@ export function useThoreminEngine(source: SourceSpec = DEFAULT_SOURCE) {
         // (the trainer, while a cue runs) has claimed, even with the Lab closed.
         resources.featureDemand = featureDemandResource;
 
-        const engine = new Engine(defaultGraph(), createAppRegistry(), { resources });
+        const registry = createAppRegistry();
+        registryRef.current = registry;
+        // `defaultGraph` validates the selection against the registry and falls
+        // back (with a warning) on anything that would not satisfy the slot
+        // contract, so a stale URL can never produce an unbuildable graph.
+        let builtKey = slotSelectionKey(slotsRef.current);
+        const engine = new Engine(defaultGraph(slotsRef.current, registry), registry, { resources });
 
         // Trainer mode (#160) needs to see the same feature vector the Lab meters read.
         // Attached once, for the engine's whole life: it is one object spread per tick
@@ -213,6 +252,15 @@ export function useThoreminEngine(source: SourceSpec = DEFAULT_SOURCE) {
         }
         engineRef.current = engine;
         setStatus('ready');
+
+        // The selection may have changed during the model load, while the
+        // re-wire effect below had no engine to talk to yet. Reconcile once.
+        if (slotSelectionKey(slotsRef.current) !== builtKey) {
+          builtKey = slotSelectionKey(slotsRef.current);
+          void engine
+            .applyGraph(defaultGraph(slotsRef.current, registry), registry)
+            .catch((err) => reportApplyFailure(engine, engineRef.current, err));
+        }
 
         // Bridge the face model's status + classified expression from the DAG
         // back to React for the indicator/readout (#65), throttled so the bars
@@ -282,25 +330,13 @@ export function useThoreminEngine(source: SourceSpec = DEFAULT_SOURCE) {
           lastPosesKey = key;
         };
 
-        const loop = () => {
-          // Guard the tick: one node throwing on a frame (e.g. a degenerate
-          // value) must never stop the loop — drop that frame and keep going,
-          // so audio + video recover instead of freezing permanently.
-          try {
-            const t = performance.now();
-            engine.tick(t / 1000);
-            reportFace(t);
-            reportMidi(t);
-            reportGesture(t);
-            // (#90) Mute is now a store flag toggled by the app-level keyboard
-            // handler (the `m` key → toggleMuted) and flows INTO the graph via
-            // store-controls, so there is no longer a graph→store mute mirror here.
-          } catch (err) {
-            console.error('[thoremin] engine tick error (frame dropped)', err);
-          }
-          rafRef.current = requestAnimationFrame(loop);
-        };
-        rafRef.current = requestAnimationFrame(loop);
+        // Pacing lives in the Clock, the frame-drop guard and the report fan-out
+        // in `runEngineLoop` (headlessly tested); the stop condition is the same
+        // `disposed` flag the rest of this effect's cleanup uses.
+        // (#90) Mute is a store flag toggled by the app-level keyboard handler
+        // (the `m` key → toggleMuted) and flows INTO the graph via store-controls,
+        // so there is no graph→store mute mirror in the loop.
+        void runEngineLoop(engine, [reportFace, reportMidi, reportGesture], () => disposed);
       } catch (e) {
         if (disposed) return;
         console.error('[thoremin] engine setup failed', e);
@@ -310,13 +346,12 @@ export function useThoreminEngine(source: SourceSpec = DEFAULT_SOURCE) {
     })();
 
     return () => {
+      // Setting `disposed` is what stops the loop: the clock polls it before
+      // every frame, so an already-scheduled frame resolves without ticking.
       disposed = true;
-      if (rafRef.current !== null) {
-        cancelAnimationFrame(rafRef.current);
-        rafRef.current = null;
-      }
       engineRef.current?.dispose();
       engineRef.current = null;
+      registryRef.current = null;
       useFaceStatus.getState().reset();
       resetLiveVector();
       useMidiStatus.getState().reset();
@@ -345,6 +380,23 @@ export function useThoreminEngine(source: SourceSpec = DEFAULT_SOURCE) {
     // Primitive deps (not the SourceSpec object) so a stable selection doesn't
     // re-run the effect; a genuine source change tears down and re-acquires.
   }, [source.kind, source.kind === 'video' ? source.url : null]);
+
+  // Re-wire the LIVE engine when the slot selection changes. Deliberately NOT a
+  // dependency of the build effect above: rebuilding the engine would re-acquire
+  // the camera and reload both MediaPipe models to change one node. `applyGraph`
+  // keeps every unchanged node (#51), so a mapping swap is one node rebuilt and
+  // the instrument keeps playing through it.
+  //
+  // On mount this finds no engine yet and no-ops — correct, because the build
+  // effect reads the current selection through `slotsRef` when it constructs.
+  useEffect(() => {
+    const engine = engineRef.current;
+    const registry = registryRef.current;
+    if (!engine || !registry) return;
+    void engine
+      .applyGraph(defaultGraph(slotsRef.current, registry), registry)
+      .catch((err) => reportApplyFailure(engine, engineRef.current, err));
+  }, [slotsKey]);
 
   // Keep master gain synced to the UI volume, and drop it to zero while muted.
   // This is the host-level catch-all mute (belt-and-suspenders with the in-graph

--- a/src/dag/clock.ts
+++ b/src/dag/clock.ts
@@ -15,10 +15,12 @@
  *   - {@link RealtimeClock} — wall-clock paced, with a speed multiplier
  *                             (real-time playback, accelerated/slowed scrub).
  *
- * A future `Applier` (M-D) will own building the engine, wiring sources/sinks
- * and picking a clock; for now `runHeadless` uses `BatchClock` and the live
- * `useEngine` rAF loop is refit onto `RealtimeClock` when the Applier lands
- * (deferred here because that surface has no headless test — see the design doc).
+ * Both are in use: `runHeadless` (`src/dag/index.ts`) drives a `BatchClock`, and
+ * the live browser loop drives a `RealtimeClock` at speed 1 via `runEngineLoop`
+ * (`src/app/engineLoop.ts`), which is where `useEngine`'s hand-rolled
+ * requestAnimationFrame recursion used to be. A future `Applier` (M-D) will own
+ * building the engine, wiring sources/sinks and picking a clock; the clock seam
+ * it needs is already the one both paths run on.
  */
 
 /** Drives an engine tick callback until a stop condition is met. */

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,16 +11,22 @@
  *
  * `?source=video&video=<url>` runs the DAG view camera-free from a pre-recorded
  * clip (Stream Applier M-A); see {@link parseSourceSpec}.
+ *
+ * `?slot.<name>=<nodeType>` (e.g. `?slot.mapping=voice-mapping`) picks which
+ * implementation fills a role-typed swap point in the graph — a developer-facing
+ * seam; see {@link parseSlotSelection}.
  */
 import {StrictMode, Suspense, lazy} from 'react';
 import {createRoot} from 'react-dom/client';
 import DagApp from './app/App.tsx';
 import {parseSourceSpec} from './app/sourceSpec';
+import {parseSlotSelection} from './app/graph';
 import './index.css';
 
 const engineParam = new URLSearchParams(window.location.search).get('engine');
 const useLegacyEngine = engineParam === 'legacy' || engineParam === 'classic';
 const source = parseSourceSpec(window.location.search);
+const slots = parseSlotSelection(window.location.search);
 
 const LegacyApp = lazy(() => import('./App.tsx'));
 
@@ -31,7 +37,7 @@ createRoot(document.getElementById('root')!).render(
         <LegacyApp />
       </Suspense>
     ) : (
-      <DagApp source={source} />
+      <DagApp source={source} slots={slots} />
     )}
   </StrictMode>,
 );

--- a/test/engine_loop.test.ts
+++ b/test/engine_loop.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Tests the live frame loop (`src/app/engineLoop.ts`) — the app's adoption of the
+ * Clock seam (Stream Applier M-B/M-D).
+ *
+ * `useEngine` used to hand-roll its own `requestAnimationFrame` recursion, so the
+ * shipped `RealtimeClock` was dead code in production and the loop's real
+ * behaviour — the frame-drop guard especially — had no coverage at all. Pulling
+ * the loop into its own module with an injectable clock makes all of it testable
+ * in plain Node: no browser, no camera, no ML model.
+ *
+ * The invariant worth the most here is the frame-drop guard: one node throwing on
+ * one frame must never stop the instrument. Before this, that `try/catch` lived
+ * inside a closure inside an async IIFE inside a React effect, where nothing
+ * could reach it.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { BatchClock, RealtimeClock, type Clock } from '../src/dag';
+import { runEngineLoop, type Tickable } from '@/app/engineLoop';
+
+/** A controllable stand-in for requestAnimationFrame. */
+function fakeScheduler() {
+  let pending: (() => void) | null = null;
+  return {
+    schedule: (cb: () => void) => {
+      pending = cb;
+    },
+    flush(n: number) {
+      for (let i = 0; i < n; i++) {
+        const cb = pending;
+        pending = null;
+        if (!cb) return;
+        cb();
+      }
+    },
+  };
+}
+
+/** Records the times the engine was ticked at. */
+function recordingEngine(onTick?: (n: number) => void): Tickable & { times: (number | undefined)[] } {
+  const times: (number | undefined)[] = [];
+  return {
+    times,
+    tick(t) {
+      times.push(t);
+      onTick?.(times.length);
+    },
+  };
+}
+
+/** A realtime clock over a fixed list of wall-clock seconds. */
+function pacedClock(times: number[], sched: ReturnType<typeof fakeScheduler>): Clock {
+  let i = 0;
+  return new RealtimeClock({ now: () => times[Math.min(i++, times.length - 1)], schedule: sched.schedule });
+}
+
+describe('runEngineLoop', () => {
+  it('ticks the engine on the clock\'s time and reports in milliseconds', async () => {
+    const sched = fakeScheduler();
+    const engine = recordingEngine();
+    const reported: number[] = [];
+    const done = runEngineLoop(engine, [(ms) => void reported.push(ms)], () => engine.times.length >= 3, {
+      clock: pacedClock([100, 100.5, 101], sched),
+    });
+    sched.flush(10);
+    await done;
+
+    expect(engine.times).toEqual([100, 100.5, 101]);
+    // Reporters get milliseconds — the gesture dispatcher's hold/cooldown timing
+    // and the face/MIDI report throttles are all in ms.
+    expect(reported).toEqual([100_000, 100_500, 101_000]);
+  });
+
+  it('runs every reporter, in order, once per tick', async () => {
+    const sched = fakeScheduler();
+    const engine = recordingEngine();
+    const order: string[] = [];
+    const done = runEngineLoop(
+      engine,
+      [() => void order.push('face'), () => void order.push('midi'), () => void order.push('gesture')],
+      () => engine.times.length >= 2,
+      { clock: pacedClock([0, 1], sched) },
+    );
+    sched.flush(10);
+    await done;
+    expect(order).toEqual(['face', 'midi', 'gesture', 'face', 'midi', 'gesture']);
+  });
+
+  it('DROPS a frame whose tick throws and keeps the loop alive', async () => {
+    const sched = fakeScheduler();
+    let n = 0;
+    const engine: Tickable = {
+      tick() {
+        n += 1;
+        if (n === 2) throw new Error('degenerate value');
+      },
+    };
+    const errors: unknown[] = [];
+    const reported: number[] = [];
+    const done = runEngineLoop(engine, [(ms) => void reported.push(ms)], () => n >= 4, {
+      clock: pacedClock([0, 1, 2, 3], sched),
+      onError: (e) => void errors.push(e),
+    });
+    sched.flush(10);
+    await done;
+
+    expect(n).toBe(4); // the loop kept going past the throw
+    expect(errors).toHaveLength(1);
+    expect((errors[0] as Error).message).toBe('degenerate value');
+    // The throwing frame reported nothing; the other three did.
+    expect(reported).toEqual([0, 2000, 3000]);
+  });
+
+  it('a throwing reporter costs its frame, not the session', async () => {
+    const sched = fakeScheduler();
+    const engine = recordingEngine();
+    const errors: unknown[] = [];
+    const late: number[] = [];
+    const done = runEngineLoop(
+      engine,
+      [
+        (ms) => {
+          if (ms === 1000) throw new Error('report blew up');
+        },
+        (ms) => void late.push(ms),
+      ],
+      () => engine.times.length >= 3,
+      { clock: pacedClock([0, 1, 2], sched), onError: (e) => void errors.push(e) },
+    );
+    sched.flush(10);
+    await done;
+
+    expect(engine.times).toHaveLength(3); // every frame still ticked
+    expect(errors).toHaveLength(1);
+    expect(late).toEqual([0, 2000]); // the second reporter was skipped only on the bad frame
+  });
+
+  it('stops as soon as the stop condition flips, without ticking again', async () => {
+    const sched = fakeScheduler();
+    const engine = recordingEngine();
+    let disposed = false;
+    const done = runEngineLoop(engine, [], () => disposed, { clock: pacedClock([0, 1, 2, 3, 4], sched) });
+    sched.flush(2);
+    expect(engine.times).toHaveLength(2);
+    disposed = true; // what the effect cleanup does
+    sched.flush(5); // an already-scheduled frame fires and must NOT tick
+    await done;
+    expect(engine.times).toHaveLength(2);
+  });
+
+  it('never ticks if it is already stopped when it starts', async () => {
+    const sched = fakeScheduler();
+    const engine = recordingEngine();
+    const done = runEngineLoop(engine, [], () => true, { clock: pacedClock([0], sched) });
+    sched.flush(5);
+    await done;
+    expect(engine.times).toEqual([]);
+  });
+
+  it('falls back to the wall clock when the clock omits the tick time', async () => {
+    // BatchClock passes no argument (the engine synthesizes its own time), but the
+    // reporters still need a real millisecond stamp rather than an invented one.
+    const engine = recordingEngine();
+    const reported: number[] = [];
+    let fake = 5;
+    await runEngineLoop(engine, [(ms) => void reported.push(ms)], () => engine.times.length >= 2, {
+      clock: new BatchClock(2),
+      now: () => fake++,
+    });
+    expect(engine.times).toEqual([5, 6]);
+    expect(reported).toEqual([5000, 6000]);
+  });
+
+  it('defaults to a wall-clock RealtimeClock when no clock is given', async () => {
+    // The production default: rAF-driven, speed 1. Drive it through a stubbed rAF.
+    const frames: Array<() => void> = [];
+    const raf = vi.fn((cb: FrameRequestCallback) => {
+      frames.push(() => cb(0));
+      return frames.length;
+    });
+    vi.stubGlobal('requestAnimationFrame', raf);
+    try {
+      const engine = recordingEngine();
+      const done = runEngineLoop(engine, [], () => engine.times.length >= 2);
+      for (let i = 0; i < 5 && frames.length; i++) frames.shift()!();
+      await done;
+      expect(engine.times).toHaveLength(2);
+      expect(raf).toHaveBeenCalled();
+      // Wall-clock times, in seconds, monotonically non-decreasing.
+      expect(engine.times[1]!).toBeGreaterThanOrEqual(engine.times[0]!);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});

--- a/test/engine_wiring.test.ts
+++ b/test/engine_wiring.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Structural guard on the React↔DAG bridge's wiring (`src/app/useEngine.ts`).
+ *
+ * This is the #137 lesson applied to the engine host: MIDI out shipped with a
+ * dial, a node and no edge — every unit test passed and the feature did nothing,
+ * because the thing that was broken was a *connection*, not a computation. Two
+ * connections here are exactly that shape, and neither has a behavioural test
+ * that could catch them coming undone:
+ *
+ *  1. **The Clock reaches the live loop.** If `useEngine` goes back to calling
+ *     `requestAnimationFrame` itself, `RealtimeClock` silently becomes dead code
+ *     again while every clock test stays green.
+ *  2. **The slot selection reaches the graph.** `?slot.<name>=…` → `main.tsx` →
+ *     `App` → `useThoreminEngine` → `defaultGraph(selection, registry)`. Any one
+ *     of those links dropping leaves a seam that parses, validates, is unit
+ *     tested — and is never consulted.
+ *
+ * It reads source rather than rendering because mounting the hook boots the
+ * webcam and the ML models, which no unit test should do (same rationale as
+ * `app_shell.test.ts`). The loop's actual behaviour is covered headlessly in
+ * `engine_loop.test.ts`, and the re-wire mechanism in `engine_lifecycle.test.ts`.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const read = (p: string) => readFileSync(resolve(process.cwd(), p), 'utf8');
+const useEngine = read('src/app/useEngine.ts');
+const app = read('src/app/App.tsx');
+const main = read('src/main.tsx');
+
+/** Strip block and line comments, so a mention in prose never satisfies a check. */
+const code = (s: string) => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+
+describe('useEngine drives the live loop from the Clock seam', () => {
+  it('does not hand-roll a requestAnimationFrame loop', () => {
+    expect(code(useEngine)).not.toMatch(/requestAnimationFrame|cancelAnimationFrame/);
+  });
+
+  it('drives the engine through runEngineLoop', () => {
+    expect(code(useEngine)).toMatch(/runEngineLoop\(/);
+  });
+
+  it('feeds the loop the three per-frame reporters', () => {
+    // A reporter dropped from this list stops updating its panel at frame rate
+    // while nothing fails — the face readout, the MIDI status, or (worst) the
+    // gesture dispatcher, which would stop dispatching commands entirely.
+    expect(code(useEngine)).toMatch(/runEngineLoop\(\s*engine,\s*\[reportFace,\s*reportMidi,\s*reportGesture\]/);
+  });
+});
+
+describe('the slot selection reaches the graph', () => {
+  it('main.tsx parses it from the URL and passes it to the app', () => {
+    const m = code(main);
+    expect(m).toMatch(/parseSlotSelection\(window\.location\.search\)/);
+    expect(m).toMatch(/<DagApp[^>]*\bslots=\{slots\}/);
+  });
+
+  it('App forwards it to the engine hook', () => {
+    expect(code(app)).toMatch(/useThoreminEngine\(\s*source,\s*slots\s*\)/);
+  });
+
+  it('useEngine builds the graph WITH the selection and the registry', () => {
+    const c = code(useEngine);
+    // `defaultGraph()` with no arguments is the bug this guards: it silently
+    // ignores every selection and validates nothing.
+    expect(c).not.toMatch(/defaultGraph\(\s*\)/);
+    expect(c).toMatch(/new Engine\(\s*defaultGraph\(slotsRef\.current,\s*registry\)/);
+  });
+
+  it('re-wires the LIVE engine on a selection change instead of rebuilding it', () => {
+    // Rebuilding would re-acquire the camera and reload both MediaPipe models to
+    // change one node; applyGraph keeps every unchanged node (#51).
+    const c = code(useEngine);
+    expect(c).toMatch(/\.applyGraph\(defaultGraph\(slotsRef\.current,\s*registry\)/);
+    // ...and it is actually TRIGGERED by a selection change. An applyGraph call
+    // sitting in an effect that never re-runs is the #137 shape exactly: present,
+    // correct, and never reached.
+    expect(c).toMatch(/\}, \[\s*slotsKey\s*\]\)/);
+    // The selection must NOT be a dependency of the build effect, or a swap would
+    // tear the camera down and reload both models.
+    expect(c).not.toMatch(/\[source\.kind[^\]]*slotsKey/);
+  });
+});

--- a/test/gesture_dispatch.test.ts
+++ b/test/gesture_dispatch.test.ts
@@ -300,6 +300,10 @@ describe('the classifier output reaches the app dispatch path (the #137-style gu
     expect(src).toMatch(/getOutput\(\s*'gesture'\s*,\s*'poses'\s*\)/);
     expect(src).toMatch(/createGestureDispatcher\(/);
     expect(src).toMatch(/gestureDispatcher\.tick\(/);
-    expect(src).toMatch(/reportGesture\(t\)/); // wired into the rAF loop, not just defined
+    // Wired into the live frame loop, not merely defined. The loop is now driven
+    // by a Clock via `runEngineLoop` (it used to be a hand-rolled rAF recursion),
+    // so the reporter is passed in the per-frame list rather than called inline —
+    // same guarantee, one indirection later.
+    expect(src).toMatch(/runEngineLoop\([^)]*\breportGesture\b/s);
   });
 });

--- a/test/slots.test.ts
+++ b/test/slots.test.ts
@@ -13,7 +13,15 @@ import { Engine, createRegistry, defineNode, type NodeRegistry } from '@/dag';
 import { createAppRegistry, BROWSER_NODES } from '@/nodes/browser';
 import { CORE_NODES } from '@/nodes';
 import { voiceMappingNode } from '@/nodes/mapping/voice_mapping';
-import { SLOTS, resolveSlot, defaultGraph, type SlotSelection } from '@/app/graph';
+import {
+  SLOTS,
+  resolveSlot,
+  defaultGraph,
+  parseSlotSelection,
+  slotSelectionKey,
+  NO_SLOTS,
+  type SlotSelection,
+} from '@/app/graph';
 import {
   MAPPING_SLOT_INPUTS,
   MAPPING_SLOT_OUTPUT,
@@ -148,5 +156,56 @@ describe('defaultGraph slot binding', () => {
     const spec = defaultGraph({ mapping: 'indirect-map' }, reg, );
     expect(spec.nodes.find((n) => n.id === 'map')?.type).toBe('voice-mapping');
     expect(() => new Engine(spec, reg)).not.toThrow();
+  });
+});
+
+describe('parseSlotSelection (the URL seam)', () => {
+  it('selects nothing by default, so every slot uses its default', () => {
+    expect(parseSlotSelection('')).toEqual({});
+    expect(parseSlotSelection('?engine=dag&source=video&video=/a.mp4')).toEqual({});
+    expect(defaultGraph(parseSlotSelection(''), appRegistry())).toEqual(defaultGraph());
+  });
+
+  it('reads ?slot.<name>=<nodeType> for each known slot', () => {
+    expect(parseSlotSelection('?slot.mapping=voice-mapping')).toEqual({ mapping: 'voice-mapping' });
+    expect(parseSlotSelection('slot.mapping=alt-mapping')).toEqual({ mapping: 'alt-mapping' });
+  });
+
+  it('ignores blank values and unknown slot names', () => {
+    expect(parseSlotSelection('?slot.mapping=')).toEqual({});
+    expect(parseSlotSelection('?slot.mapping=%20%20')).toEqual({});
+    expect(parseSlotSelection('?slot.nonesuch=whatever')).toEqual({});
+  });
+
+  it('leaves validation to resolveSlot, which warns and falls back', () => {
+    const warnings: string[] = [];
+    const sel = parseSlotSelection('?slot.mapping=not-a-node');
+    expect(sel).toEqual({ mapping: 'not-a-node' }); // parsed, not judged
+    expect(resolveSlot('mapping', sel, appRegistry(), (m) => warnings.push(m))).toBe('voice-mapping');
+    expect(warnings[0]).toContain('is not a registered node type');
+  });
+
+  it('coexists with the other URL params (?source=video, ?engine=)', () => {
+    expect(parseSlotSelection('?engine=dag&slot.mapping=voice-mapping&source=video&video=/c.mp4')).toEqual({
+      mapping: 'voice-mapping',
+    });
+  });
+});
+
+describe('slotSelectionKey (the React effect identity)', () => {
+  it('is stable for equal selections and distinct for different ones', () => {
+    expect(slotSelectionKey({ mapping: 'a' })).toBe(slotSelectionKey({ mapping: 'a' }));
+    expect(slotSelectionKey({ mapping: 'a' })).not.toBe(slotSelectionKey({ mapping: 'b' }));
+    expect(slotSelectionKey({})).toBe(slotSelectionKey(NO_SLOTS));
+    expect(slotSelectionKey()).toBe(slotSelectionKey({}));
+  });
+
+  it('covers every slot, so adding one cannot silently stop triggering re-wires', () => {
+    for (const name of Object.keys(SLOTS)) expect(slotSelectionKey({})).toContain(`${name}=`);
+  });
+
+  it('does not depend on object identity (a fresh literal each render is fine)', () => {
+    const renders = [{ mapping: 'x' }, { mapping: 'x' }, { mapping: 'x' }];
+    expect(new Set(renders.map(slotSelectionKey)).size).toBe(1);
   });
 });


### PR DESCRIPTION
Two seams existed and the app used neither.

`RealtimeClock` shipped in M-B (PR #106) and was referenced only by its own unit tests, because `useEngine` hand-rolled its own `requestAnimationFrame` recursion. `defaultGraph(selection, registry)` shipped with the mapping contract (#51) and was only ever called as `defaultGraph()`. A seam nothing runs through is a seam nobody is testing.

Follows #165 (the engine graph lifecycle), which is what makes the second half safe.

## Pacing

`src/app/engineLoop.ts` (`runEngineLoop`) drives the engine from a `Clock` and fans each frame out to the per-frame reporters. The live path now runs `RealtimeClock` at speed 1 — arithmetically identical to the old loop (`base + (real - base) * 1` **is** `performance.now() / 1000`), so this is an adoption, not a behaviour change.

It is a module rather than a closure inside the hook because that is what makes it testable. The frame-drop guard — *one node throwing on one frame must never stop the instrument* — previously lived inside a closure inside an async IIFE inside a React effect, where no test could reach it. It now has one, along with the report fan-out, the millisecond stamping the gesture dispatcher's hold/cooldown timing depends on, and the stop condition.

The stop condition also replaces `cancelAnimationFrame`: the clock polls `disposed` before every frame, so an already-scheduled frame resolves without ticking. Same guarantee, one mechanism.

This lifts the deferral recorded in `clock.ts`'s own docstring ("the live `useEngine` rAF loop is refit onto `RealtimeClock` when the Applier lands — deferred here because that surface has no headless test"). Splitting the loop out of the hook is what let it be lifted early: what remains for M-D's browser smoke test is the *effect* (StrictMode guards, camera acquisition, AudioContext lifecycle), not pacing.

## Which graph

`?slot.<name>=<nodeType>` → `parseSlotSelection` → `main.tsx` → `App` → `useThoreminEngine` → `defaultGraph(selection, registry)`, which validates the choice against the slot contract and falls back with a warning on anything stale.

A selection change **re-wires the live engine** through `Engine.applyGraph` rather than re-running the build effect. Rebuilding would re-acquire the camera and reload both MediaPipe models to change one node; `applyGraph` keeps every unchanged node, so the instrument plays through the swap. The build effect reads the selection through a ref and reconciles once after `init()`, so a selection that changes while the models are still loading is not lost. A teardown landing mid-swap rejects the apply by design (#165), and that rejection is deliberately not logged — it is the ordinary unmount path.

## Reachability (the #136/#137 question)

**How many clicks from a cold load? Zero** — the loop change is invisible, and the slot seam is a URL parameter, not a control.

It gets no `tools.ts` entry and no dial because it is **neither a tool nor an instrument parameter**: it is a developer-facing graph seam, the same shape as M-A's `?source=video`. Per the component-model governance rule, a slot earns a player-facing dropdown only once its role has >= 2 real implementations, and `mapping` has one. `docs/design/component-model.md` states this explicitly: "Deeper node swapping stays developer-facing (graphs are data) with the seam ready to surface later."

What this PR does instead is guard the *connections*, because what breaks in this shape is a connection, not a computation — the #137 lesson. `test/engine_wiring.test.ts` fails if `useEngine` goes back to a raw rAF loop, if a reporter is dropped from the frame list, if `main.tsx` stops passing the parsed selection, if `App` stops forwarding it, if the graph is built with a bare `defaultGraph()`, or if the re-wire effect stops being triggered by a selection change.

## Verification

- 8 new headless loop tests (`test/engine_loop.test.ts`), 10 new slot-selection/URL tests, 7 structural connection guards (`test/engine_wiring.test.ts`).
- A **7-mutant harness**: each guard fails when its connection is cut. 7/7 caught.
- `test/gesture_dispatch.test.ts`'s existing `reportGesture` guard was updated to the new call shape; its guarantee is unchanged.
- `npm run typecheck` clean, `npm test` 1140 passed, `npm run build` green. Rebased onto #164 (the trainer session's `useEngine` changes) with no conflicts; both changesets verified present.

Refs #101, #51, #104.
