### PR TITLE
fix: the Feature Lab's meters could not be turned off

### DIFF
--- a/src/app/ToolsBar.tsx
+++ b/src/app/ToolsBar.tsx
@@ -8,12 +8,20 @@
  * robot icon and the palette's hotkey-only affordance are exactly the two things a first
  * time player never discovers.
  *
- * Purely presentational: it reads {@link useTools} for which tool is open and toggles it.
- * Each tool's actual surface mounts itself in App and renders when it is the open one.
+ * It reads {@link useTools} for which tool is open and toggles it. Each tool's actual
+ * surface mounts itself in App and renders when it is the open one.
+ *
+ * It also owns the way OUT of a tool that {@link Tool.runsDetached}. A panel being shut
+ * is not the same as its tool being off: the Feature Lab's meters keep drawing over the
+ * video after you close the panel, and the checkbox that stops them lives *inside* the
+ * panel you just closed. So the bar shows a live dot while such a tool is running and
+ * puts a stop button next to it — the state and its undo in the one place a player
+ * already looks for "what else is here".
  */
-import { FlaskConical, Command, BookOpen, Hand, type LucideIcon } from 'lucide-react';
+import { FlaskConical, Command, BookOpen, Hand, X, type LucideIcon } from 'lucide-react';
 import { TOOLS, type Tool } from './tools';
 import { useTools } from './toolsStore';
