### PR TITLE
fix: untrack the node_modules symlink accidentally committed in #173

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ Thumbs.db
 
 # Generated/large test media (commit derived NDJSON fixtures, not raw video)
 /media/
+/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/thorwhalen/Dropbox/py/proj/tt/thoremin/node_modules


### PR DESCRIPTION
A trainer-v2 PR (#173) was authored in a git worktree whose `node_modules` was a symlink to the main checkout. `git add -A` there recorded that symlink (mode `120000`), and it reached `main` via #173/#174.

On a fresh clone git would recreate `node_modules -> <an absolute path>`, breaking `npm install` for anyone else (and pointing the server's checkout at a Mac path). This untracks it (`git rm --cached node_modules`; the real directory is untouched) and adds a bare `/node_modules` to `.gitignore` so a symlink of that name is ignored too — the existing `node_modules/` entry only matches a directory, which is how the symlink slipped through.

Verified: `git ls-files node_modules` is now empty; the suite still runs.

https://claude.ai/code/session_01X3jUdZKZNcW4QzuBrAEwpj