### PR TITLE
#163: trainer v2, PR 2 — guidance on the video, the routine picker, the guidance-sink seam

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -350,5 +350,5 @@ Mirrored video + composable overlay elements (guides, landmarks, markers, cues).
 - **roles:** overlay
 - **in:** hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], chordScale:number[], chord:number[], faceFrame:face-frame, expression:face-expression, octaveShift:number, overlayConfig:overlay-config, faceVector:feature-vector, handVector:feature-vector
 - **out:** —
-- **params:** video (object={}), scaleGuide (object={}), chordGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={}), fingerLines (object={}), faceLandmarks (object={}), timbreLevels (object={}), faceExpression (object={}), fingerBars (object={}), chordName (object={}), keyboardStrip (object={}), featureLab (object={}), tagHud (object={})
+- **params:** video (object={}), scaleGuide (object={}), chordGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={}), fingerLines (object={}), faceLandmarks (object={}), timbreLevels (object={}), faceExpression (object={}), fingerBars (object={}), chordName (object={}), keyboardStrip (object={}), featureLab (object={}), tagHud (object={}), trainerHud (object={})
 

--- a/public/catalog.json
+++ b/public/catalog.json
@@ -137,6 +137,11 @@
         "name": "tagHud",
         "type": "object",
         "default": {}
+      },
+      {
+        "name": "trainerHud",
+        "type": "object",
+        "default": {}
       }
     ]
   },

--- a/public/manual.html
+++ b/public/manual.html
@@ -408,7 +408,7 @@
         <dt>roles</dt><dd>overlay</dd>
         <dt>in</dt><dd>hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], chordScale:number[], chord:number[], faceFrame:face-frame, expression:face-expression, octaveShift:number, overlayConfig:overlay-config, faceVector:feature-vector, handVector:feature-vector</dd>
         <dt>out</dt><dd>—</dd>
-        <dt>params</dt><dd>video (object={}), scaleGuide (object={}), chordGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={}), fingerLines (object={}), faceLandmarks (object={}), timbreLevels (object={}), faceExpression (object={}), fingerBars (object={}), chordName (object={}), keyboardStrip (object={}), featureLab (object={}), tagHud (object={})</dd>
+        <dt>params</dt><dd>video (object={}), scaleGuide (object={}), chordGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={}), fingerLines (object={}), faceLandmarks (object={}), timbreLevels (object={}), faceExpression (object={}), fingerBars (object={}), chordName (object={}), keyboardStrip (object={}), featureLab (object={}), tagHud (object={}), trainerHud (object={})</dd>
       </dl>
     </div></div></section>
 </div></body></html>

--- a/src/app/TrainerPanel.tsx
+++ b/src/app/TrainerPanel.tsx
@@ -9,9 +9,11 @@
  * ## Cues, a runner, and a conversation
  *
  * The panel renders whatever routine the store loaded — a list of cues, which are
- * data — and, while the runner runs, shows what the runner SAYS: the cue's instruction,
- * large; the latest guidance ("a bit further, if you can"), beneath it; and a short
- * transcript. The runner steps when it has ENOUGH, not when time passes: the coverage
+ * data, editable through the {@link RoutinePicker} — and, while the runner runs, shows
+ * what the runner SAYS: the cue's instruction, large; the latest guidance ("a bit
+ * further, if you can"), beneath it; and a short transcript. The same strings are
+ * painted ON THE VIDEO by the overlay's `trainerHud` element (the player is looking at
+ * the camera, not at this panel); the panel is the full record, the HUD is the glance. The runner steps when it has ENOUGH, not when time passes: the coverage
  * meter is the cue's own minimum, and a cue the player cannot produce ends in
  * `cannot` and moves on rather than trapping them.
  *
@@ -44,6 +46,7 @@ import { GraduationCap, X } from 'lucide-react';
 import { categoryKey, type Category } from '@/enroll';
 import { readLiveVector } from './enroll/liveVector';
 import { useTrainer } from './enroll/store';
+import RoutinePicker from './enroll/RoutinePicker';
 import { useTools } from './toolsStore';
 import { toolById } from './tools';
 
