### PR TITLE
#163: trainer live feedback — accurate excursion bar, Done/Enter override, manual mode, recording on by default

### DIFF
--- a/src/app/TrainerPanel.tsx
+++ b/src/app/TrainerPanel.tsx
@@ -184,6 +184,8 @@ export default function TrainerPanel() {
   const setTrainerHud = useControls((s) => s.setTrainerHud);
   const recordTake = useTrainerPrefs((s) => s.recordTake);
   const setRecordTake = useTrainerPrefs((s) => s.setRecordTake);
+  const manualAdvance = useTrainerPrefs((s) => s.manualAdvance);
+  const setManualAdvance = useTrainerPrefs((s) => s.setManualAdvance);
   const recording = useTrainer((s) => s.recording);
   const voiceOn = useVoice((s) => s.enabled);
   const setVoice = useVoice((s) => s.setEnabled);
@@ -213,6 +215,29 @@ export default function TrainerPanel() {
     }, SAMPLE_INTERVAL_MS);
     return () => clearInterval(id);
   }, [running]);
+
+  // Enter = "I've done it, move on" while a cue is running — the manual override, and
+  // the only way forward in manual mode. Ignored when a form field OR another
+  // interactive element is focused: a focused button (Done/Skip/Stop) already activates
+  // on Enter, so handling it here too would fire complete() twice and skip a cue.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Enter') return;
+      // One advance per physical press, never per auto-repeat: holding Enter would else
+      // march through every cue (each freshly begun after the beat, with ~0 samples).
+      // (Same guard as src/app/tagging/keymap.ts.)
+      if (e.repeat) return;
+      const el = e.target as HTMLElement | null;
+      if (el && (['INPUT', 'TEXTAREA', 'SELECT', 'BUTTON', 'A'].includes(el.tagName) || el.isContentEditable)) return;
+      if (useTrainer.getState().status === 'running') {
+        e.preventDefault();
+        useTrainer.getState().complete(nowMs());
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open]);
 
   // Closing the panel (the X, or switching tools) must stop a running routine: otherwise
   // the poll keeps sampling and the feature-demand claim (#163) keeps the catalog
