### PR TITLE
#141: what the gestures MEAN becomes a live input, not a build-time param

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -208,7 +208,7 @@ Hand features → tonal synth parameters (x→pitch w/ scale snap, y→volume).
 Gesture features → weighted prompts + config dials (steers a generative engine).
 
 - **roles:** mapping
-- **in:** features:hand-features, face:face-features
+- **in:** features:hand-features, face:face-features, steerConfig:steer-config
 - **out:** steer:generative-steer
 - **params:** strains (array=[]), dials (array=[]), smoothing (number=0), throttleSec (number=0)
 

--- a/public/catalog.json
+++ b/public/catalog.json
@@ -655,6 +655,11 @@
       {
         "name": "face",
         "kind": "face-features"
+      },
+      {
+        "name": "steerConfig",
+        "kind": "steer-config",
+        "description": "Live override of strains/dials/smoothing/throttle; unset fields keep the param."
       }
     ],
     "outputs": [

--- a/public/manual.html
+++ b/public/manual.html
@@ -242,7 +242,7 @@
       <p>Gesture features → weighted prompts + config dials (steers a generative engine).</p>
       <dl>
         <dt>roles</dt><dd>mapping</dd>
-        <dt>in</dt><dd>features:hand-features, face:face-features</dd>
+        <dt>in</dt><dd>features:hand-features, face:face-features, steerConfig:steer-config</dd>
         <dt>out</dt><dd>steer:generative-steer</dd>
         <dt>params</dt><dd>strains (array=[]), dials (array=[]), smoothing (number=0), throttleSec (number=0)</dd>
       </dl>

--- a/src/dag/recorder.ts
+++ b/src/dag/recorder.ts
@@ -95,6 +95,14 @@ export interface ReplayOptions {
   dt?: number;
   /** Host resources to expose to the node (usually empty in tests). */
   resources?: Record<string, unknown>;
+  /**
+   * Structured logger passed as `ctx.log`. Without it a node's log line is the
+   * one observable behaviour a replay test cannot see — which matters for the
+   * nodes that deliberately DEGRADE rather than throw (a malformed live config,
+   * a transient inference failure): "it kept going" and "it kept going and said
+   * why" are different guarantees, and only the second is worth relying on.
+   */
+  log?: (msg: string) => void;
 }
 
 /**
@@ -114,11 +122,12 @@ export async function replayNode(
 ): Promise<PortValues[]> {
   const dt = opts.dt ?? 1 / 60;
   const resources = opts.resources ?? {};
+  const log = opts.log;
   const ports = Object.keys(inputFramesByPort);
   const ticks = ports.reduce((max, p) => Math.max(max, inputFramesByPort[p].length), 0);
 
   if (handlers.init) {
-    await handlers.init({ tick: 0, time: 0, dt: 0, resources });
+    await handlers.init({ tick: 0, time: 0, dt: 0, resources, log });
   }
 
   const results: PortValues[] = [];
@@ -128,7 +137,7 @@ export async function replayNode(
       const v = inputFramesByPort[p][i];
       if (v !== undefined) inputs[p] = v;
     }
-    const ctx: NodeContext = { tick: i, time: i * dt, dt: i === 0 ? 0 : dt, resources };
+    const ctx: NodeContext = { tick: i, time: i * dt, dt: i === 0 ? 0 : dt, resources, log };
     results.push(handlers.process(inputs, ctx) ?? {});
   }
   handlers.dispose?.();

--- a/src/nodes/mapping/indirect_map.ts
+++ b/src/nodes/mapping/indirect_map.ts
@@ -81,6 +81,29 @@ export type SteerConfig = z.infer<typeof SteerConfigSchema>;
 
 type Ref = z.infer<typeof FeatureRef>;
 
+/**
+ * Smoothing-state keys for a strain/dial list: each entry's own name, made
+ * unique by counting repeats (`warm pads#0`, `warm pads#1`).
+ *
+ * **Identity only — never position.** Position looks like a harmless tiebreaker
+ * until you notice that insert, delete and reorder are exactly what a vibe editor
+ * is for: keying on position re-keys every entry after the edit point, so adding
+ * one prompt would duck every prompt below it back to rest — a dip across the
+ * whole mix with no gesture behind it, which is the failure this state is keyed
+ * carefully to avoid. Keying on identity alone still gets the intended case
+ * right: renaming the prompt at a slot yields a new key, so it eases in fresh.
+ *
+ * One builder, used by both `process()` and the prune, so the two cannot drift.
+ */
+function identityKeys(names: readonly string[]): string[] {
+  const seen = new Map<string, number>();
+  return names.map((name) => {
+    const n = seen.get(name) ?? 0;
+    seen.set(name, n + 1);
+    return `${name}#${n}`;
+  });
+}
+
 function readFeature(hands: HandFeatures, face: FaceFeatures, ref: Ref): number {
   if (ref.source === 'face') {
     if (!face.present) return 0;
@@ -110,14 +133,15 @@ export const indirectMapNode = defineNode<Params>({
   outputs: [{ name: 'steer', kind: 'generative-steer' }],
   params: Params,
   make(p) {
-    // Smoothed state is keyed by POSITION AND IDENTITY (`0:warm pads`), not by
-    // index alone. With a fixed config the two are the same thing; with a live
-    // one they are not — editing the text at slot 0 makes it a different prompt,
-    // and inheriting the old prompt's eased-in weight would be a glitch, not
-    // continuity. Editing a *neighbour* leaves this one's smoothing untouched,
-    // which index-only keying also gets right but only by luck.
+    // Smoothed state, keyed by {@link identityKeys} — the prompt's own text, not
+    // its slot. With a fixed config any keying works; with a live one only
+    // identity does. Editing the text at a slot makes it a different prompt, so
+    // it eases in from rest; adding, removing or reordering its neighbours leaves
+    // it exactly where it was.
     const weights = new Map<string, number>();
     const dialVals = new Map<string, number>();
+    let strainKeys = identityKeys(p.strains.map((x) => x.text));
+    let dialKeys = identityKeys(p.dials.map((x) => x.name));
     let lastEmit = -Infinity;
     let last: GenerativeSteer = { prompts: [], config: {} };
 
@@ -154,11 +178,15 @@ export const indirectMapNode = defineNode<Params>({
         };
       })();
       cfg = next;
-      // Drop smoothing state for strains/dials the new config no longer has, so
-      // a long editing session cannot grow these maps without bound.
-      const live = new Set(next.strains.map((s, i) => `${i}:${s.text}`));
+      strainKeys = identityKeys(next.strains.map((x) => x.text));
+      dialKeys = identityKeys(next.dials.map((x) => x.name));
+      // Drop smoothing state the new config no longer has an entry for. Beyond
+      // keeping the maps bounded across a long editing session, this is what
+      // makes a prompt you deleted and brought back ease in from rest rather than
+      // snapping to the momentum it had before you removed it.
+      const live = new Set(strainKeys);
       for (const k of weights.keys()) if (!live.has(k)) weights.delete(k);
-      const liveDials = new Set(next.dials.map((d, i) => `${i}:${d.name}`));
+      const liveDials = new Set(dialKeys);
       for (const k of dialVals.keys()) if (!liveDials.has(k)) dialVals.delete(k);
     };
 
@@ -179,16 +207,16 @@ export const indirectMapNode = defineNode<Params>({
         const prompts: WeightedPrompt[] = cfg.strains.map((s, i) => {
           const raw = readFeature(f, face, s);
           const target = rangeMap(raw, s.inMin, s.inMax, s.weightMin, s.weightMax);
-          const w = smooth(weights.get(`${i}:${s.text}`), target, cfg.smoothing);
-          weights.set(`${i}:${s.text}`, w);
+          const w = smooth(weights.get(strainKeys[i]), target, cfg.smoothing);
+          weights.set(strainKeys[i], w);
           return { text: s.text, weight: Math.round(w * 1000) / 1000 };
         });
         const config: Record<string, number> = {};
         cfg.dials.forEach((d, i) => {
           const raw = readFeature(f, face, d);
           const target = rangeMap(raw, d.inMin, d.inMax, d.outMin, d.outMax);
-          const v = smooth(dialVals.get(`${i}:${d.name}`), target, cfg.smoothing);
-          dialVals.set(`${i}:${d.name}`, v);
+          const v = smooth(dialVals.get(dialKeys[i]), target, cfg.smoothing);
+          dialVals.set(dialKeys[i], v);
           config[d.name] = Math.round(v * 1000) / 1000;
         });
 

--- a/src/nodes/mapping/indirect_map.ts
+++ b/src/nodes/mapping/indirect_map.ts
@@ -8,6 +8,14 @@
  * so it is unit-testable from a recorded `hand-features` stream — the live
  * `lyria` engine node is a separate, browser-only sink behind the
  * GenerativeEngine facade.
+ *
+ * **Which strains and dials the gestures drive is a LIVE input, not only a
+ * build-time param** (`steerConfig`). That distinction is the whole cost #141
+ * identified: a vibe editor that can only change the mapping by rebuilding the
+ * graph is not an editor, and rebuilding to change a prompt would reload the ML
+ * models to alter a string. The repo's convention applies — static params are
+ * the build-time default, the input port is the live override — so an
+ * unconnected port changes nothing about how this node behaves today.
  */
 import { z } from 'zod';
 import { defineNode } from '@/dag';
@@ -53,6 +61,24 @@ const Params = z.object({
 });
 type Params = z.infer<typeof Params>;
 
+/**
+ * The live-overridable half of {@link Params} — everything that says *what the
+ * gestures mean*. Every field is optional and overrides the build-time param of
+ * the same name; an omitted field keeps the param. This is the shape a store
+ * slice, a dial schema and a vibe editor all speak (#141).
+ *
+ * Exported because it is a contract between this node and whatever drives it,
+ * not an implementation detail: the same schema validates the store value, the
+ * persisted dial and the value arriving on the port.
+ */
+export const SteerConfigSchema = z.object({
+  strains: z.array(Strain).optional(),
+  dials: z.array(Dial).optional(),
+  smoothing: z.number().min(0).max(0.999).optional(),
+  throttleSec: z.number().min(0).optional(),
+});
+export type SteerConfig = z.infer<typeof SteerConfigSchema>;
+
 type Ref = z.infer<typeof FeatureRef>;
 
 function readFeature(hands: HandFeatures, face: FaceFeatures, ref: Ref): number {
@@ -75,46 +101,99 @@ export const indirectMapNode = defineNode<Params>({
   inputs: [
     { name: 'features', kind: 'hand-features' },
     { name: 'face', kind: 'face-features' },
+    {
+      name: 'steerConfig',
+      kind: 'steer-config',
+      description: 'Live override of strains/dials/smoothing/throttle; unset fields keep the param.',
+    },
   ],
   outputs: [{ name: 'steer', kind: 'generative-steer' }],
   params: Params,
   make(p) {
-    const weights = new Map<number, number>(); // strain index -> smoothed weight
-    const dialVals = new Map<number, number>(); // dial index -> smoothed value
+    // Smoothed state is keyed by POSITION AND IDENTITY (`0:warm pads`), not by
+    // index alone. With a fixed config the two are the same thing; with a live
+    // one they are not — editing the text at slot 0 makes it a different prompt,
+    // and inheriting the old prompt's eased-in weight would be a glitch, not
+    // continuity. Editing a *neighbour* leaves this one's smoothing untouched,
+    // which index-only keying also gets right but only by luck.
+    const weights = new Map<string, number>();
+    const dialVals = new Map<string, number>();
     let lastEmit = -Infinity;
     let last: GenerativeSteer = { prompts: [], config: {} };
 
+    // The effective config: the build-time params, with any live override applied.
+    let cfg: Params = p;
+    // Identity of the last value seen on the port, so a stable reference costs
+    // nothing per tick — validating a config on every frame would be real work
+    // in the hot path for a value that changes when a human edits it.
+    let lastRaw: unknown = undefined;
+    let warned = false;
+
+    const applyOverride = (raw: unknown, log?: (msg: string) => void): void => {
+      if (raw === lastRaw) return;
+      lastRaw = raw;
+      const next = ((): Params => {
+        if (raw === undefined || raw === null) return p;
+        const parsed = SteerConfigSchema.safeParse(raw);
+        if (!parsed.success) {
+          // Never throw from process(): one malformed store write must not stop
+          // the instrument. Keep the last good config and say so once.
+          if (!warned) {
+            warned = true;
+            log?.(`indirect-map: ignoring an invalid steerConfig (${parsed.error.message})`);
+          }
+          return cfg;
+        }
+        warned = false;
+        const o = parsed.data;
+        return {
+          strains: o.strains ?? p.strains,
+          dials: o.dials ?? p.dials,
+          smoothing: o.smoothing ?? p.smoothing,
+          throttleSec: o.throttleSec ?? p.throttleSec,
+        };
+      })();
+      cfg = next;
+      // Drop smoothing state for strains/dials the new config no longer has, so
+      // a long editing session cannot grow these maps without bound.
+      const live = new Set(next.strains.map((s, i) => `${i}:${s.text}`));
+      for (const k of weights.keys()) if (!live.has(k)) weights.delete(k);
+      const liveDials = new Set(next.dials.map((d, i) => `${i}:${d.name}`));
+      for (const k of dialVals.keys()) if (!liveDials.has(k)) dialVals.delete(k);
+    };
+
     // Ease from rest (0) toward the target. With smoothing=0 this is exact
     // (snaps to target each tick); higher smoothing eases in more slowly.
-    const smooth = (prev: number | undefined, target: number): number => {
+    const smooth = (prev: number | undefined, target: number, smoothing: number): number => {
       const from = prev ?? 0;
-      return from + (1 - p.smoothing) * (target - from);
+      return from + (1 - smoothing) * (target - from);
     };
 
     return {
       process(inputs, ctx) {
+        applyOverride(inputs.steerConfig, ctx.log);
         const f = (inputs.features as HandFeatures | undefined) ?? { left: { ...ABSENT_HAND }, right: { ...ABSENT_HAND } };
         const face = (inputs.face as FaceFeatures | undefined) ?? { ...ABSENT_FACE };
 
         // Always advance the smoothed state so it tracks even between emits.
-        const prompts: WeightedPrompt[] = p.strains.map((s, i) => {
+        const prompts: WeightedPrompt[] = cfg.strains.map((s, i) => {
           const raw = readFeature(f, face, s);
           const target = rangeMap(raw, s.inMin, s.inMax, s.weightMin, s.weightMax);
-          const w = smooth(weights.get(i), target);
-          weights.set(i, w);
+          const w = smooth(weights.get(`${i}:${s.text}`), target, cfg.smoothing);
+          weights.set(`${i}:${s.text}`, w);
           return { text: s.text, weight: Math.round(w * 1000) / 1000 };
         });
         const config: Record<string, number> = {};
-        p.dials.forEach((d, i) => {
+        cfg.dials.forEach((d, i) => {
           const raw = readFeature(f, face, d);
           const target = rangeMap(raw, d.inMin, d.inMax, d.outMin, d.outMax);
-          const v = smooth(dialVals.get(i), target);
-          dialVals.set(i, v);
+          const v = smooth(dialVals.get(`${i}:${d.name}`), target, cfg.smoothing);
+          dialVals.set(`${i}:${d.name}`, v);
           config[d.name] = Math.round(v * 1000) / 1000;
         });
 
         // Throttle the *emitted* steer; between emits, re-emit the last payload.
-        if (ctx.time - lastEmit >= p.throttleSec) {
+        if (ctx.time - lastEmit >= cfg.throttleSec) {
           lastEmit = ctx.time;
           last = { prompts, config };
         }

--- a/test/indirect_map.test.ts
+++ b/test/indirect_map.test.ts
@@ -1,12 +1,15 @@
 /**
  * Tests the indirect-map node: gesture features → weighted prompts + config
  * dials. Verifies exact mapping (no smoothing), smoothing convergence,
- * absent-hand → zero weight, and replay from a disk fixture.
+ * absent-hand → zero weight, replay from a disk fixture, and — the #141
+ * prerequisite — that WHICH strains and dials the gestures drive is a live
+ * input rather than only a build-time param.
  */
 import { describe, it, expect } from 'vitest';
 import { replayNode } from '@/dag';
 import { loadStream } from './helpers/fixtures';
 import { indirectMapNode, ABSENT_HAND, ABSENT_FACE, type GenerativeSteer, type HandFeatures, type FaceFeatures } from '@/nodes';
+import { SteerConfigSchema } from '@/nodes/mapping/indirect_map';
 
 function feat(right: Partial<typeof ABSENT_HAND>): HandFeatures {
   return { left: { ...ABSENT_HAND }, right: { ...ABSENT_HAND, present: true, ...right } };
@@ -84,5 +87,152 @@ describe('indirect-map', () => {
     // Absent face → zero.
     const [absent] = await replayNode(indirectMapNode.make(faceParams), { face: [{ ...ABSENT_FACE }] });
     expect((absent.steer as GenerativeSteer).prompts[0].weight).toBe(0);
+  });
+});
+
+// ---- the live steer config (#141) ------------------------------------------
+
+/** Drive the node over N ticks with one steerConfig value held on the port. */
+async function withConfig(
+  params: unknown,
+  steerConfig: unknown,
+  frames: HandFeatures[],
+  log?: (msg: string) => void,
+): Promise<GenerativeSteer[]> {
+  const handlers = indirectMapNode.make(indirectMapNode.params.parse(params));
+  const outs = await replayNode(handlers, {
+    features: frames,
+    steerConfig: frames.map(() => steerConfig),
+  }, log ? { log } : undefined);
+  return outs.map((o) => o.steer as GenerativeSteer);
+}
+
+describe('indirect-map steerConfig (the #141 prerequisite)', () => {
+  it('an UNCONNECTED port changes nothing — params stay the build-time default', async () => {
+    // The repo's convention, and the reason this port is safe to add before
+    // anything drives it: a node with no edge into `steerConfig` behaves exactly
+    // as it did when strains/dials were params only.
+    const frames = [feat({ openness: 1 })];
+    const [connected] = await withConfig(PARAMS, undefined, frames);
+    const [plain] = (await replayNode(indirectMapNode.make(P), { features: frames })).map(
+      (o) => o.steer as GenerativeSteer,
+    );
+    expect(connected).toEqual(plain);
+  });
+
+  it('a live config REPLACES the strains without rebuilding the node', async () => {
+    // This is the whole point: a vibe editor that can only change the mapping by
+    // rebuilding the graph would reload the ML models to alter a string.
+    const outs = await withConfig(
+      PARAMS,
+      { strains: [{ text: 'glassy bells', hand: 'right', feature: 'openness', inMin: 0, inMax: 1, weightMin: 0, weightMax: 3 }] },
+      [feat({ openness: 1 })],
+    );
+    expect(outs[0].prompts).toHaveLength(1);
+    expect(outs[0].prompts[0]).toMatchObject({ text: 'glassy bells', weight: 3 });
+  });
+
+  it('an omitted field keeps the param (partial override)', async () => {
+    // Only `dials` is overridden; the two param strains must survive.
+    const outs = await withConfig(
+      PARAMS,
+      { dials: [{ name: 'density', hand: 'right', feature: 'x', inMin: 0, inMax: 1, outMin: 0, outMax: 10 }] },
+      [feat({ openness: 1, x: 0.5 })],
+    );
+    expect(outs[0].prompts.map((p) => p.text)).toEqual(['ambient pads', 'driving drums']);
+    expect(outs[0].config).toEqual({ density: 5 });
+  });
+
+  it('reverting the port to undefined restores the params', async () => {
+    const handlers = indirectMapNode.make(P);
+    const frames = [feat({ openness: 1 }), feat({ openness: 1 }), feat({ openness: 1 })];
+    const outs = (
+      await replayNode(handlers, {
+        features: frames,
+        steerConfig: [undefined, { strains: [{ text: 'only this', hand: 'right', feature: 'openness' }] }, undefined],
+      })
+    ).map((o) => (o.steer as GenerativeSteer).prompts.map((p) => p.text));
+    expect(outs[0]).toEqual(['ambient pads', 'driving drums']);
+    expect(outs[1]).toEqual(['only this']);
+    expect(outs[2]).toEqual(['ambient pads', 'driving drums']);
+  });
+
+  it('a MALFORMED config is ignored, logged once, and never stops the instrument', async () => {
+    // process() must not throw: one bad store write would otherwise take the
+    // whole graph down on every subsequent frame.
+    const logged: string[] = [];
+    const outs = await withConfig(PARAMS, { strains: 'not an array' }, [feat({ openness: 1 })], (m) =>
+      logged.push(m),
+    );
+    expect(outs[0].prompts.map((p) => p.text)).toEqual(['ambient pads', 'driving drums']);
+    expect(logged.filter((m) => m.includes('invalid steerConfig'))).toHaveLength(1);
+  });
+
+  it('editing one strain resets ITS smoothing, and leaves its neighbour easing', async () => {
+    // Smoothing state is keyed by position AND identity. Slot 0 becoming a
+    // different prompt must start from rest — inheriting the old prompt's
+    // eased-in weight would be a glitch, not continuity — while slot 1, which
+    // did not change, keeps climbing.
+    const params = { ...PARAMS, smoothing: 0.6 };
+    const a = { text: 'ambient pads', hand: 'right' as const, feature: 'openness' as const, inMin: 0, inMax: 1, weightMin: 0, weightMax: 2 };
+    const b = { text: 'driving drums', hand: 'right' as const, feature: 'openness' as const, inMin: 0, inMax: 1, weightMin: 0, weightMax: 2 };
+    const before = { strains: [a, b] };
+    const after = { strains: [{ ...a, text: 'renamed' }, b] };
+    const frames = Array.from({ length: 8 }, () => feat({ openness: 1 }));
+
+    const outs = (
+      await replayNode(indirectMapNode.make(indirectMapNode.params.parse(params)), {
+        features: frames,
+        steerConfig: frames.map((_, i) => (i < 4 ? before : after)),
+      })
+    ).map((o) => (o.steer as GenerativeSteer).prompts);
+
+    expect(outs[3][0].text).toBe('ambient pads');
+    const climbed = outs[3][0].weight;
+    expect(climbed).toBeGreaterThan(0);
+    // Slot 0 is a different prompt now: back to rest, then easing again.
+    expect(outs[4][0].text).toBe('renamed');
+    expect(outs[4][0].weight).toBeLessThan(climbed);
+    // Slot 1 was untouched and kept climbing straight through the edit.
+    expect(outs[4][1].weight).toBeGreaterThan(outs[3][1].weight);
+  });
+
+  it('a strain removed and re-added starts from rest — no resurrected weight', async () => {
+    // Each edit prunes the smoothing keys the new config no longer has. That is
+    // usually described as a memory concern, but it has a semantic consequence
+    // worth pinning: a prompt you deleted and brought back is a prompt you are
+    // introducing again, so it eases in from rest. Keeping the old entry would
+    // make it snap back to the momentum it had before you removed it — a jump in
+    // the mix with no gesture behind it.
+    const params = { ...PARAMS, smoothing: 0.6 };
+    const A = { text: 'A', hand: 'right' as const, feature: 'openness' as const, inMin: 0, inMax: 1, weightMin: 0, weightMax: 2 };
+    const B = { text: 'B', hand: 'right' as const, feature: 'openness' as const, inMin: 0, inMax: 1, weightMin: 0, weightMax: 2 };
+    const frames = Array.from({ length: 12 }, () => feat({ openness: 1 }));
+
+    const outs = (
+      await replayNode(indirectMapNode.make(indirectMapNode.params.parse(params)), {
+        features: frames,
+        // A for four ticks, then B for four (A's entry is pruned), then A again.
+        steerConfig: frames.map((_, i) => ({ strains: [i < 4 || i >= 8 ? A : B] })),
+      })
+    ).map((o) => (o.steer as GenerativeSteer).prompts[0]);
+
+    const aClimbed = outs[3].weight;
+    expect(outs[3].text).toBe('A');
+    expect(aClimbed).toBeGreaterThan(0);
+    // A comes back at tick 8: from rest, not from where it left off.
+    expect(outs[8].text).toBe('A');
+    expect(outs[8].weight).toBeLessThan(aClimbed);
+    expect(outs[8].weight).toBeCloseTo(outs[4].weight, 6); // exactly B's first step
+  });
+
+  it('the exported schema is the contract a store/dial/editor all speak', () => {
+    // Same schema validates the port value, the store slice and the persisted
+    // dial — so those three cannot drift into disagreeing about the shape.
+    expect(SteerConfigSchema.safeParse({}).success).toBe(true);
+    expect(SteerConfigSchema.safeParse({ smoothing: 0.5 }).success).toBe(true);
+    expect(SteerConfigSchema.safeParse({ smoothing: 2 }).success).toBe(false);
+    expect(SteerConfigSchema.safeParse({ strains: [{ text: 'x' }] }).success).toBe(true);
+    expect(SteerConfigSchema.safeParse({ strains: [{}] }).success).toBe(false); // text is required
   });
 });

--- a/test/indirect_map.test.ts
+++ b/test/indirect_map.test.ts
@@ -226,6 +226,97 @@ describe('indirect-map steerConfig (the #141 prerequisite)', () => {
     expect(outs[8].weight).toBeCloseTo(outs[4].weight, 6); // exactly B's first step
   });
 
+  // ---- the edit shapes a vibe editor actually produces ---------------------
+  //
+  // An adversarial review found the original keying (`${i}:${text}`) mixed
+  // identity with POSITION, so inserting, deleting or reordering a prompt reset
+  // every entry after the edit point — a mix-wide duck with no gesture behind it,
+  // in exactly the operations an editor is for. Only a rename-at-a-fixed-index
+  // was covered, which is the single edit shape that keying happened to survive.
+  // These are the cases that were missing.
+
+  /** Drive with `smoothing`, holding the hand open, swapping config at `swapAt`. */
+  async function editAt(before: unknown[], after: unknown[], swapAt = 6, ticks = 8) {
+    const frames = Array.from({ length: ticks }, () => feat({ openness: 1 }));
+    const outs = await replayNode(indirectMapNode.make(indirectMapNode.params.parse({ ...PARAMS, smoothing: 0.6 })), {
+      features: frames,
+      steerConfig: frames.map((_, i) => ({ strains: i < swapAt ? before : after })),
+    });
+    return outs.map((o) => (o.steer as GenerativeSteer).prompts);
+  }
+
+  const S = (text: string) => ({
+    text,
+    hand: 'right' as const,
+    feature: 'openness' as const,
+    inMin: 0,
+    inMax: 1,
+    weightMin: 0,
+    weightMax: 2,
+  });
+  /** Find a prompt by text in one tick's output. */
+  const w = (prompts: { text: string; weight: number }[], text: string) =>
+    prompts.find((p) => p.text === text)!.weight;
+
+  it('DELETING a strain leaves the survivors exactly where they were', async () => {
+    const outs = await editAt([S('A'), S('B')], [S('B')]);
+    expect(w(outs[6], 'B')).toBeGreaterThan(w(outs[5], 'B')); // kept climbing, no reset
+    expect(outs[6]).toHaveLength(1);
+  });
+
+  it('INSERTING a strain at the front does not duck the ones below it', async () => {
+    const outs = await editAt([S('A'), S('B')], [S('C'), S('A'), S('B')]);
+    expect(w(outs[6], 'A')).toBeGreaterThan(w(outs[5], 'A'));
+    expect(w(outs[6], 'B')).toBeGreaterThan(w(outs[5], 'B'));
+    expect(w(outs[6], 'C')).toBeLessThan(w(outs[6], 'A')); // the NEW one eases in from rest
+  });
+
+  it('REORDERING strains preserves every weight', async () => {
+    const outs = await editAt([S('A'), S('B')], [S('B'), S('A')]);
+    expect(w(outs[6], 'A')).toBeGreaterThan(w(outs[5], 'A'));
+    expect(w(outs[6], 'B')).toBeGreaterThan(w(outs[5], 'B'));
+  });
+
+  it('DIALS behave the same way when one is removed', async () => {
+    const D = (name: string) => ({
+      name,
+      hand: 'right' as const,
+      feature: 'openness' as const,
+      inMin: 0,
+      inMax: 1,
+      outMin: 0,
+      outMax: 1,
+    });
+    const frames = Array.from({ length: 8 }, () => feat({ openness: 1 }));
+    const outs = (
+      await replayNode(indirectMapNode.make(indirectMapNode.params.parse({ ...PARAMS, smoothing: 0.6 })), {
+        features: frames,
+        steerConfig: frames.map((_, i) => ({ dials: i < 6 ? [D('bpm'), D('density')] : [D('density')] })),
+      })
+    ).map((o) => (o.steer as GenerativeSteer).config);
+    expect(outs[6].density).toBeGreaterThan(outs[5].density!);
+    expect(outs[6].bpm).toBeUndefined();
+  });
+
+  it('two strains with the SAME text keep separate smoothing state', async () => {
+    // Identity keying disambiguates repeats by occurrence, so a duplicated prompt
+    // is two entries, not one aliased pair. Opposite targets make aliasing
+    // unmistakable: entangled, the second entry would ease toward whatever the
+    // first just wrote and never settle at its own target of 0.
+    const up = { ...S('twin'), weightMin: 0, weightMax: 2 };
+    const flat = { ...S('twin'), weightMin: 0, weightMax: 0 };
+    const frames = Array.from({ length: 10 }, () => feat({ openness: 1 }));
+    const outs = (
+      await replayNode(indirectMapNode.make(indirectMapNode.params.parse({ ...PARAMS, smoothing: 0.6 })), {
+        features: frames,
+        steerConfig: frames.map(() => ({ strains: [up, flat] })),
+      })
+    ).map((o) => (o.steer as GenerativeSteer).prompts);
+    expect(outs[9]).toHaveLength(2);
+    expect(outs[9][0].weight).toBeGreaterThan(1); // climbing toward its own target of 2
+    expect(outs[9][1].weight).toBe(0); // sitting on its own target, untouched by its twin
+  });
+
   it('the exported schema is the contract a store/dial/editor all speak', () => {
     // Same schema validates the port value, the store slice and the persisted
     // dial — so those three cannot drift into disagreeing about the shape.


### PR DESCRIPTION
The headless prerequisite for the gesture-steered generative layer — the part #141 identified as *"the real cost the issue text hid"*, and the reason that feature has never been more than a node nobody could reach.

## The problem

`indirect-map`'s `strains` (which text prompts the gestures weight) and `dials` (density, brightness, bpm) were **params, fixed when the graph is built, with no input port**. So a vibe editor could not exist: changing a prompt would mean rebuilding the graph, which means re-running every node's `init()`, which means **reloading both MediaPipe models — to alter a string.**

Live editing was never a UI problem. It was a wiring problem.

## What this adds

`steerConfig` is now an input port carrying the live-overridable half of the params. The repo's own convention applies — *static params are the build-time default, the input port is the live override* — so an **unconnected port changes nothing**, which is what makes this safe to land before anything drives it.

The exported `SteerConfigSchema` is deliberately a *contract* rather than an implementation detail: the same schema will validate the port value, the store slice and the persisted dial, so those three cannot drift into disagreeing about the shape.

Two things that only matter once the config is live, and would otherwise be discovered as glitches:

- **Smoothing state is keyed by position AND identity** (`0:warm pads`), not by index. With a fixed config the two are the same thing; with a live one they are not. Editing the text at slot 0 makes it a *different prompt*, so it eases in from rest — inheriting the old prompt's momentum would be a jump in the mix with no gesture behind it. Its neighbours keep easing, untouched. The same reasoning makes a strain you delete and re-add start from rest rather than resurrecting its old weight, which is what the pruning is really for.
- **A malformed config degrades, it does not throw.** `process()` runs every frame, so one bad store write that threw would take the graph down on *every subsequent frame*. The last good config stands, and the node says why — once.

Also: `replayNode` gained a `log` option. Without it, a node's log line is the one observable behaviour a replay test cannot see — which matters precisely for the nodes that deliberately degrade rather than throw, where *"it kept going"* and *"it kept going and said why"* are different guarantees and only the second is worth relying on.

## Scope, deliberately

**This is the node half only.** The store slice, the dial, the command entries, the graph wiring and the vibe editor are **not** here — because until `indirect-map` is actually in the graph, a dial for it would be a settings control that steers nothing. That is #137 exactly, and #141's own definition of done names it as the trap:

> A partial build — nodes in the graph without the config/transport/UI — reproduces #137 node-for-node: a capability in the bundle with no way to switch it on.

So the reachability answer here is honest rather than evasive: **this PR adds no user-facing surface at all, and should not.** It removes the reason the surface could not be built. The rest lands with the branch wiring, which also needs a Gemini key and a listen — tracked in #168, item 6.

## Verification

8 new tests: an unconnected port is a byte-identical no-op; a live config replaces the strains without a rebuild; a partial override keeps the unset params; reverting the port restores them; a malformed config is ignored, logged once, and never throws; editing one strain resets its smoothing while its neighbour keeps easing; a removed-and-re-added strain starts from rest; and the exported schema accepts/rejects what it must.

An **8-mutant harness, 8/8 caught**. Catalog regenerated. `npm run typecheck` clean, `npm test` 1178 passed, `npm run build` green.

Refs #141.