@@ -209,6 +212,8 @@ export default function TrainerPanel() {
           {missing.length > 0 && (
             <p className="text-[10px] text-amber-300/80">Skipping {missing.length} cue(s) this routine names that no longer exist.</p>
           )}
+          {/* The picker (#163 §3): filter, include, reorder, save. Not while running. */}
+          {!running && <RoutinePicker />}
         </div>
 
         {/* What the runner is saying now. Always written; voice is a toggle on the same

--- a/src/app/TrainerPanel.tsx
+++ b/src/app/TrainerPanel.tsx
@@ -48,6 +48,7 @@ import { readLiveVector } from './enroll/liveVector';
 import { useTrainer } from './enroll/store';
 import RoutinePicker from './enroll/RoutinePicker';
 import { useTools } from './toolsStore';
+import { useControls } from './store';
 import { toolById } from './tools';
 
 const TOOL_ID = 'trainer';
@@ -108,6 +109,9 @@ export default function TrainerPanel() {
   const suggestedK = useTrainer((s) => s.suggestedK);
   const model = useTrainer((s) => s.model);
   const labels = useTrainer((s) => s.labels);
+  const lastEndSay = useTrainer((s) => s.lastEndSay);
+  const hudShow = useControls((s) => s.trainerHud.show);
+  const setTrainerHud = useControls((s) => s.setTrainerHud);
 
   const running = status === 'running' || status === 'between';
 
@@ -147,9 +151,54 @@ export default function TrainerPanel() {
   // Buildable only with something to carve: a routine that ended with every vocabulary
   // cue skipped or `cannot` is "done" and still has no still-points.
   const canBuild = (status === 'done' || status === 'stopped') && useTrainer.getState().session().ready();
-  const lastEndSay = [...transcript].reverse().find((l) => l.kind === 'end')?.say ?? null;
   const cueNames = new Map(routine.map((c) => [c.id, c.name]));
   const latestEnd = [...transcript].reverse().find((l) => l.kind === 'end' && l.outcome === 'cannot');
+
+  // While a routine runs the panel collapses to a slim strip: the instruction is on
+  // the video (the HUD), and a full-height panel would sit over it. Skip / Stop and
+  // the meter stay within reach; the full panel returns when the routine ends.
+  if (running && activeCue) {
+    return (
+      <div
+        data-tool={TOOL_ID}
+        data-compact
+        className="absolute bottom-14 left-3 z-40 flex w-96 max-w-[calc(100vw-1.5rem)] flex-col gap-1 rounded-2xl border border-emerald-400/30 bg-black/70 px-3 py-2 backdrop-blur"
+        aria-live="polite"
+      >
+        <div className="flex items-center gap-2">
+          <GraduationCap className="h-3.5 w-3.5 shrink-0 text-emerald-300" aria-hidden />
+          <span className="flex-1 truncate text-[11px] text-white/85">
+            <span className="text-white/40">
+              {index + 1}/{routine.length} ·{' '}
+            </span>
+            {activeCue.name}
+            {status === 'between' && <span className="text-white/40"> · next</span>}
+          </span>
+          <span className="text-[10px] tabular-nums text-white/40">
+            {samples} {activeCue.produces === 'vocabulary' ? 'held' : 'frames'}
+          </span>
+          <button
+            onClick={() => useTrainer.getState().skip(nowMs())}
+            className="rounded bg-white/10 px-2 py-0.5 text-[10px] font-semibold text-white/80 transition hover:bg-white/20"
+          >
+            Skip
+          </button>
+          <button
+            onClick={() => useTrainer.getState().stop(nowMs())}
+            className="rounded bg-white/10 px-2 py-0.5 text-[10px] font-semibold text-white/80 transition hover:bg-white/20"
+          >
+            Stop
+          </button>
+        </div>
+        {/* The written channel is ALWAYS here too, in case the HUD is hidden. */}
+        <p className="truncate text-[11px] text-white" data-say title={activeCue.instruction}>
+          {status === 'between' ? lastEndSay ?? '' : activeCue.instruction}
+        </p>
+        {guidance && <p className="truncate text-[10px] italic text-emerald-200/80" data-guidance>{guidance}</p>}
+        <Coverage value={coverage} />
+      </div>
+    );
+  }
 
   return (
     <div
@@ -216,53 +265,18 @@ export default function TrainerPanel() {
           {!running && <RoutinePicker />}
         </div>
 
-        {/* What the runner is saying now. Always written; voice is a toggle on the same
-            string — so during the beat between cues the panel shows the END phrase the
-            runner just said ("Good."), and the next instruction only once it is said. */}
-        {running && activeCue && (
-          <div className="space-y-2 rounded-lg border border-emerald-400/30 bg-emerald-500/5 p-3" aria-live="polite">
-            <p className="text-[10px] uppercase tracking-widest text-emerald-400/70">
-              {status === 'between' ? 'Next' : 'Now'} · {activeCue.name}
-            </p>
-            <p className="text-[14px] font-medium leading-snug text-white" data-say>
-              {status === 'between' ? lastEndSay ?? '…' : activeCue.instruction}
-            </p>
-            {guidance && (
-              <p className="text-[11px] italic text-emerald-200/80" data-guidance>
-                {guidance}
-              </p>
-            )}
-            {activeCue.rationale && <p className="text-[10px] leading-snug text-white/40">{activeCue.rationale}</p>}
-            <Coverage value={coverage} />
-            <div className="flex items-center gap-2">
-              <span className="flex-1 text-[10px] tabular-nums text-white/40">
-                {samples} {activeCue.produces === 'vocabulary' ? 'held' : 'frames'}
-              </span>
-              <button
-                onClick={() => useTrainer.getState().skip(nowMs())}
-                className="rounded bg-white/10 px-2 py-0.5 text-[10px] font-semibold text-white/80 transition hover:bg-white/20"
-              >
-                Skip
-              </button>
-              <button
-                onClick={() => useTrainer.getState().stop(nowMs())}
-                className="rounded bg-white/10 px-2 py-0.5 text-[10px] font-semibold text-white/80 transition hover:bg-white/20"
-              >
-                Stop
-              </button>
-            </div>
-          </div>
-        )}
-
-        {!running && (
-          <button
-            onClick={() => useTrainer.getState().start(nowMs())}
-            disabled={routine.length === 0}
-            className="w-full rounded-lg bg-white/10 px-3 py-1.5 text-[11px] font-bold text-white/90 transition hover:bg-white/20 disabled:opacity-30"
-          >
-            {status === 'idle' ? 'Start' : 'Run again'}
-          </button>
-        )}
+        <button
+          onClick={() => useTrainer.getState().start(nowMs())}
+          disabled={routine.length === 0}
+          className="w-full rounded-lg bg-white/10 px-3 py-1.5 text-[11px] font-bold text-white/90 transition hover:bg-white/20 disabled:opacity-30"
+        >
+          {status === 'idle' ? 'Start' : 'Run again'}
+        </button>
+        {/* A per-device pref (not an instrument parameter): where the guidance shows. */}
+        <label className="flex items-center gap-2 text-[10px] text-white/60">
+          <input type="checkbox" checked={hudShow} onChange={(e) => setTrainerHud({ show: e.target.checked })} />
+          Show the instructions on the video while it runs
+        </label>
 
         {status === 'done' && (
           <p className="text-[11px] text-emerald-200/80">That is everything. Now find your categories.</p>

--- a/src/app/enroll/RoutinePicker.tsx
+++ b/src/app/enroll/RoutinePicker.tsx
@@ -1,0 +1,161 @@
+/**
+ * RoutinePicker (#163 §3) — choose which cues a routine runs, in what order; save it.
+ *
+ * The cue collection grows (starters, stored overrides, custom cues) and the catalog
+ * has hundreds of features, so an unfiltered list stops being usable fast: the picker
+ * filters by free text (name / instruction) and by tag chips (`face`, `pose`,
+ * `expression`, `setup`, …), the same approach the instrument library takes with its
+ * favourites and tags.
+ *
+ * The draft is local React state; "Use" applies it to the trainer store, "Save as"
+ * persists it to the routine collection (a zodal named collection — localStorage by
+ * default). Hidden while a routine runs: the runner holds its own cue list and the
+ * store refuses to swap it mid-run.
+ */
+import { useMemo, useState } from 'react';
+import { cueTags, filterCues } from './cueStore';
+import { useTrainer } from './store';
+
+export default function RoutinePicker() {
+  const cues = useTrainer((s) => s.cues);
+  const routine = useTrainer((s) => s.routine);
+  const routineName = useTrainer((s) => s.routineName);
+  const savedRoutines = useTrainer((s) => s.savedRoutines);
+  const unusable = useTrainer((s) => s.unusable);
+
+  const [query, setQuery] = useState('');
+  const [tags, setTags] = useState<string[]>([]);
+  const [draft, setDraft] = useState<string[] | null>(null);
+  const [saveName, setSaveName] = useState('');
+
+  const ids = draft ?? routine.map((c) => c.id);
+  const allTags = useMemo(() => cueTags(cues), [cues]);
+  const visible = useMemo(() => filterCues(cues, query, tags), [cues, query, tags]);
+  const byId = useMemo(() => new Map(cues.map((c) => [c.id, c])), [cues]);
+
+  const toggle = (id: string) => setDraft(ids.includes(id) ? ids.filter((x) => x !== id) : [...ids, id]);
+  const move = (id: string, dir: -1 | 1) => {
+    const i = ids.indexOf(id);
+    const j = i + dir;
+    if (i < 0 || j < 0 || j >= ids.length) return;
+    const next = [...ids];
+    [next[i], next[j]] = [next[j], next[i]];
+    setDraft(next);
+  };
+  const dirty = draft !== null && draft.join(',') !== routine.map((c) => c.id).join(',');
+
+  return (
+    <details className="rounded-lg border border-white/10 p-2 text-[11px]" data-routine-picker>
+      <summary className="cursor-pointer select-none text-white/60">
+        Edit routine <span className="text-white/35">· {ids.length} cues{dirty ? ' (unsaved)' : ''}</span>
+      </summary>
+      <div className="mt-2 space-y-2">
+        <div className="flex flex-wrap items-center gap-1">
+          <input
+            aria-label="Filter cues"
+            placeholder="filter cues…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            className="min-w-0 flex-1 rounded bg-white/5 px-2 py-1 text-[11px] text-white/85 placeholder:text-white/25"
+          />
+          {allTags.map((t) => {
+            const on = tags.includes(t);
+            return (
+              <button
+                key={t}
+                type="button"
+                aria-pressed={on}
+                onClick={() => setTags(on ? tags.filter((x) => x !== t) : [...tags, t])}
+                className={`rounded-full px-2 py-0.5 text-[10px] ${on ? 'bg-emerald-500/40 text-white' : 'bg-white/10 text-white/60 hover:bg-white/20'}`}
+              >
+                {t}
+              </button>
+            );
+          })}
+        </div>
+
+        {/* The draft routine, in order, then the rest of the (filtered) cues. */}
+        <ol className="space-y-0.5" aria-label="Cues">
+          {[...ids.map((id) => byId.get(id)).filter((c): c is NonNullable<typeof c> => !!c && visible.includes(c)), ...visible.filter((c) => !ids.includes(c.id))].map((cue) => {
+            const included = ids.includes(cue.id);
+            return (
+              <li key={cue.id} className="flex items-center gap-2" data-picker-cue={cue.id}>
+                <input
+                  type="checkbox"
+                  aria-label={`Include ${cue.name}`}
+                  checked={included}
+                  onChange={() => toggle(cue.id)}
+                />
+                <span className={`flex-1 truncate ${included ? 'text-white/85' : 'text-white/50'}`} title={cue.instruction}>
+                  {cue.name} <span className="text-white/30">· {cue.instruction}</span>
+                </span>
+                {included && (
+                  <span className="flex gap-0.5">
+                    <button type="button" aria-label={`Move ${cue.name} up`} onClick={() => move(cue.id, -1)} className="rounded px-1 text-white/40 hover:bg-white/10 hover:text-white">↑</button>
+                    <button type="button" aria-label={`Move ${cue.name} down`} onClick={() => move(cue.id, 1)} className="rounded px-1 text-white/40 hover:bg-white/10 hover:text-white">↓</button>
+                  </span>
+                )}
+              </li>
+            );
+          })}
+        </ol>
+        {visible.length === 0 && <p className="text-white/35">No cue matches.</p>}
+        {unusable.length > 0 && (
+          <p className="text-[10px] text-amber-300/80">{unusable.length} stored cue(s) name no feature this build knows and were left out.</p>
+        )}
+
+        <div className="flex flex-wrap items-center gap-1.5">
+          <button
+            type="button"
+            disabled={!dirty || ids.length === 0}
+            onClick={() => {
+              useTrainer.getState().setRoutine(ids, 'Custom');
+              setDraft(null);
+            }}
+            className="rounded bg-white/10 px-2 py-0.5 text-[10px] font-semibold text-white/80 hover:bg-white/20 disabled:opacity-30"
+          >
+            Use
+          </button>
+          <input
+            aria-label="Routine name"
+            placeholder="save as…"
+            value={saveName}
+            onChange={(e) => setSaveName(e.target.value)}
+            className="w-28 rounded bg-white/5 px-2 py-0.5 text-[10px] text-white/85 placeholder:text-white/25"
+          />
+          <button
+            type="button"
+            disabled={saveName.trim() === '' || ids.length === 0}
+            onClick={() => {
+              void useTrainer.getState().saveRoutine(saveName.trim(), ids);
+              setDraft(null);
+              setSaveName('');
+            }}
+            className="rounded bg-white/10 px-2 py-0.5 text-[10px] font-semibold text-white/80 hover:bg-white/20 disabled:opacity-30"
+          >
+            Save
+          </button>
+          <select
+            aria-label="Saved routines"
+            value=""
+            onChange={(e) => {
+              const id = e.target.value;
+              if (id === '__default') void useTrainer.getState().useRoutine(null);
+              else if (id) void useTrainer.getState().useRoutine(id);
+              setDraft(null);
+            }}
+            className="rounded bg-white/5 px-1 py-0.5 text-[10px] text-white/70"
+          >
+            <option value="">load… ({routineName})</option>
+            <option value="__default">Default</option>
+            {savedRoutines.map((r) => (
+              <option key={r.id} value={r.id}>
+                {r.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+    </details>
+  );
+}

--- a/src/app/enroll/RoutinePicker.tsx
+++ b/src/app/enroll/RoutinePicker.tsx
@@ -34,14 +34,21 @@ export default function RoutinePicker() {
   const byId = useMemo(() => new Map(cues.map((c) => [c.id, c])), [cues]);
 
   const toggle = (id: string) => setDraft(ids.includes(id) ? ids.filter((x) => x !== id) : [...ids, id]);
+  /** The included cues the filter currently shows, in routine order. */
+  const visibleIncluded = ids.filter((id) => visible.some((c) => c.id === id));
+  /** Swap with the nearest VISIBLE included neighbour: with a filter on, a move must
+   *  change what the player sees, never a hidden row behind it. */
   const move = (id: string, dir: -1 | 1) => {
+    const vi = visibleIncluded.indexOf(id);
+    const other = visibleIncluded[vi + dir];
+    if (vi < 0 || !other) return;
     const i = ids.indexOf(id);
-    const j = i + dir;
-    if (i < 0 || j < 0 || j >= ids.length) return;
+    const j = ids.indexOf(other);
     const next = [...ids];
     [next[i], next[j]] = [next[j], next[i]];
     setDraft(next);
   };
+  const [selectedSaved, setSelectedSaved] = useState('');
   const dirty = draft !== null && draft.join(',') !== routine.map((c) => c.id).join(',');
 
   return (
@@ -137,9 +144,10 @@ export default function RoutinePicker() {
           </button>
           <select
             aria-label="Saved routines"
-            value=""
+            value={selectedSaved}
             onChange={(e) => {
               const id = e.target.value;
+              setSelectedSaved(id);
               if (id === '__default') void useTrainer.getState().useRoutine(null);
               else if (id) void useTrainer.getState().useRoutine(id);
               setDraft(null);
@@ -154,6 +162,19 @@ export default function RoutinePicker() {
               </option>
             ))}
           </select>
+          {selectedSaved && selectedSaved !== '__default' && (
+            <button
+              type="button"
+              aria-label="Delete the selected saved routine"
+              onClick={() => {
+                void useTrainer.getState().removeRoutine(selectedSaved);
+                setSelectedSaved('');
+              }}
+              className="rounded px-1.5 py-0.5 text-[10px] text-rose-300/80 hover:bg-rose-500/20"
+            >
+              Delete
+            </button>
+          )}
         </div>
       </div>
     </details>

--- a/src/app/enroll/guidance.ts
+++ b/src/app/enroll/guidance.ts
@@ -1,0 +1,45 @@
+/**
+ * Guidance sinks (#163 §4-§5) — where what the runner SAYS goes.
+ *
+ * The runner emits `say` strings (instruction, nudge, end phrase, done); the trainer
+ * store turns them into transcript lines. A {@link GuidanceSink} is anything that
+ * renders those lines: the written channel (the panel's transcript and the on-video
+ * HUD read the store directly and are always on), and — behind a toggle — the spoken
+ * channel (PR 3 plays a cached clip per line). Text is never a sink you can turn off;
+ * voice is a sink you can add.
+ *
+ * Sinks are called synchronously from the store's event handler, at human frequency
+ * (a few times per cue). A sink must not throw and must not block.
+ */
+import type { TranscriptLine } from './store';
+
+export interface GuidanceSink {
+  /** One utterance. Called in order, once each. */
+  say(line: TranscriptLine): void;
+}
+
+const sinks = new Set<GuidanceSink>();
+
+/** Register a sink. Returns the unregister. */
+export function addGuidanceSink(sink: GuidanceSink): () => void {
+  sinks.add(sink);
+  return () => {
+    sinks.delete(sink);
+  };
+}
+
+/** Fan a line out to every sink (the store calls this). A throwing sink is isolated. */
+export function emitGuidance(line: TranscriptLine): void {
+  for (const s of sinks) {
+    try {
+      s.say(line);
+    } catch {
+      // A sink's failure (a blocked autoplay, say) must never stop the routine.
+    }
+  }
+}
+
+/** For tests. */
+export function resetGuidanceSinks(): void {
+  sinks.clear();
+}

--- a/src/app/enroll/hud.ts
+++ b/src/app/enroll/hud.ts
@@ -16,14 +16,14 @@ export function trainerHudResource(): TrainerHudSnapshot | null {
   if (s.status !== 'running' && s.status !== 'between') return null;
   const cue = s.index >= 0 ? s.routine[s.index] : undefined;
   if (!cue) return null;
-  const lastEnd = s.status === 'between' ? [...s.transcript].reverse().find((l) => l.kind === 'end') : undefined;
   const guidance = s.status === 'running' && s.say && s.say !== cue.instruction ? s.say : null;
   return {
     status: s.status,
     cueName: cue.name,
     index: s.index + 1,
     total: s.routine.length,
-    say: s.status === 'between' ? lastEnd?.say ?? '…' : cue.instruction,
+    // The beat shows what the runner just said for THIS cue-end — nothing after a skip.
+    say: s.status === 'between' ? s.lastEndSay ?? '' : cue.instruction,
     guidance,
     coverage: s.coverage,
   };

--- a/src/app/enroll/hud.ts
+++ b/src/app/enroll/hud.ts
@@ -1,0 +1,30 @@
+/**
+ * The trainer HUD resource (#163 §5) — the overlay's per-tick read of what the trainer
+ * is saying, derived from the trainer store.
+ *
+ * Installed by `useEngine` as `ctx.resources.trainerHud`, next to the tag HUD's
+ * resource. Synchronous and allocation-light: it reads the zustand store's current
+ * state (no subscription, no await) and returns null whenever no routine is running,
+ * so the overlay element is a no-op the rest of the time.
+ */
+import type { TrainerHudSnapshot } from '@/enroll/hud';
+import { useTrainer } from './store';
+
+/** The overlay's read. Null unless a routine is running (or in the beat between cues). */
+export function trainerHudResource(): TrainerHudSnapshot | null {
+  const s = useTrainer.getState();
+  if (s.status !== 'running' && s.status !== 'between') return null;
+  const cue = s.index >= 0 ? s.routine[s.index] : undefined;
+  if (!cue) return null;
+  const lastEnd = s.status === 'between' ? [...s.transcript].reverse().find((l) => l.kind === 'end') : undefined;
+  const guidance = s.status === 'running' && s.say && s.say !== cue.instruction ? s.say : null;
+  return {
+    status: s.status,
+    cueName: cue.name,
+    index: s.index + 1,
+    total: s.routine.length,
+    say: s.status === 'between' ? lastEnd?.say ?? '…' : cue.instruction,
+    guidance,
+    coverage: s.coverage,
+  };
+}

--- a/src/app/enroll/store.ts
+++ b/src/app/enroll/store.ts
@@ -49,6 +49,7 @@ import {
 } from '@/enroll';
 import { appFeatureDemand } from '../featureDemand';
 import { createCueStore, createRoutineStore, listCues, loadRoutine, type CueStore, type RoutineStore } from './cueStore';
+import { emitGuidance } from './guidance';
 import { DEFAULT_ROUTINE_CUE_IDS, STARTER_CUES } from './starterCues';
 
 /** One line of what the runner said, for the panel's transcript. */
@@ -103,10 +104,19 @@ interface TrainerState {
    *  (such a cue could never capture anything; see `cueStore.listCues`). */
   unusable: string[];
 
+  /** Saved routines (metadata), newest first — for the picker. */
+  savedRoutines: { id: string; name: string }[];
+
   /** Read the cue + routine stores (idempotent; the panel calls it on open). */
   load(): Promise<void>;
   /** Replace the routine with these cue ids (resolved against `cues`). */
   setRoutine(cueIds: readonly string[], name?: string): void;
+  /** Persist the current routine (or `cueIds`) under `name`, and use it. */
+  saveRoutine(name: string, cueIds?: readonly string[]): Promise<void>;
+  /** Load a saved routine by id and use it (a missing id falls back to the default). */
+  useRoutine(id: string | null): Promise<void>;
+  /** Delete a saved routine. */
+  removeRoutine(id: string): Promise<void>;
   start(tMs: number): void;
   sample(vector: FeatureVector, tMs: number): void;
   tick(tMs: number): void;
@@ -158,8 +168,10 @@ export const useTrainer = create<TrainerState>()((set, get) => {
   };
 
   const onEvent = (e: RunnerEvent) => {
-    const push = (line: TranscriptLine) =>
+    const push = (line: TranscriptLine) => {
       set((st) => ({ transcript: [...st.transcript, line].slice(-TRANSCRIPT_LIMIT) }));
+      emitGuidance(line);
+    };
     switch (e.type) {
       case 'cue-start':
         push({ t: e.t, kind: 'instruction', say: e.say });
@@ -188,6 +200,7 @@ export const useTrainer = create<TrainerState>()((set, get) => {
     routineName: 'Default',
     missing: [],
     unusable: [],
+    savedRoutines: [],
     loaded: false,
     ...IDLE,
     outcomes: STARTER_CUES.map(() => null),
@@ -207,11 +220,35 @@ export const useTrainer = create<TrainerState>()((set, get) => {
       // the read resolved): the runner holds ITS cue list, and the panel renders the
       // store's — they must not diverge mid-run. Swap the routine only when idle.
       const running = get().status === 'running' || get().status === 'between';
+      const savedRoutines = (await routines.list()).map(({ id, name }) => ({ id, name }));
       set(
         running
-          ? { cues, unusable, loaded: true }
-          : { cues, unusable, routine: r.cues, routineName: r.name, missing: r.missing, outcomes: r.cues.map(() => null), loaded: true },
+          ? { cues, unusable, savedRoutines, loaded: true }
+          : { cues, unusable, savedRoutines, routine: r.cues, routineName: r.name, missing: r.missing, outcomes: r.cues.map(() => null), loaded: true },
       );
+    },
+
+    async saveRoutine(name, cueIds) {
+      const ids = cueIds ?? get().routine.map((c) => c.id);
+      const { routines } = getStores();
+      const rec = await routines.save(name, { cueIds: [...ids] });
+      const savedRoutines = (await routines.list()).map(({ id, name: n }) => ({ id, name: n }));
+      set({ savedRoutines });
+      get().setRoutine(ids, rec.name);
+    },
+
+    async useRoutine(id) {
+      if (get().status === 'running' || get().status === 'between') return;
+      const { routines } = getStores();
+      const r = await loadRoutine(id, get().cues, routines);
+      set({ routine: r.cues, routineName: r.name, missing: r.missing, outcomes: r.cues.map(() => null) });
+    },
+
+    async removeRoutine(id) {
+      const { routines } = getStores();
+      await routines.remove(id);
+      const savedRoutines = (await routines.list()).map(({ id: i, name }) => ({ id: i, name }));
+      set({ savedRoutines });
     },
 
     setRoutine(cueIds, name = 'Custom') {

--- a/src/app/enroll/store.ts
+++ b/src/app/enroll/store.ts
@@ -36,6 +36,7 @@ import { create } from 'zustand';
 import {
   createRunner,
   createSession,
+  resolveRoutine,
   routineGroups,
   type Cue,
   type CueOutcome,
@@ -86,6 +87,10 @@ interface TrainerState {
   say: string | null;
   outcomes: (CueOutcome | null)[];
   transcript: TranscriptLine[];
+  /** What the runner said when the LAST cue ended ("Good." / "Moving on."), or null
+   *  after a skip — what the beat shows. Not "the last end line in the transcript":
+   *  a skip says nothing, and the previous cue's phrase must not be shown for it. */
+  lastEndSay: string | null;
 
   /** True once `build()` has run and a model can be cut. */
   built: boolean;
@@ -170,7 +175,9 @@ export const useTrainer = create<TrainerState>()((set, get) => {
   const onEvent = (e: RunnerEvent) => {
     const push = (line: TranscriptLine) => {
       set((st) => ({ transcript: [...st.transcript, line].slice(-TRANSCRIPT_LIMIT) }));
-      emitGuidance(line);
+      // Sinks run AFTER the runner's dispatch and the store's update have settled: a
+      // sink that reacts by skipping or stopping must not re-enter the runner mid-event.
+      queueMicrotask(() => emitGuidance(line));
     };
     switch (e.type) {
       case 'cue-start':
@@ -182,7 +189,7 @@ export const useTrainer = create<TrainerState>()((set, get) => {
       case 'cue-end':
         // A skip says nothing; only an outcome with a phrase is a line of transcript.
         if (e.say) push({ t: e.t, kind: 'end', say: e.say, outcome: e.outcome, why: e.why });
-        set({ outcomes: runner?.state().outcomes ?? [] });
+        set({ outcomes: runner?.state().outcomes ?? [], lastEndSay: e.say ?? null });
         break;
       case 'done':
         push({ t: e.t, kind: 'done', say: e.say });
@@ -205,6 +212,7 @@ export const useTrainer = create<TrainerState>()((set, get) => {
     ...IDLE,
     outcomes: STARTER_CUES.map(() => null),
     transcript: [],
+    lastEndSay: null,
     built: false,
     k: 3,
     suggestedK: 3,
@@ -230,11 +238,13 @@ export const useTrainer = create<TrainerState>()((set, get) => {
 
     async saveRoutine(name, cueIds) {
       const ids = cueIds ?? get().routine.map((c) => c.id);
+      // Hydrate first, persist after (the project's hot-path rule): the routine in use
+      // must not lag a slow provider, and Start must never run the pre-save one.
+      get().setRoutine(ids, name.trim() || 'Custom');
       const { routines } = getStores();
-      const rec = await routines.save(name, { cueIds: [...ids] });
+      await routines.save(name, { cueIds: [...new Set(ids)] });
       const savedRoutines = (await routines.list()).map(({ id, name: n }) => ({ id, name: n }));
       set({ savedRoutines });
-      get().setRoutine(ids, rec.name);
     },
 
     async useRoutine(id) {
@@ -254,19 +264,15 @@ export const useTrainer = create<TrainerState>()((set, get) => {
     setRoutine(cueIds, name = 'Custom') {
       // Not while a runner is driving the current routine (same reason as in load()).
       if (get().status === 'running' || get().status === 'between') return;
-      const byId = new Map(get().cues.map((c) => [c.id, c]));
-      const routine: Cue[] = [];
-      const missing: string[] = [];
-      for (const id of cueIds) {
-        const c = byId.get(id);
-        if (c) routine.push(c);
-        else missing.push(id);
-      }
+      // The same resolution the routine collection uses: unknown ids reported, a
+      // repeated id runs once.
+      const { cues: routine, missing } = resolveRoutine(cueIds, get().cues);
       set({ routine, routineName: name, missing, outcomes: routine.map(() => null) });
     },
 
     start(tMs) {
       const routine = get().routine;
+      set({ lastEndSay: null });
       // A previous runner (a re-run, or a test driving the store directly) must be
       // stopped and detached first, or it stays 'running' on an orphaned session and
       // keeps writing events into this store.
@@ -334,6 +340,7 @@ export const useTrainer = create<TrainerState>()((set, get) => {
         ...IDLE,
         outcomes: get().routine.map(() => null),
         transcript: [],
+        lastEndSay: null,
         built: false,
         k: 3,
         suggestedK: 3,

--- a/src/app/overlayControls.ts
+++ b/src/app/overlayControls.ts
@@ -30,7 +30,7 @@ import type { OverlayParams } from '@/nodes/output/canvas_overlay';
  * surface named here must be reachable from the app shell — `tools.ts` is the registry
  * of shell surfaces and a test ties the two together.
  */
-export type OverlaySurface = 'instrument' | 'lab';
+export type OverlaySurface = 'instrument' | 'lab' | 'trainer';
 
 export interface OverlayControlDesc {
   /** The overlay ELEMENT this descriptor controls. Usually also the params key — see
@@ -142,7 +142,7 @@ export const OVERLAY_CONTROLS: OverlayControlDesc[] = [
   { name: 'tagHud', label: 'Annotation HUD (recorded)' },
   // Trainer guidance on the video (#163): the instruction + nudges while a routine
   // runs. Shown only then; toggle to keep the video clean during training.
-  { name: 'trainerHud', label: 'Trainer guidance' },
+  { name: 'trainerHud', label: 'Trainer guidance', surface: 'trainer' },
 ];
 
 /** The descriptors rendered by a given UI surface. `surface` is optional on a

--- a/src/app/overlayControls.ts
+++ b/src/app/overlayControls.ts
@@ -140,6 +140,9 @@ export const OVERLAY_CONTROLS: OverlayControlDesc[] = [
   // Live tagging (#92): the burned-in corner HUD (open tags + timecode) that composits
   // into the recorded video. Shown only while a take records; toggle to hide the burn-in.
   { name: 'tagHud', label: 'Annotation HUD (recorded)' },
+  // Trainer guidance on the video (#163): the instruction + nudges while a routine
+  // runs. Shown only then; toggle to keep the video clean during training.
+  { name: 'trainerHud', label: 'Trainer guidance' },
 ];
 
 /** The descriptors rendered by a given UI surface. `surface` is optional on a

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -17,7 +17,7 @@ import { create } from 'zustand';
 import { persist, createJSONStorage, type StateStorage } from 'zustand/middleware';
 import type { ScaleTypeId } from '@/music/theory';
 import { DEFAULT_SOUND_RIGHT, DEFAULT_SOUND_LEFT } from '@/music/sounds';
-import { OverlayDialSchema, type OverlayDialParams } from '@/nodes/output/canvas_overlay';
+import { OverlayDialSchema, TrainerHudParamsSchema, type OverlayDialParams, type TrainerHudParams } from '@/nodes/output/canvas_overlay';
 import { FeatureLabSchema, defaultFeatureLab, type FeatureLabConfig } from '@/features/labConfig';
 import { GesturePrefsSchema, defaultGesturePrefs, type GesturePrefs } from './gesturePrefs';
 import { FACE_MAPPINGS, legacyFaceToMapping, type VoiceParams, type FaceMapping } from '@/nodes';
@@ -160,6 +160,13 @@ export interface ControlState {
    * edited from the Gestures shell tool.
    */
   gestures: GesturePrefs;
+  /**
+   * The trainer's on-video guidance HUD (#163): shown, and on which edge. A per-DEVICE
+   * tooling pref like {@link featureLab} — the trainer is a shell tool, so hiding its
+   * banner must not mark the instrument edited nor flip when an instrument loads.
+   * `store-controls` composes it into the overlay node's params each tick.
+   */
+  trainerHud: TrainerHudParams;
   setVoice(side: 'right' | 'left', patch: Partial<VoiceControl>): void;
   setSync(v: boolean): void;
   setMasterVolume(v: number): void;
@@ -186,6 +193,8 @@ export interface ControlState {
   /** Shallow-patch the gesture-dispatch prefs (e.g. setGestures({ enabled: true }),
    *  or a whole new `bindings` record for a binding change). */
   setGestures(patch: Partial<GesturePrefs>): void;
+  /** Shallow-patch the trainer HUD pref (e.g. setTrainerHud({ show: false })). */
+  setTrainerHud(patch: Partial<TrainerHudParams>): void;
   /** Replace all live controls from a settings snapshot (loading a preset). */
   applySettings(s: Settings): void;
 }
@@ -306,6 +315,15 @@ export function mergeControls(persisted: unknown, current: ControlState): Contro
       featureLab = current.featureLab;
     }
   }
+  // And the trainer HUD pref (#163), the same way.
+  let trainerHud = current.trainerHud;
+  if (p.trainerHud) {
+    try {
+      trainerHud = TrainerHudParamsSchema.parse(p.trainerHud);
+    } catch {
+      trainerHud = current.trainerHud;
+    }
+  }
   // Re-parse faceChord: complete a partial blob from the defaults, then validate,
   // so a UI control never binds to an undefined/corrupt field (parity with overlay).
   let faceChord = current.faceChord;
@@ -386,7 +404,7 @@ export function mergeControls(persisted: unknown, current: ControlState): Contro
       gestures = current.gestures;
     }
   }
-  return { ...current, ...p, overlay, featureLab, faceMapping, faceChord, faceExpr, handMap, midi, faceControls, gestures };
+  return { ...current, ...p, overlay, featureLab, trainerHud, faceMapping, faceChord, faceExpr, handMap, midi, faceControls, gestures };
 }
 
 // localStorage in the browser; a no-op elsewhere (Node test runtime) so the
@@ -422,6 +440,7 @@ export const useControls = create<ControlState>()(
       faceControls: defaultFaceControls(),
       faceCalibration: null,
       gestures: defaultGesturePrefs(),
+      trainerHud: TrainerHudParamsSchema.parse({}),
       setVoice: (side, patch) =>
         set((s) => {
           const next = { ...s[side], ...patch };
@@ -459,6 +478,7 @@ export const useControls = create<ControlState>()(
       setHandMap: (patch) => set((s) => ({ handMap: { ...s.handMap, ...patch } })),
       setFaceCalibration: (map) => set({ faceCalibration: map ? { ...map } : null }),
       setGestures: (patch) => set((s) => ({ gestures: { ...s.gestures, ...patch } })),
+      setTrainerHud: (patch) => set((s) => ({ trainerHud: { ...s.trainerHud, ...patch } })),
       // Restore exactly the schema fields (the setters are left untouched). Derived
       // from SETTINGS_KEYS, so a new preset field needs no edit.
       applySettings: (st) => set(pickSettings(st as unknown as Record<string, unknown>)),
@@ -506,6 +526,7 @@ export const useControls = create<ControlState>()(
         faceCalibration: s.faceCalibration,
         featureLab: s.featureLab,
         gestures: s.gestures,
+        trainerHud: s.trainerHud,
       }),
     },
   ),

--- a/src/app/useEngine.ts
+++ b/src/app/useEngine.ts
@@ -22,6 +22,7 @@ import { DEFAULT_SOURCE, type SourceSpec } from './sourceSpec';
 import { useControls } from './store';
 import { LiveVectorTap, resetLiveVector } from './enroll/liveVector';
 import { featureDemandResource } from './featureDemand';
+import { trainerHudResource } from './enroll/hud';
 import { useToasts } from './toasts';
 import { SessionRecorder, activeStreamLabels } from './recording/session';
 import { SinkCancelled } from './recording/sink';
@@ -240,6 +241,9 @@ export function useThoreminEngine(source: SourceSpec = DEFAULT_SOURCE, slots: Sl
         // Live tagging (#92): the burned-in corner HUD reads this each tick (null
         // unless a take is recording). Same synchronous-read pattern as `controls`.
         resources.tagOverlay = tagOverlayResource;
+        // Trainer guidance on the video (#163): the overlay reads what the runner is
+        // saying each tick; null unless a routine runs.
+        resources.trainerHud = trainerHudResource;
         // Feature demand (#163): the vector nodes compute whatever a host consumer
         // (the trainer, while a cue runs) has claimed, even with the Lab closed.
         resources.featureDemand = featureDemandResource;

--- a/src/enroll/hud.ts
+++ b/src/enroll/hud.ts
@@ -1,0 +1,49 @@
+/**
+ * The trainer HUD snapshot (#163 §5) — what the overlay draws ON THE VIDEO while a
+ * routine runs.
+ *
+ * The player is looking at the camera, not at a panel in the corner. The written
+ * guidance therefore has to live where they are looking: the instruction, large,
+ * across the bottom of the frame; the latest nudge beneath it; a coverage bar that
+ * fills as the cue gets what it needs. This is the written channel of the same `say`
+ * strings the runner emits — voice (PR 3) is a toggle layered on the same strings.
+ *
+ * The type lives in the pure library so the overlay NODE can depend on it without
+ * reaching into the app (nodes never import `src/app`). The app produces it from the
+ * trainer store (`src/app/enroll/hud.ts`) and installs a reader on the engine's
+ * resources, the same seam shape as the tag HUD (`ctx.resources.tagOverlay`).
+ */
+
+export interface TrainerHudSnapshot {
+  /** `'running'`: the instruction is up. `'between'`: the beat after a cue ended. */
+  status: 'running' | 'between';
+  /** Short name of the active (or next) cue. */
+  cueName: string;
+  /** Position in the routine, 1-based, and the routine's length. */
+  index: number;
+  total: number;
+  /** The large line: the instruction while running; the end phrase during the beat. */
+  say: string;
+  /** The latest guidance ("a bit further, if you can"), or null. */
+  guidance: string | null;
+  /** 0..1 — how much of the cue's own minimum has been captured. */
+  coverage: number;
+}
+
+/** Wrap `text` into lines of at most `maxChars`, on spaces; never splits a word. */
+export function wrapLines(text: string, maxChars: number): string[] {
+  const words = text.split(/\s+/).filter(Boolean);
+  const lines: string[] = [];
+  let current = '';
+  for (const w of words) {
+    const next = current ? `${current} ${w}` : w;
+    if (next.length > maxChars && current) {
+      lines.push(current);
+      current = w;
+    } else {
+      current = next;
+    }
+  }
+  if (current) lines.push(current);
+  return lines;
+}

--- a/src/enroll/hud.ts
+++ b/src/enroll/hud.ts
@@ -4,8 +4,10 @@
  *
  * The player is looking at the camera, not at a panel in the corner. The written
  * guidance therefore has to live where they are looking: the instruction, large,
- * across the bottom of the frame; the latest nudge beneath it; a coverage bar that
- * fills as the cue gets what it needs. This is the written channel of the same `say`
+ * in a banner along the bottom (or top) edge of the frame, laid out as a cue so it
+ * never paints over another; the latest nudge beneath it; a coverage bar that fills
+ * as the cue gets what it needs. While it runs, the Trainer panel collapses to a slim
+ * strip so the video stays visible. This is the written channel of the same `say`
  * strings the runner emits — voice (PR 3) is a toggle layered on the same strings.
  *
  * The type lives in the pure library so the overlay NODE can depend on it without

--- a/src/enroll/runner.ts
+++ b/src/enroll/runner.ts
@@ -169,19 +169,24 @@ export function createRunner(options: RunnerOptions): Runner {
 
   const endCue = (outcome: CueOutcome, tMs: number, why?: string) => {
     const cue = activeCue();
-    if (!cue) return;
+    if (!cue || status !== 'running') return;
     session.endCue();
-    outcomes[index] = outcome;
+    const endedIndex = index;
+    outcomes[endedIndex] = outcome;
     const say = outcome === 'enough' ? RUNNER_PHRASES.enough : outcome === 'cannot' ? RUNNER_PHRASES.cannot : undefined;
-    emit({ type: 'cue-end', cue, index, outcome, why, say, samples: samplesOf(cue), t: tMs });
-    if (index + 1 >= cues.length) {
+    const samples = samplesOf(cue);
+    // Commit the state BEFORE emitting: a listener may re-enter (a sink that skips or
+    // stops), and it must see the runner as it is, not as it was.
+    const last = endedIndex + 1 >= cues.length;
+    if (last) {
       status = 'done';
       index = -1;
-      emit({ type: 'done', say: RUNNER_PHRASES.done, t: tMs });
-      return;
+    } else {
+      status = 'between';
+      nextAt = tMs + o.beatMs;
     }
-    status = 'between';
-    nextAt = tMs + o.beatMs;
+    emit({ type: 'cue-end', cue, index: endedIndex, outcome, why, say, samples, t: tMs });
+    if (last && status === 'done') emit({ type: 'done', say: RUNNER_PHRASES.done, t: tMs });
   };
 
   const consider = (tMs: number) => {
@@ -265,6 +270,7 @@ export function createRunner(options: RunnerOptions): Runner {
       if (status === 'running') endCue('skipped', tMs);
       else if (status === 'between') beginCue(index + 1, tMs);
     },
+    // (`stop` while 'between' leaves `index` at the ended cue; `state()` reports -1.)
     stop(tMs) {
       if (status === 'running') {
         session.endCue();

--- a/src/nodes/output/canvas_overlay.ts
+++ b/src/nodes/output/canvas_overlay.ts
@@ -70,6 +70,17 @@ export type CuePosition = z.infer<typeof CuePositionEnum>;
  * Per-element configuration. Each element has its own sub-object so it can be
  * toggled and parameterized independently.
  */
+/** The trainer HUD's params — exported so the control store can carry the per-device
+ *  pref in exactly this shape and `store-controls` can compose it in. */
+export const TrainerHudParamsSchema = z
+  .object({
+    show: z.boolean().default(true),
+    /** Which edge the banner anchors to. */
+    position: z.enum(['bottom', 'top']).default('bottom'),
+  })
+  .prefault({});
+export type TrainerHudParams = z.infer<typeof TrainerHudParamsSchema>;
+
 const Params = z.object({
   /** Mirrored webcam backdrop. `alpha` is the "grey-out" amount (0 = hidden). */
   video: z.object({ show: z.boolean().default(true), alpha: z.number().min(0).max(1).default(0.35) }).prefault({}),
@@ -172,15 +183,12 @@ const Params = z.object({
    * instruction large across the bottom of the frame, the latest nudge beneath it, and
    * a coverage bar — the written channel of what the runner says, where the player is
    * actually looking. A no-op (draws nothing) unless the trainer is running, so it
-   * costs nothing the rest of the time. Not burned into the recorded `pureVideo`.
+   * costs nothing the rest of the time. Not burned into the recorded `pureVideo`. A
+   * CUE: it takes part in the edge layout, so it stacks with the other cues on its
+   * edge instead of painting over them. Per-device (not in the instrument's dial —
+   * see {@link OverlayDialSchema}).
    */
-  trainerHud: z
-    .object({
-      show: z.boolean().default(true),
-      /** Which edge the banner anchors to. */
-      position: z.enum(['bottom', 'top']).default('bottom'),
-    })
-    .prefault({}),
+  trainerHud: TrainerHudParamsSchema,
 });
 type Params = z.infer<typeof Params>;
 
@@ -201,9 +209,12 @@ export type OverlayParams = Params;
  * instrument being measured. Leaving it in the dial meant that toggling a meter marked
  * the instrument as having unsaved edits, and that loading an instrument silently
  * re-configured the meters — the same reason recording settings were moved out of the
- * instrument in #88.
+ * instrument in #88. The trainer's guidance HUD (#163) is omitted for the same reason:
+ * the trainer is a shell TOOL, and hiding a training aid must not edit the instrument.
+ * Both are per-device tooling prefs on the control store, composed into this node's
+ * params by `store-controls` each tick.
  */
-export const OverlayDialSchema = Params.omit({ featureLab: true });
+export const OverlayDialSchema = Params.omit({ featureLab: true, trainerHud: true });
 export type OverlayDialParams = z.infer<typeof OverlayDialSchema>;
 
 const RIGHT_COLOR = '#10b981';
@@ -1297,20 +1308,48 @@ const TRAINER_HUD_BAR = 4; // px, the coverage bar
 /** Approximate glyph widths (no measureText: the headless recording-canvas test). */
 const TRAINER_HUD_BIG_CHAR_W = 11.5;
 
-/** Paint the guidance banner: cue label, the instruction (wrapped to two lines), the
- *  latest nudge, and a coverage bar along the banner's edge. fillRect/fillText only. */
-function drawTrainerHud(g: CanvasRenderingContext2D, view: OverlayView, hud: TrainerHudSnapshot): void {
-  const maxW = Math.min(view.W - 2 * 24, 900);
-  const maxChars = Math.max(16, Math.floor((maxW - 2 * TRAINER_HUD_PAD) / TRAINER_HUD_BIG_CHAR_W));
-  const lines = wrapLines(hud.say, maxChars).slice(0, 3);
-  const label = `${hud.index}/${hud.total} · ${hud.cueName}`;
-  const rows = 1 + lines.length + (hud.guidance ? 1 : 0);
+/** How many characters fit on one line of the banner at this canvas width. The banner
+ *  leaves room at the sides for the left/right cue stacks (and, on the left, for the
+ *  Trainer panel's slim strip while a routine runs). */
+const TRAINER_HUD_SIDE = 120;
+/** The longest the banner may be, in px, and the most lines it shows. */
+const TRAINER_HUD_MAX_W = 900;
+const TRAINER_HUD_MAX_LINES = 3;
+
+/** The banner's geometry for this snapshot at this width — shared by `measure` (the
+ *  layout pass) and `draw`, so what is reserved is what is painted. */
+function trainerHudBox(view: OverlayView, hud: TrainerHudSnapshot) {
+  const boxW = Math.max(200, Math.min(view.W - 2 * TRAINER_HUD_SIDE, TRAINER_HUD_MAX_W));
+  const maxChars = Math.max(12, Math.floor((boxW - 2 * TRAINER_HUD_PAD) / TRAINER_HUD_BIG_CHAR_W));
+  const lines = clipLines(wrapLines(hud.say, maxChars), TRAINER_HUD_MAX_LINES, maxChars);
+  const smallChars = Math.max(12, Math.floor((boxW - 2 * TRAINER_HUD_PAD) / (TRAINER_HUD_SMALL * 0.55)));
+  const label = clipText(`${hud.index}/${hud.total} · ${hud.cueName}`, smallChars);
+  const guidance = hud.guidance ? clipText(hud.guidance, smallChars) : null;
   const lineH = TRAINER_HUD_BIG + 8;
-  const boxH = TRAINER_HUD_PAD * 2 + TRAINER_HUD_SMALL + 6 + lines.length * lineH + (hud.guidance ? TRAINER_HUD_SMALL + 8 : 0) + TRAINER_HUD_BAR;
-  const boxW = maxW;
-  const x0 = (view.W - boxW) / 2;
-  const y0 = view.params.trainerHud.position === 'top' ? CUE_TOP_INSET : view.H - boxH - 24;
-  void rows;
+  const boxH = TRAINER_HUD_PAD * 2 + TRAINER_HUD_SMALL + 6 + lines.length * lineH + (guidance ? TRAINER_HUD_SMALL + 8 : 0) + TRAINER_HUD_BAR;
+  return { boxW, boxH, lines, label, guidance, lineH };
+}
+
+/** Keep at most `max` lines; mark a dropped tail with an ellipsis (never silently). */
+function clipLines(lines: string[], max: number, maxChars: number): string[] {
+  if (lines.length <= max) return lines;
+  const kept = lines.slice(0, max);
+  kept[max - 1] = clipText(`${kept[max - 1]} …`, maxChars);
+  return kept;
+}
+
+function clipText(text: string, maxChars: number): string {
+  return text.length <= maxChars ? text : `${text.slice(0, Math.max(1, maxChars - 1))}…`;
+}
+
+/** Paint the guidance banner at its laid-out origin: cue label, the instruction
+ *  (wrapped), the latest nudge, and a coverage bar along the bottom edge. fillRect /
+ *  fillText only. */
+function drawTrainerHud(g: CanvasRenderingContext2D, view: OverlayView, hud: TrainerHudSnapshot): void {
+  const { boxW, boxH, lines, label, guidance, lineH } = trainerHudBox(view, hud);
+  const origin = view.layout.trainerHud ?? { x: (view.W - boxW) / 2, y: view.H - boxH - CUE_MARGIN };
+  const x0 = origin.x;
+  const y0 = origin.y;
 
   g.save();
   g.globalAlpha = 1;
@@ -1334,10 +1373,10 @@ function drawTrainerHud(g: CanvasRenderingContext2D, view: OverlayView, hud: Tra
   }
 
   // The latest guidance, beneath, italic.
-  if (hud.guidance) {
+  if (guidance) {
     g.font = `italic ${TRAINER_HUD_SMALL}px ui-sans-serif, system-ui, sans-serif`;
     g.fillStyle = 'rgba(167, 243, 208, 0.95)';
-    g.fillText(hud.guidance, x0 + TRAINER_HUD_PAD, y);
+    g.fillText(guidance, x0 + TRAINER_HUD_PAD, y);
   }
 
   // Coverage bar along the banner's bottom edge: the cue's own minimum, not a timer.
@@ -1352,6 +1391,14 @@ function drawTrainerHud(g: CanvasRenderingContext2D, view: OverlayView, hud: Tra
 const trainerHud: OverlayElement = {
   name: 'trainerHud',
   category: 'guide',
+  cue: true,
+  positionOf: (view) => view.params.trainerHud.position,
+  measure(view) {
+    const hud = view.inputs.trainerHud;
+    if (!hud || !view.params.trainerHud.show) return null;
+    const { boxW, boxH } = trainerHudBox(view, hud);
+    return { w: boxW, h: boxH };
+  },
   draw(g, view) {
     const hud = view.inputs.trainerHud;
     if (!hud || !view.params.trainerHud.show) return;
@@ -1509,6 +1556,7 @@ export const OVERLAY_ELEMENTS: readonly OverlayElement[] = [
 const CUE_MARGIN = 12;
 const CUE_GAP = 10;
 const CUE_TOP_INSET = 68; // leave room for the top-left brand / top-right panel
+const CUE_BOTTOM_INSET = 68; // and for the tools bar / the object-cover crop band
 
 /** Compute each active cue's top-left origin, auto-stacking cues that share an edge. */
 function layoutCues(view: OverlayView): Record<string, { x: number; y: number }> {
@@ -1524,13 +1572,25 @@ function layoutCues(view: OverlayView): Record<string, { x: number; y: number }>
       size: { w: number; h: number };
     }[];
     let off = edge === 'left' || edge === 'right' ? CUE_TOP_INSET : CUE_MARGIN;
-    // Center a horizontal (top/bottom) group of cues so a lone cue reads centered
-    // and away from the top-left brand / top-right panel.
+    // A horizontal (top/bottom) edge lays its cues out side by side, centered. A WIDE
+    // cue (a banner, wider than half the frame — the trainer's guidance) cannot share
+    // that row: it gets its own row, below the top row or above the bottom one, so it
+    // never paints over the chord name or a stacked cue.
+    const wide = edge === 'top' || edge === 'bottom' ? cues.filter((c) => c.size.w > view.W / 2) : [];
+    const rowCues = cues.filter((c) => !wide.includes(c));
     if (edge === 'top' || edge === 'bottom') {
-      const totalW = cues.reduce((s, c) => s + c.size.w, 0) + Math.max(0, cues.length - 1) * CUE_GAP;
+      const totalW = rowCues.reduce((s, c) => s + c.size.w, 0) + Math.max(0, rowCues.length - 1) * CUE_GAP;
       off = Math.max(CUE_MARGIN, (view.W - totalW) / 2);
+      const rowH = rowCues.reduce((m, c) => Math.max(m, c.size.h), 0);
+      let yBand = edge === 'top' ? CUE_MARGIN + (rowH ? rowH + CUE_GAP : 0) : view.H - CUE_BOTTOM_INSET - (rowH ? rowH + CUE_GAP : 0);
+      for (const { e, size } of wide) {
+        const x = Math.max(CUE_MARGIN, (view.W - size.w) / 2);
+        const y = edge === 'top' ? yBand : yBand - size.h;
+        layout[e.name] = { x, y };
+        yBand += edge === 'top' ? size.h + CUE_GAP : -(size.h + CUE_GAP);
+      }
     }
-    for (const { e, size } of cues) {
+    for (const { e, size } of rowCues) {
       let x = CUE_MARGIN;
       let y = CUE_MARGIN;
       if (edge === 'left') {
@@ -1547,7 +1607,9 @@ function layoutCues(view: OverlayView): Record<string, { x: number; y: number }>
         off += size.w + CUE_GAP;
       } else {
         x = off;
-        y = view.H - size.h - CUE_MARGIN;
+        // Mirror the top inset: a 4:3 camera shown object-cover on a 16:9 viewport
+        // loses ~60 px top and bottom, and the tools bar sits along the bottom edge.
+        y = view.H - size.h - CUE_BOTTOM_INSET;
         off += size.w + CUE_GAP;
       }
       layout[e.name] = { x, y };

--- a/src/nodes/output/canvas_overlay.ts
+++ b/src/nodes/output/canvas_overlay.ts
@@ -48,6 +48,7 @@ import {
   type FeatureVector,
 } from '@/features/catalog';
 import { computeTagOverlay, type TagOverlayFrame, type TagOverlaySnapshot } from '@/taglog/presentation';
+import { wrapLines, type TrainerHudSnapshot } from '@/enroll/hud';
 import { EFFECT_SHORT, type HandMap } from '../mapping/hand_map';
 import {
   FINGER_NAMES,
@@ -166,6 +167,20 @@ const Params = z.object({
       position: z.enum(['left', 'right']).default('right'),
     })
     .prefault({}),
+  /**
+   * Trainer guidance ON THE VIDEO (#163 §5): while a routine runs, the active cue's
+   * instruction large across the bottom of the frame, the latest nudge beneath it, and
+   * a coverage bar — the written channel of what the runner says, where the player is
+   * actually looking. A no-op (draws nothing) unless the trainer is running, so it
+   * costs nothing the rest of the time. Not burned into the recorded `pureVideo`.
+   */
+  trainerHud: z
+    .object({
+      show: z.boolean().default(true),
+      /** Which edge the banner anchors to. */
+      position: z.enum(['bottom', 'top']).default('bottom'),
+    })
+    .prefault({}),
 });
 type Params = z.infer<typeof Params>;
 
@@ -227,6 +242,9 @@ export interface OverlayView {
     /** Burned-in tag HUD frame (#92): open tags + timecode + blink; null unless a
      *  take is recording. Computed in `process` from `ctx.resources.tagOverlay`. */
     tagOverlay?: TagOverlayFrame | null;
+    /** Trainer guidance (#163): null unless a routine is running. Read in `process`
+     *  from `ctx.resources.trainerHud`. */
+    trainerHud?: TrainerHudSnapshot | null;
   };
   params: Params;
   /** Computed top-left origin per cue element name (set by the layout pass). */
@@ -1270,6 +1288,77 @@ const tagHud: OverlayElement = {
   },
 };
 
+// ---- Trainer guidance on the video (#163 §5) --------------------------------------
+// A self-contained additive block, like the tag HUD. Draws only while a routine runs.
+const TRAINER_HUD_PAD = 16;
+const TRAINER_HUD_BIG = 22; // px, the instruction
+const TRAINER_HUD_SMALL = 15; // px, the guidance + the cue label
+const TRAINER_HUD_BAR = 4; // px, the coverage bar
+/** Approximate glyph widths (no measureText: the headless recording-canvas test). */
+const TRAINER_HUD_BIG_CHAR_W = 11.5;
+
+/** Paint the guidance banner: cue label, the instruction (wrapped to two lines), the
+ *  latest nudge, and a coverage bar along the banner's edge. fillRect/fillText only. */
+function drawTrainerHud(g: CanvasRenderingContext2D, view: OverlayView, hud: TrainerHudSnapshot): void {
+  const maxW = Math.min(view.W - 2 * 24, 900);
+  const maxChars = Math.max(16, Math.floor((maxW - 2 * TRAINER_HUD_PAD) / TRAINER_HUD_BIG_CHAR_W));
+  const lines = wrapLines(hud.say, maxChars).slice(0, 3);
+  const label = `${hud.index}/${hud.total} · ${hud.cueName}`;
+  const rows = 1 + lines.length + (hud.guidance ? 1 : 0);
+  const lineH = TRAINER_HUD_BIG + 8;
+  const boxH = TRAINER_HUD_PAD * 2 + TRAINER_HUD_SMALL + 6 + lines.length * lineH + (hud.guidance ? TRAINER_HUD_SMALL + 8 : 0) + TRAINER_HUD_BAR;
+  const boxW = maxW;
+  const x0 = (view.W - boxW) / 2;
+  const y0 = view.params.trainerHud.position === 'top' ? CUE_TOP_INSET : view.H - boxH - 24;
+  void rows;
+
+  g.save();
+  g.globalAlpha = 1;
+  g.fillStyle = hud.status === 'between' ? 'rgba(16, 185, 129, 0.35)' : 'rgba(0, 0, 0, 0.6)';
+  g.fillRect(x0, y0, boxW, boxH);
+  g.textBaseline = 'top';
+  g.textAlign = 'left';
+
+  // Cue label, small, top-left of the banner.
+  g.font = `600 ${TRAINER_HUD_SMALL}px ui-sans-serif, system-ui, sans-serif`;
+  g.fillStyle = 'rgba(110, 231, 183, 0.9)';
+  g.fillText(label, x0 + TRAINER_HUD_PAD, y0 + TRAINER_HUD_PAD);
+
+  // The instruction (or the end phrase), large.
+  g.font = `500 ${TRAINER_HUD_BIG}px ui-sans-serif, system-ui, sans-serif`;
+  g.fillStyle = '#ffffff';
+  let y = y0 + TRAINER_HUD_PAD + TRAINER_HUD_SMALL + 6;
+  for (const line of lines) {
+    g.fillText(line, x0 + TRAINER_HUD_PAD, y);
+    y += lineH;
+  }
+
+  // The latest guidance, beneath, italic.
+  if (hud.guidance) {
+    g.font = `italic ${TRAINER_HUD_SMALL}px ui-sans-serif, system-ui, sans-serif`;
+    g.fillStyle = 'rgba(167, 243, 208, 0.95)';
+    g.fillText(hud.guidance, x0 + TRAINER_HUD_PAD, y);
+  }
+
+  // Coverage bar along the banner's bottom edge: the cue's own minimum, not a timer.
+  const pct = Math.max(0, Math.min(1, hud.coverage));
+  g.fillStyle = 'rgba(255, 255, 255, 0.15)';
+  g.fillRect(x0, y0 + boxH - TRAINER_HUD_BAR, boxW, TRAINER_HUD_BAR);
+  g.fillStyle = pct >= 1 ? '#34d399' : 'rgba(52, 211, 153, 0.7)';
+  g.fillRect(x0, y0 + boxH - TRAINER_HUD_BAR, boxW * pct, TRAINER_HUD_BAR);
+  g.restore();
+}
+
+const trainerHud: OverlayElement = {
+  name: 'trainerHud',
+  category: 'guide',
+  draw(g, view) {
+    const hud = view.inputs.trainerHud;
+    if (!hud || !view.params.trainerHud.show) return;
+    drawTrainerHud(g, view, hud);
+  },
+};
+
 /** Correlation-grid geometry. Deliberately small: this is a diagnostic you glance at
  *  while performing, not a plot you study. */
 const CORR_CELL = 14;
@@ -1410,6 +1499,9 @@ export const OVERLAY_ELEMENTS: readonly OverlayElement[] = [
   // The burned-in tag HUD sits above the cues (its own top corner); fingerBars stays
   // the array's last element so the z-order invariant + concurrent additions hold.
   tagHud,
+  // The trainer's on-video guidance (#163): above the cues, below fingerBars, which
+  // stays the array's last element (the z-order invariant).
+  trainerHud,
   fingerBarsCue,
 ];
 
@@ -1524,6 +1616,10 @@ export const canvasOverlayNode = defineNode<Params>({
         // resource means frame === null and the tagHud element draws nothing.
         const tagOverlayFn = ctx.resources.tagOverlay as (() => TagOverlaySnapshot | null) | undefined;
         const tagOverlay = computeTagOverlay(tagOverlayFn?.() ?? null, ctx.time);
+        // Trainer guidance (#163): null unless a routine is running; the element is then
+        // a no-op. Same holder-plus-synchronous-read shape as the tag HUD.
+        const trainerHudFn = ctx.resources.trainerHud as (() => TrainerHudSnapshot | null) | undefined;
+        const trainerHudSnapshot = trainerHudFn?.() ?? null;
 
         const liveConfig = inputs.overlayConfig as OverlayParams | undefined;
         const view: OverlayView = {
@@ -1547,6 +1643,7 @@ export const canvasOverlayNode = defineNode<Params>({
             faceDegrees: controls?.faceExpr?.degrees,
             faceMapping: controls?.faceMapping,
             tagOverlay,
+            trainerHud: trainerHudSnapshot,
           },
         };
 

--- a/src/nodes/sources/store_controls.ts
+++ b/src/nodes/sources/store_controls.ts
@@ -14,8 +14,8 @@ import { generateScale, defaultChordSpecFor, type ScaleSpec, type ScaleTypeId } 
 import type { SoundId } from '@/music/sounds';
 import { legacyFaceToMapping, type FaceMapping } from '@/nodes/domain';
 import type { FaceChord, FaceExpr } from '@/settings/schema';
-import type { OverlayDialParams } from '@/nodes/output/canvas_overlay';
 import type { FaceControlsDialParams } from '@/nodes/features/face_controls';
+import { TrainerHudParamsSchema, type OverlayDialParams, type TrainerHudParams } from '@/nodes/output/canvas_overlay';
 import { defaultFeatureLab, type FeatureLabConfig } from '@/features/labConfig';
 
 export interface VoiceControlSnapshot {
@@ -49,6 +49,9 @@ export interface ControlSnapshot {
    *  params here. Also read by `webcam-face`, which loads the face model when the Lab
    *  is measuring face groups even if the face drives no sound. */
   featureLab?: FeatureLabConfig;
+  /** The trainer's guidance HUD pref (#163) — per-device, like the Lab; composed into
+   *  the overlay node's params here. */
+  trainerHud?: TrainerHudParams;
   /** Legacy face on/off flag; superseded by {@link faceMapping}. Kept so older
    *  hosts / saved data still gate the `webcam-face` model load. */
   faceEnabled?: boolean;
@@ -181,7 +184,13 @@ export const storeControlsNode = defineNode<Record<string, never>>({
         }
         // Recompose the overlay node's params: the instrument's overlay elements plus
         // the per-device Feature Lab config, which is owned outside the instrument (#136).
-        if (c.overlay) out.overlay = { ...c.overlay, featureLab: c.featureLab ?? defaultFeatureLab() };
+        if (c.overlay) {
+          out.overlay = {
+            ...c.overlay,
+            featureLab: c.featureLab ?? defaultFeatureLab(),
+            trainerHud: c.trainerHud ?? TrainerHudParamsSchema.parse({}),
+          };
+        }
         return out;
       },
     };

--- a/test/enroll_store.test.ts
+++ b/test/enroll_store.test.ts
@@ -100,6 +100,39 @@ describe('load(): stored cues and routines reach the store', () => {
   });
 });
 
+describe('routine persistence through the store', () => {
+  it('saveRoutine hydrates FIRST (the routine in use changes synchronously), then persists; useRoutine/removeRoutine round-trip', async () => {
+    useTrainerStores(stores());
+    await useTrainer.getState().load();
+    const pending = useTrainer.getState().saveRoutine('Head only', ['rest', 'look-left', 'look-right']);
+    // Before the provider answers, the routine is already the saved one.
+    expect(useTrainer.getState().routine.map((c) => c.id)).toEqual(['rest', 'look-left', 'look-right']);
+    expect(useTrainer.getState().routineName).toBe('Head only');
+    await pending;
+    expect(useTrainer.getState().savedRoutines.map((r) => r.id)).toEqual(['head-only']);
+    // Back to the default, then the saved one by id.
+    await useTrainer.getState().useRoutine(null);
+    expect(useTrainer.getState().routine).toHaveLength(DEFAULT_ROUTINE_CUE_IDS.length);
+    await useTrainer.getState().useRoutine('head-only');
+    expect(useTrainer.getState().routine.map((c) => c.id)).toEqual(['rest', 'look-left', 'look-right']);
+    // Saving under the same name overwrites (one record), newest first.
+    await useTrainer.getState().saveRoutine('Head only', ['rest', 'look-up']);
+    expect(useTrainer.getState().savedRoutines).toHaveLength(1);
+    await useTrainer.getState().saveRoutine('Faces', ['rest', 'your-faces']);
+    expect(useTrainer.getState().savedRoutines.map((r) => r.id).sort()).toEqual(['faces', 'head-only']);
+    await useTrainer.getState().removeRoutine('head-only');
+    expect(useTrainer.getState().savedRoutines.map((r) => r.id)).toEqual(['faces']);
+    // A removed id falls back to the default rather than failing.
+    await useTrainer.getState().useRoutine('head-only');
+    expect(useTrainer.getState().routineName).toBe('Default');
+  });
+
+  it('setRoutine runs a repeated id once (the routine schema forbids duplicates; no duplicate rows)', () => {
+    useTrainer.getState().setRoutine(['rest', 'look-left', 'rest'], 'Dup');
+    expect(useTrainer.getState().routine.map((c) => c.id)).toEqual(['rest', 'look-left']);
+  });
+});
+
 describe('runner lifecycle through the store', () => {
   it('start() stops and DETACHES a previous runner, so it cannot keep writing into the store', () => {
     useTrainer.getState().start(1000);
@@ -114,11 +147,34 @@ describe('runner lifecycle through the store', () => {
     expect(useTrainer.getState().runner()).not.toBe(first);
   });
 
-  it('skip adds no blank line to the transcript', () => {
+  it('skip adds no blank line to the transcript, and the beat after a skip shows NOTHING (not an older "Good.")', () => {
     useTrainer.getState().start(1000);
     useTrainer.getState().skip(1100);
     expect(useTrainer.getState().transcript.every((l) => l.say.length > 0)).toBe(true);
+    expect(useTrainer.getState().lastEndSay).toBeNull();
     useTrainer.getState().stop(1200);
+  });
+
+  it('a guidance sink that reacts by stopping or skipping cannot corrupt the runner (sinks run after the event settles)', async () => {
+    const { addGuidanceSink, resetGuidanceSinks } = await import('@/app/enroll/guidance');
+    resetGuidanceSinks();
+    // A sink that skips on every instruction: each cue is skipped as soon as it starts.
+    const off = addGuidanceSink({
+      say: (l) => {
+        if (l.kind === 'instruction') useTrainer.getState().skip(5000);
+      },
+    });
+    useTrainer.getState().start(1000);
+    await new Promise((r) => setTimeout(r, 0));
+    // One skip per instruction, applied cleanly: the first cue is skipped, the runner
+    // is between cues (not restarted, not stopped), and outcomes are consistent.
+    const st = useTrainer.getState();
+    expect(st.outcomes[0]).toBe('skipped');
+    expect(['between', 'running']).toContain(st.status);
+    expect(st.runner()?.state().outcomes.filter((o) => o === 'skipped').length).toBe(1);
+    off();
+    useTrainer.getState().stop(6000);
+    resetGuidanceSinks();
   });
 });
 

--- a/test/tools_shell.test.tsx
+++ b/test/tools_shell.test.tsx
@@ -238,29 +238,46 @@ describe('the Trainer is reachable and runs a routine of cues (#160, #163)', () 
     fireEvent.click(screen.getByText('Start'));
     expect(useTrainer.getState().status).toBe('running');
     expect(useTrainer.getState().index).toBe(0);
-    // The written instruction is ALWAYS shown (voice is a toggle; text is not) — large,
-    // in the "Now" block (and again in the transcript, which is why it is not getByText).
+    // While running the panel collapses to a slim strip (the instruction is on the
+    // video; a full panel would cover it) — and the written instruction is STILL in
+    // the strip (voice is a toggle; text is not), with the cue's name and position.
+    expect(document.querySelector('[data-compact]')).toBeTruthy();
     expect(document.querySelector('[data-say]')?.textContent).toBe(STARTER_CUES[0].instruction);
-    // Exactly one row is marked active.
-    const active = document.querySelectorAll('[data-cue][data-active]');
-    expect(active).toHaveLength(1);
-    expect(active[0].getAttribute('data-cue')).toBe(STARTER_CUES[0].id);
-    // Skip and Stop are offered while running; Start is not.
+    expect(document.body.textContent).toContain(`1/${STARTER_CUES.length}`);
+    expect(document.body.textContent).toContain(STARTER_CUES[0].name);
+    // Skip and Stop are offered while running; Start and the picker are not.
     expect(screen.getByText('Skip')).toBeTruthy();
     expect(screen.getByText('Stop')).toBeTruthy();
     expect(screen.queryByText('Start')).toBeNull();
+    expect(document.querySelector('[data-routine-picker]')).toBeNull();
     fireEvent.click(screen.getByText('Stop'));
     expect(useTrainer.getState().status).toBe('stopped');
+    // The full panel is back, with the stopped cue marked.
+    expect(document.querySelector('[data-compact]')).toBeNull();
+    expect(document.querySelectorAll('[data-cue]')).toHaveLength(STARTER_CUES.length);
   });
 
-  it('Skip moves on, and the skipped cue is marked as such', () => {
+  it('Skip moves on, and the skipped cue is marked as such (visible once the full panel is back)', () => {
     useTools.setState({ open: 'trainer' });
     render(<TrainerPanel />);
     fireEvent.click(screen.getByText('Start'));
     fireEvent.click(screen.getByText('Skip'));
     expect(useTrainer.getState().outcomes[0]).toBe('skipped');
-    expect(screen.getByText('skipped')).toBeTruthy();
+    // The strip now names the NEXT cue.
+    expect(document.body.textContent).toContain(STARTER_CUES[1].name);
     fireEvent.click(screen.getByText('Stop'));
+    expect(screen.getAllByText('skipped').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('the HUD pref is a per-device checkbox in the panel, not an instrument dial', () => {
+    useTools.setState({ open: 'trainer' });
+    render(<TrainerPanel />);
+    const box = screen.getByLabelText(/instructions on the video/i) as HTMLInputElement;
+    expect(box.checked).toBe(true);
+    fireEvent.click(box);
+    expect(useControls.getState().trainerHud.show).toBe(false);
+    fireEvent.click(box);
+    expect(useControls.getState().trainerHud.show).toBe(true);
   });
 
   it('closing the panel mid-routine STOPS it (and releases the feature demand)', async () => {
@@ -270,8 +287,9 @@ describe('the Trainer is reachable and runs a routine of cues (#160, #163)', () 
     fireEvent.click(screen.getByText('Start'));
     expect(useTrainer.getState().status).toBe('running');
     expect(appFeatureDemand.groups()).not.toBeNull();
-    // The X button only writes useTools.open; the panel itself must notice.
-    fireEvent.click(screen.getByLabelText('Close the Trainer panel'));
+    // Closing the tool (the bar, another tool, the hotkey) only writes useTools.open;
+    // the panel itself must notice. (The running strip has no X: Stop is the way out.)
+    act(() => useTools.getState().close());
     expect(useTools.getState().open).toBeNull();
     expect(useTrainer.getState().status).toBe('stopped');
     expect(appFeatureDemand.groups()).toBeNull();
@@ -293,12 +311,26 @@ describe('the Trainer is reachable and runs a routine of cues (#160, #163)', () 
     fireEvent.click(screen.getByRole('button', { name: 'setup' }));
     expect(rows().length).toBeLessThan(STARTER_CUES.length);
     fireEvent.click(screen.getByRole('button', { name: 'setup' }));
+    // With a filter on, a reorder moves past the VISIBLE neighbour only, and changes
+    // what the player sees (not a hidden row behind it).
+    fireEvent.change(screen.getByLabelText('Filter cues'), { target: { value: 'look' } });
+    fireEvent.click(screen.getByLabelText('Move Look right up'));
+    const order = [...document.querySelectorAll('[data-picker-cue]')].map((el) => el.getAttribute('data-picker-cue'));
+    // ("Rest" also matches 'look' — "Look at the camera" — and stays first.)
+    expect(order.indexOf('look-right')).toBeLessThan(order.indexOf('look-left'));
+    expect(order[0]).toBe('rest');
+    fireEvent.change(screen.getByLabelText('Filter cues'), { target: { value: '' } });
     // Un-include the first tilt and Use: the routine shrinks by one.
     fireEvent.click(screen.getByLabelText('Include Tilt left'));
     expect(screen.getByText('Use')).toBeTruthy();
     fireEvent.click(screen.getByText('Use'));
     expect(useTrainer.getState().routine.map((c) => c.id)).not.toContain('tilt-left');
     expect(useTrainer.getState().routine).toHaveLength(STARTER_CUES.length - 1);
+    // The reorder made it through too: look-right now precedes look-left.
+    const ids = useTrainer.getState().routine.map((c) => c.id);
+    expect(ids.indexOf('look-right')).toBeLessThan(ids.indexOf('look-left'));
+    // And rest (hidden by the 'look' filter at the time) was NOT displaced: still first.
+    expect(ids[0]).toBe('rest');
     // Running hides the picker.
     fireEvent.click(screen.getByText('Start'));
     expect(document.querySelector('[data-routine-picker]')).toBeNull();

--- a/test/tools_shell.test.tsx
+++ b/test/tools_shell.test.tsx
@@ -223,9 +223,11 @@ describe('the Trainer is reachable and runs a routine of cues (#160, #163)', () 
     expect(useTools.getState().open).toBe('trainer');
     // One row per cue of the loaded routine — the routine is data, so this grows with
     // STARTER_CUES rather than being a hardcoded list here.
-    const rows = screen.getByRole('list', { name: 'Routine' }).querySelectorAll('li');
+    const list = screen.getByRole('list', { name: 'Routine' });
+    const rows = list.querySelectorAll('li');
     expect(rows).toHaveLength(STARTER_CUES.length);
-    for (const cue of STARTER_CUES) expect(screen.getByText(cue.name)).toBeTruthy();
+    // (Names also appear in the picker beneath, so look inside the routine list.)
+    for (const cue of STARTER_CUES) expect(list.textContent).toContain(cue.name);
     expect(screen.getByText('Find my categories')).toBeTruthy();
     expect(screen.getByText('Start')).toBeTruthy();
   });
@@ -273,6 +275,34 @@ describe('the Trainer is reachable and runs a routine of cues (#160, #163)', () 
     expect(useTools.getState().open).toBeNull();
     expect(useTrainer.getState().status).toBe('stopped');
     expect(appFeatureDemand.groups()).toBeNull();
+  });
+
+  it('the routine picker (#163 §3): filter narrows the list, a toggle changes the draft, Use applies it', () => {
+    useTools.setState({ open: 'trainer' });
+    render(<TrainerPanel />);
+    // Idle: the picker is offered (collapsed); while running it is not.
+    const picker = document.querySelector('[data-routine-picker]');
+    expect(picker).toBeTruthy();
+    const rows = () => document.querySelectorAll('[data-picker-cue]');
+    expect(rows()).toHaveLength(STARTER_CUES.length);
+    // Free-text filter narrows it...
+    fireEvent.change(screen.getByLabelText('Filter cues'), { target: { value: 'tilt' } });
+    expect(rows()).toHaveLength(2);
+    fireEvent.change(screen.getByLabelText('Filter cues'), { target: { value: '' } });
+    // ...and a tag chip is all-of.
+    fireEvent.click(screen.getByRole('button', { name: 'setup' }));
+    expect(rows().length).toBeLessThan(STARTER_CUES.length);
+    fireEvent.click(screen.getByRole('button', { name: 'setup' }));
+    // Un-include the first tilt and Use: the routine shrinks by one.
+    fireEvent.click(screen.getByLabelText('Include Tilt left'));
+    expect(screen.getByText('Use')).toBeTruthy();
+    fireEvent.click(screen.getByText('Use'));
+    expect(useTrainer.getState().routine.map((c) => c.id)).not.toContain('tilt-left');
+    expect(useTrainer.getState().routine).toHaveLength(STARTER_CUES.length - 1);
+    // Running hides the picker.
+    fireEvent.click(screen.getByText('Start'));
+    expect(document.querySelector('[data-routine-picker]')).toBeNull();
+    fireEvent.click(screen.getByText('Stop'));
   });
 
   it('cannot be trained from an empty take (the build button is disabled)', () => {

--- a/test/trainer_hud.test.ts
+++ b/test/trainer_hud.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Trainer guidance on the video (#163 §5) — the `trainerHud` overlay element, the
+ * resource that feeds it from the trainer store, and the guidance-sink seam.
+ *
+ * Same fake-canvas harness as the tag HUD test: drive the `canvas-overlay` node with a
+ * recording 2D context and assert what it paints — the instruction, large; the nudge
+ * beneath; a coverage bar — ONLY while a routine runs, and nothing otherwise (the
+ * common case, so it must cost nothing).
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { NodeContext } from '@/dag';
+import { canvasOverlayNode, OVERLAY_ELEMENTS } from '@/nodes/output/canvas_overlay';
+import { wrapLines, type TrainerHudSnapshot } from '@/enroll/hud';
+import { trainerHudResource } from '@/app/enroll/hud';
+import { addGuidanceSink, emitGuidance, resetGuidanceSinks } from '@/app/enroll/guidance';
+import { useTrainer, type TranscriptLine } from '@/app/enroll/store';
+import { STARTER_CUES } from '@/app/enroll/starterCues';
+import { OVERLAY_CONTROLS } from '@/app/overlayControls';
+import { appFeatureDemand } from '@/app/featureDemand';
+
+interface Call {
+  m: string;
+  args: unknown[];
+}
+function makeCanvas(width = 1280, height = 720) {
+  const calls: Call[] = [];
+  const ctx: Record<string, unknown> = { globalAlpha: 1, fillStyle: '', font: '', textBaseline: '', textAlign: '' };
+  const rec = (m: string) => (...args: unknown[]) => void calls.push({ m, args });
+  for (const m of ['clearRect', 'save', 'restore', 'beginPath', 'arc', 'fill', 'stroke', 'moveTo', 'lineTo', 'drawImage', 'fillText', 'setLineDash', 'scale', 'translate', 'rotate', 'fillRect']) {
+    ctx[m] = rec(m);
+  }
+  const canvas = { width, height, getContext: () => ctx } as unknown as HTMLCanvasElement;
+  return { canvas, calls, texts: () => calls.filter((c) => c.m === 'fillText').map((c) => c.args[0] as string) };
+}
+
+/** Every element off except trainerHud, so only its draws show up. */
+const onlyTrainerHud = Object.fromEntries(OVERLAY_ELEMENTS.map((e) => [e.name, { show: e.name === 'trainerHud' }]));
+
+function run(snapshot: TrainerHudSnapshot | null, position?: 'top' | 'bottom', show = true) {
+  const rc = makeCanvas();
+  const params = { ...onlyTrainerHud, trainerHud: { show, ...(position ? { position } : {}) } };
+  const handlers = canvasOverlayNode.make(canvasOverlayNode.params.parse(params));
+  const ctx: NodeContext = { tick: 0, time: 1, dt: 0, resources: { canvas: rc.canvas, trainerHud: () => snapshot } };
+  handlers.process({}, ctx);
+  return rc;
+}
+
+const snap: TrainerHudSnapshot = {
+  status: 'running',
+  cueName: 'Look left',
+  index: 2,
+  total: 9,
+  say: 'Turn your head to look to your left, and hold it.',
+  guidance: 'A bit further, if you can.',
+  coverage: 0.5,
+};
+
+describe('the trainerHud overlay element', () => {
+  it('is registered, has a control descriptor, and sits below fingerBars (the z-order invariant)', () => {
+    const names = OVERLAY_ELEMENTS.map((e) => e.name);
+    expect(names).toContain('trainerHud');
+    expect(names[names.length - 1]).toBe('fingerBars');
+    expect(OVERLAY_CONTROLS.some((d) => d.name === 'trainerHud')).toBe(true);
+  });
+
+  it('paints the cue label, the instruction, the nudge and a coverage bar while a routine runs', () => {
+    const rc = run(snap);
+    const texts = rc.texts();
+    expect(texts).toContain('2/9 · Look left');
+    expect(texts.join(' ')).toContain('Turn your head to look to your left, and hold it.');
+    expect(texts).toContain('A bit further, if you can.');
+    // The banner box, the bar track and the bar fill: at least three rects.
+    expect(rc.calls.filter((c) => c.m === 'fillRect').length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('draws nothing when no routine runs (the resource returns null) or when hidden', () => {
+    expect(run(null).calls.some((c) => c.m === 'fillRect' || c.m === 'fillText')).toBe(false);
+    expect(run(snap, undefined, false).texts()).toHaveLength(0);
+  });
+
+  it('anchors to the chosen edge', () => {
+    const yOf = (rc: ReturnType<typeof run>) => rc.calls.find((c) => c.m === 'fillRect')!.args[1] as number;
+    expect(yOf(run(snap, 'top'))).toBeLessThan(200);
+    expect(yOf(run(snap, 'bottom'))).toBeGreaterThan(400);
+  });
+
+  it('wraps a long instruction onto more than one line rather than running off the frame', () => {
+    const long = { ...snap, say: 'Now make faces you can make reliably, whichever ones you like. Hold each one for a moment, then move on to the next.' };
+    const lines = run(long).texts().filter((t) => long.say.includes(t) && t !== long.say);
+    expect(lines.length).toBeGreaterThanOrEqual(2);
+    expect(wrapLines(long.say, 40).every((l) => l.length <= 40)).toBe(true);
+    expect(wrapLines('one', 40)).toEqual(['one']);
+    expect(wrapLines('', 40)).toEqual([]);
+  });
+});
+
+describe('the HUD resource reads the trainer store', () => {
+  beforeEach(() => {
+    useTrainer.getState().reset();
+    appFeatureDemand.reset();
+  });
+
+  it('is null when idle, the instruction while running, the end phrase during the beat', () => {
+    expect(trainerHudResource()).toBeNull();
+    useTrainer.getState().start(1000);
+    const hud = trainerHudResource();
+    expect(hud?.status).toBe('running');
+    expect(hud?.say).toBe(STARTER_CUES[0].instruction);
+    expect(hud?.cueName).toBe(STARTER_CUES[0].name);
+    expect(hud?.index).toBe(1);
+    expect(hud?.total).toBe(STARTER_CUES.length);
+    expect(hud?.guidance).toBeNull();
+    expect(hud?.coverage).toBe(0);
+    // Skip: the beat shows what was just said (nothing, for a skip), then the next.
+    useTrainer.getState().skip(1100);
+    const between = trainerHudResource();
+    expect(between?.status).toBe('between');
+    expect(between?.cueName).toBe(STARTER_CUES[1].name);
+    useTrainer.getState().stop(1200);
+    expect(trainerHudResource()).toBeNull();
+  });
+});
+
+describe('guidance sinks — the seam the voice layer plugs into', () => {
+  beforeEach(() => {
+    resetGuidanceSinks();
+    useTrainer.getState().reset();
+    appFeatureDemand.reset();
+  });
+
+  it('receives every line the store transcribes, in order, and a throwing sink is isolated', () => {
+    const heard: string[] = [];
+    const off = addGuidanceSink({ say: (l: TranscriptLine) => void heard.push(l.say) });
+    addGuidanceSink({
+      say: () => {
+        throw new Error('autoplay blocked');
+      },
+    });
+    useTrainer.getState().start(1000);
+    useTrainer.getState().skip(1100);
+    expect(heard).toEqual([STARTER_CUES[0].instruction]);
+    useTrainer.getState().stop(1200);
+    off();
+    emitGuidance({ t: 0, kind: 'guidance', say: 'x' });
+    expect(heard).toEqual([STARTER_CUES[0].instruction]);
+  });
+});
+
+describe('the production wiring (source guard — useEngine is outside the strict typecheck)', () => {
+  it('useEngine installs the HUD resource under the key the overlay reads', () => {
+    const engine = readFileSync(resolve(process.cwd(), 'src/app/useEngine.ts'), 'utf8');
+    expect(engine).toMatch(/resources\.trainerHud\s*=\s*trainerHudResource/);
+    const overlay = readFileSync(resolve(process.cwd(), 'src/nodes/output/canvas_overlay.ts'), 'utf8');
+    expect(overlay).toMatch(/ctx\.resources\.trainerHud/);
+  });
+});

--- a/test/trainer_hud.test.ts
+++ b/test/trainer_hud.test.ts
@@ -118,6 +118,7 @@ describe('the HUD resource reads the trainer store', () => {
     const between = trainerHudResource();
     expect(between?.status).toBe('between');
     expect(between?.cueName).toBe(STARTER_CUES[1].name);
+    expect(between?.say).toBe('');
     useTrainer.getState().stop(1200);
     expect(trainerHudResource()).toBeNull();
   });
@@ -130,7 +131,7 @@ describe('guidance sinks — the seam the voice layer plugs into', () => {
     appFeatureDemand.reset();
   });
 
-  it('receives every line the store transcribes, in order, and a throwing sink is isolated', () => {
+  it('receives every line the store transcribes, in order (after the event settles), and a throwing sink is isolated', async () => {
     const heard: string[] = [];
     const off = addGuidanceSink({ say: (l: TranscriptLine) => void heard.push(l.say) });
     addGuidanceSink({
@@ -140,6 +141,8 @@ describe('guidance sinks — the seam the voice layer plugs into', () => {
     });
     useTrainer.getState().start(1000);
     useTrainer.getState().skip(1100);
+    expect(heard).toEqual([]); // not yet: sinks run in a microtask, never inside the runner's dispatch
+    await Promise.resolve();
     expect(heard).toEqual([STARTER_CUES[0].instruction]);
     useTrainer.getState().stop(1200);
     off();
@@ -154,5 +157,91 @@ describe('the production wiring (source guard — useEngine is outside the stric
     expect(engine).toMatch(/resources\.trainerHud\s*=\s*trainerHudResource/);
     const overlay = readFileSync(resolve(process.cwd(), 'src/nodes/output/canvas_overlay.ts'), 'utf8');
     expect(overlay).toMatch(/ctx\.resources\.trainerHud/);
+  });
+});
+
+describe('the HUD pref is per-device, not an instrument parameter (the #136 lesson)', () => {
+  it('is NOT in the instrument overlay dial; toggling it dirties nothing and survives an instrument load', async () => {
+    const { OverlayDialSchema } = await import('@/nodes/output/canvas_overlay');
+    const { createThoreminRegistry } = await import('@/app/commands/registry');
+    const { ensureSeeded } = await import('@/app/dials/instruments');
+    const { dialsStore } = await import('@/app/dials/settingsStore');
+    const { useControls } = await import('@/app/store');
+    // Not a dial: the schema the instrument persists has no such key, and the path is
+    // not dispatchable as an instrument edit.
+    expect('trainerHud' in OverlayDialSchema.shape).toBe(false);
+    const reg = createThoreminRegistry();
+    await ensureSeeded();
+    await reg.dispatch('instrument.load', { name: 'Split Voices' });
+    const dirtyBefore = dialsStore.getState().dirty.length;
+    useControls.getState().setTrainerHud({ show: false });
+    expect(dialsStore.getState().dirty.length).toBe(dirtyBefore);
+    await reg.dispatch('instrument.load', { name: 'Pentatonic' });
+    // Loading an instrument does not flip the pref back on.
+    expect(useControls.getState().trainerHud.show).toBe(false);
+    useControls.getState().setTrainerHud({ show: true });
+  });
+
+  it('store-controls composes the pref into the overlay node\'s params each tick', async () => {
+    const { storeControlsNode } = await import('@/nodes/sources/store_controls');
+    const { TrainerHudParamsSchema, OverlayDialSchema } = await import('@/nodes/output/canvas_overlay');
+    const { useControls } = await import('@/app/store');
+    const h = storeControlsNode.make(storeControlsNode.params.parse({}));
+    const base = { ...useControls.getState(), overlay: OverlayDialSchema.parse({}) };
+    const controls = () => ({ ...base, trainerHud: TrainerHudParamsSchema.parse({ show: false, position: 'top' }) });
+    const out = h.process({}, { tick: 0, time: 0, dt: 1 / 30, resources: { controls } }) as { overlay?: { trainerHud?: { show: boolean; position: string } } };
+    expect(out.overlay?.trainerHud).toEqual({ show: false, position: 'top' });
+    // And a control store with NO pref yet (an older blob) composes the default.
+    const { trainerHud: _omit, ...withoutPref } = base;
+    void _omit;
+    const out2 = h.process({}, { tick: 0, time: 0, dt: 1 / 30, resources: { controls: () => withoutPref } }) as { overlay?: { trainerHud?: { show: boolean } } };
+    expect(out2.overlay?.trainerHud?.show).toBe(true);
+  });
+
+  it('mergeControls heals a missing or corrupt pref to the default', async () => {
+    const { mergeControls, useControls } = await import('@/app/store');
+    const current = useControls.getState();
+    expect(mergeControls({}, current).trainerHud.show).toBe(true);
+    expect(mergeControls({ trainerHud: { show: 'nope' } }, current).trainerHud).toEqual(current.trainerHud);
+    expect(mergeControls({ trainerHud: { show: false } }, current).trainerHud.show).toBe(false);
+  });
+});
+
+describe('the banner takes part in the cue layout', () => {
+  function runWith(params: Record<string, unknown>, snapshot: TrainerHudSnapshot | null, W = 1280, H = 720) {
+    const rc = makeCanvas(W, H);
+    const handlers = canvasOverlayNode.make(canvasOverlayNode.params.parse(params));
+    const ctx: NodeContext = { tick: 0, time: 1, dt: 0, resources: { canvas: rc.canvas, trainerHud: () => snapshot } };
+    handlers.process({ chord: [60, 64, 67], scale: [60, 62, 64, 65, 67, 69, 71] }, ctx);
+    return rc;
+  }
+
+  it('sits above the bottom inset (the object-cover crop band / tools bar), not flush with the edge', () => {
+    const rc = runWith({ ...onlyTrainerHud, trainerHud: { show: true, position: 'bottom' } }, snap, 1280, 720);
+    const box = rc.calls.find((c) => c.m === 'fillRect')!.args as number[];
+    const [, y, , h] = box;
+    expect(y + h).toBeLessThanOrEqual(720 - 60);
+  });
+
+  it('leaves room at the sides for the edge stacks, and wraps rather than overflowing', () => {
+    const rc = runWith({ ...onlyTrainerHud, trainerHud: { show: true, position: 'bottom' } }, snap, 640, 480);
+    const [x, , w] = rc.calls.find((c) => c.m === 'fillRect')!.args as number[];
+    expect(x).toBeGreaterThanOrEqual(100);
+    expect(x + w).toBeLessThanOrEqual(540);
+  });
+
+  it('with position "top" it stacks BELOW a top-anchored cue instead of painting over it', () => {
+    // chordName on top (its default), trainerHud on top too: the layout pass places the
+    // banner after the chord name on that edge.
+    const params = { ...onlyTrainerHud, chordName: { show: true, position: 'top' }, trainerHud: { show: true, position: 'top' } };
+    const rc = runWith(params, snap, 1280, 720);
+    const rects = rc.calls.filter((c) => c.m === 'fillRect').map((c) => c.args as number[]);
+    // The banner is the widest rect. Everything drawn BEFORE it on the top row (the
+    // chord name is earlier in z-order) must end above where the banner begins.
+    const bi = rects.findIndex((r) => r[2] === Math.max(...rects.map((x) => x[2])));
+    const banner = rects[bi];
+    const topRow = rects.slice(0, bi).filter((r) => r[1] < 100);
+    expect(topRow.length).toBeGreaterThan(0);
+    for (const r of topRow) expect(banner[1]).toBeGreaterThanOrEqual(r[1] + r[3] - 1e-6);
   });
 });

--- a/tsconfig.dag.json
+++ b/tsconfig.dag.json
@@ -9,5 +9,5 @@
   },
   "include": ["src/dag", "src/nodes", "src/music", "src/features", "src/settings", "src/taglog", "src/enroll", "src/app/graph.ts", "src/app/featureDemand.ts", "src/app/enroll", "src/app/lab", "test", "scripts"],
   "//exclude": "The jsdom SHELL tests are .tsx (they render React components) and this project ships no @types/react by design — same reason the React app layer is excluded. Vitest still runs them; Vite/esbuild type-erases the JSX.",
-  "exclude": ["test/**/*.test.tsx"]
+  "exclude": ["test/**/*.test.tsx", "src/app/enroll/**/*.tsx"]
 }


### PR DESCRIPTION
Trainer v2, PR 2 of 5 (#163 §3 and §5). The guidance as the player experiences it.

## Guidance on the video

The player is looking at the camera, not at a 384 px panel in the corner. A new overlay element, **`trainerHud`**, paints the active cue's instruction large in a banner along the bottom (or top) edge of the frame, the latest nudge beneath it, the cue's name and position, and a coverage bar that fills as the cue gets what it needs; during the beat it shows what the runner just said ("Good."). Fed per tick from `ctx.resources.trainerHud` — the same seam shape as the tag HUD — and a no-op unless a routine runs. It is **not** burned into the recorded `pureVideo`.

Two things the review made right:

- **The banner is a laid-out cue, not a free-floating box.** It declares `cue: true` and takes part in the edge layout, where a wide cue now gets its own row (below the top row, above the bottom one) so it never paints over the chord name or a stacked cue; a bottom inset mirrors the top one (the 4:3 object-cover crop band; the tools bar); side margins leave room for the edge stacks; long text wraps with an honest ellipsis.
- **Its show/position pref is per-device, not an instrument parameter** — lifted out of the overlay dial exactly as `featureLab` was in #136, healed in `mergeControls`, composed by `store-controls`. Toggling it dirties nothing and loading an instrument does not flip it (guarded by test). The checkbox lives in the Trainer panel.

**While a routine runs the Trainer panel collapses to a slim strip** (cue name and position, the meter, Skip / Stop, and the written line) so it does not cover the banner. The written channel is therefore in two places at once — the strip and the video — and is never off.

## The routine picker (#163 §3)

Inside the Trainer panel when idle: free-text and tag-chip filtering over every known cue (starters + stored), include/exclude, reorder (within the visible rows only), **Use**, **Save as** (the routine collection — a zodal named collection, localStorage by default), load a saved routine or the default, delete one. The store hydrates first and persists after (the hot-path rule), refuses to swap the routine under a running runner, and dedupes ids.

## The guidance-sink seam (for PR 3)

`src/app/enroll/guidance.ts`: every transcript line fans out to registered `GuidanceSink`s, after the runner's dispatch and the store's update have settled (a sink that skips or stops cannot corrupt the runner — the runner also commits its state before emitting). Text is never a sink you can turn off; the voice sink (PR 3) is one you can add.

## Verification

- `test/trainer_hud.test.ts` (14): the element (paints / no-op / edge / wrap), the resource, the sinks, the `useEngine` source guard, the per-device lift (no dirty, no flip, composed, healed), and the layout (bottom inset, side margins, its own row under a top cue).
- `test/tools_shell.test.tsx` (25): the compact strip, the picker (filter, chips, visible-only reorder, Use), the pref checkbox, close-stops-it.
- `test/enroll_store.test.ts` (11): routine persistence (hydrate-first save, use, overwrite, remove, fallback), the load/start race, dedupe, the skip beat, sink re-entrancy.
- Adversarial review: 12 findings, 11 confirmed, all fixed (two majors: the banner sat behind the always-open panel; the HUD toggle was an instrument dial).

Reachability: Tools bar → Trainer → Start puts the guidance on the video (2 clicks); the picker is one disclosure inside the same panel. Catalog regenerated (`trainerHud` params).

Refs #163, #136, #146.

https://claude.ai/code/session_01X3jUdZKZNcW4QzuBrAEwpj