@@ -262,6 +287,15 @@ export default function TrainerPanel() {
             {samples} {activeCue.produces === 'vocabulary' ? 'held' : 'frames'}
           </span>
           <VoiceToggle on={voiceOn} setOn={setVoice} />
+          {status === 'running' && (
+            <button
+              onClick={() => useTrainer.getState().complete(nowMs())}
+              title="I've done this one — move on (Enter)"
+              className="rounded bg-emerald-500/80 px-2 py-0.5 text-[10px] font-bold text-black transition hover:bg-emerald-400"
+            >
+              Done
+            </button>
+          )}
           <button
             onClick={() => useTrainer.getState().skip(nowMs())}
             className="rounded bg-white/10 px-2 py-0.5 text-[10px] font-semibold text-white/80 transition hover:bg-white/20"
@@ -368,6 +402,10 @@ export default function TrainerPanel() {
         <label className="flex items-center gap-2 text-[10px] text-white/60" title="Saves the clean camera video, the feature vectors and the cue/verdict annotations as a recording (like the Record button does).">
           <input type="checkbox" checked={recordTake} onChange={(e) => setRecordTake(e.target.checked)} />
           Record the take (camera + features + annotations)
+        </label>
+        <label className="flex items-center gap-2 text-[10px] text-white/60" title="Instead of the trainer deciding when you've done each cue, you press Done (or Enter) to move on.">
+          <input type="checkbox" checked={manualAdvance} onChange={(e) => setManualAdvance(e.target.checked)} />
+          I'll say when I'm done (press Done or Enter to advance)
         </label>
 
         {status === 'done' && (

--- a/src/app/enroll/prefs.ts
+++ b/src/app/enroll/prefs.ts
@@ -1,20 +1,37 @@
 /**
  * Trainer tooling prefs (#163) — per-device, persisted, never part of an instrument.
  *
- * `recordTake`: when on, a routine is also RECORDED — the clean camera stream, the
+ * `recordTake` (default ON): a routine is also RECORDED — the clean camera stream, the
  * feature vectors and the cue/verdict annotations — through the app's own session
  * recorder (#88), so the take can be replayed, exported and labelled later.
+ *
+ * `manualAdvance` (default off): the trainer waits for the player to press Done/Enter
+ * before moving to the next cue, instead of deciding for itself.
  */
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
 interface TrainerPrefs {
+  /** Record the take (clean camera + features + cue annotations). Default ON. */
   recordTake: boolean;
   setRecordTake(on: boolean): void;
+  /**
+   * Manual advance: the trainer never decides a cue is done on its own — you press
+   * Done (or Enter) to move to the next. Default OFF (the automatic advance is the
+   * out-of-the-box experience). See the runner's `manualAdvance`.
+   */
+  manualAdvance: boolean;
+  setManualAdvance(on: boolean): void;
 }
 
 export const useTrainerPrefs = create<TrainerPrefs>()(
-  persist((set) => ({ recordTake: false, setRecordTake: (on) => set({ recordTake: on }) }), {
-    name: 'thoremin-trainer-prefs',
-  }),
+  persist(
+    (set) => ({
+      recordTake: true,
+      setRecordTake: (on) => set({ recordTake: on }),
+      manualAdvance: false,
+      setManualAdvance: (on) => set({ manualAdvance: on }),
+    }),
+    { name: 'thoremin-trainer-prefs' },
+  ),
 );

--- a/src/app/enroll/store.ts
+++ b/src/app/enroll/store.ts
@@ -169,6 +169,8 @@ interface TrainerState {
   startTake(now: () => number): Promise<void>;
   sample(vector: FeatureVector, tMs: number): void;
   tick(tMs: number): void;
+  /** The player's "Done": complete the active cue, keeping its samples, and move on. */
+  complete(tMs: number): void;
   skip(tMs: number): void;
   stop(tMs: number): void;
   build(): void;
@@ -399,7 +401,7 @@ export const useTrainer = create<TrainerState>()((set, get) => {
       unsubscribe = null;
       runner?.stop(tMs);
       session = createSession();
-      runner = createRunner({ cues: routine, session });
+      runner = createRunner({ cues: routine, session, manualAdvance: useTrainerPrefs.getState().manualAdvance });
       const offEvents = runner.subscribe(onEvent);
       const offTake = runner.subscribe(onEventForTake);
       unsubscribe = () => {
@@ -447,6 +449,11 @@ export const useTrainer = create<TrainerState>()((set, get) => {
       if (!runner) return;
       runner.tick(tMs);
       reconcileRecording(get, set);
+      set(fromRunner());
+    },
+
+    complete(tMs) {
+      runner?.complete(tMs);
       set(fromRunner());
     },
 

--- a/src/enroll/cue.ts
+++ b/src/enroll/cue.ts
@@ -79,7 +79,24 @@ export const SufficiencySchema = z.discriminatedUnion('kind', [
   z.object({
     kind: z.literal('excursion'),
     minPoints: z.number().int().min(1).default(1),
-    minExcursion: z.number().min(0).default(8),
+    /**
+     * Default 12 noise-sigma. The distance is the RMS of the cue's features (a head cue:
+     * yaw, pitch, roll), each in units of its own jitter — so a single-axis turn is
+     * DILUTED by ~sqrt(3), and this is measured against that RMS, not one axis.
+     *
+     * Measured on the recorded clip (`video_head_pose`), the genuinely-held deliberate
+     * moves read (RMS, shipped sampler): look-right ~46σ, look-up ~38σ, look-down ~19σ —
+     * the weakest, a soft chin-down, is ~19. The old default of 8 fired on a sub-2° twitch
+     * ("Good" before the player did the cue); an over-eager 30 would REJECT that ~19σ
+     * look-down and time out. 12 clears the weakest held move with ~1.5x margin (and room
+     * for the ~1.8x sigma inflation across a routine of back-to-back moves) while still
+     * rejecting a held sub-2° drift (~9σ RMS).
+     *
+     * A fixed sigma bar is inherently camera-dependent (the player's live report of "fires
+     * too early" was on a different sensor than this clip): the RELIABLE controls for
+     * pacing are the Done/Enter override and manual mode. Live-tune per #146 §8.
+     */
+    minExcursion: z.number().min(0).default(12),
     patienceMs: z.number().min(1000).default(20000),
   }),
   /**
@@ -90,7 +107,12 @@ export const SufficiencySchema = z.discriminatedUnion('kind', [
   z.object({
     kind: z.literal('variety'),
     minPoints: z.number().int().min(1).default(6),
-    minSeparation: z.number().min(0).default(6),
+    /** Noise-sigma (RMS over the cue's features) two held poses must differ by to count
+     *  as DISTINCT. Bumped modestly from 6 (which accepted micro-variations of one
+     *  expression) to 10 — a separable expression change, without demanding so much that
+     *  a player's real repertoire fails to accumulate. No expression clip to measure
+     *  against yet; provisional, live-tune per #146 §8. */
+    minSeparation: z.number().min(0).default(10),
     /** Without a new still-point for this long, ask the player to hold still. */
     holdNudgeMs: z.number().min(1000).default(8000),
     patienceMs: z.number().min(1000).default(60000),

--- a/src/enroll/runner.ts
+++ b/src/enroll/runner.ts
@@ -87,9 +87,17 @@ export interface RunnerOptions {
   beatMs?: number;
   /** Minimum gap before the same guidance is repeated with no new sample in between. */
   repeatSayMs?: number;
+  /**
+   * Manual mode (#163 live feedback): the runner NEVER decides a cue is done — no
+   * `enough`, no `cannot`, no nudges. It shows the instruction and the meter and waits
+   * for the player's {@link Runner.complete} (a "Done" press) or {@link Runner.skip}.
+   * The take is still sampled; the meter still fills. For a player who finds the
+   * automatic advance too eager, or wants to take their time.
+   */
+  manualAdvance?: boolean;
 }
 
-const DEFAULTS = { evaluateEveryMs: 250, beatMs: 1500, repeatSayMs: 6000 };
+const DEFAULTS = { evaluateEveryMs: 250, beatMs: 1500, repeatSayMs: 6000, manualAdvance: false };
 
 export interface Runner {
   /** Begin the routine at `tMs` (cue 0 starts immediately). */
@@ -101,6 +109,9 @@ export interface Runner {
   push(vector: FeatureVector, tMs: number): void;
   /** Advance time without a sample (so patience and beats still elapse). */
   tick(tMs: number): void;
+  /** The player says they have DONE the active cue: end it as complete, keeping whatever
+   *  was captured, and move on. Works in either mode — it is the manual override. */
+  complete(tMs: number): void;
   /** The player skips the active cue. */
   skip(tMs: number): void;
   /** Abort the routine. Captured samples stay in the session. */
@@ -192,6 +203,9 @@ export function createRunner(options: RunnerOptions): Runner {
   const consider = (tMs: number) => {
     const cue = activeCue();
     if (!cue || status !== 'running') return;
+    // Manual mode: the player decides when a cue is done. The runner never ends a cue
+    // on its own and stays silent (no nudges); the meter still fills from the samples.
+    if (o.manualAdvance) return;
     if (tMs - lastEvaluatedAt < o.evaluateEveryMs) return;
     lastEvaluatedAt = tMs;
     const samples = samplesOf(cue);
@@ -265,6 +279,12 @@ export function createRunner(options: RunnerOptions): Runner {
     tick(tMs) {
       advance(tMs);
       consider(tMs);
+    },
+    complete(tMs) {
+      // The player's "Done": the cue is complete (its samples kept), whatever the
+      // evaluator thinks. In 'between', it jumps straight to the next cue.
+      if (status === 'running') endCue('enough', tMs);
+      else if (status === 'between') beginCue(index + 1, tMs);
     },
     skip(tMs) {
       if (status === 'running') endCue('skipped', tMs);

--- a/test/enroll_cues.test.ts
+++ b/test/enroll_cues.test.ts
@@ -116,13 +116,13 @@ describe('cue schema — what a cue IS (the zodal SSOT)', () => {
     expect(SufficiencySchema.parse({ kind: 'excursion' })).toEqual({
       kind: 'excursion',
       minPoints: 1,
-      minExcursion: 8,
+      minExcursion: 12,
       patienceMs: 20000,
     });
     expect(SufficiencySchema.parse({ kind: 'variety' })).toEqual({
       kind: 'variety',
       minPoints: 6,
-      minSeparation: 6,
+      minSeparation: 10,
       holdNudgeMs: 8000,
       patienceMs: 60000,
     });

--- a/test/enroll_projection_store.test.ts
+++ b/test/enroll_projection_store.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { categoryKey, classify, type FeatureVector } from '@/enroll';
 import { useTrainer } from '@/app/enroll/store';
+import { useTrainerPrefs } from '@/app/enroll/prefs';
 import { appFeatureDemand } from '@/app/featureDemand';
 
 const prng = (seed: number) => () => {
@@ -20,7 +21,10 @@ function threePoseTake() {
   const jit = () => 0.3 * r();
   const base = (): FeatureVector => ({ 'face.head.yaw': jit(), 'face.head.pitch': jit(), 'face.head.roll': jit() });
   useTrainer.getState().setRoutine(['rest', 'look-left', 'look-right', 'look-up', 'look-down', 'tilt-left', 'tilt-right']);
+  // Manual advance: `complete()` drives every boundary, so the take is deterministic.
+  useTrainerPrefs.getState().setManualAdvance(true);
   useTrainer.getState().start(1000);
+  useTrainerPrefs.getState().setManualAdvance(false);
   let t = 1000;
   const feed = (n: number, make: () => FeatureVector) => {
     for (let i = 0; i < n; i++) {
@@ -28,16 +32,14 @@ function threePoseTake() {
       useTrainer.getState().sample(make(), t);
     }
   };
-  const holdThrough = (ms: number, make: () => FeatureVector) => {
-    const end = t + ms;
-    while (t < end) {
-      t += 33;
-      useTrainer.getState().sample(make(), t);
-    }
+  // Hold each pose long enough for a still-point, then press "Done" (complete) to move
+  // on: the manual-advance flow, deterministic and independent of the excursion bar.
+  const advance = () => {
+    t += 100;
+    useTrainer.getState().complete(t);
   };
   feed(120, base); // rest
-  let held = base;
-  holdThrough(1700, () => held());
+  advance(); // "Done" with rest -> between
   const poses: FeatureVector[] = [
     { 'face.head.yaw': -25 },
     { 'face.head.yaw': 25 },
@@ -47,12 +49,13 @@ function threePoseTake() {
     { 'face.head.roll': -20 },
   ];
   for (const pose of poses) {
+    advance(); // between -> begin the next movement cue (running)
     const at = () => ({ ...base(), ...Object.fromEntries(Object.entries(pose).map(([k, v]) => [k, v + jit()])) });
     feed(8, () => ({ ...base(), ...Object.fromEntries(Object.entries(pose).map(([k, v]) => [k, v * 0.5])) }));
     feed(25, at);
-    held = at;
-    holdThrough(1700, () => held());
+    advance(); // "Done" -> end this cue
   }
+  for (let guard = 0; useTrainer.getState().status !== 'done' && guard < 20; guard++) advance();
 }
 
 beforeEach(() => {

--- a/test/enroll_runner.test.ts
+++ b/test/enroll_runner.test.ts
@@ -12,6 +12,7 @@ import {
   CANNOT_REASONS,
   createRunner,
   createSession,
+  CueSchema,
   defaultSufficiency,
   RUNNER_PHRASES,
   type Cue,
@@ -453,6 +454,94 @@ describe('the session invalidates its build when a cue is re-run', () => {
   });
 });
 
+describe('manual advance — the player decides, and the override', () => {
+  it('complete() ends the active cue as done (keeping its samples) and moves on — the "I did it" override', () => {
+    // A HIGH excursion bar (100 sigma) so a solidly-held pose is CAPTURED as a
+    // still-point yet has not auto-completed: exactly the case the override is for.
+    const look = cue('look', {
+      collects: { groups: ['head'], omit: [], axes: [] },
+      sufficiency: { kind: 'excursion', minPoints: 1, minExcursion: 100, patienceMs: 20000 },
+    });
+    const h = harness([REST, look, FACES]);
+    const r = prng(50);
+    h.runner.start(h.t);
+    h.feed(40, restFrame(r)); // rest reaches enough on its own
+    h.wait(600);
+    expect(h.runner.state().cue?.id).toBe('look');
+    // Turn ~8 degrees and hold: captured (~37 sigma at this jitter) but under 100.
+    h.feed(6, (i) => v({ ...restFrame(r)(), yaw: (8 * (i + 1)) / 6 }));
+    h.feed(20, () => v({ ...restFrame(r)(), yaw: 8 + 0.3 * r() }));
+    expect(h.runner.state().status).toBe('running'); // auto did not fire (37 < 100)
+    const captured = h.session.pointsFor('look').length;
+    expect(captured).toBeGreaterThanOrEqual(1); // a still-point WAS captured
+    // The player presses Done: the cue completes as 'enough', its samples kept.
+    h.runner.complete(h.t);
+    expect(h.kinds().at(-1)).toBe('end:enough');
+    expect(h.session.pointsFor('look')).toHaveLength(captured);
+    h.wait(600); // the beat elapses and 'faces' begins on its own
+    expect(h.runner.state().cue?.id).toBe('faces');
+    // complete() on the running last cue finishes the routine.
+    h.runner.complete(h.t);
+    expect(h.runner.state().status).toBe('done');
+  });
+
+  it('manual mode: the runner NEVER auto-advances or nudges — only the player moves on', () => {
+    const h = harness([REST, LOOK], { manualAdvance: true });
+    const r = prng(51);
+    h.runner.start(h.t);
+    // Feed far more than enough of REST (a frames cue): it must NOT advance on its own.
+    h.feed(200, restFrame(r));
+    expect(h.runner.state().status).toBe('running');
+    expect(h.runner.state().cue?.id).toBe('rest');
+    expect(h.events.some((e) => e.type === 'guidance')).toBe(false);
+    expect(h.events.some((e) => e.type === 'cue-end')).toBe(false);
+    // A big deliberate movement also does not auto-advance.
+    h.runner.complete(h.t); // done with rest
+    h.wait(600);
+    expect(h.runner.state().cue?.id).toBe('look');
+    h.feed(15, (i) => v({ ...restFrame(r)(), yaw: (30 * i) / 15 }));
+    h.feed(40, () => v({ ...restFrame(r)(), yaw: 30 + 0.3 * r() }));
+    expect(h.runner.state().status).toBe('running'); // still waiting for the player
+    expect(h.events.some((e) => e.type === 'guidance')).toBe(false); // no nudges in manual mode
+    h.runner.complete(h.t);
+    expect(h.kinds().at(-1)).toBe('done');
+  });
+
+  it('the raised excursion default rejects incidental drift but accepts a real look', () => {
+    // Build the cue through the SHIPPED schema so the excursion bar is the real
+    // default (30 sigma), not the toy helper's 8. (enroll_cues.test.ts pins the 30.)
+    // CueSchema = {id, name} & CueSpecSchema — CueSpecSchema alone strips id/name.
+    const look = CueSchema.parse({
+      id: 'look-default',
+      name: 'Look',
+      instruction: 'Look.',
+      rationale: '',
+      collects: { groups: ['head'], omit: [], axes: [] },
+      produces: 'vocabulary',
+      sufficiency: { kind: 'excursion' },
+      variations: [],
+      tags: [],
+    }) as Cue;
+    expect(look.sufficiency).toMatchObject({ kind: 'excursion', minExcursion: 12 });
+    const h2 = harness([REST, look]);
+    const r = prng(52);
+    h2.runner.start(h2.t);
+    h2.feed(60, restFrame(r));
+    h2.wait(600);
+    expect(h2.runner.state().cue?.id).toBe('look-default');
+    // The excursion is RMS over {yaw,pitch,roll}; at this jitter (sigma_yaw ~0.12) a pure
+    // yaw of d degrees is ~4.7*d sigma. A held ~2-degree drift (~9 sigma) is CAPTURED but
+    // below the 12 bar -> must NOT complete.
+    h2.feed(3, (i) => v({ ...restFrame(r)(), yaw: (2 * (i + 1)) / 3 }));
+    h2.feed(30, () => v({ ...restFrame(r)(), yaw: 2 + 0.3 * r() }));
+    expect(h2.runner.state().status).toBe('running');
+    // A real ~10-degree turn (~47 sigma), held: above the bar -> completes.
+    h2.feed(12, (i) => v({ ...restFrame(r)(), yaw: 2 + (8 * (i + 1)) / 12 }));
+    h2.feed(30, () => v({ ...restFrame(r)(), yaw: 10 + 0.3 * r() }));
+    expect(h2.runner.state().status).toBe('done');
+  });
+});
+
 describe('the default evaluator, directly', () => {
   const sigma = () => 1;
   const base = {
@@ -594,5 +683,54 @@ describe('a routine over the REAL recording, in RAW units', () => {
     // told to hold it, would — and the runner would say "a bit further" if they did not.
     expect(h.runner.state().status).toBe('running');
     expect(h.session.pointsFor('look-left')).toHaveLength(0);
+  });
+
+  it('the SHIPPED default excursion (not the toy 8) still lets the clip\'s genuinely-held head moves reach ENOUGH', () => {
+    // The regression guard for the excursion bar: the metric is RMS over {yaw,pitch,roll},
+    // so a single-axis turn is diluted ~sqrt(3). On this clip the genuinely-held moves
+    // read (RMS) right ~46, up ~38, DOWN ~19 sigma. A bar of 30 would REJECT the ~19 sigma
+    // look-down and time it out; the shipped default (12) must accept it. This drives head
+    // cues built through the REAL schema (default excursion), not the toy cue() helper
+    // that hardcodes 8, so if the default is ever raised too far this goes red.
+    const headDefault = (id: string, instruction: string): Cue =>
+      CueSchema.parse({
+        id,
+        name: id,
+        instruction,
+        rationale: '',
+        collects: { groups: ['head'], omit: [], axes: [] },
+        produces: 'vocabulary',
+        sufficiency: { kind: 'excursion' },
+        variations: ['A bit further, if you can.'],
+        tags: [],
+      }) as Cue;
+    const routine: Cue[] = [
+      cue('rest', { produces: 'baseline', sufficiency: { kind: 'frames', minFrames: 15, patienceMs: 5000 } }),
+      headDefault('look-right', 'Look right.'),
+      headDefault('look-up', 'Look up.'),
+      headDefault('look-down', 'Look down.'),
+    ];
+    // The shipped-like sampler (dwell 200, stillSigma 5, the harness default): these three
+    // are genuinely HELD in the clip and each yields a still-point (unlike the left sweep).
+    const h2 = harness(routine);
+    h2.runner.start(h2.t);
+    for (const [from, to] of [
+      [7.7, 8.5], // rest
+      [5.9, 7.1], // right (+35)
+      [0.2, 1.5], // up (pitch -37)
+      [1.6, 3.4], // down (+26)
+    ] as [number, number][]) {
+      const seg = window(from, to);
+      h2.feed(seg.length, (i) => seg[i]);
+      h2.wait(600);
+    }
+    const ends = h2.events.filter((e): e is Extract<RunnerEvent, { type: 'cue-end' }> => e.type === 'cue-end');
+    expect(ends.map((e) => `${e.cue.id}:${e.outcome}`)).toEqual([
+      'rest:enough',
+      'look-right:enough',
+      'look-up:enough',
+      'look-down:enough',
+    ]);
+    expect(h2.runner.state().status).toBe('done');
   });
 });

--- a/test/enroll_store.test.ts
+++ b/test/enroll_store.test.ts
@@ -12,6 +12,7 @@ import { createInMemoryProvider } from '@zodal/store';
 import { CueSpecSchema, categoryKey, type CueRecord, type FeatureVector, type RoutineRecord } from '@/enroll';
 import { createCueStore, createRoutineStore } from '@/app/enroll/cueStore';
 import { useTrainer, useTrainerStores } from '@/app/enroll/store';
+import { useTrainerPrefs } from '@/app/enroll/prefs';
 import { DEFAULT_ROUTINE_CUE_IDS, STARTER_CUES } from '@/app/enroll/starterCues';
 import { appFeatureDemand } from '@/app/featureDemand';
 
@@ -155,6 +156,43 @@ describe('runner lifecycle through the store', () => {
     useTrainer.getState().stop(1200);
   });
 
+  it('with manualAdvance=false (the default), a fed movement AUTO-advances the cue — guards the store->runner wiring', () => {
+    // The mutation guard for start()'s `manualAdvance: useTrainerPrefs.getState().manualAdvance`
+    // (store.ts): were the runner built in manual mode, the default player's routine would
+    // never advance on its own. Here a real fed movement must reach 'enough' with NO
+    // complete() call — so hardcoding manualAdvance:true turns this red.
+    useTrainerPrefs.setState({ manualAdvance: false });
+    const st = useTrainer.getState();
+    st.setRoutine(['rest', 'look-left']);
+    st.start(1000);
+    const r = prng(11);
+    const jit = () => 0.3 * r();
+    const base = (): FeatureVector => ({ 'face.head.yaw': jit(), 'face.head.pitch': jit(), 'face.head.roll': jit() });
+    let t = 1000;
+    const feed = (n: number, make: (i: number) => FeatureVector) => {
+      for (let i = 0; i < n; i++) {
+        t += 33;
+        useTrainer.getState().sample(make(i), t);
+      }
+    };
+    const tick = (ms: number) => {
+      const e = t + ms;
+      while (t < e) {
+        t += 100;
+        useTrainer.getState().tick(t);
+      }
+    };
+    feed(100, () => base()); // rest (minFrames 90) reaches enough on its own
+    tick(1700); // the beat elapses -> look-left begins on its own
+    expect(useTrainer.getState().outcomes[0]).toBe('enough');
+    expect(useTrainer.getState().status).toBe('running');
+    // A big, held ~30-degree yaw: excursion far past the 12-sigma bar -> auto 'enough'.
+    feed(8, (i) => ({ ...base(), 'face.head.yaw': (30 * (i + 1)) / 8 }));
+    feed(40, () => ({ ...base(), 'face.head.yaw': 30 + jit() }));
+    expect(useTrainer.getState().outcomes[1]).toBe('enough');
+    useTrainer.getState().stop(t + 100);
+  });
+
   it('a guidance sink that reacts by stopping or skipping cannot corrupt the runner (sinks run after the event settles)', async () => {
     const { addGuidanceSink, resetGuidanceSinks } = await import('@/app/enroll/guidance');
     resetGuidanceSinks();
@@ -180,14 +218,21 @@ describe('runner lifecycle through the store', () => {
 
 describe('labels survive a re-cut', () => {
   /** Drive a take with three well-separated held "faces" via a one-cue routine. */
+  // A deterministic take: hold each pose long enough for a still-point, then press
+  // "Done" (complete) to advance — the manual-advance flow, so it never depends on the
+  // excursion threshold. Distinct held poses become distinct clusters to label.
   function takeWithThreeFaces() {
     const r = prng(4);
     const jitter = () => 0.3 * r();
     const base = (): FeatureVector => ({ 'face.head.yaw': jitter(), 'face.head.pitch': jitter(), 'face.head.roll': jitter() });
-    // Head cues only, for a fast, deterministic take.
     const st = useTrainer.getState();
     st.setRoutine(['rest', 'look-left', 'look-right', 'look-up']);
+    // Manual advance: every cue boundary is a `complete()` here, so the take is
+    // deterministic and never depends on the excursion threshold. Restore the pref
+    // right after start() — the runner has already captured it.
+    useTrainerPrefs.getState().setManualAdvance(true);
     st.start(1000);
+    useTrainerPrefs.getState().setManualAdvance(false);
     let t = 1000;
     const feed = (n: number, make: () => FeatureVector) => {
       for (let i = 0; i < n; i++) {
@@ -195,28 +240,22 @@ describe('labels survive a re-cut', () => {
         useTrainer.getState().sample(make(), t);
       }
     };
-    const wait = (ms: number) => {
-      const end = t + ms;
-      while (t < end) {
-        t += 100;
-        useTrainer.getState().tick(t);
-      }
+    const advance = () => {
+      t += 100;
+      useTrainer.getState().complete(t);
     };
-    feed(120, base); // rest
-    // Through each beat the player keeps holding the previous pose (frames keep
-    // arriving, as the live panel's poll does); the move happens inside the next cue.
-    let held: () => FeatureVector = base;
-    const holdThrough = (ms: number) => feed(Math.round(ms / 33), held);
-    holdThrough(1700);
+    feed(120, base); // rest baseline (fixes the noise scale)
+    advance(); // "Done" with rest -> between
     const poses: FeatureVector[] = [{ 'face.head.yaw': -25 }, { 'face.head.yaw': 25 }, { 'face.head.pitch': -25 }];
     for (const pose of poses) {
+      advance(); // between -> begin the next movement cue (running)
       const at = () => ({ ...base(), ...Object.fromEntries(Object.entries(pose).map(([k, v]) => [k, v + jitter()])) });
-      feed(8, (): FeatureVector => ({ ...base(), ...Object.fromEntries(Object.entries(pose).map(([k, v]) => [k, v * 0.5])) })); // the move
-      feed(25, at); // the hold
-      held = at;
-      holdThrough(1700);
+      feed(8, (): FeatureVector => ({ ...base(), ...Object.fromEntries(Object.entries(pose).map(([k, v]) => [k, v * 0.5])) })); // the move arms the sampler
+      feed(25, at); // the hold -> a still-point for this pose
+      advance(); // "Done" -> end this cue
     }
-    void wait;
+    // Drain any cue the poses did not cover, so the routine reaches 'done'.
+    for (let guard = 0; useTrainer.getState().status !== 'done' && guard < 20; guard++) advance();
     return useTrainer.getState();
   }
 

--- a/test/tools_shell.test.tsx
+++ b/test/tools_shell.test.tsx
@@ -23,6 +23,7 @@ import { STARTER_CUES } from '@/app/enroll/starterCues';
 import { useTools } from '@/app/toolsStore';
 import { useControls } from '@/app/store';
 import { useTrainer } from '@/app/enroll/store';
+import { useTrainerPrefs } from '@/app/enroll/prefs';
 import { defaultFeatureLab } from '@/features/labConfig';
 import { GESTURE_IDS, GESTURE_LABELS, defaultGesturePrefs } from '@/app/gesturePrefs';
 import { OVERLAY_CONTROLS, controlsForSurface } from '@/app/overlayControls';
@@ -32,6 +33,10 @@ beforeEach(() => {
   useControls.getState().setFeatureLab(defaultFeatureLab());
   useControls.setState({ gestures: defaultGesturePrefs() });
   useTrainer.getState().reset();
+  // Recording defaults ON in production (its own test below covers that path); the
+  // routine-mechanics tests turn it OFF so Start begins the routine synchronously,
+  // and clear manual mode so the runner auto-advances.
+  useTrainerPrefs.setState({ recordTake: false, manualAdvance: false });
 });
 afterEach(cleanup);
 
@@ -362,6 +367,86 @@ describe('the Trainer is reachable and runs a routine of cues (#160, #163)', () 
     expect(useControls.getState().trainerHud.show).toBe(true);
   });
 
+  it('recording the take is ON by default (the maintainer\'s call) and the box shows it', () => {
+    // The SHIPPED default, read past whatever the deterministic beforeEach set.
+    expect(useTrainerPrefs.getInitialState().recordTake).toBe(true);
+    useTrainerPrefs.setState({ recordTake: true });
+    useTools.setState({ open: 'trainer' });
+    render(<TrainerPanel />);
+    const box = screen.getByLabelText(/Record the take/i) as HTMLInputElement;
+    expect(box.checked).toBe(true);
+  });
+
+  it('manual advance is a per-device checkbox, OFF by default, and toggling it wires the pref', () => {
+    expect(useTrainerPrefs.getInitialState().manualAdvance).toBe(false);
+    useTools.setState({ open: 'trainer' });
+    render(<TrainerPanel />);
+    const box = screen.getByLabelText(/I'll say when I'm done/i) as HTMLInputElement;
+    expect(box.checked).toBe(false);
+    fireEvent.click(box);
+    expect(useTrainerPrefs.getState().manualAdvance).toBe(true);
+    fireEvent.click(box);
+    expect(useTrainerPrefs.getState().manualAdvance).toBe(false);
+  });
+
+  it('the Done button ends the running cue as complete (the "I did it" override)', () => {
+    useTools.setState({ open: 'trainer' });
+    render(<TrainerPanel />);
+    fireEvent.click(screen.getByText('Start'));
+    expect(useTrainer.getState().status).toBe('running');
+    expect(useTrainer.getState().index).toBe(0);
+    // The Done button is offered while running; clicking it completes the cue.
+    fireEvent.click(screen.getByText('Done'));
+    expect(useTrainer.getState().outcomes[0]).toBe('enough');
+    fireEvent.click(screen.getByText('Stop'));
+  });
+
+  it('pressing Enter advances the cue (the keyboard override), but not while typing, and not on auto-repeat', () => {
+    useTools.setState({ open: 'trainer' });
+    render(<TrainerPanel />);
+    fireEvent.click(screen.getByText('Start'));
+    expect(useTrainer.getState().status).toBe('running');
+    // Enter from a text field is ignored (you might be naming something).
+    const field = document.createElement('input');
+    document.body.appendChild(field);
+    fireEvent.keyDown(field, { key: 'Enter' });
+    expect(useTrainer.getState().outcomes[0]).toBeNull();
+    document.body.removeChild(field);
+    // A held-key AUTO-REPEAT is ignored — else leaning on Enter would march through every
+    // cue, each freshly begun with ~0 samples (the review's finding).
+    fireEvent.keyDown(document.body, { key: 'Enter', repeat: true });
+    expect(useTrainer.getState().outcomes[0]).toBeNull();
+    // A genuine (non-repeat) Enter anywhere else is the "I did it" override.
+    fireEvent.keyDown(document.body, { key: 'Enter' });
+    expect(useTrainer.getState().outcomes[0]).toBe('enough');
+    fireEvent.click(screen.getByText('Stop'));
+  });
+
+  it('in manual mode the routine never auto-advances — only Done/Enter moves it on', () => {
+    useTrainerPrefs.setState({ manualAdvance: true });
+    useTools.setState({ open: 'trainer' });
+    render(<TrainerPanel />);
+    fireEvent.click(screen.getByText('Start'));
+    // Drive far more than enough of the first (frames) cue directly through the store:
+    // in manual mode it must NOT advance on its own.
+    const rest = STARTER_CUES[0];
+    act(() => {
+      let t = 2000;
+      for (let i = 0; i < 200; i++) {
+        t += 33;
+        useTrainer.getState().sample({ 'face.head.yaw': 0, 'face.head.pitch': 0, 'face.head.roll': 0 }, t);
+      }
+    });
+    expect(rest.produces).toBe('baseline');
+    expect(useTrainer.getState().status).toBe('running');
+    expect(useTrainer.getState().index).toBe(0);
+    expect(useTrainer.getState().outcomes[0]).toBeNull();
+    // The player presses Done: now it moves on.
+    fireEvent.click(screen.getByText('Done'));
+    expect(useTrainer.getState().outcomes[0]).toBe('enough');
+    fireEvent.click(screen.getByText('Stop'));
+  });
+
   it('closing the panel mid-routine STOPS it (and releases the feature demand)', async () => {
     const { appFeatureDemand } = await import('@/app/featureDemand');
     useTools.setState({ open: 'trainer' });
@@ -462,7 +547,11 @@ describe('the projection view (#163 §7-§8) is reachable and labels categories 
     const jit = () => 0.3 * r();
     const base = () => ({ 'face.head.yaw': jit(), 'face.head.pitch': jit(), 'face.head.roll': jit() });
     useTrainer.getState().setRoutine(['rest', 'look-left', 'look-right', 'look-up', 'look-down', 'tilt-left', 'tilt-right']);
+    // Manual advance: `complete()` drives every boundary, so the take is deterministic
+    // and independent of the excursion threshold. Restore right after start().
+    useTrainerPrefs.setState({ manualAdvance: true });
     useTrainer.getState().start(1000);
+    useTrainerPrefs.setState({ manualAdvance: false });
     let t = 1000;
     const feed = (n: number, make: () => Record<string, number>) => {
       for (let i = 0; i < n; i++) {
@@ -477,16 +566,21 @@ describe('the projection view (#163 §7-§8) is reachable and labels categories 
         useTrainer.getState().sample(make(), t);
       }
     };
-    feed(120, base);
-    let held = base;
-    hold(1700, () => held());
+    const advance = () => {
+      t += 100;
+      useTrainer.getState().complete(t);
+    };
+    void hold;
+    feed(120, base); // rest baseline
+    advance(); // "Done" with rest
     for (const pose of [{ 'face.head.yaw': -25 }, { 'face.head.yaw': 25 }, { 'face.head.pitch': -25 }, { 'face.head.pitch': 25 }, { 'face.head.roll': 20 }, { 'face.head.roll': -20 }]) {
+      advance(); // begin the next movement cue
       const at = () => ({ ...base(), ...Object.fromEntries(Object.entries(pose).map(([k, v]) => [k, v + jit()])) });
       feed(8, () => ({ ...base(), ...Object.fromEntries(Object.entries(pose).map(([k, v]) => [k, v * 0.5])) }));
-      feed(25, at);
-      held = at;
-      hold(1700, () => held());
+      feed(25, at); // hold -> a still-point for this pose
+      advance(); // "Done" -> end this cue
     }
+    for (let guard = 0; useTrainer.getState().status !== 'done' && guard < 20; guard++) advance();
     useTrainer.getState().build();
   }
 


### PR DESCRIPTION
Trainer v2 (#163) live-feedback follow-up. Three things the maintainer found on a real webcam, plus the fixes an adversarial review turned up.

## 1. "Good" fired before I did anything — the excursion bar, done right this time

A movement cue ends when a held pose is far enough from the resting baseline, in **noise units** (multiples of the feature's own jitter, sigma). The default was **8** — and on the recorded `video_head_pose` clip a sub-2-degree twitch already clears it, so "Good." arrives before the cue is done.

The subtlety the review caught: the distance is the **RMS over the cue's features** (a head cue: yaw/pitch/roll), so a single-axis turn is diluted by ~sqrt(3). Measured on the clip, the genuinely-held deliberate moves read (RMS): look-right ~46σ, look-up ~38σ, **look-down ~19σ** — the weakest, a soft chin-down. An over-eager 30 (my first pass) would have *rejected* that look-down and timed it out to "Moving on." The shipped default is now **12**: it clears the weakest held move with ~1.5x margin (and headroom for the ~1.8x sigma inflation across a routine) while still rejecting a held sub-2-degree drift (~9σ). `variety.minSeparation` went 6 → **10** (a separable expression, provisional — no expression clip to measure against yet).

A fixed sigma bar is inherently camera-dependent (your "fires too early" was on a different sensor than the clip), so the **reliable** pacing controls are the override and manual mode below. A new **real-fixture guard** drives head cues through the actual schema default and asserts the clip's held moves — including the ~19σ look-down — reach ENOUGH; it goes red if the default is ever raised too far again.

## 2. An override — "I've done it, move on"

- `Runner.complete(tMs)` (pure core): ends the running cue as `enough` keeping its samples; during the beat it jumps to the next. The manual override in **either** mode.
- A **Done** button in the running strip + a window **Enter** shortcut. Enter ignores focused form fields *and* buttons (so it can't double-fire) **and auto-repeat** (so leaning on the key can't march through every cue with ~0 samples — a review finding, guarded by a test).

## 3. A manual-only mode

`manualAdvance` runner option + per-device pref + a panel checkbox ("I'll say when I'm done"): the runner never auto-decides or nudges; it fills the meter and waits for Done/Enter. `start()` reads the pref once when the runner is built.

## 4. Recording the take is ON by default

`recordTake` now defaults **true** — every take recorded (clean camera + features + cue annotations) without ticking a box. Still a per-device toggle.

## Adversarial review + the guards it earned

A multi-agent review of the runner core loop and the new mode found three real defects, all now fixed **and mutation-verified** (each guard goes red when its fix is reverted):

1. **Enter auto-repeat cascade** — holding Enter marched through every cue. Fixed with `if (e.repeat) return` (the same guard `tagging/keymap.ts` already uses); guarded in `tools_shell.test.tsx`.
2. **excursion 30 too high** — broke real head cues on the fixture (look-down 19σ < 30 → timeout). Corrected to 12; guarded by the real-fixture ENOUGH test in `enroll_runner.test.ts`.
3. **test-integrity gap** — rewriting the take helpers to manual mode left the default auto-advance path unguarded (hardcoding `manualAdvance:true` passed all tests). Closed with a store-level test that feeds a real movement and asserts it auto-advances, in `enroll_store.test.ts`.

## Reachability (the shipping rule)

From a cold load: Tools bar → Trainer → the Done button and Enter work the moment a routine runs; the manual-mode and record checkboxes are in the panel body. `tools_shell.test.tsx` covers each: the default-on record box, the manual checkbox wiring, the Done button, the Enter override (ignored while typing and on auto-repeat), and that manual mode never auto-advances.

## Verification

- `npm test` — **1346 pass** (106 files). New: runner override + raised-default + real-fixture guard; store auto-advance guard; five trainer shell reachability tests.
- `npm run typecheck`, `npm run build` — green.

Refs #163. Live-tuning of all thresholds against a real face is still owed (#146 §8); this lands the maths and the controls, not the final per-camera numbers.

https://claude.ai/code/session_01X3jUdZKZNcW4QzuBrAEwpj