+import { useControls } from './store';
 import VersionBadge from './VersionBadge';
 
 /** The icon per tool id. Kept here (not in `tools.ts`) so the registry stays React-free
@@ -29,7 +37,17 @@ const ICONS: Record<string, LucideIcon> = {
 const btnCls =
   'pointer-events-auto flex items-center gap-1.5 rounded-full border px-3 py-1 text-[10px] uppercase tracking-widest backdrop-blur transition';
 
-function ToolButton({ tool }: { tool: Tool }) {
+function ToolButton({
+  tool,
+  running = false,
+  onStop,
+}: {
+  tool: Tool;
+  /** The tool is DOING something right now, whether or not its panel is open. */
+  running?: boolean;
+  /** Stop it. Required (by {@link ToolsBar}) whenever `running` can be true. */
+  onStop?: () => void;
+}) {
   const open = useTools((s) => s.open);
   const toggleTool = useTools((s) => s.toggleTool);
   const Icon = ICONS[tool.id];
@@ -39,6 +57,15 @@ function ToolButton({ tool }: { tool: Tool }) {
     <>
       {Icon && <Icon className="h-3 w-3 shrink-0" aria-hidden />}
       <span>{tool.label}</span>
+      {/* A running tool reads as running even with its panel shut — otherwise the
+          meters over the video have no visible source. */}
+      {running && (
+        <span
+          data-running={tool.id}
+          title={`${tool.label} is running`}
+          className="ml-0.5 h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-400 shadow-[0_0_6px_rgba(52,211,153,0.9)]"
+        />
+      )}
       {tool.hotkey && (
         <kbd className="ml-0.5 rounded bg-white/10 px-1 py-px font-mono text-[9px] tracking-normal text-white/50">
           {tool.hotkey}
@@ -61,7 +88,7 @@ function ToolButton({ tool }: { tool: Tool }) {
     );
   }
 
-  return (
+  const toggle = (
     <button
       type="button"
       onClick={() => toggleTool(tool.id)}
@@ -69,7 +96,7 @@ function ToolButton({ tool }: { tool: Tool }) {
       data-tool={tool.id}
       aria-pressed={isOpen}
       className={`${btnCls} ${
-        isOpen
+        isOpen || running
           ? 'border-emerald-400/40 bg-emerald-500/20 text-emerald-200'
           : 'border-white/10 bg-black/40 text-white/60 hover:text-white'
       }`}
@@ -77,13 +104,46 @@ function ToolButton({ tool }: { tool: Tool }) {
       {content}
     </button>
   );
+
+  if (!running || !onStop) return toggle;
+
+  // A sibling rather than a nested button (nesting is invalid HTML), grouped tight so
+  // the two read as one control: the tool, and the way to stop it.
+  return (
+    <span className="flex items-center gap-px">
+      {toggle}
+      <button
+        type="button"
+        onClick={onStop}
+        data-stop-tool={tool.id}
+        title={`Stop ${tool.label} — turn the meters off`}
+        aria-label={`Stop ${tool.label}`}
+        className={`${btnCls} border-emerald-400/40 bg-emerald-500/20 px-2 text-emerald-200 hover:bg-emerald-500/30 hover:text-white`}
+      >
+        <X className="h-3 w-3 shrink-0" aria-hidden />
+      </button>
+    </span>
+  );
 }
 
 export default function ToolsBar() {
+  // The one detached-running signal there is today. Read here rather than inside
+  // ToolButton so the button stays presentational and `tools.ts` stays React-free:
+  // the registry declares THAT a tool can run detached, the shell knows what that
+  // means for each one.
+  const metersOn = useControls((s) => s.featureLab.show);
+  const setFeatureLab = useControls((s) => s.setFeatureLab);
+  const isRunning = (t: Tool) => t.runsDetached === true && t.id === 'lab' && metersOn;
+
   return (
     <div className="absolute bottom-3 left-3 z-40 flex max-w-[min(28rem,calc(100vw-1.5rem))] flex-wrap items-center gap-1.5">
       {TOOLS.map((t) => (
-        <ToolButton key={t.id} tool={t} />
+        <ToolButton
+          key={t.id}
+          tool={t}
+          running={isRunning(t)}
+          onStop={t.id === 'lab' ? () => setFeatureLab({ show: false }) : undefined}
+        />
       ))}
       {/* The deployed-commit badge rides the same meta strip (it used to be absolutely
           positioned into what is now the bar's space). */}

--- a/src/app/tools.ts
+++ b/src/app/tools.ts
@@ -44,6 +44,26 @@ export interface Tool {
   hotkey?: string;
   /** For `kind: 'link'` — the href. */
   href?: string;
+  /**
+   * True when the tool keeps **doing something visible after its panel is closed**.
+   * The Feature Lab is the only one: its meters go on drawing over the video, which
+   * is deliberate — you want to watch them while you play, with the panel out of the
+   * way.
+   *
+   * It is also how the Lab became un-closable. `#136` asked "can a player FIND this?"
+   * and answered it with this registry. Nobody asked the mirror question: once it is
+   * running, can a player find the way back OUT? For the Lab the answer was no. The
+   * off switch is a checkbox inside the panel, so closing the panel hid the only
+   * control that could undo what the panel had started; the state is persisted, so a
+   * reload brought the meters back; and the Lab is deliberately not a dial, so the
+   * command palette could not reach it either. The video ended up covered in bars
+   * with nothing on screen to explain them.
+   *
+   * So a tool that runs detached owes the bar a **stop** control, live whenever it is
+   * running — reachable with its panel shut, and with no memory of how it was
+   * started. `tools_shell.test.tsx` enforces that rather than trusting this comment.
+   */
+  runsDetached?: boolean;
 }
 
 export const TOOLS: readonly Tool[] = [
@@ -53,6 +73,7 @@ export const TOOLS: readonly Tool[] = [
     description:
       'Measure the raw face and hand features the instrument plays from — live, normalized meters.',
     kind: 'panel',
+    runsDetached: true,
   },
   {
     id: 'commands',

--- a/src/nodes/output/canvas_overlay.ts
+++ b/src/nodes/output/canvas_overlay.ts
@@ -1185,15 +1185,19 @@ const featureLabElement: OverlayElement = {
     g.fillText('Feature Lab', panelLeft + PAD, panelTop + 15);
     // ...and, when the panel is wide enough to hold it beside the title, where to
     // turn it off. Skipped on a one-column panel rather than overlapping the title.
+    //
+    // Left-aligned just after the title rather than right-aligned at the panel edge:
+    // the panel is right-anchored, so its outer edge is the first thing `object-cover`
+    // crops away on a window narrower than the camera's aspect ratio. Tucked against
+    // the title it survives that crop for as long as the title itself does. (The real
+    // control is the tools bar, which is DOM and never cropped — this is the signpost.)
     const titleW = 'Feature Lab'.length * LAB_TITLE_CHAR_W;
     if (titleW + LAB_HINT.length * LAB_HINT_CHAR_W + 3 * PAD <= panelW) {
       g.globalAlpha = 0.5;
       g.fillStyle = '#9ca3af';
       g.font = '10px monospace';
-      g.textAlign = 'right';
-      g.fillText(LAB_HINT, panelLeft + panelW - PAD, panelTop + 15);
+      g.fillText(LAB_HINT, panelLeft + PAD + titleW + PAD, panelTop + 15);
       g.globalAlpha = 1;
-      g.textAlign = 'left';
     }
 
     // Shown but nothing to measure (no face/hands, or the enabled groups are empty

--- a/src/nodes/output/canvas_overlay.ts
+++ b/src/nodes/output/canvas_overlay.ts
@@ -1066,6 +1066,20 @@ const LAB_HEADER_H = 16; // px per group header
 const LAB_TITLE_H = 22;
 const LAB_BAR_H = 6;
 const LAB_TOP = 68; // == CUE_TOP_INSET: clear the top-left brand / top-right panel
+/**
+ * The way out, drawn in the panel's own title row.
+ *
+ * The meters keep drawing after the Lab panel is closed — deliberate, you watch them
+ * while you play — which is exactly how this panel became something players could not
+ * get rid of: its off switch is a checkbox INSIDE the panel they had just shut, the
+ * config is persisted so a reload brings the bars back, and the Lab is not a dial so
+ * the command palette cannot reach it. The tools bar now carries the real control; this
+ * line says so, at the thing the player is actually looking at.
+ */
+const LAB_HINT = 'stop in the Tools bar';
+/** Approximate glyph widths (no measureText: the headless recording-canvas test). */
+const LAB_TITLE_CHAR_W = 7.6; // bold 13px monospace
+const LAB_HINT_CHAR_W = 6; // 10px monospace
 
 /** Terse meter label: the feature id with its group (or the `face.`/`hand.`
  *  prefix) stripped, so the group header carries the context. */
@@ -1169,6 +1183,18 @@ const featureLabElement: OverlayElement = {
     g.font = 'bold 13px monospace';
     g.textAlign = 'left';
     g.fillText('Feature Lab', panelLeft + PAD, panelTop + 15);
+    // ...and, when the panel is wide enough to hold it beside the title, where to
+    // turn it off. Skipped on a one-column panel rather than overlapping the title.
+    const titleW = 'Feature Lab'.length * LAB_TITLE_CHAR_W;
+    if (titleW + LAB_HINT.length * LAB_HINT_CHAR_W + 3 * PAD <= panelW) {
+      g.globalAlpha = 0.5;
+      g.fillStyle = '#9ca3af';
+      g.font = '10px monospace';
+      g.textAlign = 'right';
+      g.fillText(LAB_HINT, panelLeft + panelW - PAD, panelTop + 15);
+      g.globalAlpha = 1;
+      g.textAlign = 'left';
+    }
 
     // Shown but nothing to measure (no face/hands, or the enabled groups are empty
     // this frame): keep the panel + a hint so the lab doesn't read as "broken".

--- a/test/feature_lab_overlay.test.ts
+++ b/test/feature_lab_overlay.test.ts
@@ -33,6 +33,21 @@ describe('featureLab overlay element (#119)', () => {
     expect(parsed.featureLab.show).toBe(false);
   });
 
+  it('tells the player how to turn it off, in the panel they are looking at', () => {
+    // The meters keep drawing after the Lab panel is closed, and their off switch is
+    // inside that panel — which is how this became a panel players could not get rid
+    // of. The tools bar carries the real control (tools_shell.test.tsx); this line is
+    // the signpost to it, drawn at the thing covering their video.
+    const rc = runLab({ featureLab: { show: true, columns: 3, groups: ['face.blendshape.jaw'] } }, 40);
+    expect(rc.texts()).toContain('stop in the Tools bar');
+  });
+
+  it('drops the hint rather than overlapping the title on a one-column panel', () => {
+    const rc = runLab({ featureLab: { show: true, columns: 1, groups: ['face.blendshape.jaw'] } }, 40);
+    expect(rc.texts()).toContain('Feature Lab'); // still titled
+    expect(rc.texts()).not.toContain('stop in the Tools bar');
+  });
+
   it('draws a titled panel with grouped bars + labels once shown and warmed', () => {
     const rc = runLab({ featureLab: { show: true, groups: ['face.blendshape.jaw'] } }, 40);
     const texts = rc.texts();

--- a/test/tools_shell.test.tsx
+++ b/test/tools_shell.test.tsx
@@ -617,3 +617,97 @@ describe('the projection view (#163 §7-§8) is reachable and labels categories 
     expect(leftCat.centroid['face.head.yaw']).toBeCloseTo(mean, 5);
   });
 });
+
+// ---- the way back OUT of a tool that keeps running (#136's mirror image) ----
+//
+// The Feature Lab shipped findable and un-closable. "Start measuring" draws meters
+// over the video; the only switch that stops them is a checkbox INSIDE the panel, so
+// closing the panel hid the undo for what the panel had started. The config is
+// persisted, so a reload brought the bars back, and the Lab is deliberately not a dial,
+// so the command palette could not reach it either. The video ended up covered in bars
+// with nothing on screen to explain them or turn them off.
+//
+// These tests are written over the REGISTRY, not over the Lab: any tool that declares
+// `runsDetached` has to prove it can be stopped from the bar with its panel shut.
+
+/** Per detached tool: how to start it, and how to ask whether it is running. */
+const DETACHED: Record<string, { start: () => void; running: () => boolean }> = {
+  lab: {
+    start: () => useControls.getState().setFeatureLab({ show: true }),
+    running: () => useControls.getState().featureLab.show,
+  },
+};
+
+const detachedTools = TOOLS.filter((t) => t.runsDetached);
+
+describe('a tool that keeps running after its panel closes', () => {
+  it('declares at least one such tool, and each has a harness here', () => {
+    // If this fails you added `runsDetached` without teaching this file how to drive
+    // it — which would let the rest of the block silently cover nothing.
+    expect(detachedTools.length).toBeGreaterThan(0);
+    for (const t of detachedTools) {
+      expect(DETACHED[t.id], `no start/running harness for tool '${t.id}'`).toBeTruthy();
+    }
+  });
+
+  for (const tool of detachedTools) {
+    it(`${tool.id}: the bar offers a STOP control while it runs, with the panel closed`, () => {
+      act(() => DETACHED[tool.id].start());
+      useTools.setState({ open: null }); // the panel is shut — the reported situation
+      render(<ToolsBar />);
+
+      const stop = screen.getByLabelText(`Stop ${tool.label}`);
+      act(() => {
+        fireEvent.click(stop);
+      });
+      expect(DETACHED[tool.id].running()).toBe(false);
+    });
+
+    it(`${tool.id}: reads as RUNNING in the bar even with its panel closed`, () => {
+      act(() => DETACHED[tool.id].start());
+      useTools.setState({ open: null });
+      const { container } = render(<ToolsBar />);
+      // Otherwise what is drawn over the video has no visible source.
+      expect(container.querySelector(`[data-running="${tool.id}"]`)).toBeTruthy();
+    });
+
+    it(`${tool.id}: shows no stop control when it is not running`, () => {
+      const { container } = render(<ToolsBar />);
+      expect(DETACHED[tool.id].running()).toBe(false);
+      expect(screen.queryByLabelText(`Stop ${tool.label}`)).toBeNull();
+      expect(container.querySelector(`[data-running="${tool.id}"]`)).toBeNull();
+    });
+  }
+
+  it('the reported bug, end to end: start the meters, close the panel, still get out', () => {
+    render(
+      <>
+        <ToolsBar />
+        <LabPanel />
+      </>,
+    );
+
+    // Open the Lab and press its own call to action.
+    act(() => {
+      fireEvent.click(screen.getByText('Feature Lab').closest('button')!);
+    });
+    act(() => {
+      fireEvent.click(screen.getByText('Start measuring'));
+    });
+    expect(useControls.getState().featureLab.show).toBe(true);
+
+    // Close the panel the obvious way — its X. The meters keep drawing (deliberate:
+    // you watch them while you play), which is exactly where the player got stranded.
+    act(() => {
+      fireEvent.click(screen.getByLabelText('Close the Feature Lab'));
+    });
+    expect(useTools.getState().open).toBeNull();
+    expect(useControls.getState().featureLab.show).toBe(true);
+
+    // ...and the bar still offers the way out, without reopening anything.
+    act(() => {
+      fireEvent.click(screen.getByLabelText('Stop Feature Lab'));
+    });
+    expect(useControls.getState().featureLab.show).toBe(false);
+  });
+});


### PR DESCRIPTION
**Reported from the deployed app:** the Feature Lab bars cover the video and there's no visible way to close them.

Reproduced — and it's worse than a missing button. Four things line up:

- **"Start measuring"** sets `featureLab.show`, which draws the meters over the video.
- **The only switch that clears it is a checkbox *inside* the Lab panel** — so closing the panel hides the undo for what the panel just started.
- **`featureLab` is persisted**, so a reload brings the bars straight back.
- **The Lab is deliberately not a dial** (#136 — measuring must not dirty an instrument), so the command palette can't reach it either, and there's no keyboard shortcut.

Net effect: bars over the video, panel shut, the tools-bar button looking as inactive as every other one, ⌘K no help, and a refresh restoring them. Genuinely stuck unless you already knew the checkbox existed.

## Why it got here

This is **#136's mirror image**. That issue asked *"can a player FIND this?"* and answered it with the tools registry. Nobody asked whether a player could find the way back **out**. `overlayControls.ts` even says the quiet part:

> a descriptor proves an element is *controllable*, not that a player can *find* the control

## The fix

The meters and the panel stay **independent** — watching the meters with the panel out of the way is the point, and coupling them would delete a real workflow. What was missing is that the state was invisible and its undo was hidden.

- **`Tool.runsDetached`** marks a tool that keeps doing something visible after its panel closes. Such a tool owes the bar a stop control.
- **The tools bar shows a live dot** while the Lab is running — so what's drawn over the video has a visible source — and a **stop button beside it** that turns the meters off in one click, with the panel shut and no memory of how it was started.
- **The meters panel draws `stop in the Tools bar`** in its own title row, at the thing the player is actually looking at. Dropped rather than overlapped on a one-column panel; uses the codebase's approximate glyph widths, since the headless recording canvas has no `measureText`.

## Guarding it

Written over the **registry**, not over the Lab: any future `runsDetached` tool must prove it can be stopped from the bar with its panel closed, and a harness entry is *required* — otherwise the block would silently cover nothing. Plus the reported bug end to end: start the meters, close the panel with its X, and still get out from the bar.

**8-mutant harness, 8/8 caught** — including one that restores the original bug exactly.

`npm run typecheck` clean, `npm test` 1353 passed, `npm run build` green.

## Workaround until this ships

Tools bar → **Feature Lab** → untick *"Show the meters over the video"*.
