### PR TITLE
#104 (M-C): the source slot, and a port contract that is checkable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,20 @@ Discussion #3. Key rules from it:
   not DAG nodes** — the engine rejects fan-in to a single input port. Promote an
   element to a node only when something *outside* the node must consume/tap it.
 - **A role earns a settings swap-dropdown only when ≥2 real implementations
-  exist.** Don't build slot machinery for hypothetical swaps.
+  exist.** Don't build slot machinery for hypothetical swaps. (The rule says a
+  swap *may* be surfaced, not that it must: the `source` slot has three real
+  candidates and still gets no dropdown, because a replay or synthetic hand is a
+  verification affordance, not an instrument a player picks between.)
+- **Two slots exist**: `mapping` (one candidate) and `source` (#104 —
+  `webcam-hands` / `synthetic-hands` / `replay-hands`). Select with
+  `?slot.<name>=<nodeType>`. `?slot.source=synthetic-hands` runs the whole
+  instrument with no camera and no MediaPipe — the fastest way to exercise the
+  graph without hardware.
+- **`PortSpec.schema`** makes a port contract checkable (`kind` is only a label).
+  The engine checks it in `tick()`'s output path under
+  `EngineOptions.validatePorts` — off by default, **on** in `runHeadless`. It
+  exists mainly to catch a node emitting *nothing* on a port it declares, which
+  is otherwise a silent graph rather than an error.
 - Of the prerequisites before "node swapping is a config flip" is true, one
   remains: the registry is a **hand-listed array** with no discovery seam (the
   design doc's "Two corrections", #2). The other two are done — the mapping nodes
@@ -195,7 +208,8 @@ So, when you add a user-facing capability:
 |------|------|
 | DAG engine (framework-agnostic) | `src/dag/` (`engine.ts`, `types.ts`, `registry.ts`, `recorder.ts`, `clock.ts`) |
 | Node library | `src/nodes/{sources,features,mapping,music,output}/` |
-| Default graph wiring | `src/app/graph.ts` |
+| Default graph wiring + the `SLOTS` table (role-typed swap points) | `src/app/graph.ts` |
+| **Slot contracts** — what a candidate must declare to fill a slot | `src/nodes/slot_contract.ts`, `src/nodes/mapping/mapping_contract.ts`, `src/nodes/sources/source_contract.ts` |
 | React↔DAG bridge (webcam, AudioContext, recorder, slot selection) | `src/app/useEngine.ts` |
 | Live frame loop — the app's `Clock` adoption (tick + per-frame reporters + frame-drop guard) | `src/app/engineLoop.ts` |
 | Live control store (zustand+persist) — the hot per-tick mirror | `src/app/store.ts` |

--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -73,7 +73,7 @@ Two things worth knowing:
 [Get an API key](https://aistudio.google.com/app/apikey)
 
 
-## Nodes (31)
+## Nodes (32)
 
 ### Inputs (sources)
 _Where signals enter the graph._
@@ -125,6 +125,14 @@ Emits a recorded value stream, one value per tick.
 - **in:** —
 - **out:** value
 - **params:** values (array=[]), loop (boolean=false)
+
+#### `replay-hands` — Replay Hands
+Replays a recorded hand-landmark stream, one frame per tick. Camera-free and deterministic.
+
+- **roles:** source
+- **in:** —
+- **out:** hands:hands-frame
+- **params:** frames (array=[]), loop (boolean=false)
 
 ### Features
 _Raw sensor data → normalized control signals._

--- a/docs/design/component-model.md
+++ b/docs/design/component-model.md
@@ -172,9 +172,17 @@ which is free — they are just a map on each node.
 
 The `source` slot (#104) is the first with more than one real candidate, which
 makes it the first genuine test of "swapping is a config flip" — and it passes:
-`?slot.source=synthetic-hands` runs the entire downstream instrument with no
-camera and no MediaPipe, and the same swap applied to a *running* engine replaces
-exactly one node.
+`?slot.source=synthetic-hands` runs the entire instrument with no camera and no
+MediaPipe, and the same swap applied to a *running* engine replaces exactly one
+node.
+
+Note what that costs to be *true*: a slot chooses a node type inside the graph
+builder, but whether the host acquires a camera is decided in `useEngine` before
+the engine exists. A slot alone would leave the camera-free URL still calling
+`getUserMedia` — and failing to boot on a machine with no camera, which is the
+one machine it exists for. So the host reads the resolved slot
+(`sourceNeedsVideo`) before acquiring anything. **A swap point is only as real as
+the host decisions that read it.**
 
 It still gets **no player-facing dropdown**, and that is not a contradiction of
 the ">= 2 implementations" rule. That rule says when a swap *may* be surfaced,

--- a/docs/design/component-model.md
+++ b/docs/design/component-model.md
@@ -163,6 +163,33 @@ the Stream Applier's source selection all sit on top of; none of them needs to
 know about node instances. Edges are re-wired unconditionally on every apply,
 which is free — they are just a map on each node.
 
+### Slots today
+
+| slot | role | default | candidates | UI? |
+|---|---|---|---|---|
+| `mapping` | `mapping` | `voice-mapping` | `voice-mapping` | no — one implementation |
+| `source` | `source` | `webcam-hands` | `webcam-hands`, `synthetic-hands`, `replay-hands` | no — see below |
+
+The `source` slot (#104) is the first with more than one real candidate, which
+makes it the first genuine test of "swapping is a config flip" — and it passes:
+`?slot.source=synthetic-hands` runs the entire downstream instrument with no
+camera and no MediaPipe, and the same swap applied to a *running* engine replaces
+exactly one node.
+
+It still gets **no player-facing dropdown**, and that is not a contradiction of
+the ">= 2 implementations" rule. That rule says when a swap *may* be surfaced,
+not that it must be: a replay or a synthetic hand is a **verification
+affordance**, not an instrument a player chooses between. The rule's purpose is to
+stop slot machinery being built for hypothetical swaps; here the swap is real and
+the audience is a developer.
+
+Its contract also carries the first `PortSpec.schema`. `kind` was always advisory
+— a label. A slot whose candidates are written independently needs something
+checkable, and specifically it needs to catch the failure a type system cannot:
+a source that emits **nothing** on a port it declares. That is a silent graph, not
+an error, and it is why the check lives in `tick()`'s output path rather than in
+`emitTaps` (which skips `undefined` by design).
+
 ## Sub-components are functions inside a node — **not** DAG nodes
 
 The single strongest consensus across all review lenses: **overlay pieces (and

--- a/docs/design/stream-applier.md
+++ b/docs/design/stream-applier.md
@@ -206,13 +206,37 @@ boundaries allow.
   Applier + a browser smoke test; M-B ships the abstraction + the fully-tested
   `BatchClock` path and a headless `RealtimeClock`.
 - **M-C — Source contract + `source` slot + conformance (R1/R4 foundation).
-  ✅ design resolved, build DEFERRED (#104).**
-  The async-iterable `Source` (signal/event); a `source` slot with a
-  `SOURCE_SLOT_CONTRACT` guaranteeing `hands`/`hands-frame`; `PortSpec.schema?`
-  validated in `tick()` (dev/batch, incl. `undefined`); the seeded-RNG rule.
+  ✅ the node-swap half SHIPPED (#104); the async-iterable `Source` deferred to M-D.**
   **`videoFileSource` is a host-side `Source`, NOT a slot candidate** — see the
   resolution below, which corrects the earlier "slot candidate" reading. M-A's host
   wiring is the right shape and stays.
+  - ✅ **The `source` slot.** `SLOTS.source` in `src/app/graph.ts`, contract in
+    `src/nodes/sources/source_contract.ts` (`SOURCE_SLOT_CONTRACT`, guaranteeing
+    `hands` / `hands-frame`). Candidates are the finished-frame emitters:
+    `webcam-hands` (default), `synthetic-hands`, `replay-hands`. Selected with
+    `?slot.source=<type>`, and swappable on a *running* engine via `applyGraph`.
+    The payoff is pinned by a test: the real `defaultGraph()` drives sounding
+    voices in plain Node, with no camera and no MediaPipe.
+  - ✅ **`replay-hands`.** `replay-source` emits on a generic `value` port, which
+    is what makes it a fine stand-in for an arbitrary edge and a poor slot
+    candidate — a candidate is identified by the port it emits. This is the typed
+    sibling: same replay semantics, the contract's port and schema.
+  - ✅ **Port conformance.** `PortSpec.schema?: ZodType`, checked in `tick()`'s
+    output path under `EngineOptions.validatePorts` (off by default; **on** in
+    `runHeadless`, so a fixture is never recorded from a bad frame). Deliberately
+    NOT in `emitTaps`, which skips `undefined` — and "the node emitted nothing"
+    is the failure this exists to catch.
+  - ✅ **The seeded-RNG rule**, enforced as a test rather than a lint (this repo
+    lints with `tsc`, so its boundaries are tests — as with the command firewall):
+    no source-slot candidate may use `Math.random` or `Date.now`, and the
+    finished-frame candidates may read no clock at all. `webcam-hands` is exempt
+    from the clock rule **by name**, because MediaPipe's `detectForVideo` requires
+    a strictly-increasing timestamp.
+  - ⏳ **The async-iterable `Source` interface + its pump — deferred to M-D**, on
+    purpose. The pump is a private detail of the Applier, so the interface has no
+    implementation and no consumer until the Applier exists; shipping it now would
+    be a contract nobody honours, which this repo has been burned by twice
+    (#119, #120). The node-swap half above needs none of it.
 - **M-D — The Applier (R4 complete, R5 orthogonality). ⚠ untested live surface.**
   `runHeadless` delegates (BatchClock + bounded recorder tap, no audio sink);
   `useEngine`'s effect becomes a thin Applier config — **this is where the live

--- a/docs/design/stream-applier.md
+++ b/docs/design/stream-applier.md
@@ -215,8 +215,13 @@ boundaries allow.
     `hands` / `hands-frame`). Candidates are the finished-frame emitters:
     `webcam-hands` (default), `synthetic-hands`, `replay-hands`. Selected with
     `?slot.source=<type>`, and swappable on a *running* engine via `applyGraph`.
-    The payoff is pinned by a test: the real `defaultGraph()` drives sounding
-    voices in plain Node, with no camera and no MediaPipe.
+    The payoff is pinned by tests at both levels: headlessly, the real
+    `defaultGraph()` drives sounding voices in plain Node with no camera and no
+    MediaPipe; in the browser, `useEngine` reads the resolved slot
+    (`sourceNeedsVideo`) *before* acquiring anything and skips `getUserMedia`, so
+    the camera-free URL boots on a machine that has no camera. The second half is
+    not decoration — a slot that only chose the node type would leave that URL
+    demanding the hardware it exists to do without.
   - ✅ **`replay-hands`.** `replay-source` emits on a generic `value` port, which
     is what makes it a fine stand-in for an arbitrary edge and a poor slot
     candidate — a candidate is identified by the port it emits. This is the typed

--- a/public/catalog.json
+++ b/public/catalog.json
@@ -1128,6 +1128,33 @@
     ]
   },
   {
+    "type": "replay-hands",
+    "title": "Replay Hands",
+    "description": "Replays a recorded hand-landmark stream, one frame per tick. Camera-free and deterministic.",
+    "roles": [
+      "source"
+    ],
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "hands",
+        "kind": "hands-frame"
+      }
+    ],
+    "params": [
+      {
+        "name": "frames",
+        "type": "array",
+        "default": []
+      },
+      {
+        "name": "loop",
+        "type": "boolean",
+        "default": false
+      }
+    ]
+  },
+  {
     "type": "replay-source",
     "title": "Replay Source",
     "description": "Emits a recorded value stream, one value per tick.",

--- a/public/manual.html
+++ b/public/manual.html
@@ -42,7 +42,7 @@
           letter-spacing: .06em; border-radius: 999px; padding: .1rem .4rem; margin-left: .35rem; vertical-align: 1px; }
 </style></head><body><div class="wrap">
   <h1>θ Thoremin — Capabilities Manual</h1>
-  <p class="gen">Auto-generated from the node registry. 31 nodes.</p>
+  <p class="gen">Auto-generated from the node registry. 32 nodes.</p>
   <p class="guide">Looking for how to <b>use</b> the app — playing, instruments, shortcuts, the assistant, recording, annotations, the Feature Lab? → <a href="https://github.com/thorwhalen/thoremin/blob/main/docs/USER_GUIDE.md">the User Guide</a>. This page is the <b>node</b> catalog.</p>
   <p>Thoremin turns live sensor streams (webcam hand gestures, facial expressions and head pose, computer keyboard, MIDI out) into a live audiovisual stream — musical audio plus the captured video with overlaid guides. You build sounds by wiring small, typed <b>nodes</b> into a dataflow graph (DAG): inputs → features → mapping → music-logic → synthesis/generation → output. Every edge can be recorded and replayed.</p><p>The mapping layer spans a spectrum: <b>direct</b> (a gesture *is* a note/parameter — e.g. hand position → scale-snapped pitch) through <b>indirect</b> (a gesture expresses a high-level idea — e.g. openness → musical density steering an AI model), including <b>conductor</b> mode (direct a fixed piece's tempo and dynamics).</p><p>Everything runs <b>client-side</b>: gesture/face inference (MediaPipe), synthesis (Web Audio) and rendering (canvas) all happen in your browser. There is no backend — nothing you play, record, or annotate is uploaded anywhere. The only network calls are the ones you opt into by pasting your own API key (the AI assistant, and Lyria generative music), and those go straight from your browser to that provider.</p><p>This page catalogs the engine's building blocks — every node, its ports and its params. The DAG *is* the deployed instrument; a few nodes here (the generative and conductor-mode ones) are built and tested but are not wired into the default graph.</p>
   <h3>Example pipelines</h3>
@@ -143,6 +143,16 @@
         <dt>in</dt><dd>—</dd>
         <dt>out</dt><dd>value</dd>
         <dt>params</dt><dd>values (array=[]), loop (boolean=false)</dd>
+      </dl>
+    </div>
+    <div class="node">
+      <h4><code>replay-hands</code> <span class="title">Replay Hands</span></h4>
+      <p>Replays a recorded hand-landmark stream, one frame per tick. Camera-free and deterministic.</p>
+      <dl>
+        <dt>roles</dt><dd>source</dd>
+        <dt>in</dt><dd>—</dd>
+        <dt>out</dt><dd>hands:hands-frame</dd>
+        <dt>params</dt><dd>frames (array=[]), loop (boolean=false)</dd>
       </dl>
     </div></div></section>
 <section><h3>Features</h3><p class="blurb">Raw sensor data → normalized control signals.</p><div class="grid">

--- a/scripts/gen_catalog.ts
+++ b/scripts/gen_catalog.ts
@@ -19,7 +19,7 @@ const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 
 // Layer grouping for the manual (type → category, in display order).
 const CATEGORIES: Array<{ name: string; blurb: string; types: string[] }> = [
-  { name: 'Inputs (sources)', blurb: 'Where signals enter the graph.', types: ['webcam-hands', 'webcam-face', 'keyboard-source', 'store-controls', 'synthetic-hands', 'replay-source'] },
+  { name: 'Inputs (sources)', blurb: 'Where signals enter the graph.', types: ['webcam-hands', 'webcam-face', 'keyboard-source', 'store-controls', 'synthetic-hands', 'replay-source', 'replay-hands'] },
   { name: 'Features', blurb: 'Raw sensor data → normalized control signals.', types: ['hand-features', 'face-features', 'face-controls', 'face-expression', 'gesture-classifier', 'face-feature-vector', 'hand-feature-vector'] },
   { name: 'Mapping (direct ↔ indirect)', blurb: 'Features → engine parameters, across the expression spectrum.', types: ['voice-mapping', 'indirect-map', 'keyboard-control', 'pick', 'one-euro', 'synth-merge', 'chord-select'] },
   { name: 'Music logic (tonal guidance)', blurb: 'Harmony kept in-key.', types: ['chord', 'progression', 'expression-chord', 'pose-chord'] },

--- a/src/app/graph.ts
+++ b/src/app/graph.ts
@@ -62,8 +62,14 @@ export const SLOTS: Record<string, SlotDef> = {
    * Three candidates, so unlike `mapping` this slot has something real to swap
    * to. It still gets no player-facing dropdown: a replay or a synthetic hand is
    * a *verification* affordance, not an instrument a player chooses between.
-   * `?slot.source=synthetic-hands` runs the whole downstream instrument with no
-   * camera and no MediaPipe at all.
+   *
+   * `?slot.source=synthetic-hands` runs the whole instrument with no camera and
+   * no MediaPipe — in the browser too, not only headlessly: the host reads this
+   * slot through {@link sourceNeedsVideo} BEFORE acquiring anything and skips
+   * `getUserMedia` entirely, so the run needs no hardware and no permission
+   * prompt. Getting that half wrong is how the feature would have shipped as its
+   * own opposite: the one URL meant for hardware-free verification, failing to
+   * boot on a machine with no camera.
    */
   source: {
     role: 'source',
@@ -102,6 +108,21 @@ export function parseSlotSelection(search: string): SlotSelection {
     if (chosen) selection[key] = chosen;
   }
   return selection;
+}
+
+/**
+ * Does the resolved source slot need the host to supply a `<video>` element?
+ *
+ * Only the default (`webcam-hands`) does: it runs MediaPipe over a video element,
+ * which is exactly why raw-video origins stay a *host-side* concern rather than a
+ * node swap. Every other candidate emits finished frames and reads no video at
+ * all — so when one is selected the host should not acquire a camera, and the
+ * instrument runs with no hardware. Readers of `ctx.resources.video` (the overlay
+ * backdrop, the face branch) all guard on `readyState`, so the element simply
+ * stays empty.
+ */
+export function sourceNeedsVideo(selection?: SlotSelection, registry?: NodeRegistry): boolean {
+  return resolveSlot('source', selection, registry) === SLOTS.source.default;
 }
 
 /**

--- a/src/app/graph.ts
+++ b/src/app/graph.ts
@@ -23,7 +23,9 @@
  * fan-IN to a single input port is disallowed.
  */
 import type { GraphSpec, NodeRegistry, Role } from '@/dag';
-import { MAPPING_SLOT_CONTRACT, type SlotContract } from '@/nodes/mapping/mapping_contract';
+import { MAPPING_SLOT_CONTRACT } from '@/nodes/mapping/mapping_contract';
+import { SOURCE_SLOT_CONTRACT } from '@/nodes/sources/source_contract';
+import type { SlotContract } from '@/nodes/slot_contract';
 
 /**
  * A Slot is a named, role-typed swap point the graph builder fills from config.
@@ -50,6 +52,24 @@ export const SLOTS: Record<string, SlotDef> = {
     default: 'voice-mapping',
     candidates: ['voice-mapping'],
     contract: MAPPING_SLOT_CONTRACT,
+  },
+  /**
+   * Where the hand frames come from (#104 / Stream Applier M-C). The candidates
+   * are the **finished-frame emitters** only — a file or stream feeding a
+   * `<video>` is a host-side concern (`sourceSpec.ts`), not a node swap, because
+   * `webcam-hands` does the identical job whatever produced the pixels.
+   *
+   * Three candidates, so unlike `mapping` this slot has something real to swap
+   * to. It still gets no player-facing dropdown: a replay or a synthetic hand is
+   * a *verification* affordance, not an instrument a player chooses between.
+   * `?slot.source=synthetic-hands` runs the whole downstream instrument with no
+   * camera and no MediaPipe at all.
+   */
+  source: {
+    role: 'source',
+    default: 'webcam-hands',
+    candidates: ['webcam-hands', 'synthetic-hands', 'replay-hands'],
+    contract: SOURCE_SLOT_CONTRACT,
   },
 };
 
@@ -150,9 +170,16 @@ export function resolveSlot(
  */
 export function defaultGraph(selection?: SlotSelection, registry?: NodeRegistry): GraphSpec {
   const mappingType = resolveSlot('mapping', selection, registry);
+  const sourceType = resolveSlot('source', selection, registry);
+  // The default source's params are MediaPipe's (model size, hand count) and mean
+  // nothing to a replay or synthetic source. Rather than invent a shared params
+  // contract for a slot whose candidates genuinely have nothing in common, a
+  // swapped-in source takes its own defaults — the URL seam cannot express params
+  // anyway, and a candidate that needs them is a graph edit, not a selection.
+  const sourceParams = sourceType === SLOTS.source.default ? { modelType: 'full', maxHands: 2 } : {};
   return {
     nodes: [
-      { id: 'cam', type: 'webcam-hands', params: { modelType: 'full', maxHands: 2 } },
+      { id: 'cam', type: sourceType, params: sourceParams },
       { id: 'feat', type: 'hand-features', params: { mirrorX: true, mirrorHandedness: true } },
       // Face branch (idle until the player picks a face mapping in settings).
       { id: 'camFace', type: 'webcam-face', params: {} },

--- a/src/app/useEngine.ts
+++ b/src/app/useEngine.ts
@@ -16,7 +16,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Engine } from '@/dag';
 import { createAppRegistry } from '@/nodes/browser';
-import { defaultGraph, slotSelectionKey, NO_SLOTS, type SlotSelection } from './graph';
+import { defaultGraph, slotSelectionKey, sourceNeedsVideo, NO_SLOTS, type SlotSelection } from './graph';
 import { runEngineLoop } from './engineLoop';
 import { DEFAULT_SOURCE, type SourceSpec } from './sourceSpec';
 import { useControls } from './store';
@@ -134,7 +134,21 @@ export function useThoreminEngine(source: SourceSpec = DEFAULT_SOURCE, slots: Sl
       try {
         setStatus('loading');
         const video = videoRef.current!;
-        if (source.kind === 'video') {
+        // The registry is built first because the SOURCE SLOT decides whether the
+        // host has anything to acquire at all. A finished-frame source (replay /
+        // synthetic) produces its own frames and reads no video, so asking for a
+        // camera would be asking for hardware the run does not use — and on a
+        // machine without one it would fail the whole boot before the engine was
+        // ever constructed.
+        const registry = createAppRegistry();
+        registryRef.current = registry;
+        const needsVideo = sourceNeedsVideo(slotsRef.current, registry);
+        if (!needsVideo && source.kind === 'camera') {
+          // Camera-free: leave the <video> element empty. Every reader of
+          // `resources.video` guards on `readyState` (the overlay backdrop skips
+          // the draw; the face branch never downloads its model without frames),
+          // so nothing needs to know the difference.
+        } else if (source.kind === 'video') {
           // Camera-free (Stream Applier M-A): play a pre-recorded clip into the
           // same <video> the webcam would fill, so the overlays + palette run
           // with no camera. The webcam-hands/face nodes read ctx.resources.video
@@ -175,7 +189,8 @@ export function useThoreminEngine(source: SourceSpec = DEFAULT_SOURCE, slots: Sl
           // Expose the raw camera stream for the pure-webcam recording stream (#88).
           cameraStreamRef.current = stream;
         }
-        await new Promise<void>((resolve, reject) => {
+        // Nothing to wait for when there is no media: skip straight to building.
+        if (needsVideo || source.kind === 'video') await new Promise<void>((resolve, reject) => {
           // File path only: a stalling clip fires neither event, so bound the
           // wait and surface a timeout. The camera path (timer === null) keeps
           // its original "settle only on metadata" behavior.
@@ -229,8 +244,6 @@ export function useThoreminEngine(source: SourceSpec = DEFAULT_SOURCE, slots: Sl
         // (the trainer, while a cue runs) has claimed, even with the Lab closed.
         resources.featureDemand = featureDemandResource;
 
-        const registry = createAppRegistry();
-        registryRef.current = registry;
         // `defaultGraph` validates the selection against the registry and falls
         // back (with a warning) on anything that would not satisfy the slot
         // contract, so a stale URL can never produce an unbuildable graph.

--- a/src/dag/engine.ts
+++ b/src/dag/engine.ts
@@ -29,6 +29,7 @@ import type {
   Tap,
 } from './types';
 import type { NodeRegistry } from './registry';
+import type { ZodType } from 'zod';
 
 interface BuiltNode {
   id: string;
@@ -43,6 +44,8 @@ interface BuiltNode {
   handlers: NodeHandlers;
   /** Declared output port names (for tap emission and validation). */
   outputPorts: string[];
+  /** output port name -> declared schema, for ports that declare one. Usually empty. */
+  outputSchemas: Map<string, ZodType>;
   /** input port name -> default value (from PortSpec.default), if any. */
   inputDefaults: Map<string, unknown>;
   /** incoming edges, grouped by target input port. */
@@ -56,6 +59,14 @@ export interface EngineOptions {
   nominalDt?: number;
   /** Taps notified of every output-port value each tick (e.g. a recorder). */
   taps?: Tap[];
+  /**
+   * Check every emitted value against its {@link PortSpec.schema}, throwing at
+   * the offending node and tick. Off by default: this is a batch/dev gate, and
+   * running Zod over every port of every node at 60fps is not something the live
+   * instrument should pay for. `runHeadless` turns it ON, so the fixture and
+   * end-to-end runs get the check for free.
+   */
+  validatePorts?: boolean;
   log?: (msg: string) => void;
 }
 
@@ -130,6 +141,7 @@ export class Engine {
   private taps: Tap[];
   private resources: Record<string, unknown>;
   private nominalDt: number;
+  private validatePorts: boolean;
   private log?: (msg: string) => void;
 
   /** Kept so {@link applyGraph} can re-resolve node types without the caller re-supplying it. */
@@ -156,6 +168,7 @@ export class Engine {
     this.taps = opts.taps ?? [];
     this.resources = opts.resources ?? {};
     this.nominalDt = opts.nominalDt ?? 1 / 60;
+    this.validatePorts = opts.validatePorts ?? false;
     this.log = opts.log;
     this.registry = registry;
     this.spec = spec;
@@ -374,8 +387,31 @@ export class Engine {
       const node = this.nodes.get(id)!;
       const inputs = this.gatherInputs(node);
       const out = node.handlers.process(inputs, ctx) ?? {};
+      if (this.validatePorts && node.outputSchemas.size) this.checkOutputPorts(node, out);
       this.outputs.set(id, out);
       if (this.taps.length) this.emitTaps(node, out, ctx);
+    }
+  }
+
+  /**
+   * Port conformance (batch/dev only — see {@link EngineOptions.validatePorts}).
+   * Runs in `tick`'s output path rather than `emitTaps` on purpose: taps skip
+   * `undefined`, and "the node emitted nothing" is exactly the failure this is
+   * here to catch. Throwing names the node, the port and the tick, because a
+   * malformed frame surfaces far downstream as a wrong note, not as an error.
+   */
+  private checkOutputPorts(node: BuiltNode, out: PortValues): void {
+    for (const [port, schema] of node.outputSchemas) {
+      const result = schema.safeParse(out[port]);
+      if (result.success) continue;
+      const detail =
+        out[port] === undefined
+          ? 'it emitted nothing (undefined) on a port whose schema is not optional'
+          : String(result.error.message);
+      throw new Error(
+        `Engine: node "${node.id}" (${node.type}) violated the schema of output port ` +
+          `"${port}" at tick ${this.tickIndex}: ${detail}`,
+      );
     }
   }
 
@@ -485,12 +521,17 @@ function compile(
       for (const p of def.inputs) {
         if (p.default !== undefined) inputDefaults.set(p.name, p.default);
       }
+      const outputSchemas = new Map<string, ZodType>();
+      for (const p of def.outputs) {
+        if (p.schema) outputSchemas.set(p.name, p.schema);
+      }
       nodes.set(n.id, {
         id: n.id,
         type: n.type,
         params,
         handlers: def.make(params as never),
         outputPorts: def.outputs.map((p) => p.name),
+        outputSchemas,
         inputDefaults,
         incoming: new Map(),
       });

--- a/src/dag/index.ts
+++ b/src/dag/index.ts
@@ -31,6 +31,11 @@ import type { GraphSpec } from './types';
  * Build, init and tick a graph headlessly for `ticks` ticks, returning the
  * engine and a {@link StreamRecorder} capturing every edge. The default driver
  * for end-to-end DAG tests and for the `record` CLI script.
+ *
+ * Port conformance ({@link EngineOptions.validatePorts}) defaults **on** here:
+ * this is the batch path the check was designed for, and a fixture recorded
+ * from a node that emitted a malformed frame is worse than a failing run. Pass
+ * `validatePorts: false` to opt out.
  */
 export async function runHeadless(
   spec: GraphSpec,
@@ -38,7 +43,7 @@ export async function runHeadless(
   opts: { ticks: number; recordOnly?: string[] } & Omit<EngineOptions, 'taps'> = { ticks: 1 },
 ): Promise<{ engine: Engine; recorder: StreamRecorder }> {
   const recorder = new StreamRecorder({ only: opts.recordOnly });
-  const engine = new Engine(spec, registry, { ...opts, taps: [recorder] });
+  const engine = new Engine(spec, registry, { validatePorts: true, ...opts, taps: [recorder] });
   await engine.init();
   // BatchClock calls engine.tick() with no argument, exactly as the previous
   // inline for-loop did, so recorded goldens are byte-identical.

--- a/src/dag/index.ts
+++ b/src/dag/index.ts
@@ -43,7 +43,16 @@ export async function runHeadless(
   opts: { ticks: number; recordOnly?: string[] } & Omit<EngineOptions, 'taps'> = { ticks: 1 },
 ): Promise<{ engine: Engine; recorder: StreamRecorder }> {
   const recorder = new StreamRecorder({ only: opts.recordOnly });
-  const engine = new Engine(spec, registry, { validatePorts: true, ...opts, taps: [recorder] });
+  // Resolve the gate explicitly rather than by spread order: a caller forwarding
+  // an optional flag (`validatePorts: cfg.validate` where cfg.validate is unset)
+  // passes the KEY with value undefined, and a spread would let that overwrite
+  // the default with undefined — which Engine then reads as false, silently
+  // turning the gate off in exactly the batch runs it exists for.
+  const engine = new Engine(spec, registry, {
+    ...opts,
+    validatePorts: opts.validatePorts ?? true,
+    taps: [recorder],
+  });
   await engine.init();
   // BatchClock calls engine.tick() with no argument, exactly as the previous
   // inline for-loop did, so recorded goldens are byte-identical.

--- a/src/dag/types.ts
+++ b/src/dag/types.ts
@@ -66,6 +66,23 @@ export interface PortSpec {
   description?: string;
   /** Optional default value used when no edge feeds this input port. */
   default?: unknown;
+  /**
+   * Optional runtime shape check for values on this port. Where {@link kind} is
+   * an advisory *label*, this is an enforceable *contract* — but only where the
+   * cost is affordable, so the engine checks it on OUTPUT ports and only when
+   * {@link EngineOptions.validatePorts} is on (batch runs and tests; never the
+   * 60fps live path).
+   *
+   * The case worth declaring one for is the one a type system cannot catch: a
+   * node that emits **nothing** on a port it declares. `process()` returns a
+   * plain object, so a source whose pump has not latched yet, or whose generator
+   * has drained, silently yields `undefined` — the downstream node then reads
+   * its port default (or nothing) and the graph goes quiet with no error
+   * anywhere. A schema that is not `.optional()` turns that into a loud failure
+   * at the exact node and tick, which is why `emitTaps` is the wrong place for
+   * this check (it skips `undefined` by design).
+   */
+  schema?: ZodType;
 }
 
 /**

--- a/src/nodes/domain.ts
+++ b/src/nodes/domain.ts
@@ -6,6 +6,7 @@
  * Landmark indices follow MediaPipe Hands (21 points). We also tolerate named
  * keypoints (as emitted by @tensorflow-models/hand-pose-detection).
  */
+import { z } from 'zod';
 import type { SoundId } from '@/music/sounds';
 
 export interface Keypoint {
@@ -38,6 +39,37 @@ export interface HandsFrame {
   height: number;
   hands: Hand[];
 }
+
+/**
+ * Runtime shape of a {@link HandsFrame}, for `PortSpec.schema` on the source
+ * slot's output port (#104). The interfaces above stay the SSOT for the TYPE;
+ * this mirrors them for the values, which is the half a compiler cannot check —
+ * a generator or replay source that emits a malformed frame, or nothing at all,
+ * would otherwise surface far downstream as a wrong note rather than an error.
+ * `KeypointSchema` is `.passthrough()` so a detector that carries extra fields
+ * is not rejected for being richer than we modelled.
+ */
+export const KeypointSchema = z
+  .object({
+    x: z.number(),
+    y: z.number(),
+    z: z.number().optional(),
+    name: z.string().optional(),
+  })
+  .passthrough();
+
+export const HandSchema = z.object({
+  handedness: z.enum(['Left', 'Right']),
+  keypoints: z.array(KeypointSchema),
+  worldKeypoints: z.array(KeypointSchema).optional(),
+  score: z.number().optional(),
+});
+
+export const HandsFrameSchema = z.object({
+  width: z.number(),
+  height: z.number(),
+  hands: z.array(HandSchema),
+});
 
 /** The four non-thumb fingers, in radial order. */
 export const FINGER_NAMES = ['index', 'middle', 'ring', 'pinky'] as const;

--- a/src/nodes/index.ts
+++ b/src/nodes/index.ts
@@ -10,6 +10,7 @@ import { createRegistry, type NodeRegistry } from '@/dag';
 
 import { syntheticHandsNode } from './sources/synthetic_hands';
 import { replaySourceNode } from './sources/replay';
+import { replayHandsNode } from './sources/replay_hands';
 import { handFeaturesNode } from './features/hand_features';
 import { faceFeaturesNode } from './features/face_features';
 import { faceControlsNode } from './features/face_controls';
@@ -35,6 +36,13 @@ import { performanceNode } from './music/performance';
 
 export { syntheticHandsNode } from './sources/synthetic_hands';
 export { replaySourceNode } from './sources/replay';
+export { replayHandsNode } from './sources/replay_hands';
+export {
+  SOURCE_SLOT_CONTRACT,
+  SOURCE_SLOT_OUTPUT,
+  SOURCE_SLOT_INPUTS,
+} from './sources/source_contract';
+export type { SlotContract } from './slot_contract';
 export { handFeaturesNode } from './features/hand_features';
 export { faceFeaturesNode } from './features/face_features';
 export { faceControlsNode } from './features/face_controls';
@@ -66,6 +74,7 @@ export * from './domain';
 export const CORE_NODES = [
   syntheticHandsNode,
   replaySourceNode,
+  replayHandsNode,
   handFeaturesNode,
   faceFeaturesNode,
   faceControlsNode,

--- a/src/nodes/mapping/mapping_contract.ts
+++ b/src/nodes/mapping/mapping_contract.ts
@@ -19,6 +19,7 @@
  * hand-features→synth-params mapping a clean, edge-stable drop-in.
  */
 import type { PortSpec, Role } from '@/dag';
+import type { SlotContract } from '../slot_contract';
 
 /**
  * Input ports every mapping-slot node must declare so the default graph's
@@ -50,10 +51,13 @@ export const MAPPING_SLOT_OUTPUT: PortSpec = { name: 'params', kind: 'synth-para
  * name+kind (so downstream `synth`/`overlay` edges keep working). Consumed by the
  * slot resolver's validation in `src/app/graph.ts`.
  */
-export const MAPPING_SLOT_CONTRACT = {
+export const MAPPING_SLOT_CONTRACT: SlotContract = {
   role: 'mapping' as Role,
   requiredInputs: MAPPING_SLOT_INPUTS.map((p) => p.name),
   output: MAPPING_SLOT_OUTPUT,
-} as const;
+};
 
-export type SlotContract = typeof MAPPING_SLOT_CONTRACT;
+// The shared shape moved to `src/nodes/slot_contract.ts` when the `source` slot
+// (#104) became the second contract; re-exported so existing importers of
+// `SlotContract` from here keep working.
+export type { SlotContract };

--- a/src/nodes/slot_contract.ts
+++ b/src/nodes/slot_contract.ts
@@ -1,0 +1,28 @@
+/**
+ * `SlotContract` — what a node must declare to fill a role-typed swap point.
+ *
+ * A slot's contract is structural, and deliberately small: the engine's
+ * `validateEdge` accepts an edge only if the target node DECLARES an input port
+ * of that name, so port *names* are what make a swap edge-stable. Everything
+ * else here is a pre-flight the slot resolver runs so a bad swap is caught
+ * before an Engine is constructed rather than as a wiring error afterwards.
+ *
+ * This interface lives on its own (rather than being inferred from the first
+ * contract that happened to be written) so every slot's contract is the same
+ * shape: `src/app/graph.ts`'s `slotFillReason` checks all of them identically,
+ * and adding a slot is adding data, not a code path.
+ */
+import type { PortSpec, Role } from '@/dag';
+
+export interface SlotContract {
+  /** The advisory role a candidate must carry. */
+  role: Role;
+  /**
+   * Input port NAMES a candidate must declare, so the default graph's edges into
+   * the slot stay valid across a swap. Empty for slots whose candidates are
+   * zero-input (sources).
+   */
+  requiredInputs: readonly string[];
+  /** The output port a candidate must emit — name and `kind` are both checked. */
+  output: PortSpec;
+}

--- a/src/nodes/sources/replay_hands.ts
+++ b/src/nodes/sources/replay_hands.ts
@@ -13,9 +13,16 @@
  * boundary A — raw video decode is an offline pre-processing step, never an
  * in-loop batch source).
  *
- * Determinism is the point of a replay source, so it derives everything from
- * `ctx.tick` and never reads a clock or a random number generator
- * (`test/source_slot.test.ts` enforces that for every source-slot candidate).
+ * Determinism is the point of a replay source, so it never reads a clock or a
+ * random number generator — `test/source_slot.test.ts` enforces that
+ * behaviourally, by running each candidate twice under different wall clocks.
+ *
+ * It also counts its OWN frames rather than reading `ctx.tick`. The engine's tick
+ * counter is monotonic for the engine's whole life, which is only the same thing
+ * for an instance that existed at tick 0 — and the source slot's whole point is
+ * that a source can be swapped into a *running* graph (`applyGraph`, #51). Keyed
+ * on `ctx.tick`, a replay swapped in at tick 50 of a 3-frame recording would open
+ * on the last frame and never show the other two.
  */
 import { z } from 'zod';
 import { defineNode } from '@/dag';
@@ -48,10 +55,13 @@ export const replayHandsNode = defineNode<Params>({
   outputs: [SOURCE_SLOT_OUTPUT],
   params: Params,
   make({ frames, loop }) {
+    // Per-INSTANCE, so a replay swapped into a running graph starts at frame 0.
+    let n = 0;
     return {
-      process(_inputs, ctx) {
+      process() {
         if (frames.length === 0) return { hands: EMPTY };
-        const i = loop ? ctx.tick % frames.length : Math.min(ctx.tick, frames.length - 1);
+        const i = loop ? n % frames.length : Math.min(n, frames.length - 1);
+        n += 1;
         return { hands: frames[i] as HandsFrame };
       },
     };

--- a/src/nodes/sources/replay_hands.ts
+++ b/src/nodes/sources/replay_hands.ts
@@ -1,0 +1,59 @@
+/**
+ * `replay-hands` node — replays a recorded `HandsFrame` stream, one frame per
+ * tick, on the source slot's `hands` port.
+ *
+ * `replay-source` already replays *any* recorded value, but on a generic `value`
+ * port, which is what makes it a fine stand-in for an arbitrary edge and a poor
+ * fit for the **source slot**: a slot candidate is identified by the port it
+ * emits (`hands`), not by what it happens to contain. So this is the typed
+ * sibling — same replay semantics, the contract's port and schema.
+ *
+ * That is what makes the whole downstream instrument runnable in plain Node from
+ * a landmark recording: no DOM, no MediaPipe WASM, no camera (design-doc
+ * boundary A — raw video decode is an offline pre-processing step, never an
+ * in-loop batch source).
+ *
+ * Determinism is the point of a replay source, so it derives everything from
+ * `ctx.tick` and never reads a clock or a random number generator
+ * (`test/source_slot.test.ts` enforces that for every source-slot candidate).
+ */
+import { z } from 'zod';
+import { defineNode } from '@/dag';
+import { HandsFrameSchema, type HandsFrame } from '../domain';
+import { SOURCE_SLOT_OUTPUT } from './source_contract';
+
+/**
+ * What a source with nothing to replay emits. **Not** `undefined`: the contract
+ * says this port always carries a frame, and "no hands detected" is a real,
+ * well-defined frame that the whole downstream graph already handles (it is what
+ * `webcam-hands` emits before its first inference). Emitting nothing instead
+ * would be the exact failure `PortSpec.schema` exists to catch.
+ */
+const EMPTY: HandsFrame = { width: 640, height: 480, hands: [] };
+
+const Params = z.object({
+  /** The recorded frames, in tick order. */
+  frames: z.array(HandsFrameSchema).default([]),
+  /** Loop back to the start when exhausted (otherwise hold the last frame). */
+  loop: z.boolean().default(false),
+});
+type Params = z.infer<typeof Params>;
+
+export const replayHandsNode = defineNode<Params>({
+  type: 'replay-hands',
+  roles: ['source'],
+  title: 'Replay Hands',
+  description: 'Replays a recorded hand-landmark stream, one frame per tick. Camera-free and deterministic.',
+  inputs: [],
+  outputs: [SOURCE_SLOT_OUTPUT],
+  params: Params,
+  make({ frames, loop }) {
+    return {
+      process(_inputs, ctx) {
+        if (frames.length === 0) return { hands: EMPTY };
+        const i = loop ? ctx.tick % frames.length : Math.min(ctx.tick, frames.length - 1);
+        return { hands: frames[i] as HandsFrame };
+      },
+    };
+  },
+});

--- a/src/nodes/sources/source_contract.ts
+++ b/src/nodes/sources/source_contract.ts
@@ -1,0 +1,58 @@
+/**
+ * The source-slot contract — what a node must declare to stand where the
+ * instrument's hand source stands (Stream Applier M-C, issue #104).
+ *
+ * The design's resolved fork (docs/design/stream-applier.md, "M-C resolved") is
+ * that origin variability lives in **two different places**, and which one
+ * depends on what the origin emits:
+ *
+ *  - **Raw video** (a `<video>` element — camera, file, stream) is a *host-side*
+ *    concern. The element goes into `ctx.resources.video` and `webcam-hands`
+ *    runs unchanged: its job (run MediaPipe on a video element and latch the
+ *    result) is identical whatever produced the pixels. That is M-A's
+ *    `?source=video`, and it stays where it is.
+ *  - **Finished frames** (a `HandsFrame` from a recording, a generator, or a
+ *    state-feedback source) are a *node swap*. They emit the node's output type
+ *    directly; there is no inference to do and no machinery to reuse. And the
+ *    batch/test path runs in Node with no DOM, where a node that so much as
+ *    imports `@mediapipe/tasks-vision` cannot load at all — so a finished-frame
+ *    origin MUST be a different node type, not an overloaded webcam node.
+ *
+ * This contract governs the second group. Its candidates are the finished-frame
+ * emitters; `videoFileSource` is deliberately NOT among them.
+ *
+ * Unlike the mapping slot, the required-input list is **empty**: sources are
+ * zero-input nodes, and nothing in the default graph wires into the source
+ * position. What has to hold is the OUTPUT — `hands` carrying a `HandsFrame` —
+ * because `hand-features`, `canvas-overlay` and `hand-feature-vector` all read
+ * it. That port carries a `schema`, so in batch runs the engine catches a source
+ * that emits a malformed frame, or nothing at all, at the source instead of as a
+ * wrong note three nodes downstream.
+ */
+import type { PortSpec, Role } from '@/dag';
+import type { SlotContract } from '../slot_contract';
+import { HandsFrameSchema } from '../domain';
+
+/**
+ * The output port every source-slot node must emit. `schema` is what makes this
+ * a checkable contract rather than a naming convention — see
+ * `PortSpec.schema` and `EngineOptions.validatePorts`.
+ */
+export const SOURCE_SLOT_OUTPUT: PortSpec = {
+  name: 'hands',
+  kind: 'hands-frame',
+  schema: HandsFrameSchema,
+};
+
+/**
+ * Sources take no inputs, so a swap cannot orphan an edge into the slot — the
+ * whole risk is on the output side. Kept explicit (rather than omitted) so every
+ * slot's contract reads the same way.
+ */
+export const SOURCE_SLOT_INPUTS: readonly PortSpec[] = [];
+
+export const SOURCE_SLOT_CONTRACT: SlotContract = {
+  role: 'source' as Role,
+  requiredInputs: [],
+  output: SOURCE_SLOT_OUTPUT,
+};

--- a/src/nodes/sources/synthetic_hands.ts
+++ b/src/nodes/sources/synthetic_hands.ts
@@ -8,6 +8,7 @@
 import { z } from 'zod';
 import { defineNode } from '@/dag';
 import { makeHandKeypoints, type Hand, type HandsFrame } from '../domain';
+import { SOURCE_SLOT_OUTPUT } from './source_contract';
 
 const Params = z.object({
   width: z.number().default(640),
@@ -37,7 +38,7 @@ export const syntheticHandsNode = defineNode<Params>({
   title: 'Synthetic Hands',
   description: 'Camera-free animated hand landmark source for tests & demos.',
   inputs: [],
-  outputs: [{ name: 'hands', kind: 'hands-frame' }],
+  outputs: [SOURCE_SLOT_OUTPUT],
   params: Params,
   process(_inputs, p, ctx) {
     const margin = p.scale;

--- a/src/nodes/sources/webcam_hands.ts
+++ b/src/nodes/sources/webcam_hands.ts
@@ -18,6 +18,7 @@
  */
 import { z } from 'zod';
 import { defineNode } from '@/dag';
+import { SOURCE_SLOT_OUTPUT } from './source_contract';
 import type { NodeContext } from '@/dag';
 import type { Hand, Handedness, HandsFrame, Keypoint } from '../domain';
 
@@ -100,7 +101,7 @@ export const webcamHandsNode = defineNode<Params>({
   title: 'Webcam Hands',
   description: 'MediaPipe hand landmark detection from a webcam video element.',
   inputs: [],
-  outputs: [{ name: 'hands', kind: 'hands-frame' }],
+  outputs: [SOURCE_SLOT_OUTPUT],
   params: Params,
   make(p) {
     let landmarker: HandLandmarkerLike | null = null;

--- a/test/camera_free_boot.test.tsx
+++ b/test/camera_free_boot.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+/**
+ * Camera-free boot: selecting a finished-frame source must not ask for hardware.
+ *
+ * The source slot (#104) chooses the `cam` NODE TYPE inside `defaultGraph`, but
+ * the host's video acquisition is a separate decision made in `useEngine` before
+ * the engine exists. Getting the first right and the second wrong produces the
+ * worst possible version of this feature: the one URL a developer is told to use
+ * for hardware-free verification is the one URL that still demands a camera — and
+ * on a machine without one, `getUserMedia` rejects and the engine is never built
+ * at all. An adversarial review caught exactly that, in code that passed every
+ * other test, because every other source-slot test constructs an `Engine`
+ * directly and never goes through the hook.
+ *
+ * So this is the half that has to be tested through the hook. It renders the real
+ * `useThoreminEngine` in jsdom with `getUserMedia` rejecting — a machine with no
+ * camera — and asserts the camera-free selection never calls it and still boots.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, waitFor } from '@testing-library/react';
+import { useThoreminEngine } from '@/app/useEngine';
+import { DEFAULT_SOURCE } from '@/app/sourceSpec';
+import { sourceNeedsVideo, NO_SLOTS, type SlotSelection } from '@/app/graph';
+import { createAppRegistry } from '@/nodes/browser';
+
+/** A camera that is not there: every request rejects, as on a webcam-less machine. */
+function stubMissingCamera() {
+  const getUserMedia = vi.fn(() => Promise.reject(new DOMException('Requested device not found', 'NotFoundError')));
+  Object.defineProperty(navigator, 'mediaDevices', {
+    value: { getUserMedia },
+    configurable: true,
+  });
+  return getUserMedia;
+}
+
+/** Mounts the hook and exposes what it reported. */
+function Harness({ slots, seen }: { slots: SlotSelection; seen: { status?: string; error?: string | null } }) {
+  const { videoRef, canvasRef, status, error } = useThoreminEngine(DEFAULT_SOURCE, slots);
+  seen.status = status;
+  seen.error = error;
+  return (
+    <>
+      <video ref={videoRef} />
+      <canvas ref={canvasRef} />
+    </>
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('sourceNeedsVideo', () => {
+  it('is true only for the default (the one candidate that runs MediaPipe on a video)', () => {
+    const reg = createAppRegistry();
+    expect(sourceNeedsVideo(NO_SLOTS, reg)).toBe(true);
+    expect(sourceNeedsVideo({ source: 'webcam-hands' }, reg)).toBe(true);
+    expect(sourceNeedsVideo({ source: 'synthetic-hands' }, reg)).toBe(false);
+    expect(sourceNeedsVideo({ source: 'replay-hands' }, reg)).toBe(false);
+  });
+
+  it('is true for a selection that falls back to the default', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(sourceNeedsVideo({ source: 'not-a-node' }, createAppRegistry())).toBe(true);
+    warn.mockRestore();
+  });
+});
+
+describe('booting with a finished-frame source', () => {
+  it('never asks for a camera, and reaches ready on a machine that has none', async () => {
+    const getUserMedia = stubMissingCamera();
+    const seen: { status?: string; error?: string | null } = {};
+    render(<Harness slots={{ source: 'synthetic-hands' }} seen={seen} />);
+
+    await waitFor(() => expect(seen.status).toBe('ready'), { timeout: 4000 });
+    expect(getUserMedia).not.toHaveBeenCalled();
+    expect(seen.error).toBeNull();
+  });
+
+  it('the DEFAULT source still asks — and honestly reports the failure', async () => {
+    // The control case. Without it, "never asks" would also pass if the hook had
+    // simply stopped acquiring video for everyone.
+    const getUserMedia = stubMissingCamera();
+    const seen: { status?: string; error?: string | null } = {};
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    render(<Harness slots={NO_SLOTS} seen={seen} />);
+
+    await waitFor(() => expect(seen.status).toBe('error'), { timeout: 4000 });
+    expect(getUserMedia).toHaveBeenCalled();
+    err.mockRestore();
+  });
+});

--- a/test/catalog.test.ts
+++ b/test/catalog.test.ts
@@ -4,6 +4,8 @@
  * is generated from. Guards that the manual can't drift from the code.
  */
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { buildCatalog } from '@/catalog';
 import { createCoreRegistry } from '@/nodes';
 
@@ -50,6 +52,17 @@ describe('buildCatalog', () => {
 
   it('is JSON-serializable (for the frontend manual)', () => {
     expect(() => JSON.stringify(catalog)).not.toThrow();
+  });
+
+  it('every node is filed under a real manual section, never the "Other" catch-all', () => {
+    // The manual's grouping is a HAND-LISTED table in scripts/gen_catalog.ts (the
+    // registry has no discovery seam — component-model.md, "Two corrections" #2).
+    // So adding a node and forgetting that table produces a manual that is not
+    // wrong, just quietly worse: the node lands in an unexplained "Other" heap at
+    // the bottom. Nothing else notices, which is why this does.
+    const manual = readFileSync(resolve(process.cwd(), 'public/manual.html'), 'utf8');
+    expect(manual).not.toContain('<h3>Other</h3>');
+    expect(readFileSync(resolve(process.cwd(), 'docs/CATALOG.md'), 'utf8')).not.toContain('### Other');
   });
 
   it('introspects the FULL app registry (incl. browser nodes) without dropping or throwing', async () => {

--- a/test/source_slot.test.ts
+++ b/test/source_slot.test.ts
@@ -1,0 +1,322 @@
+/**
+ * The `source` slot and port conformance (issue #104 / Stream Applier M-C).
+ *
+ * Two halves, both of which the design doc argues for on the same grounds — that
+ * "where the frames come from" should be a *selection*, not a code path:
+ *
+ *  1. **The slot.** Its candidates are the finished-frame emitters only. A file
+ *     or stream feeding a `<video>` is host-side (`sourceSpec.ts`, M-A), because
+ *     `webcam-hands` does the identical job whatever produced the pixels — and
+ *     because the batch path runs in Node, where a node that so much as imports
+ *     the MediaPipe WASM runtime cannot load. So a finished-frame origin has to
+ *     be a different node type; that is what makes this a slot and not a flag.
+ *
+ *  2. **Port conformance.** `PortSpec.kind` was always advisory. A slot needs
+ *     more than a label: the payoff below (the whole instrument running from a
+ *     synthetic source, in Node, with no camera) is only trustworthy if a source
+ *     that emits a malformed frame — or, the failure that actually happens,
+ *     *nothing at all* — fails loudly at the source rather than surfacing three
+ *     nodes downstream as a wrong note.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { z } from 'zod';
+import { Engine, createRegistry, defineNode, runHeadless, type GraphSpec } from '../src/dag';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { createAppRegistry, BROWSER_NODES } from '@/nodes/browser';
+import { CORE_NODES } from '@/nodes';
+import { SLOTS, resolveSlot, defaultGraph, parseSlotSelection } from '@/app/graph';
+import { SOURCE_SLOT_CONTRACT, SOURCE_SLOT_OUTPUT } from '@/nodes/sources/source_contract';
+import { HandsFrameSchema } from '@/nodes/domain';
+import type { SynthParams, HandsFrame } from '@/nodes';
+
+const appRegistry = () => createAppRegistry();
+
+/** Where each candidate's implementation lives, for the determinism guard below. */
+const CANDIDATE_SOURCES: Record<string, string> = {
+  'webcam-hands': 'src/nodes/sources/webcam_hands.ts',
+  'synthetic-hands': 'src/nodes/sources/synthetic_hands.ts',
+  'replay-hands': 'src/nodes/sources/replay_hands.ts',
+};
+
+describe('the source slot contract', () => {
+  it('every declared candidate really satisfies it', () => {
+    const reg = appRegistry();
+    for (const type of SLOTS.source.candidates) {
+      const def = reg.get(type);
+      expect(def.roles, `${type} must carry the source role`).toContain('source');
+      const out = def.outputs.find((p) => p.name === SOURCE_SLOT_OUTPUT.name);
+      expect(out, `${type} must emit "${SOURCE_SLOT_OUTPUT.name}"`).toBeTruthy();
+      expect(out!.kind).toBe(SOURCE_SLOT_OUTPUT.kind);
+      // The schema is what makes this contract checkable rather than nominal.
+      expect(out!.schema, `${type}'s hands port must carry the contract schema`).toBe(HandsFrameSchema);
+      // Sources are zero-input by definition; the slot's risk is all on the output.
+      expect(def.inputs).toEqual([]);
+    }
+    expect(SOURCE_SLOT_CONTRACT.requiredInputs).toEqual([]);
+  });
+
+  it('has more than one real implementation, unlike the mapping slot', () => {
+    expect(SLOTS.source.default).toBe('webcam-hands');
+    expect(SLOTS.source.candidates.length).toBeGreaterThan(1);
+  });
+
+  it('rejects a node that is role:source but emits the wrong thing', () => {
+    const reg = appRegistry();
+    const warnings: string[] = [];
+    // store-controls carries role 'source' but emits control values, not frames.
+    expect(resolveSlot('source', { source: 'store-controls' }, reg, (m) => warnings.push(m))).toBe(
+      'webcam-hands',
+    );
+    expect(warnings[0]).toContain('has no output port "hands"');
+  });
+
+  it('rejects a wrong-kind hands port', () => {
+    const reg = appRegistry();
+    reg.register(
+      defineNode({
+        type: 'bogus-source',
+        roles: ['source'],
+        inputs: [],
+        outputs: [{ name: 'hands', kind: 'not-a-frame' }],
+        process: () => ({ hands: null }),
+      }),
+    );
+    const warnings: string[] = [];
+    expect(resolveSlot('source', { source: 'bogus-source' }, reg, (m) => warnings.push(m))).toBe(
+      'webcam-hands',
+    );
+    expect(warnings[0]).toContain('not "hands-frame"');
+  });
+
+  it('is reachable from the URL like every other slot', () => {
+    expect(parseSlotSelection('?slot.source=synthetic-hands')).toEqual({ source: 'synthetic-hands' });
+    expect(parseSlotSelection('?slot.source=replay-hands&slot.mapping=voice-mapping')).toEqual({
+      source: 'replay-hands',
+      mapping: 'voice-mapping',
+    });
+  });
+});
+
+describe('swapping the source in the real graph', () => {
+  it('replaces only the source node and leaves every edge valid', () => {
+    const reg = appRegistry();
+    const spec = defaultGraph({ source: 'synthetic-hands' }, reg);
+    expect(spec.nodes.find((n) => n.id === 'cam')?.type).toBe('synthetic-hands');
+    // Its MediaPipe params are dropped: they mean nothing to a synthetic source.
+    expect(spec.nodes.find((n) => n.id === 'cam')?.params).toEqual({});
+    expect(() => new Engine(spec, reg)).not.toThrow();
+    // Same node count, same edges — the swap is edge-stable by contract.
+    expect(spec.nodes).toHaveLength(defaultGraph().nodes.length);
+    expect(spec.edges).toEqual(defaultGraph().edges);
+  });
+
+  it('is byte-identical to the default when the default is selected explicitly', () => {
+    expect(defaultGraph({ source: 'webcam-hands' }, appRegistry())).toEqual(defaultGraph());
+  });
+
+  it('swaps on a RUNNING engine, keeping every other node (#51)', async () => {
+    const reg = appRegistry();
+    const engine = new Engine(defaultGraph(), reg);
+    const change = await engine.applyGraph(defaultGraph({ source: 'synthetic-hands' }, reg), reg);
+    expect(change.replaced).toEqual(['cam']);
+    expect(change.added).toEqual([]);
+    expect(change.removed).toEqual([]);
+    expect(change.rewired).toBe(false);
+    expect(change.kept).toContain('camFace'); // the face model is NOT reloaded
+    expect(change.kept).toContain('synth');
+  });
+});
+
+describe('the payoff: the whole instrument runs with no camera', () => {
+  it('a synthetic source drives the real graph to sounding voices, headlessly', () => {
+    // No DOM, no MediaPipe, no camera. `init()` is deliberately not called (the
+    // browser nodes lazy-load their models there); every node the synthetic path
+    // touches works without it, which is the point of the finished-frame origin.
+    const reg = appRegistry();
+    const engine = new Engine(defaultGraph({ source: 'synthetic-hands' }, reg), reg, {
+      validatePorts: true,
+    });
+    for (let i = 0; i < 30; i++) engine.tick();
+
+    const hands = engine.getOutput('cam', 'hands') as HandsFrame;
+    expect(HandsFrameSchema.safeParse(hands).success).toBe(true);
+    expect(hands.hands).toHaveLength(1);
+
+    const params = engine.getOutput('merge', 'params') as SynthParams;
+    expect(params.voices.length).toBeGreaterThan(0);
+    expect(params.voices[0].freq).toBeGreaterThan(0);
+  });
+
+  it('a replay source reproduces a recorded frame stream exactly', () => {
+    const reg = appRegistry();
+    const frames: HandsFrame[] = [
+      { width: 10, height: 10, hands: [] },
+      { width: 20, height: 20, hands: [] },
+      { width: 30, height: 30, hands: [] },
+    ];
+    const spec = defaultGraph({ source: 'replay-hands' }, reg);
+    spec.nodes = spec.nodes.map((n) => (n.id === 'cam' ? { ...n, params: { frames } } : n));
+    const engine = new Engine(spec, reg, { validatePorts: true });
+
+    const widths: number[] = [];
+    for (let i = 0; i < 5; i++) {
+      engine.tick();
+      widths.push((engine.getOutput('cam', 'hands') as HandsFrame).width);
+    }
+    // Holds the last frame past the end (loop defaults off).
+    expect(widths).toEqual([10, 20, 30, 30, 30]);
+  });
+
+  it('a replay source with nothing to replay emits an EMPTY frame, never undefined', () => {
+    // Emitting nothing is the exact failure the schema exists to catch, so the
+    // node must have a well-defined "no hands" answer of its own.
+    const reg = appRegistry();
+    const engine = new Engine(defaultGraph({ source: 'replay-hands' }, reg), reg, { validatePorts: true });
+    expect(() => engine.tick()).not.toThrow();
+    expect((engine.getOutput('cam', 'hands') as HandsFrame).hands).toEqual([]);
+  });
+});
+
+// ---- port conformance ------------------------------------------------------
+
+describe('port conformance (PortSpec.schema)', () => {
+  const checked = defineNode({
+    type: 'checked-source',
+    roles: ['source'],
+    inputs: [],
+    outputs: [SOURCE_SLOT_OUTPUT],
+    params: z.object({ emit: z.enum(['good', 'malformed', 'nothing']).default('good') }),
+    process: (_i, p) => {
+      if (p.emit === 'nothing') return {};
+      if (p.emit === 'malformed') return { hands: { width: 'wide', hands: [] } };
+      return { hands: { width: 1, height: 1, hands: [] } };
+    },
+  });
+  const reg = () => createRegistry([checked]);
+  const spec = (emit: string): GraphSpec => ({ nodes: [{ id: 's', type: 'checked-source', params: { emit } }], edges: [] });
+
+  it('passes a schema-valid value through', () => {
+    const engine = new Engine(spec('good'), reg(), { validatePorts: true });
+    expect(() => engine.tick()).not.toThrow();
+  });
+
+  it('trips on a malformed value, naming the node, the port and the tick', () => {
+    const engine = new Engine(spec('malformed'), reg(), { validatePorts: true });
+    expect(() => engine.tick()).toThrow(/node "s" \(checked-source\).*output port "hands" at tick 0/s);
+  });
+
+  it('trips when the node emits NOTHING — the failure a type system cannot catch', () => {
+    const engine = new Engine(spec('nothing'), reg(), { validatePorts: true });
+    expect(() => engine.tick()).toThrow(/emitted nothing \(undefined\)/);
+  });
+
+  it('is OFF by default, so the live 60fps path pays nothing for it', () => {
+    const engine = new Engine(spec('nothing'), reg());
+    expect(() => engine.tick()).not.toThrow();
+    expect(engine.getOutput('s', 'hands')).toBeUndefined();
+  });
+
+  it('runHeadless turns it ON, so a fixture is never recorded from a bad frame', async () => {
+    await expect(runHeadless(spec('nothing'), reg(), { ticks: 1 })).rejects.toThrow(
+      /emitted nothing \(undefined\)/,
+    );
+    // ...and can be opted out of explicitly.
+    await expect(
+      runHeadless(spec('nothing'), reg(), { ticks: 1, validatePorts: false }),
+    ).resolves.toBeTruthy();
+  });
+
+  it('ignores ports that declare no schema (every existing node)', () => {
+    const plain = defineNode({
+      type: 'plain',
+      inputs: [],
+      outputs: [{ name: 'v', kind: 'number' }],
+      process: () => ({}), // emits nothing, and that is allowed without a schema
+    });
+    const engine = new Engine({ nodes: [{ id: 'p', type: 'plain' }], edges: [] }, createRegistry([plain]), {
+      validatePorts: true,
+    });
+    expect(() => engine.tick()).not.toThrow();
+  });
+
+  it('accepts an explicitly optional schema emitting nothing', () => {
+    const maybe = defineNode({
+      type: 'maybe',
+      inputs: [],
+      outputs: [{ name: 'v', kind: 'number', schema: z.number().optional() }],
+      process: () => ({}),
+    });
+    const engine = new Engine({ nodes: [{ id: 'm', type: 'maybe' }], edges: [] }, createRegistry([maybe]), {
+      validatePorts: true,
+    });
+    expect(() => engine.tick()).not.toThrow();
+  });
+
+  it('the real graph passes conformance on the camera-free path', () => {
+    const reg = appRegistry();
+    const engine = new Engine(defaultGraph({ source: 'synthetic-hands' }, reg), reg, { validatePorts: true });
+    expect(() => {
+      for (let i = 0; i < 10; i++) engine.tick();
+    }).not.toThrow();
+  });
+});
+
+// ---- determinism -----------------------------------------------------------
+
+describe('source determinism (the seeded-RNG rule)', () => {
+  it('the candidate table covers every declared candidate', () => {
+    expect(Object.keys(CANDIDATE_SOURCES).sort()).toEqual([...SLOTS.source.candidates].sort());
+  });
+
+  it('no source-slot candidate reaches for Math.random or Date.now', () => {
+    // A recording is only worth keeping if replaying it reproduces the run. Any
+    // randomness in a generator source must come from `seed + ctx.tick`, never an
+    // ambient RNG, and no source may read the wall clock for its VALUES.
+    for (const [type, file] of Object.entries(CANDIDATE_SOURCES)) {
+      const src = readFileSync(resolve(process.cwd(), file), 'utf8');
+      expect(src, `${type} must not use Math.random`).not.toMatch(/Math\.random/);
+      expect(src, `${type} must not use Date.now`).not.toMatch(/Date\.now/);
+    }
+  });
+
+  it('the finished-frame candidates read no clock at all — their output is a function of ctx', () => {
+    // webcam-hands is exempt and must stay so: MediaPipe's detectForVideo
+    // REQUIRES a strictly-increasing timestamp, and performance.now() is it. The
+    // exemption is named here rather than left implicit.
+    const finishedFrame = SLOTS.source.candidates.filter((t) => t !== SLOTS.source.default);
+    expect(finishedFrame.length).toBeGreaterThan(0);
+    for (const type of finishedFrame) {
+      const src = readFileSync(resolve(process.cwd(), CANDIDATE_SOURCES[type]), 'utf8');
+      expect(src, `${type} must not read a clock`).not.toMatch(/performance\.now/);
+    }
+  });
+
+  it('a synthetic source replays identically from the same tick sequence', () => {
+    const reg = createRegistry([...CORE_NODES, ...BROWSER_NODES]);
+    const run = () => {
+      const engine = new Engine(
+        { nodes: [{ id: 's', type: 'synthetic-hands' }], edges: [] },
+        reg,
+        { validatePorts: true },
+      );
+      const out: number[] = [];
+      for (let i = 0; i < 20; i++) {
+        engine.tick();
+        out.push((engine.getOutput('s', 'hands') as HandsFrame).hands[0].keypoints[0].x);
+      }
+      return out;
+    };
+    expect(run()).toEqual(run());
+  });
+});
+
+describe('slot governance', () => {
+  it('a bad source selection warns and falls back so the app still starts', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const spec = defaultGraph(parseSlotSelection('?slot.source=nonesuch'), appRegistry());
+    expect(spec.nodes.find((n) => n.id === 'cam')?.type).toBe('webcam-hands');
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});

--- a/test/source_slot.test.ts
+++ b/test/source_slot.test.ts
@@ -28,7 +28,7 @@ import { CORE_NODES } from '@/nodes';
 import { SLOTS, resolveSlot, defaultGraph, parseSlotSelection } from '@/app/graph';
 import { SOURCE_SLOT_CONTRACT, SOURCE_SLOT_OUTPUT } from '@/nodes/sources/source_contract';
 import { HandsFrameSchema } from '@/nodes/domain';
-import type { SynthParams, HandsFrame } from '@/nodes';
+import type { SynthParams, HandsFrame, HandFeatures } from '@/nodes';
 
 const appRegistry = () => createAppRegistry();
 
@@ -143,9 +143,17 @@ describe('the payoff: the whole instrument runs with no camera', () => {
     expect(HandsFrameSchema.safeParse(hands).success).toBe(true);
     expect(hands.hands).toHaveLength(1);
 
+    // The hand really was detected and mirrored into a side (the synthetic
+    // source emits a Right hand; mirrorHandedness routes it to `left`).
+    const feats = engine.getOutput('feat', 'features') as HandFeatures;
+    expect(feats.left.present || feats.right.present).toBe(true);
+
+    // And a voice is actually SOUNDING. `voices.length > 0` and `freq > 0` are
+    // both true of a silent, absent voice, so asserting those would pass on a
+    // graph where the source reaches nothing — which is the failure this whole
+    // test exists to notice.
     const params = engine.getOutput('merge', 'params') as SynthParams;
-    expect(params.voices.length).toBeGreaterThan(0);
-    expect(params.voices[0].freq).toBeGreaterThan(0);
+    expect(params.voices.some((v) => v.present && v.gain > 0)).toBe(true);
   });
 
   it('a replay source reproduces a recorded frame stream exactly', () => {
@@ -225,6 +233,14 @@ describe('port conformance (PortSpec.schema)', () => {
     await expect(
       runHeadless(spec('nothing'), reg(), { ticks: 1, validatePorts: false }),
     ).resolves.toBeTruthy();
+    // But an OMITTED-yet-present key must not be a silent opt-out. A caller
+    // forwarding an optional flag (`validatePorts: cfg.validate`, cfg.validate
+    // unset) passes the key with value undefined; resolving the default by spread
+    // order rather than by `??` would let that turn the gate off in exactly the
+    // batch runs it exists for, and record the fixture it exists to prevent.
+    await expect(
+      runHeadless(spec('nothing'), reg(), { ticks: 1, validatePorts: undefined }),
+    ).rejects.toThrow(/emitted nothing \(undefined\)/);
   });
 
   it('ignores ports that declare no schema (every existing node)', () => {
@@ -269,45 +285,90 @@ describe('source determinism (the seeded-RNG rule)', () => {
     expect(Object.keys(CANDIDATE_SOURCES).sort()).toEqual([...SLOTS.source.candidates].sort());
   });
 
-  it('no source-slot candidate reaches for Math.random or Date.now', () => {
-    // A recording is only worth keeping if replaying it reproduces the run. Any
-    // randomness in a generator source must come from `seed + ctx.tick`, never an
-    // ambient RNG, and no source may read the wall clock for its VALUES.
+  /** Drive one candidate over an explicit (tick, time) sequence and capture its frames. */
+  const driveSource = (type: string, times: number[], params: unknown = {}): string => {
+    const reg = createRegistry([...CORE_NODES, ...BROWSER_NODES]);
+    const engine = new Engine({ nodes: [{ id: 's', type, params }], edges: [] }, reg, {
+      validatePorts: true,
+    });
+    const out: unknown[] = [];
+    for (const t of times) {
+      engine.tick(t);
+      out.push(engine.getOutput('s', 'hands'));
+    }
+    return JSON.stringify(out);
+  };
+
+  const FRAMES = [
+    { width: 11, height: 11, hands: [] },
+    { width: 22, height: 22, hands: [] },
+    { width: 33, height: 33, hands: [] },
+  ];
+  const paramsFor = (type: string) => (type === 'replay-hands' ? { frames: FRAMES } : {});
+
+  it('BEHAVIOURAL: a finished-frame source is a pure function of the ctx it is given', () => {
+    // This is the real determinism check, and it replaces a source-text grep that
+    // could only ever see the spellings it was told about. Driving the same node
+    // twice over the SAME (tick, time) sequence catches `Math.random`,
+    // `Date.now`, `performance.now`, `crypto`, `new Date`, and anything reached
+    // through an imported helper — none of which a regex over one file can.
+    for (const type of SLOTS.source.candidates.filter((t) => t !== SLOTS.source.default)) {
+      const times = Array.from({ length: 20 }, (_, i) => i / 60);
+      expect(driveSource(type, times, paramsFor(type)), `${type} is not reproducible`).toBe(
+        driveSource(type, times, paramsFor(type)),
+      );
+    }
+  });
+
+  it('BEHAVIOURAL: a replay source ignores the clock entirely — same ticks, different times', () => {
+    // Stronger than the above and true only of a replay: its frames are a function
+    // of how many times it has been called, so re-running the same tick COUNT under
+    // a different wall clock must be byte-identical. `synthetic-hands` is exempt
+    // and must stay so — it is an animation, so varying with `ctx.time` is its job;
+    // `ctx.time` is the engine's INJECTED time (deterministic under a given clock),
+    // not an ambient one, which is the distinction the rule is really about.
+    const fast = Array.from({ length: 12 }, (_, i) => i / 60);
+    const slow = Array.from({ length: 12 }, (_, i) => 1000 + i / 5);
+    expect(driveSource('replay-hands', fast, { frames: FRAMES })).toBe(
+      driveSource('replay-hands', slow, { frames: FRAMES }),
+    );
+  });
+
+  it('BEHAVIOURAL: a replay swapped into a RUNNING graph still starts at frame 0', async () => {
+    // The engine's tick counter is monotonic for its whole life, so a source that
+    // indexed by `ctx.tick` would open on the last frame of a recording when
+    // swapped in mid-run — which is precisely what the source slot is for (#51).
+    const reg = appRegistry();
+    const engine = new Engine(defaultGraph({ source: 'synthetic-hands' }, reg), reg);
+    for (let i = 0; i < 50; i++) engine.tick();
+
+    const next = defaultGraph({ source: 'replay-hands' }, reg);
+    next.nodes = next.nodes.map((n) => (n.id === 'cam' ? { ...n, params: { frames: FRAMES } } : n));
+    expect((await engine.applyGraph(next, reg)).replaced).toEqual(['cam']);
+
+    const widths: number[] = [];
+    for (let i = 0; i < 4; i++) {
+      engine.tick();
+      widths.push((engine.getOutput('cam', 'hands') as HandsFrame).width);
+    }
+    expect(widths).toEqual([11, 22, 33, 33]);
+  });
+
+  it('a cheap source grep backs the behavioural checks up (widened, and honest about scope)', () => {
+    // Kept as a second line of defence for the spellings that are unambiguous.
+    // `webcam-hands` is exempt from the clock rule BY NAME: MediaPipe's
+    // detectForVideo REQUIRES a strictly-increasing timestamp, and
+    // performance.now() is it.
+    const AMBIENT = [/Math\.random/, /Date\.now/, /new Date\(/, /crypto\./];
     for (const [type, file] of Object.entries(CANDIDATE_SOURCES)) {
       const src = readFileSync(resolve(process.cwd(), file), 'utf8');
-      expect(src, `${type} must not use Math.random`).not.toMatch(/Math\.random/);
-      expect(src, `${type} must not use Date.now`).not.toMatch(/Date\.now/);
-    }
-  });
-
-  it('the finished-frame candidates read no clock at all — their output is a function of ctx', () => {
-    // webcam-hands is exempt and must stay so: MediaPipe's detectForVideo
-    // REQUIRES a strictly-increasing timestamp, and performance.now() is it. The
-    // exemption is named here rather than left implicit.
-    const finishedFrame = SLOTS.source.candidates.filter((t) => t !== SLOTS.source.default);
-    expect(finishedFrame.length).toBeGreaterThan(0);
-    for (const type of finishedFrame) {
-      const src = readFileSync(resolve(process.cwd(), CANDIDATE_SOURCES[type]), 'utf8');
-      expect(src, `${type} must not read a clock`).not.toMatch(/performance\.now/);
-    }
-  });
-
-  it('a synthetic source replays identically from the same tick sequence', () => {
-    const reg = createRegistry([...CORE_NODES, ...BROWSER_NODES]);
-    const run = () => {
-      const engine = new Engine(
-        { nodes: [{ id: 's', type: 'synthetic-hands' }], edges: [] },
-        reg,
-        { validatePorts: true },
-      );
-      const out: number[] = [];
-      for (let i = 0; i < 20; i++) {
-        engine.tick();
-        out.push((engine.getOutput('s', 'hands') as HandsFrame).hands[0].keypoints[0].x);
+      for (const pattern of AMBIENT) {
+        expect(src, `${type} must not use ${pattern}`).not.toMatch(pattern);
       }
-      return out;
-    };
-    expect(run()).toEqual(run());
+      if (type !== SLOTS.source.default) {
+        expect(src, `${type} must not read the wall clock`).not.toMatch(/performance\.now/);
+      }
+    }
   });
 });
 


### PR DESCRIPTION
Two halves of the same argument — that **"where the frames come from" should be a selection, not a code path.**

## The slot

`SLOTS.source` binds the graph's source node. Its candidates are the **finished-frame emitters** only: `webcam-hands` (default), `synthetic-hands`, `replay-hands`.

A file or stream feeding a `<video>` stays **host-side** (M-A's `?source=video`), because `webcam-hands` does the identical job whatever produced the pixels — and because the batch path runs in Node, where a node that so much as *imports* the MediaPipe WASM runtime cannot load at all. That is what makes this a slot rather than a flag, and it is exactly the fork #104 resolved in July.

`replay-source` already replays any recorded value, but on a generic `value` port — which makes it a fine stand-in for an arbitrary edge and a poor slot candidate, because a candidate is identified by the port it emits. `replay-hands` is the typed sibling: same replay semantics, the contract's port and schema.

**The payoff is pinned by a test, not asserted:** the real `defaultGraph()` with `slot.source=synthetic-hands` drives sounding voices in plain Node — no camera, no DOM, no MediaPipe. And the same swap applied to a **running** engine (`applyGraph`, #165) replaces exactly `cam` and keeps every other node, including the face model.

This is the first slot with more than one real candidate — the first genuine test of "swapping is a config flip", and it passes.

## The port contract

`PortSpec.kind` was always advisory: a label. A slot whose candidates are written independently needs something *checkable*, and specifically needs to catch the failure a type system cannot — **a node that emits nothing on a port it declares.** `process()` returns a plain object, so a drained generator or an unlatched pump silently yields `undefined`; the downstream node reads its port default and the graph goes quiet with no error anywhere.

`PortSpec.schema?: ZodType`, checked in `tick()`'s output path under `EngineOptions.validatePorts` — **off** by default (the live path should not run Zod over every port at 60fps), **on** in `runHeadless`, so a fixture is never recorded from a bad frame. Deliberately *not* in `emitTaps`, which skips `undefined` by design and therefore cannot see the failure this is for.

## Determinism

The seeded-RNG rule is enforced as a **test**, not a lint — this repo lints with `tsc`, so its boundaries are tests (as with the command firewall and the dials write path). No source-slot candidate may use `Math.random` or `Date.now`; the finished-frame candidates may read no clock at all. `webcam-hands` is exempt from the clock rule **by name**, because MediaPipe's `detectForVideo` requires a strictly-increasing timestamp — an exemption worth stating rather than leaving implicit.

## Deferred, on purpose

The **async-iterable `Source` interface and its pump stay with M-D.** The pump is a private detail of the Applier, so the interface would have no implementation and no consumer until the Applier exists — a contract nobody honours is precisely what #119 and #120 both were. The node-swap half above needs none of it. Recorded in `docs/design/stream-applier.md`.

## Also in here

- `SlotContract` moved from "the type of whichever contract happened to be written first" to a real interface (`src/nodes/slot_contract.ts`), so adding a slot is adding data.
- `scripts/gen_catalog.ts`'s section table is hand-listed (the registry has no discovery seam — component-model.md, "Two corrections" #2), so a new node silently lands in an unexplained **"Other"** heap at the bottom of the manual. `test/catalog.test.ts` now fails if that heap exists at all. It caught this exact mistake while I was writing this PR.

## Reachability

**How many clicks from a cold load? Zero** — it is a URL parameter, and by governance it stays that way: the audience for a synthetic or replay source is a developer verifying the graph, not a player. What it buys is real, though: `?slot.source=synthetic-hands` is now the fastest way to exercise the whole instrument with no hardware, which several items on #146's live-verification list would otherwise need a webcam for.

## Verification

- 24 new tests (`test/source_slot.test.ts`) — contract conformance for every candidate, the running-engine swap, the camera-free end-to-end, port conformance (valid / malformed / **emits nothing** / off by default / on in `runHeadless` / optional schema), and the determinism guards.
- A **9-mutant harness, 9/9 caught**, including one for the "Other" heap.
- `npm run catalog` regenerated and committed. `npm run typecheck` clean, `npm test` 1165 passed, `npm run build` green.

Closes #104. Refs #101, #51.
