### PR TITLE
#160/#163/#146: a trainer take becomes a committed fixture — and stops recording the face mesh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,7 +245,8 @@ So, when you add a user-facing capability:
 | **Trainer** (#160/#163) — learn a player's OWN categories. Pure core over `FeatureVector` (never a face type): `cue.ts` (Zod cues/routines), `noise.ts` (every distance in multiples of a feature's own jitter), `sampler.ts`, `sufficiency.ts` (the `SufficiencyEvaluator` seam), `runner.ts`, `session.ts`, `cluster.ts`, `classify.ts`. Host glue: starter face cues + the two zodal collections + the store | `src/enroll/`, `src/app/enroll/` (`starterCues.ts`, `cueStore.ts`, `store.ts`), `src/app/TrainerPanel.tsx` |
 | **Feature demand** (#163) — a non-Lab consumer claims feature GROUPS; the vector nodes (and the face-model gate) compute them with the Lab closed | `src/features/demand.ts`, `src/app/featureDemand.ts` |
 | Legacy app (**frozen**) | `src/App.tsx`, `src/components/`, `src/hooks/`, `src/plugins/ai-dj/` |
-| Fixtures + replay | `test/fixtures/`, `scripts/record_stream.ts`, `src/dag/recorder.ts` |
+| Fixtures + replay | `test/fixtures/`, `scripts/record_stream.ts`, `src/dag/recorder.ts`, `test/helpers/fixtures.ts` (the one loader) |
+| **Trainer take → fixture** — the cue interval is the ground truth a clip cannot supply; refuses landmark geometry | `scripts/trainer_take_to_fixture.ts`, `docs/TESTING.md` |
 | Conceptual model | `docs/design/component-model.md` |
 
 ## Roadmap & tracking

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,7 +246,7 @@ So, when you add a user-facing capability:
 | **Feature demand** (#163) — a non-Lab consumer claims feature GROUPS; the vector nodes (and the face-model gate) compute them with the Lab closed | `src/features/demand.ts`, `src/app/featureDemand.ts` |
 | Legacy app (**frozen**) | `src/App.tsx`, `src/components/`, `src/hooks/`, `src/plugins/ai-dj/` |
 | Fixtures + replay | `test/fixtures/`, `scripts/record_stream.ts`, `src/dag/recorder.ts`, `test/helpers/fixtures.ts` (the one loader) |
-| **Trainer take → fixture** — the cue interval is the ground truth a clip cannot supply; refuses landmark geometry | `scripts/trainer_take_to_fixture.ts`, `docs/TESTING.md` |
+| **Trainer take → fixture** — the cue interval is the ground truth a clip cannot supply; refuses landmark geometry | `scripts/lib_trainer_take.ts` (logic) + `scripts/trainer_take_to_fixture.ts` (CLI), `docs/TESTING.md` |
 | Conceptual model | `docs/design/component-model.md` |
 
 ## Roadmap & tracking

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -131,12 +131,24 @@ inside a cue, and writes `test/fixtures/<scenario>/` with the per-edge streams, 
 
 Two behaviours worth knowing:
 
-- **It refuses a take carrying landmark or keypoint geometry** rather than trimming it.
-  A 478-point face mesh is facial geometry in a way blendshape coefficients and a pose
-  triple are not, and a converter that silently drops a field is one nobody checks.
-  `trainerTakeSession` also pins `featureEdges` so the mesh never reaches the take —
+- **It refuses a take carrying a point cloud** — a face mesh or a hand keypoint list —
+  rather than trimming it, because a converter that silently drops a field is one nobody
+  checks. `trainerTakeSession` also pins `featureEdges` so neither reaches the take:
   before that pin the field was always empty, and **empty means every edge**, so takes
-  were recording `camFace.face` and its full mesh.
+  were recording `camFace.face` and its full 478-point mesh.
+
+  Be precise about the claim: it excludes *shape*, not every landmark-derived number.
+  Four catalog features are single-point **positions** — `face.head.x`/`face.head.y` are
+  the nose tip's normalized coordinates, `palm.x`/`palm.y` the palm centroid. Those locate
+  a face in a frame; they do not describe one, and they are the same class of thing as the
+  head-pose matrix translation the committed `video_head_pose` fixture already carries. If
+  that ever stops being acceptable, the fix is a feature-id denylist, not a change to the
+  array check.
+
+- **It refuses to overwrite an existing fixture** without `--force`. Every committed
+  fixture name matches the scenario regex, so `video_head_pose` is a reachable typo — and
+  its ground-truth table was established by reading traces against video frames, so it is
+  not regenerable.
 - **A cue the take stopped during extends to the end of the recording**, not to a point.
   `resolveIntervals` returns `end === start` for an unclosed open unless told when
   recording stopped; taking that literally would discard every sample of the one cue an

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -97,9 +97,50 @@ test/fixtures/<scenario>/
 ```
 
 Each NDJSON line is one `StreamRecord`: `{"tick":N,"t":seconds,"value":...}`.
-`meta.json`'s `graphSpecHash` is the **staleness key**: if a node's params or
-the upstream graph change, the hash mismatches and the fixture is flagged for
-re-recording rather than letting a stale stream silently pass.
+A large stream may be committed gzipped (`<key>.ndjson.gz`); `loadStream` in
+`test/helpers/fixtures.ts` decompresses transparently, so tests always address a
+stream by its logical key and never see the envelope.
+
+> **`meta.json` is written, never read.** This section used to claim
+> `graphSpecHash` was "the staleness key… the fixture is flagged for re-recording
+> rather than letting a stale stream silently pass". **Nothing enforces that.**
+> Two scripts emit `meta.json` and no code in `test/` or `src/` opens it — and the
+> two face fixtures ship without one at all. Treat it as provenance for a human
+> reading the directory, which is genuinely useful, and not as a guard. Making it
+> a real staleness key would mean a test that loads it and compares, which does
+> not exist.
+
+## Fixtures from a trainer take
+
+A recorded training take is the cheapest ground truth this repo can produce, because
+the cue states what the player was *asked* to do in their own words. That is the frame
+of reference a video clip cannot supply: `test/fixtures/video_head_pose/README.md`
+records why yaw and roll stayed open after #161 — nothing in a file says whether the
+recording was mirrored, so "the person turned to *their* left" is unrecoverable from
+the pixels.
+
+```bash
+# unzip the take first: a 'downloads' take is a .zip
+npx vite-node scripts/trainer_take_to_fixture.ts -- <take-dir> <scenario> [--dry-run]
+```
+
+It resolves the cue intervals through taglog's own `resolveIntervals` (the same one the
+Audacity/WebVTT/CSV exporters use, so the boundaries agree), keeps only the records
+inside a cue, and writes `test/fixtures/<scenario>/` with the per-edge streams, a
+`cues.json` index, `meta.json` and a generated `README.md`.
+
+Two behaviours worth knowing:
+
+- **It refuses a take carrying landmark or keypoint geometry** rather than trimming it.
+  A 478-point face mesh is facial geometry in a way blendshape coefficients and a pose
+  triple are not, and a converter that silently drops a field is one nobody checks.
+  `trainerTakeSession` also pins `featureEdges` so the mesh never reaches the take —
+  before that pin the field was always empty, and **empty means every edge**, so takes
+  were recording `camFace.face` and its full mesh.
+- **A cue the take stopped during extends to the end of the recording**, not to a point.
+  `resolveIntervals` returns `end === start` for an unclosed open unless told when
+  recording stopped; taking that literally would discard every sample of the one cue an
+  abandoned take still has.
 
 ## Recording fixtures
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -29,7 +29,7 @@ Tiers 1–3 are the CI gate: `npm test` (vitest, Node env, no camera/GPU/audio).
 
 ```bash
 npm run typecheck   # strict DAG typecheck (tsconfig.dag.json)
-npm test            # vitest — 87+ test files
+npm test            # vitest — 108 test files, 1384 tests
 npm run build       # vite build (this is what verifies the React layer)
 npm run catalog     # regenerate docs/CATALOG.md + public/manual.html + public/catalog.json
 ```
@@ -63,7 +63,7 @@ verdict on the PR, before merge.
 
 ## The test families
 
-The suite grew from ~33 files to 75+ across the 2026-06/07 tracks. Roughly:
+The suite grew from ~33 files to 108 across the 2026-06 → 2026-09 tracks. Roughly:
 
 | Family | Files | Covers |
 |--------|-------|--------|
@@ -104,7 +104,8 @@ stream by its logical key and never see the envelope.
 > **`meta.json` is written, never read.** This section used to claim
 > `graphSpecHash` was "the staleness key… the fixture is flagged for re-recording
 > rather than letting a stale stream silently pass". **Nothing enforces that.**
-> Two scripts emit `meta.json` and no code in `test/` or `src/` opens it — and the
+> Three scripts emit `meta.json` (`record_stream.ts`, `build_video_fixture.ts` and the
+> trainer-take converter) and no code in `test/` or `src/` opens it — and the
 > two face fixtures ship without one at all. Treat it as provenance for a human
 > reading the directory, which is genuinely useful, and not as a guard. Making it
 > a real staleness key would mean a test that loads it and compares, which does
@@ -131,19 +132,22 @@ inside a cue, and writes `test/fixtures/<scenario>/` with the per-edge streams, 
 
 Two behaviours worth knowing:
 
-- **It refuses a take carrying a point cloud** — a face mesh or a hand keypoint list —
-  rather than trimming it, because a converter that silently drops a field is one nobody
-  checks. `trainerTakeSession` also pins `featureEdges` so neither reaches the take:
-  before that pin the field was always empty, and **empty means every edge**, so takes
-  were recording `camFace.face` and its full 478-point mesh.
+- **No image-space geometry reaches a fixture**, by two mechanisms, because they are two
+  different problems:
+  - A face mesh or hand keypoint **array** makes it reject the take outright rather than
+    trim it — a converter that silently drops a field is one nobody checks.
+    `trainerTakeSession` also pins `featureEdges` so neither reaches the take: before that
+    pin the field was always empty, and **empty means every edge**, so takes were
+    recording `camFace.face` and its full 478-point mesh.
+  - Individual landmark **coordinates flattened into the vector as scalars** are invisible
+    to any check on a container's shape, so they are stripped by feature id and the removal
+    is **reported** in `meta.json` and the generated README. `face.head.x`/`face.head.y`
+    are the nose tip's normalized coordinates — over a take, a nose trajectory.
 
-  Be precise about the claim: it excludes *shape*, not every landmark-derived number.
-  Four catalog features are single-point **positions** — `face.head.x`/`face.head.y` are
-  the nose tip's normalized coordinates, `palm.x`/`palm.y` the palm centroid. Those locate
-  a face in a frame; they do not describe one, and they are the same class of thing as the
-  head-pose matrix translation the committed `video_head_pose` fixture already carries. If
-  that ever stops being acceptable, the fix is a feature-id denylist, not a change to the
-  array check.
+  Stripping costs nothing: `FACE_OMIT` (`src/app/enroll/starterCues.ts`) is the trainer's
+  own declaration that the learner does not use those features. They are recorded only
+  because `routineGroups` unions a routine's demanded groups without applying each cue's
+  `omit`, so the engine computes a superset of what the learner consumes.
 
 - **It refuses to overwrite an existing fixture** without `--force`. Every committed
   fixture name matches the scenario regex, so `video_head_pose` is a reachable typo — and

--- a/scripts/lib_trainer_take.ts
+++ b/scripts/lib_trainer_take.ts
@@ -1,0 +1,521 @@
+/**
+ * Turn a recorded trainer take into a committed replay fixture (#160 / #163 / #146) —
+ * the library half, with no side effects.
+ *
+ * A training take is the cheapest ground truth this repo can produce. The trainer asks
+ * the player, in the player's own words, to do one thing ("look to your left"), records
+ * the clean camera, the feature vectors and a cue interval per instruction — all on one
+ * clock. That last part is what no video clip can supply: `test/fixtures/video_head_pose`
+ * settled pitch, smile and brow but had to leave **yaw and roll open**, because a file's
+ * own metadata cannot say whether the recording was mirrored, so "the person turned to
+ * *their* left" is unrecoverable from the pixels. A cue asks for it directly.
+ *
+ * This script is the join. It reads a take folder, resolves the cue intervals through
+ * taglog's own {@link resolveIntervals} (not a private re-implementation), slices each
+ * recorded edge to the ticks that fall inside a cue, and writes a fixture directory that
+ * `test/helpers/fixtures.ts` can load unchanged.
+ *
+ * ## Three things it refuses to do
+ *
+ * 1. **Emit a face MESH or a hand keypoint list.** Any value carrying a `landmarks` or
+ *    `keypoints` array is rejected outright rather than trimmed, because a converter that
+ *    silently drops a field is a converter nobody checks. `trainerTakeSession` also pins
+ *    `featureEdges` so the mesh never reaches the take in the first place; this is the
+ *    second line of defence, and the one that guards what enters the repo.
+ *
+ *    **Be precise about what this does and does not claim.** It excludes *point clouds* —
+ *    the 478-point mesh and the 21-point hand keypoint list, which are shape and do
+ *    reconstruct a face. It does **not** claim the emitted vectors are free of every
+ *    landmark-derived number: four catalog features are positions computed from a single
+ *    point — `face.head.x` / `face.head.y` are the nose tip's normalized image coordinates
+ *    (`src/features/face_catalog.ts`), and `palm.x` / `palm.y` are the palm centroid. Two
+ *    coordinates of one point are the same class of thing as the head-pose matrix's
+ *    translation, which the committed `video_head_pose` fixture already carries by
+ *    deliberate decision. They locate a face in a frame; they do not describe it.
+ *    If that distinction ever stops being acceptable, the fix is a feature-id denylist
+ *    here, not a change to the array check.
+ * 2. **Write outside `test/fixtures/`.** The output name is a bare scenario name, not a
+ *    path.
+ * 3. **Invent a clock.** Every emitted record keeps the take's own `tick` and `t`, so the
+ *    streams stay mutually aligned and joinable back to the source take.
+ *
+ * **Pure: importing this never runs anything.** The CLI is
+ * `scripts/trainer_take_to_fixture.ts`, which is the only caller that touches `process`
+ * — the same lib/CLI split `lib_audio.ts` and `render_audio.ts` already use here, and
+ * the reason it matters is in that CLI's header.
+ */
+import { readdirSync, readFileSync, existsSync, mkdirSync, writeFileSync, rmSync, statSync } from 'node:fs';
+import { join, basename } from 'node:path';
+import { gzipSync } from 'node:zlib';
+import { resolveIntervals } from '@/taglog/affordances/resolve';
+import type { EdgeEvent, ResolvedInterval, TagKind, TagStatus } from '@/taglog/affordances/schema';
+import { FACE_OMIT } from '@/app/enroll/starterCues';
+import { ALL_FEATURES } from '@/features/catalog';
+
+/** Gzip anything at or above this many bytes, mirroring the existing committed fixtures. */
+const GZIP_THRESHOLD_BYTES = 200_000;
+
+/**
+ * The one feature GROUP whose values are raw image-space point coordinates. Sourced from
+ * the catalog rather than restated, so a feature added to it is stripped automatically.
+ */
+const RAW_POSITION_GROUP = 'hand.position.raw';
+
+/**
+ * Feature ids that are raw image-space coordinates flattened into the vector as scalars.
+ *
+ * These are the reason the array check is not sufficient on its own: the point cloud is
+ * excluded, but a handful of *individual* landmark coordinates survive as plain numbers,
+ * and no check on a container's shape can see them. `face.head.x` / `face.head.y` are the
+ * nose tip's normalized coordinates; over a take they are a frame-by-frame nose
+ * trajectory.
+ *
+ * Stripping them costs the fixture nothing, which is what makes this the right call
+ * rather than a trade-off: `FACE_OMIT` is the trainer's own declaration that the learner
+ * does not use them. They are recorded only because `routineGroups` unions a cue's
+ * `groups` without applying its `omit` (`src/enroll/cue.ts`), so the engine computes a
+ * superset of what the learner consumes. The fixture should carry what the learner used.
+ */
+function rawPositionIds(): Set<string> {
+  const ids = new Set<string>(FACE_OMIT);
+  for (const f of ALL_FEATURES) if (f.group === RAW_POSITION_GROUP) ids.add(f.id);
+  return ids;
+}
+
+/**
+ * Refuse a features file bigger than this rather than hit Node's ~512 MiB string cap
+ * with an opaque `ERR_STRING_TOO_LONG`. A take with the edges pinned is a few MB for a
+ * multi-minute routine; anything near this is a pre-pin take carrying the face mesh.
+ */
+const MAX_FEATURES_BYTES = 256 * 1024 * 1024;
+
+/** One line of `features.jsonl`, as written by `FeatureJsonlTap`. */
+interface FeatureLine {
+  tick: number;
+  t: number;
+  key: string;
+  value: unknown;
+}
+
+/** One emitted fixture line — the `StreamRecord` shape `valuesFromNDJSON` reads. */
+interface StreamRecordOut {
+  tick: number;
+  t: number;
+  value: unknown;
+}
+
+/** The take's annotation anchor (first line of `annotations.jsonl`). */
+interface Anchor {
+  anchor: true;
+  t: number;
+  session: string;
+  schema: string;
+  wallClockISO: string;
+}
+
+export interface CueWindow {
+  /** The cue id, with taglog's `cue:` prefix stripped. */
+  cue: string;
+  /** Interval start/end as offsets into the take, seconds (`t - t0`). */
+  start: number;
+  end: number;
+  /** Absolute engine-clock times, as recorded. */
+  startAbs: number;
+  endAbs: number;
+  /** True if the take ended before the cue closed. */
+  openEnded: boolean;
+}
+
+export interface ConvertResult {
+  scenario: string;
+  stem: string;
+  t0: number;
+  cues: CueWindow[];
+  /** Per-edge: how many records survived the cue slice, out of how many were recorded. */
+  streams: { key: string; kept: number; total: number; bytes: number; gzipped: boolean }[];
+  verdicts: { cue: string; outcome: string; t: number }[];
+  /** Raw image-space coordinate ids removed, and from how many records. */
+  strippedRawPositions: { id: string; records: number }[];
+}
+
+/** A JSONL parse that reports the line number, because a truncated take is a real case. */
+function* parseJsonl<T>(text: string, what: string): Generator<T> {
+  let n = 0;
+  for (const line of text.split('\n')) {
+    n++;
+    const s = line.trim();
+    if (!s) continue;
+    try {
+      yield JSON.parse(s) as T;
+    } catch (err) {
+      throw new Error(`${what}: line ${n} is not JSON (${err instanceof Error ? err.message : String(err)})`);
+    }
+  }
+}
+
+/**
+ * The one thing that must never pass. Recursively true if `v` carries a `landmarks`
+ * array — the 478-point face mesh, or a hand's 21-point keypoint list under that name.
+ * Deliberately a *detector*, not a stripper: see the module docstring.
+ */
+export function carriesLandmarks(v: unknown): boolean {
+  if (Array.isArray(v)) return v.some(carriesLandmarks);
+  if (v && typeof v === 'object') {
+    const o = v as Record<string, unknown>;
+    if (Array.isArray(o.landmarks) || Array.isArray(o.keypoints)) return true;
+    return Object.values(o).some(carriesLandmarks);
+  }
+  return false;
+}
+
+/**
+ * Remove raw image-space coordinates from one recorded value, returning the cleaned value
+ * and which ids were removed. A non-object value passes through untouched.
+ */
+export function stripRawPositions(
+  value: unknown,
+  rawIds: ReadonlySet<string>,
+): { value: unknown; stripped: string[] } {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return { value, stripped: [] };
+  const obj = value as Record<string, unknown>;
+  const hits = Object.keys(obj).filter((k) => rawIds.has(k));
+  if (hits.length === 0) return { value, stripped: [] };
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) if (!rawIds.has(k)) out[k] = v;
+  return { value: out, stripped: hits };
+}
+
+/** Find the take's stem from the files present, so the caller need not repeat it. */
+export function findStem(dir: string): string {
+  const feats = readdirSync(dir).filter((n) => n.endsWith('.features.jsonl')).sort();
+  if (feats.length === 0) {
+    throw new Error(
+      `${dir}: no *.features.jsonl. Is this an unzipped take folder? A 'downloads' take is a .zip — unzip it first.`,
+    );
+  }
+  if (feats.length > 1) {
+    // Downloads is where takes accumulate and the instruction here is "unzip it first",
+    // so two takes in one folder is an ordinary mistake. `readdirSync` order is not
+    // specified, so picking the first would convert an arbitrary one and say nothing.
+    throw new Error(
+      `${dir}: ${feats.length} takes found (${feats.map((f) => basename(f, '.features.jsonl')).join(', ')}). ` +
+        `Point this at one take folder, not a directory holding several.`,
+    );
+  }
+  return basename(feats[0], '.features.jsonl');
+}
+
+/**
+ * Turn the take's annotation rows into taglog {@link EdgeEvent}s so
+ * {@link resolveIntervals} can pair opens with closes. The rows already carry every
+ * field an EdgeEvent needs except `kind`, which the tag id determines: the trainer
+ * writes intervals as `cue:<id>` and everything else as points (`annotations.ts`).
+ */
+export function edgeEventsFromRows(rows: readonly Record<string, unknown>[]): EdgeEvent[] {
+  return rows.map((r) => {
+    const tag = String(r.tag);
+    const status = String(r.status) as TagStatus;
+    const kind: TagKind = tag.startsWith('cue:') ? 'interval' : 'point';
+    return {
+      tag,
+      kind,
+      status,
+      t: Number(r.t),
+      tCorrected: Number(r.tCorrected ?? r.t),
+      seq: Number(r.seq),
+      clock: (r.clock ?? 'media') as EdgeEvent['clock'],
+      src: (r.src ?? 'auto') as EdgeEvent['src'],
+    };
+  });
+}
+
+/**
+ * Cue windows from resolved intervals, take-relative.
+ *
+ * **An open-ended cue extends to `Infinity`, not to its own start.** `resolveIntervals`
+ * gives an unclosed open `end === start` when it is not told when the recording stopped
+ * (`options.endT`) — a zero-length interval. Taking that literally would silently discard
+ * every sample of the cue the take stopped during, which is the one cue whose data a
+ * crashed or abandoned take still has. Semantically the cue *was still running* when the
+ * recording ended, so every later record belongs to it. {@link sealOpenEnded} then
+ * replaces the sentinel with the last time actually observed, so `cues.json` reports a
+ * real number rather than `null`.
+ */
+export function cueWindows(intervals: readonly ResolvedInterval[], t0: number): CueWindow[] {
+  return intervals
+    .filter((iv) => iv.kind === 'interval' && iv.tag.startsWith('cue:'))
+    .map((iv) => ({
+      cue: iv.tag.slice('cue:'.length),
+      start: iv.start - t0,
+      end: iv.openEnded ? Infinity : iv.end - t0,
+      startAbs: iv.start,
+      endAbs: iv.openEnded ? Infinity : iv.end,
+      openEnded: iv.openEnded,
+    }))
+    .sort((a, b) => a.start - b.start);
+}
+
+/**
+ * Replace the `Infinity` end of any open-ended window with the last record time actually
+ * seen, so the emitted index carries a real duration. Mutates in place, after the pass.
+ */
+export function sealOpenEnded(windows: CueWindow[], lastT: number, t0: number): void {
+  for (const w of windows) {
+    if (!Number.isFinite(w.endAbs)) {
+      w.endAbs = Math.max(lastT, w.startAbs);
+      w.end = w.endAbs - t0;
+    }
+  }
+}
+
+/** True if an absolute time falls inside any cue window (inclusive of both ends). */
+export function insideAnyCue(tAbs: number, windows: readonly CueWindow[]): boolean {
+  return windows.some((w) => tAbs >= w.startAbs && tAbs <= w.endAbs);
+}
+
+export interface ConvertOptions {
+  /** Write nothing; just report what would be written. */
+  dryRun?: boolean;
+  /** Replace an existing fixture directory. Off by default — see the overwrite guard. */
+  force?: boolean;
+  /** Where `test/fixtures` lives (injected so tests can point at a temp dir). */
+  fixturesRoot: string;
+}
+
+/**
+ * Convert one take folder into one fixture directory. Pure enough to unit-test: the only
+ * side effects are the writes, and `dryRun` removes those.
+ */
+export function convertTake(takeDir: string, scenario: string, opts: ConvertOptions): ConvertResult {
+  if (!/^[a-z0-9_]+$/.test(scenario)) {
+    throw new Error(`scenario "${scenario}" must be lowercase letters, digits and underscores — it becomes a directory name`);
+  }
+  const stem = findStem(takeDir);
+
+  const annPath = join(takeDir, `${stem}.annotations.jsonl`);
+  if (!existsSync(annPath)) {
+    throw new Error(
+      `${annPath} is missing. A take without annotations carries no cue intervals, and the cue intervals are the entire point of this conversion.`,
+    );
+  }
+  const annRows = [...parseJsonl<Record<string, unknown>>(readFileSync(annPath, 'utf8'), annPath)];
+  const anchor = annRows[0] as unknown as Anchor;
+  if (!anchor || anchor.anchor !== true || typeof anchor.t !== 'number') {
+    throw new Error(`${annPath}: first line must be the anchor record carrying t0`);
+  }
+  const t0 = anchor.t;
+
+  const events = edgeEventsFromRows(annRows.slice(1));
+  const windows = cueWindows(resolveIntervals(events), t0);
+  if (windows.length === 0) {
+    throw new Error(`${annPath}: no cue intervals resolved — nothing to slice by`);
+  }
+  const verdicts = events
+    .filter((e) => e.status === 'point' && e.tag.startsWith('verdict:'))
+    .map((e) => {
+      const w = windows.filter((x) => e.t >= x.startAbs && e.t <= x.endAbs).pop();
+      return { cue: w?.cue ?? '(outside any cue)', outcome: e.tag.slice('verdict:'.length), t: e.t - t0 };
+    });
+
+  // Group the feature stream by edge key, keeping only ticks inside a cue.
+  const featPath = join(takeDir, `${stem}.features.jsonl`);
+  if (!existsSync(featPath)) throw new Error(`${featPath} is missing`);
+  // The file is read whole, so it is bounded by Node's maximum string length
+  // (~512 MiB of chars). That limit is not theoretical here: it is reached by exactly
+  // the takes the landmark guard exists for. Every take recorded before `featureEdges`
+  // was pinned used the empty default, which `FeatureJsonlTap` reads as "record every
+  // edge" — including `camFace.face` and its 478 mesh points on every tick, ~36 KB per
+  // line. Such a take blows the string limit long before the guard can look at it, and
+  // `ERR_STRING_TOO_LONG` names neither the cause nor the fix. So check the size first
+  // and say the thing the guard would have said.
+  const featBytes = statSync(featPath).size;
+  if (featBytes > MAX_FEATURES_BYTES) {
+    throw new Error(
+      `${featPath} is ${(featBytes / 1024 / 1024).toFixed(0)} MB, past what this converter reads in one pass. ` +
+        `A take that large was almost certainly recorded before \`trainerTakeSession\` pinned \`featureEdges\`: ` +
+        `the empty default records EVERY edge, including the 478-point face mesh on \`camFace.face\`. ` +
+        `Re-record on a current build (a pinned take is a few MB), or pre-filter the file to the two vector edges.`,
+    );
+  }
+  const byKey = new Map<string, StreamRecordOut[]>();
+  const totals = new Map<string, number>();
+  const rawIds = rawPositionIds();
+  /** Which raw-position ids were removed, and from how many records — REPORTED, never
+   *  silent. Dropping a field without saying so is the failure this converter's whole
+   *  refuse-rather-than-trim posture exists to avoid. */
+  const strippedIds = new Map<string, number>();
+  let lastT = t0;
+  for (const line of parseJsonl<FeatureLine>(readFileSync(featPath, 'utf8'), featPath)) {
+    totals.set(line.key, (totals.get(line.key) ?? 0) + 1);
+    if (line.t > lastT) lastT = line.t;
+    if (carriesLandmarks(line.value)) {
+      throw new Error(
+        `${featPath}: edge "${line.key}" carries a landmarks/keypoints array. Face-mesh and hand-keypoint geometry must not enter a committed fixture. ` +
+          `Re-record the take on a build where trainerTakeSession pins featureEdges (it records only the derived feature vectors), or drop the edge before converting.`,
+      );
+    }
+    if (!insideAnyCue(line.t, windows)) continue;
+    const { value, stripped } = stripRawPositions(line.value, rawIds);
+    for (const id of stripped) strippedIds.set(id, (strippedIds.get(id) ?? 0) + 1);
+    const arr = byKey.get(line.key) ?? [];
+    arr.push({ tick: line.tick, t: line.t, value });
+    byKey.set(line.key, arr);
+  }
+  if (byKey.size === 0) {
+    throw new Error(`${featPath}: no feature records fell inside a cue interval — check that the take and its annotations share a clock`);
+  }
+  sealOpenEnded(windows, lastT, t0);
+
+  const outDir = join(opts.fixturesRoot, scenario);
+  if (!opts.dryRun && !opts.force && existsSync(outDir)) {
+    // Every committed fixture name matches the scenario regex, so a typo — or reusing the
+    // name of the fixture this take was meant to supersede — silently clobbered a
+    // hand-written README and its ground-truth table, which is the irreplaceable part.
+    throw new Error(
+      `${outDir} already exists. Converting would overwrite its streams and its README ` +
+        `(the ground-truth table is hand-written and not regenerable). Choose another scenario name, ` +
+        `or pass --force if replacing it is what you mean.`,
+    );
+  }
+  if (!opts.dryRun) {
+    mkdirSync(outDir, { recursive: true });
+    // Clear every previous stream before writing. The narrow case is the gzip threshold
+    // flipping (loadStream tries `.ndjson` before `.ndjson.gz`, so a stale plain file
+    // wins over a fresh compressed one) — but the general case is worse: a re-record
+    // that produces FEWER keys (no hands in frame, so `handVec.vector` is never emitted)
+    // would leave the old key's file behind, and the directory would then report the new
+    // counts in meta.json while serving one stream from the previous take.
+    for (const f of readdirSync(outDir)) {
+      if (f.endsWith('.ndjson') || f.endsWith('.ndjson.gz')) rmSync(join(outDir, f), { force: true });
+    }
+  }
+
+  const streams: ConvertResult['streams'] = [];
+  for (const [key, records] of [...byKey].sort(([a], [b]) => a.localeCompare(b))) {
+    // Compact + stable key order, matching the committed `face.pose.ndjson.gz` serializer.
+    const text = records.map((r) => JSON.stringify(r)).join('\n') + '\n';
+    const raw = Buffer.from(text, 'utf8');
+    const gzipped = raw.byteLength >= GZIP_THRESHOLD_BYTES;
+    // Node's gzipSync writes a zero MTIME in the gzip header and is byte-reproducible
+    // across runs and machines (verified), which is what lets the committed .gz be
+    // diffed and re-generated without spurious churn. The Python-generated fixtures
+    // pass `mtime=0` explicitly for the same reason.
+    const bytes = gzipped ? gzipSync(raw) : raw;
+    if (!opts.dryRun) {
+      writeFileSync(join(outDir, `${key}.ndjson${gzipped ? '.gz' : ''}`), bytes);
+    }
+    streams.push({ key, kept: records.length, total: totals.get(key) ?? 0, bytes: bytes.byteLength, gzipped });
+  }
+
+  const result: ConvertResult = {
+    scenario, stem, t0, cues: windows, streams, verdicts,
+    strippedRawPositions: [...strippedIds].map(([id, records]) => ({ id, records })).sort((a, b) => a.id.localeCompare(b.id)),
+  };
+  if (!opts.dryRun) {
+    writeFileSync(join(outDir, 'cues.json'), JSON.stringify({ t0, cues: windows, verdicts }, null, 2) + '\n');
+    writeFileSync(join(outDir, 'meta.json'), JSON.stringify(metaFor(result, takeDir), null, 2) + '\n');
+    writeFileSync(join(outDir, 'README.md'), readmeFor(result));
+  }
+  return result;
+}
+
+/** Provenance, in the shape the other fixtures use. Never carries a local path. */
+function metaFor(r: ConvertResult, takeDir: string): Record<string, unknown> {
+  const manifestPath = join(takeDir, `${r.stem}.manifest.json`);
+  let manifest: Record<string, unknown> | null = null;
+  if (existsSync(manifestPath)) {
+    try {
+      manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as Record<string, unknown>;
+    } catch {
+      manifest = null;
+    }
+  }
+  return {
+    scenario: r.scenario,
+    source: 'trainer-take',
+    // The stem is a timestamp, not a path — safe to commit, and it is the only way to
+    // correlate a fixture back to the take it came from.
+    takeStem: r.stem,
+    t0: r.t0,
+    cues: r.cues.map((c) => c.cue),
+    recordedKeys: r.streams.map((s) => s.key),
+    strippedRawPositions: r.strippedRawPositions,
+    frames: Object.fromEntries(r.streams.map((s) => [s.key, s.kept])),
+    fps: (manifest?.fps as number | undefined) ?? null,
+    converterVersion: 1,
+  };
+}
+
+/** A provenance README, following `test/fixtures/video_head_pose/README.md`. */
+function readmeFor(r: ConvertResult): string {
+  const rows = r.cues
+    .map((c) => {
+      const v = r.verdicts.find((x) => x.cue === c.cue);
+      return `| \`${c.cue}\` | ${c.start.toFixed(2)} – ${c.end.toFixed(2)} s | ${(c.end - c.start).toFixed(2)} s | ${v ? v.outcome : '—'}${c.openEnded ? ' (open-ended)' : ''} |`;
+    })
+    .join('\n');
+  const streamRows = r.streams
+    .map((s) => `| \`${s.key}\` | ${s.kept} / ${s.total} | ${(s.bytes / 1024).toFixed(1)} KB${s.gzipped ? ' (gz)' : ''} |`)
+    .join('\n');
+  return `# \`${r.scenario}\` — a trainer take, sliced by cue
+
+Generated by \`scripts/trainer_take_to_fixture.ts\` from a recorded training take.
+**Do not hand-edit** — re-run the converter instead.
+
+## Why a trainer take and not a clip
+
+The cue is the ground truth. \`test/fixtures/video_head_pose/README.md\` records why yaw
+and roll stayed open after #161: a clip's metadata cannot say whether it was mirrored, so
+"the person turned to *their* left" is unrecoverable from the file. A cue asks the player
+for that directly, in their own frame of reference, and the interval says exactly when
+they did it.
+
+## What is in here
+
+Each \`<nodeId>.<port>.ndjson[.gz]\` is a \`StreamRecord\` stream — \`{tick, t, value}\`
+per line, loadable with \`loadStream('${r.scenario}', '<nodeId>.<port>')\`. Only records
+whose \`t\` falls inside a cue interval are kept; the dead time between cues is dropped.
+The take's own \`tick\`/\`t\` are preserved, so the streams stay mutually aligned.
+
+| stream | records kept / recorded | size |
+|---|---|---|
+${streamRows}
+
+**No image-space geometry.** Two mechanisms, because they are different problems:
+
+- A face mesh or hand keypoint **array** makes the converter reject the take outright,
+  rather than trimming it — a converter that silently drops a field is one nobody checks.
+  \`trainerTakeSession\` also pins the recorded edges to the derived feature vectors, so
+  neither reaches the take in the first place.
+- Individual landmark **coordinates flattened into the vector as scalars** cannot be seen
+  by any check on a container's shape, so they are stripped by feature id and the removal
+  is reported below. \`face.head.x\`/\`face.head.y\` are the nose tip's normalized
+  coordinates — over a take, a frame-by-frame nose trajectory.
+
+Stripping costs this fixture nothing: \`FACE_OMIT\` is the trainer's own declaration that
+the learner does not use them. They are recorded only because a routine's demanded groups
+are unioned without applying each cue's \`omit\`.
+
+${
+  r.strippedRawPositions.length
+    ? '| stripped id | records |\n|---|---|\n' + r.strippedRawPositions.map((x) => `| \`${x.id}\` | ${x.records} |`).join('\n')
+    : '_No raw-position features were present in this take._'
+}
+
+## The cues
+
+Times are seconds from \`t0\` (\`cues.json\` carries \`t0\` and the absolute times).
+
+| cue | window | held | verdict |
+|---|---|---|---|
+${rows}
+
+## Regenerating
+
+Record a take through the trainer, unzip it, then:
+
+\`\`\`
+npx vite-node scripts/trainer_take_to_fixture.ts -- <take-dir> ${r.scenario}
+\`\`\`
+`;
+}

--- a/scripts/trainer_take_to_fixture.ts
+++ b/scripts/trainer_take_to_fixture.ts
@@ -1,0 +1,408 @@
+/**
+ * Turn a recorded trainer take into a committed replay fixture (#160 / #163 / #146).
+ *
+ * A training take is the cheapest ground truth this repo can produce. The trainer asks
+ * the player, in the player's own words, to do one thing ("look to your left"), records
+ * the clean camera, the feature vectors and a cue interval per instruction — all on one
+ * clock. That last part is what no video clip can supply: `test/fixtures/video_head_pose`
+ * settled pitch, smile and brow but had to leave **yaw and roll open**, because a file's
+ * own metadata cannot say whether the recording was mirrored, so "the person turned to
+ * *their* left" is unrecoverable from the pixels. A cue asks for it directly.
+ *
+ * This script is the join. It reads a take folder, resolves the cue intervals through
+ * taglog's own {@link resolveIntervals} (not a private re-implementation), slices each
+ * recorded edge to the ticks that fall inside a cue, and writes a fixture directory that
+ * `test/helpers/fixtures.ts` can load unchanged.
+ *
+ * ## Three things it refuses to do
+ *
+ * 1. **Emit face-mesh landmarks.** A 478-point mesh is facial geometry; blendshape
+ *    coefficients and a head-pose triple are not, and neither reconstructs a face. The
+ *    committed `video_head_pose` fixture already strips them by hand for exactly this
+ *    reason. Here it is enforced: any value carrying a `landmarks` array is rejected
+ *    outright rather than trimmed, because a converter that silently drops a field is a
+ *    converter nobody checks. (`trainerTakeSession` now also pins `featureEdges` so the
+ *    mesh never reaches the take in the first place — this is the second line of defence,
+ *    and it is the one that guards what enters the repo.)
+ * 2. **Write outside `test/fixtures/`.** The output name is a bare scenario name, not a
+ *    path.
+ * 3. **Invent a clock.** Every emitted record keeps the take's own `tick` and `t`, so the
+ *    streams stay mutually aligned and joinable back to the source take.
+ *
+ * ## Usage
+ *
+ *     npx vite-node scripts/trainer_take_to_fixture.ts -- <take-dir> <scenario> [--dry-run]
+ *
+ * `<take-dir>` is an unzipped take folder holding `<stem>.features.jsonl`,
+ * `<stem>.annotations.jsonl` and `<stem>.manifest.json`. `<scenario>` becomes
+ * `test/fixtures/<scenario>/`.
+ */
+import { readdirSync, readFileSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join, basename } from 'node:path';
+import { gzipSync } from 'node:zlib';
+import { resolveIntervals } from '@/taglog/affordances/resolve';
+import type { EdgeEvent, ResolvedInterval, TagKind, TagStatus } from '@/taglog/affordances/schema';
+
+/** Gzip anything at or above this many bytes, mirroring the existing committed fixtures. */
+const GZIP_THRESHOLD_BYTES = 200_000;
+
+/** One line of `features.jsonl`, as written by `FeatureJsonlTap`. */
+interface FeatureLine {
+  tick: number;
+  t: number;
+  key: string;
+  value: unknown;
+}
+
+/** One emitted fixture line — the `StreamRecord` shape `valuesFromNDJSON` reads. */
+interface StreamRecordOut {
+  tick: number;
+  t: number;
+  value: unknown;
+}
+
+/** The take's annotation anchor (first line of `annotations.jsonl`). */
+interface Anchor {
+  anchor: true;
+  t: number;
+  session: string;
+  schema: string;
+  wallClockISO: string;
+}
+
+export interface CueWindow {
+  /** The cue id, with taglog's `cue:` prefix stripped. */
+  cue: string;
+  /** Interval start/end as offsets into the take, seconds (`t - t0`). */
+  start: number;
+  end: number;
+  /** Absolute engine-clock times, as recorded. */
+  startAbs: number;
+  endAbs: number;
+  /** True if the take ended before the cue closed. */
+  openEnded: boolean;
+}
+
+export interface ConvertResult {
+  scenario: string;
+  stem: string;
+  t0: number;
+  cues: CueWindow[];
+  /** Per-edge: how many records survived the cue slice, out of how many were recorded. */
+  streams: { key: string; kept: number; total: number; bytes: number; gzipped: boolean }[];
+  verdicts: { cue: string; outcome: string; t: number }[];
+}
+
+/** A JSONL parse that reports the line number, because a truncated take is a real case. */
+function* parseJsonl<T>(text: string, what: string): Generator<T> {
+  let n = 0;
+  for (const line of text.split('\n')) {
+    n++;
+    const s = line.trim();
+    if (!s) continue;
+    try {
+      yield JSON.parse(s) as T;
+    } catch (err) {
+      throw new Error(`${what}: line ${n} is not JSON (${err instanceof Error ? err.message : String(err)})`);
+    }
+  }
+}
+
+/**
+ * The one thing that must never pass. Recursively true if `v` carries a `landmarks`
+ * array — the 478-point face mesh, or a hand's 21-point keypoint list under that name.
+ * Deliberately a *detector*, not a stripper: see the module docstring.
+ */
+export function carriesLandmarks(v: unknown): boolean {
+  if (Array.isArray(v)) return v.some(carriesLandmarks);
+  if (v && typeof v === 'object') {
+    const o = v as Record<string, unknown>;
+    if (Array.isArray(o.landmarks) || Array.isArray(o.keypoints)) return true;
+    return Object.values(o).some(carriesLandmarks);
+  }
+  return false;
+}
+
+/** Find the take's stem from the files present, so the caller need not repeat it. */
+export function findStem(dir: string): string {
+  const names = readdirSync(dir);
+  const feat = names.find((n) => n.endsWith('.features.jsonl'));
+  if (!feat) {
+    throw new Error(
+      `${dir}: no *.features.jsonl. Is this an unzipped take folder? A 'downloads' take is a .zip — unzip it first.`,
+    );
+  }
+  return basename(feat, '.features.jsonl');
+}
+
+/**
+ * Turn the take's annotation rows into taglog {@link EdgeEvent}s so
+ * {@link resolveIntervals} can pair opens with closes. The rows already carry every
+ * field an EdgeEvent needs except `kind`, which the tag id determines: the trainer
+ * writes intervals as `cue:<id>` and everything else as points (`annotations.ts`).
+ */
+export function edgeEventsFromRows(rows: readonly Record<string, unknown>[]): EdgeEvent[] {
+  return rows.map((r) => {
+    const tag = String(r.tag);
+    const status = String(r.status) as TagStatus;
+    const kind: TagKind = tag.startsWith('cue:') ? 'interval' : 'point';
+    return {
+      tag,
+      kind,
+      status,
+      t: Number(r.t),
+      tCorrected: Number(r.tCorrected ?? r.t),
+      seq: Number(r.seq),
+      clock: (r.clock ?? 'media') as EdgeEvent['clock'],
+      src: (r.src ?? 'auto') as EdgeEvent['src'],
+    };
+  });
+}
+
+/**
+ * Cue windows from resolved intervals, take-relative.
+ *
+ * **An open-ended cue extends to `Infinity`, not to its own start.** `resolveIntervals`
+ * gives an unclosed open `end === start` when it is not told when the recording stopped
+ * (`options.endT`) — a zero-length interval. Taking that literally would silently discard
+ * every sample of the cue the take stopped during, which is the one cue whose data a
+ * crashed or abandoned take still has. Semantically the cue *was still running* when the
+ * recording ended, so every later record belongs to it. {@link sealOpenEnded} then
+ * replaces the sentinel with the last time actually observed, so `cues.json` reports a
+ * real number rather than `null`.
+ */
+export function cueWindows(intervals: readonly ResolvedInterval[], t0: number): CueWindow[] {
+  return intervals
+    .filter((iv) => iv.kind === 'interval' && iv.tag.startsWith('cue:'))
+    .map((iv) => ({
+      cue: iv.tag.slice('cue:'.length),
+      start: iv.start - t0,
+      end: iv.openEnded ? Infinity : iv.end - t0,
+      startAbs: iv.start,
+      endAbs: iv.openEnded ? Infinity : iv.end,
+      openEnded: iv.openEnded,
+    }))
+    .sort((a, b) => a.start - b.start);
+}
+
+/**
+ * Replace the `Infinity` end of any open-ended window with the last record time actually
+ * seen, so the emitted index carries a real duration. Mutates in place, after the pass.
+ */
+export function sealOpenEnded(windows: CueWindow[], lastT: number, t0: number): void {
+  for (const w of windows) {
+    if (!Number.isFinite(w.endAbs)) {
+      w.endAbs = Math.max(lastT, w.startAbs);
+      w.end = w.endAbs - t0;
+    }
+  }
+}
+
+/** True if an absolute time falls inside any cue window (inclusive of both ends). */
+export function insideAnyCue(tAbs: number, windows: readonly CueWindow[]): boolean {
+  return windows.some((w) => tAbs >= w.startAbs && tAbs <= w.endAbs);
+}
+
+export interface ConvertOptions {
+  /** Write nothing; just report what would be written. */
+  dryRun?: boolean;
+  /** Where `test/fixtures` lives (injected so tests can point at a temp dir). */
+  fixturesRoot: string;
+}
+
+/**
+ * Convert one take folder into one fixture directory. Pure enough to unit-test: the only
+ * side effects are the writes, and `dryRun` removes those.
+ */
+export function convertTake(takeDir: string, scenario: string, opts: ConvertOptions): ConvertResult {
+  if (!/^[a-z0-9_]+$/.test(scenario)) {
+    throw new Error(`scenario "${scenario}" must be lowercase letters, digits and underscores — it becomes a directory name`);
+  }
+  const stem = findStem(takeDir);
+
+  const annPath = join(takeDir, `${stem}.annotations.jsonl`);
+  if (!existsSync(annPath)) {
+    throw new Error(
+      `${annPath} is missing. A take without annotations carries no cue intervals, and the cue intervals are the entire point of this conversion.`,
+    );
+  }
+  const annRows = [...parseJsonl<Record<string, unknown>>(readFileSync(annPath, 'utf8'), annPath)];
+  const anchor = annRows[0] as unknown as Anchor;
+  if (!anchor || anchor.anchor !== true || typeof anchor.t !== 'number') {
+    throw new Error(`${annPath}: first line must be the anchor record carrying t0`);
+  }
+  const t0 = anchor.t;
+
+  const events = edgeEventsFromRows(annRows.slice(1));
+  const windows = cueWindows(resolveIntervals(events), t0);
+  if (windows.length === 0) {
+    throw new Error(`${annPath}: no cue intervals resolved — nothing to slice by`);
+  }
+  const verdicts = events
+    .filter((e) => e.status === 'point' && e.tag.startsWith('verdict:'))
+    .map((e) => {
+      const w = windows.filter((x) => e.t >= x.startAbs && e.t <= x.endAbs).pop();
+      return { cue: w?.cue ?? '(outside any cue)', outcome: e.tag.slice('verdict:'.length), t: e.t - t0 };
+    });
+
+  // Group the feature stream by edge key, keeping only ticks inside a cue.
+  const featPath = join(takeDir, `${stem}.features.jsonl`);
+  if (!existsSync(featPath)) throw new Error(`${featPath} is missing`);
+  const byKey = new Map<string, StreamRecordOut[]>();
+  const totals = new Map<string, number>();
+  let lastT = t0;
+  for (const line of parseJsonl<FeatureLine>(readFileSync(featPath, 'utf8'), featPath)) {
+    totals.set(line.key, (totals.get(line.key) ?? 0) + 1);
+    if (line.t > lastT) lastT = line.t;
+    if (carriesLandmarks(line.value)) {
+      throw new Error(
+        `${featPath}: edge "${line.key}" carries a landmarks/keypoints array. Face-mesh and hand-keypoint geometry must not enter a committed fixture. ` +
+          `Re-record the take on a build where trainerTakeSession pins featureEdges (it records only the derived feature vectors), or drop the edge before converting.`,
+      );
+    }
+    if (!insideAnyCue(line.t, windows)) continue;
+    const arr = byKey.get(line.key) ?? [];
+    arr.push({ tick: line.tick, t: line.t, value: line.value });
+    byKey.set(line.key, arr);
+  }
+  if (byKey.size === 0) {
+    throw new Error(`${featPath}: no feature records fell inside a cue interval — check that the take and its annotations share a clock`);
+  }
+  sealOpenEnded(windows, lastT, t0);
+
+  const outDir = join(opts.fixturesRoot, scenario);
+  if (!opts.dryRun) mkdirSync(outDir, { recursive: true });
+
+  const streams: ConvertResult['streams'] = [];
+  for (const [key, records] of [...byKey].sort(([a], [b]) => a.localeCompare(b))) {
+    // Compact + stable key order, matching the committed `face.pose.ndjson.gz` serializer.
+    const text = records.map((r) => JSON.stringify(r)).join('\n') + '\n';
+    const raw = Buffer.from(text, 'utf8');
+    const gzipped = raw.byteLength >= GZIP_THRESHOLD_BYTES;
+    // Node's gzipSync writes a zero MTIME in the gzip header and is byte-reproducible
+    // across runs and machines (verified), which is what lets the committed .gz be
+    // diffed and re-generated without spurious churn. The Python-generated fixtures
+    // pass `mtime=0` explicitly for the same reason.
+    const bytes = gzipped ? gzipSync(raw) : raw;
+    if (!opts.dryRun) writeFileSync(join(outDir, `${key}.ndjson${gzipped ? '.gz' : ''}`), bytes);
+    streams.push({ key, kept: records.length, total: totals.get(key) ?? 0, bytes: bytes.byteLength, gzipped });
+  }
+
+  const result: ConvertResult = { scenario, stem, t0, cues: windows, streams, verdicts };
+  if (!opts.dryRun) {
+    writeFileSync(join(outDir, 'cues.json'), JSON.stringify({ t0, cues: windows, verdicts }, null, 2) + '\n');
+    writeFileSync(join(outDir, 'meta.json'), JSON.stringify(metaFor(result, takeDir), null, 2) + '\n');
+    writeFileSync(join(outDir, 'README.md'), readmeFor(result));
+  }
+  return result;
+}
+
+/** Provenance, in the shape the other fixtures use. Never carries a local path. */
+function metaFor(r: ConvertResult, takeDir: string): Record<string, unknown> {
+  const manifestPath = join(takeDir, `${r.stem}.manifest.json`);
+  let manifest: Record<string, unknown> | null = null;
+  if (existsSync(manifestPath)) {
+    try {
+      manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as Record<string, unknown>;
+    } catch {
+      manifest = null;
+    }
+  }
+  return {
+    scenario: r.scenario,
+    source: 'trainer-take',
+    // The stem is a timestamp, not a path — safe to commit, and it is the only way to
+    // correlate a fixture back to the take it came from.
+    takeStem: r.stem,
+    t0: r.t0,
+    cues: r.cues.map((c) => c.cue),
+    recordedKeys: r.streams.map((s) => s.key),
+    frames: Object.fromEntries(r.streams.map((s) => [s.key, s.kept])),
+    fps: (manifest?.fps as number | undefined) ?? null,
+    converterVersion: 1,
+  };
+}
+
+/** A provenance README, following `test/fixtures/video_head_pose/README.md`. */
+function readmeFor(r: ConvertResult): string {
+  const rows = r.cues
+    .map((c) => {
+      const v = r.verdicts.find((x) => x.cue === c.cue);
+      return `| \`${c.cue}\` | ${c.start.toFixed(2)} – ${c.end.toFixed(2)} s | ${(c.end - c.start).toFixed(2)} s | ${v ? v.outcome : '—'}${c.openEnded ? ' (open-ended)' : ''} |`;
+    })
+    .join('\n');
+  const streamRows = r.streams
+    .map((s) => `| \`${s.key}\` | ${s.kept} / ${s.total} | ${(s.bytes / 1024).toFixed(1)} KB${s.gzipped ? ' (gz)' : ''} |`)
+    .join('\n');
+  return `# \`${r.scenario}\` — a trainer take, sliced by cue
+
+Generated by \`scripts/trainer_take_to_fixture.ts\` from a recorded training take.
+**Do not hand-edit** — re-run the converter instead.
+
+## Why a trainer take and not a clip
+
+The cue is the ground truth. \`test/fixtures/video_head_pose/README.md\` records why yaw
+and roll stayed open after #161: a clip's metadata cannot say whether it was mirrored, so
+"the person turned to *their* left" is unrecoverable from the file. A cue asks the player
+for that directly, in their own frame of reference, and the interval says exactly when
+they did it.
+
+## What is in here
+
+Each \`<nodeId>.<port>.ndjson[.gz]\` is a \`StreamRecord\` stream — \`{tick, t, value}\`
+per line, loadable with \`loadStream('${r.scenario}', '<nodeId>.<port>')\`. Only records
+whose \`t\` falls inside a cue interval are kept; the dead time between cues is dropped.
+The take's own \`tick\`/\`t\` are preserved, so the streams stay mutually aligned.
+
+| stream | records kept / recorded | size |
+|---|---|---|
+${streamRows}
+
+**No landmark or keypoint geometry.** The converter rejects any take carrying it rather
+than trimming it, and \`trainerTakeSession\` pins the recorded edges to the derived feature
+vectors so it never reaches the take.
+
+## The cues
+
+Times are seconds from \`t0\` (\`cues.json\` carries \`t0\` and the absolute times).
+
+| cue | window | held | verdict |
+|---|---|---|---|
+${rows}
+
+## Regenerating
+
+Record a take through the trainer, unzip it, then:
+
+\`\`\`
+npx vite-node scripts/trainer_take_to_fixture.ts -- <take-dir> ${r.scenario}
+\`\`\`
+`;
+}
+
+/** CLI. Kept below the exports so the module stays importable by tests. */
+function main(argv: string[]): void {
+  const args = argv.filter((a) => a !== '--');
+  const dryRun = args.includes('--dry-run');
+  const positional = args.filter((a) => !a.startsWith('--'));
+  const [takeDir, scenario] = positional;
+  if (!takeDir || !scenario) {
+    console.error('usage: vite-node scripts/trainer_take_to_fixture.ts -- <take-dir> <scenario> [--dry-run]');
+    process.exit(2);
+    return;
+  }
+  const fixturesRoot = join(process.cwd(), 'test', 'fixtures');
+  const r = convertTake(takeDir, scenario, { dryRun, fixturesRoot });
+  const where = join('test', 'fixtures', scenario);
+  console.log(`${dryRun ? '[dry run] would write' : 'wrote'} ${where}/`);
+  console.log(`  take   ${r.stem}  (t0 = ${r.t0})`);
+  console.log(`  cues   ${r.cues.length}: ${r.cues.map((c) => c.cue).join(', ')}`);
+  for (const s of r.streams) {
+    console.log(`  stream ${s.key}: ${s.kept}/${s.total} records, ${(s.bytes / 1024).toFixed(1)} KB${s.gzipped ? ' gz' : ''}`);
+  }
+}
+
+// vite-node runs this as the entry module; a test importing it must not trigger the CLI.
+if (process.argv[1] && process.argv[1].includes('trainer_take_to_fixture')) {
+  main(process.argv.slice(2));
+}

--- a/scripts/trainer_take_to_fixture.ts
+++ b/scripts/trainer_take_to_fixture.ts
@@ -1,460 +1,47 @@
 /**
- * Turn a recorded trainer take into a committed replay fixture (#160 / #163 / #146).
+ * CLI: turn a recorded trainer take into a committed replay fixture (#160 / #163 / #146).
  *
- * A training take is the cheapest ground truth this repo can produce. The trainer asks
- * the player, in the player's own words, to do one thing ("look to your left"), records
- * the clean camera, the feature vectors and a cue interval per instruction — all on one
- * clock. That last part is what no video clip can supply: `test/fixtures/video_head_pose`
- * settled pitch, smile and brow but had to leave **yaw and roll open**, because a file's
- * own metadata cannot say whether the recording was mirrored, so "the person turned to
- * *their* left" is unrecoverable from the pixels. A cue asks for it directly.
+ *     npx vite-node scripts/trainer_take_to_fixture.ts -- <take-dir> <scenario> [--dry-run] [--force]
  *
- * This script is the join. It reads a take folder, resolves the cue intervals through
- * taglog's own {@link resolveIntervals} (not a private re-implementation), slices each
- * recorded edge to the ticks that fall inside a cue, and writes a fixture directory that
- * `test/helpers/fixtures.ts` can load unchanged.
+ * `<take-dir>` is an **unzipped** take folder holding `<stem>.features.jsonl`,
+ * `<stem>.annotations.jsonl` and `<stem>.manifest.json` (a `downloads` take is a `.zip`).
+ * `<scenario>` becomes `test/fixtures/<scenario>/`.
  *
- * ## Three things it refuses to do
+ * ## Why this is a separate file from the logic
  *
- * 1. **Emit a face MESH or a hand keypoint list.** Any value carrying a `landmarks` or
- *    `keypoints` array is rejected outright rather than trimmed, because a converter that
- *    silently drops a field is a converter nobody checks. `trainerTakeSession` also pins
- *    `featureEdges` so the mesh never reaches the take in the first place; this is the
- *    second line of defence, and the one that guards what enters the repo.
+ * The first version put both in one module and guarded the entry point with
+ * `if (process.argv[1]?.includes('trainer_take_to_fixture'))`, so that importing it from
+ * a test would not run the CLI. **That guard is always false under `vite-node`**, which
+ * is the documented way to run it: `argv[1]` is
+ * `node_modules/.bin/vite-node`, and the script's own path never appears in `argv` at
+ * all. The result was a documented command that printed nothing and exited 0 — a tool
+ * nobody could invoke, in a repo whose CLAUDE.md rule is "a feature nobody can find is
+ * not shipped". It was caught by an adversarial review actually *running* the documented
+ * command, which is the only check that would have caught it.
  *
- *    **Be precise about what this does and does not claim.** It excludes *point clouds* —
- *    the 478-point mesh and the 21-point hand keypoint list, which are shape and do
- *    reconstruct a face. It does **not** claim the emitted vectors are free of every
- *    landmark-derived number: four catalog features are positions computed from a single
- *    point — `face.head.x` / `face.head.y` are the nose tip's normalized image coordinates
- *    (`src/features/face_catalog.ts`), and `palm.x` / `palm.y` are the palm centroid. Two
- *    coordinates of one point are the same class of thing as the head-pose matrix's
- *    translation, which the committed `video_head_pose` fixture already carries by
- *    deliberate decision. They locate a face in a frame; they do not describe it.
- *    If that distinction ever stops being acceptable, the fix is a feature-id denylist
- *    here, not a change to the array check.
- * 2. **Write outside `test/fixtures/`.** The output name is a bare scenario name, not a
- *    path.
- * 3. **Invent a clock.** Every emitted record keeps the take's own `tick` and `t`, so the
- *    streams stay mutually aligned and joinable back to the source take.
- *
- * ## Usage
- *
- *     npx vite-node scripts/trainer_take_to_fixture.ts -- <take-dir> <scenario> [--dry-run]
- *
- * `<take-dir>` is an unzipped take folder holding `<stem>.features.jsonl`,
- * `<stem>.annotations.jsonl` and `<stem>.manifest.json`. `<scenario>` becomes
- * `test/fixtures/<scenario>/`.
+ * So the split is the fix, and it is the convention already here: `lib_audio.ts` holds
+ * the logic and is imported by tests, `render_audio.ts` is the CLI and calls `main()`
+ * unconditionally. Nothing needs to detect whether it is the entry module, because only
+ * the CLI file has a side effect.
  */
-import { readdirSync, readFileSync, existsSync, mkdirSync, writeFileSync, rmSync, statSync } from 'node:fs';
-import { join, basename } from 'node:path';
-import { gzipSync } from 'node:zlib';
-import { resolveIntervals } from '@/taglog/affordances/resolve';
-import type { EdgeEvent, ResolvedInterval, TagKind, TagStatus } from '@/taglog/affordances/schema';
+import { join } from 'node:path';
+import { convertTake } from './lib_trainer_take';
 
-/** Gzip anything at or above this many bytes, mirroring the existing committed fixtures. */
-const GZIP_THRESHOLD_BYTES = 200_000;
-
-/**
- * Refuse a features file bigger than this rather than hit Node's ~512 MiB string cap
- * with an opaque `ERR_STRING_TOO_LONG`. A take with the edges pinned is a few MB for a
- * multi-minute routine; anything near this is a pre-pin take carrying the face mesh.
- */
-const MAX_FEATURES_BYTES = 256 * 1024 * 1024;
-
-/** One line of `features.jsonl`, as written by `FeatureJsonlTap`. */
-interface FeatureLine {
-  tick: number;
-  t: number;
-  key: string;
-  value: unknown;
-}
-
-/** One emitted fixture line — the `StreamRecord` shape `valuesFromNDJSON` reads. */
-interface StreamRecordOut {
-  tick: number;
-  t: number;
-  value: unknown;
-}
-
-/** The take's annotation anchor (first line of `annotations.jsonl`). */
-interface Anchor {
-  anchor: true;
-  t: number;
-  session: string;
-  schema: string;
-  wallClockISO: string;
-}
-
-export interface CueWindow {
-  /** The cue id, with taglog's `cue:` prefix stripped. */
-  cue: string;
-  /** Interval start/end as offsets into the take, seconds (`t - t0`). */
-  start: number;
-  end: number;
-  /** Absolute engine-clock times, as recorded. */
-  startAbs: number;
-  endAbs: number;
-  /** True if the take ended before the cue closed. */
-  openEnded: boolean;
-}
-
-export interface ConvertResult {
-  scenario: string;
-  stem: string;
-  t0: number;
-  cues: CueWindow[];
-  /** Per-edge: how many records survived the cue slice, out of how many were recorded. */
-  streams: { key: string; kept: number; total: number; bytes: number; gzipped: boolean }[];
-  verdicts: { cue: string; outcome: string; t: number }[];
-}
-
-/** A JSONL parse that reports the line number, because a truncated take is a real case. */
-function* parseJsonl<T>(text: string, what: string): Generator<T> {
-  let n = 0;
-  for (const line of text.split('\n')) {
-    n++;
-    const s = line.trim();
-    if (!s) continue;
-    try {
-      yield JSON.parse(s) as T;
-    } catch (err) {
-      throw new Error(`${what}: line ${n} is not JSON (${err instanceof Error ? err.message : String(err)})`);
-    }
-  }
-}
-
-/**
- * The one thing that must never pass. Recursively true if `v` carries a `landmarks`
- * array — the 478-point face mesh, or a hand's 21-point keypoint list under that name.
- * Deliberately a *detector*, not a stripper: see the module docstring.
- */
-export function carriesLandmarks(v: unknown): boolean {
-  if (Array.isArray(v)) return v.some(carriesLandmarks);
-  if (v && typeof v === 'object') {
-    const o = v as Record<string, unknown>;
-    if (Array.isArray(o.landmarks) || Array.isArray(o.keypoints)) return true;
-    return Object.values(o).some(carriesLandmarks);
-  }
-  return false;
-}
-
-/** Find the take's stem from the files present, so the caller need not repeat it. */
-export function findStem(dir: string): string {
-  const feats = readdirSync(dir).filter((n) => n.endsWith('.features.jsonl')).sort();
-  if (feats.length === 0) {
-    throw new Error(
-      `${dir}: no *.features.jsonl. Is this an unzipped take folder? A 'downloads' take is a .zip — unzip it first.`,
-    );
-  }
-  if (feats.length > 1) {
-    // Downloads is where takes accumulate and the instruction here is "unzip it first",
-    // so two takes in one folder is an ordinary mistake. `readdirSync` order is not
-    // specified, so picking the first would convert an arbitrary one and say nothing.
-    throw new Error(
-      `${dir}: ${feats.length} takes found (${feats.map((f) => basename(f, '.features.jsonl')).join(', ')}). ` +
-        `Point this at one take folder, not a directory holding several.`,
-    );
-  }
-  return basename(feats[0], '.features.jsonl');
-}
-
-/**
- * Turn the take's annotation rows into taglog {@link EdgeEvent}s so
- * {@link resolveIntervals} can pair opens with closes. The rows already carry every
- * field an EdgeEvent needs except `kind`, which the tag id determines: the trainer
- * writes intervals as `cue:<id>` and everything else as points (`annotations.ts`).
- */
-export function edgeEventsFromRows(rows: readonly Record<string, unknown>[]): EdgeEvent[] {
-  return rows.map((r) => {
-    const tag = String(r.tag);
-    const status = String(r.status) as TagStatus;
-    const kind: TagKind = tag.startsWith('cue:') ? 'interval' : 'point';
-    return {
-      tag,
-      kind,
-      status,
-      t: Number(r.t),
-      tCorrected: Number(r.tCorrected ?? r.t),
-      seq: Number(r.seq),
-      clock: (r.clock ?? 'media') as EdgeEvent['clock'],
-      src: (r.src ?? 'auto') as EdgeEvent['src'],
-    };
-  });
-}
-
-/**
- * Cue windows from resolved intervals, take-relative.
- *
- * **An open-ended cue extends to `Infinity`, not to its own start.** `resolveIntervals`
- * gives an unclosed open `end === start` when it is not told when the recording stopped
- * (`options.endT`) — a zero-length interval. Taking that literally would silently discard
- * every sample of the cue the take stopped during, which is the one cue whose data a
- * crashed or abandoned take still has. Semantically the cue *was still running* when the
- * recording ended, so every later record belongs to it. {@link sealOpenEnded} then
- * replaces the sentinel with the last time actually observed, so `cues.json` reports a
- * real number rather than `null`.
- */
-export function cueWindows(intervals: readonly ResolvedInterval[], t0: number): CueWindow[] {
-  return intervals
-    .filter((iv) => iv.kind === 'interval' && iv.tag.startsWith('cue:'))
-    .map((iv) => ({
-      cue: iv.tag.slice('cue:'.length),
-      start: iv.start - t0,
-      end: iv.openEnded ? Infinity : iv.end - t0,
-      startAbs: iv.start,
-      endAbs: iv.openEnded ? Infinity : iv.end,
-      openEnded: iv.openEnded,
-    }))
-    .sort((a, b) => a.start - b.start);
-}
-
-/**
- * Replace the `Infinity` end of any open-ended window with the last record time actually
- * seen, so the emitted index carries a real duration. Mutates in place, after the pass.
- */
-export function sealOpenEnded(windows: CueWindow[], lastT: number, t0: number): void {
-  for (const w of windows) {
-    if (!Number.isFinite(w.endAbs)) {
-      w.endAbs = Math.max(lastT, w.startAbs);
-      w.end = w.endAbs - t0;
-    }
-  }
-}
-
-/** True if an absolute time falls inside any cue window (inclusive of both ends). */
-export function insideAnyCue(tAbs: number, windows: readonly CueWindow[]): boolean {
-  return windows.some((w) => tAbs >= w.startAbs && tAbs <= w.endAbs);
-}
-
-export interface ConvertOptions {
-  /** Write nothing; just report what would be written. */
-  dryRun?: boolean;
-  /** Replace an existing fixture directory. Off by default — see the overwrite guard. */
-  force?: boolean;
-  /** Where `test/fixtures` lives (injected so tests can point at a temp dir). */
-  fixturesRoot: string;
-}
-
-/**
- * Convert one take folder into one fixture directory. Pure enough to unit-test: the only
- * side effects are the writes, and `dryRun` removes those.
- */
-export function convertTake(takeDir: string, scenario: string, opts: ConvertOptions): ConvertResult {
-  if (!/^[a-z0-9_]+$/.test(scenario)) {
-    throw new Error(`scenario "${scenario}" must be lowercase letters, digits and underscores — it becomes a directory name`);
-  }
-  const stem = findStem(takeDir);
-
-  const annPath = join(takeDir, `${stem}.annotations.jsonl`);
-  if (!existsSync(annPath)) {
-    throw new Error(
-      `${annPath} is missing. A take without annotations carries no cue intervals, and the cue intervals are the entire point of this conversion.`,
-    );
-  }
-  const annRows = [...parseJsonl<Record<string, unknown>>(readFileSync(annPath, 'utf8'), annPath)];
-  const anchor = annRows[0] as unknown as Anchor;
-  if (!anchor || anchor.anchor !== true || typeof anchor.t !== 'number') {
-    throw new Error(`${annPath}: first line must be the anchor record carrying t0`);
-  }
-  const t0 = anchor.t;
-
-  const events = edgeEventsFromRows(annRows.slice(1));
-  const windows = cueWindows(resolveIntervals(events), t0);
-  if (windows.length === 0) {
-    throw new Error(`${annPath}: no cue intervals resolved — nothing to slice by`);
-  }
-  const verdicts = events
-    .filter((e) => e.status === 'point' && e.tag.startsWith('verdict:'))
-    .map((e) => {
-      const w = windows.filter((x) => e.t >= x.startAbs && e.t <= x.endAbs).pop();
-      return { cue: w?.cue ?? '(outside any cue)', outcome: e.tag.slice('verdict:'.length), t: e.t - t0 };
-    });
-
-  // Group the feature stream by edge key, keeping only ticks inside a cue.
-  const featPath = join(takeDir, `${stem}.features.jsonl`);
-  if (!existsSync(featPath)) throw new Error(`${featPath} is missing`);
-  // The file is read whole, so it is bounded by Node's maximum string length
-  // (~512 MiB of chars). That limit is not theoretical here: it is reached by exactly
-  // the takes the landmark guard exists for. Every take recorded before `featureEdges`
-  // was pinned used the empty default, which `FeatureJsonlTap` reads as "record every
-  // edge" — including `camFace.face` and its 478 mesh points on every tick, ~36 KB per
-  // line. Such a take blows the string limit long before the guard can look at it, and
-  // `ERR_STRING_TOO_LONG` names neither the cause nor the fix. So check the size first
-  // and say the thing the guard would have said.
-  const featBytes = statSync(featPath).size;
-  if (featBytes > MAX_FEATURES_BYTES) {
-    throw new Error(
-      `${featPath} is ${(featBytes / 1024 / 1024).toFixed(0)} MB, past what this converter reads in one pass. ` +
-        `A take that large was almost certainly recorded before \`trainerTakeSession\` pinned \`featureEdges\`: ` +
-        `the empty default records EVERY edge, including the 478-point face mesh on \`camFace.face\`. ` +
-        `Re-record on a current build (a pinned take is a few MB), or pre-filter the file to the two vector edges.`,
-    );
-  }
-  const byKey = new Map<string, StreamRecordOut[]>();
-  const totals = new Map<string, number>();
-  let lastT = t0;
-  for (const line of parseJsonl<FeatureLine>(readFileSync(featPath, 'utf8'), featPath)) {
-    totals.set(line.key, (totals.get(line.key) ?? 0) + 1);
-    if (line.t > lastT) lastT = line.t;
-    if (carriesLandmarks(line.value)) {
-      throw new Error(
-        `${featPath}: edge "${line.key}" carries a landmarks/keypoints array. Face-mesh and hand-keypoint geometry must not enter a committed fixture. ` +
-          `Re-record the take on a build where trainerTakeSession pins featureEdges (it records only the derived feature vectors), or drop the edge before converting.`,
-      );
-    }
-    if (!insideAnyCue(line.t, windows)) continue;
-    const arr = byKey.get(line.key) ?? [];
-    arr.push({ tick: line.tick, t: line.t, value: line.value });
-    byKey.set(line.key, arr);
-  }
-  if (byKey.size === 0) {
-    throw new Error(`${featPath}: no feature records fell inside a cue interval — check that the take and its annotations share a clock`);
-  }
-  sealOpenEnded(windows, lastT, t0);
-
-  const outDir = join(opts.fixturesRoot, scenario);
-  if (!opts.dryRun && !opts.force && existsSync(outDir)) {
-    // Every committed fixture name matches the scenario regex, so a typo — or reusing the
-    // name of the fixture this take was meant to supersede — silently clobbered a
-    // hand-written README and its ground-truth table, which is the irreplaceable part.
-    throw new Error(
-      `${outDir} already exists. Converting would overwrite its streams and its README ` +
-        `(the ground-truth table is hand-written and not regenerable). Choose another scenario name, ` +
-        `or pass --force if replacing it is what you mean.`,
-    );
-  }
-  if (!opts.dryRun) mkdirSync(outDir, { recursive: true });
-
-  const streams: ConvertResult['streams'] = [];
-  for (const [key, records] of [...byKey].sort(([a], [b]) => a.localeCompare(b))) {
-    // Compact + stable key order, matching the committed `face.pose.ndjson.gz` serializer.
-    const text = records.map((r) => JSON.stringify(r)).join('\n') + '\n';
-    const raw = Buffer.from(text, 'utf8');
-    const gzipped = raw.byteLength >= GZIP_THRESHOLD_BYTES;
-    // Node's gzipSync writes a zero MTIME in the gzip header and is byte-reproducible
-    // across runs and machines (verified), which is what lets the committed .gz be
-    // diffed and re-generated without spurious churn. The Python-generated fixtures
-    // pass `mtime=0` explicitly for the same reason.
-    const bytes = gzipped ? gzipSync(raw) : raw;
-    if (!opts.dryRun) {
-      writeFileSync(join(outDir, `${key}.ndjson${gzipped ? '.gz' : ''}`), bytes);
-      // Crossing the threshold on a regeneration would otherwise leave BOTH forms, and
-      // `loadStream` tries `.ndjson` before `.ndjson.gz` — so a re-recorded take that
-      // grew past the threshold would be silently ignored in favour of the stale plain
-      // file. Remove the counterpart rather than trusting whoever regenerates to notice.
-      const stale = join(outDir, `${key}.ndjson${gzipped ? '' : '.gz'}`);
-      if (existsSync(stale)) rmSync(stale);
-    }
-    streams.push({ key, kept: records.length, total: totals.get(key) ?? 0, bytes: bytes.byteLength, gzipped });
-  }
-
-  const result: ConvertResult = { scenario, stem, t0, cues: windows, streams, verdicts };
-  if (!opts.dryRun) {
-    writeFileSync(join(outDir, 'cues.json'), JSON.stringify({ t0, cues: windows, verdicts }, null, 2) + '\n');
-    writeFileSync(join(outDir, 'meta.json'), JSON.stringify(metaFor(result, takeDir), null, 2) + '\n');
-    writeFileSync(join(outDir, 'README.md'), readmeFor(result));
-  }
-  return result;
-}
-
-/** Provenance, in the shape the other fixtures use. Never carries a local path. */
-function metaFor(r: ConvertResult, takeDir: string): Record<string, unknown> {
-  const manifestPath = join(takeDir, `${r.stem}.manifest.json`);
-  let manifest: Record<string, unknown> | null = null;
-  if (existsSync(manifestPath)) {
-    try {
-      manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as Record<string, unknown>;
-    } catch {
-      manifest = null;
-    }
-  }
-  return {
-    scenario: r.scenario,
-    source: 'trainer-take',
-    // The stem is a timestamp, not a path — safe to commit, and it is the only way to
-    // correlate a fixture back to the take it came from.
-    takeStem: r.stem,
-    t0: r.t0,
-    cues: r.cues.map((c) => c.cue),
-    recordedKeys: r.streams.map((s) => s.key),
-    frames: Object.fromEntries(r.streams.map((s) => [s.key, s.kept])),
-    fps: (manifest?.fps as number | undefined) ?? null,
-    converterVersion: 1,
-  };
-}
-
-/** A provenance README, following `test/fixtures/video_head_pose/README.md`. */
-function readmeFor(r: ConvertResult): string {
-  const rows = r.cues
-    .map((c) => {
-      const v = r.verdicts.find((x) => x.cue === c.cue);
-      return `| \`${c.cue}\` | ${c.start.toFixed(2)} – ${c.end.toFixed(2)} s | ${(c.end - c.start).toFixed(2)} s | ${v ? v.outcome : '—'}${c.openEnded ? ' (open-ended)' : ''} |`;
-    })
-    .join('\n');
-  const streamRows = r.streams
-    .map((s) => `| \`${s.key}\` | ${s.kept} / ${s.total} | ${(s.bytes / 1024).toFixed(1)} KB${s.gzipped ? ' (gz)' : ''} |`)
-    .join('\n');
-  return `# \`${r.scenario}\` — a trainer take, sliced by cue
-
-Generated by \`scripts/trainer_take_to_fixture.ts\` from a recorded training take.
-**Do not hand-edit** — re-run the converter instead.
-
-## Why a trainer take and not a clip
-
-The cue is the ground truth. \`test/fixtures/video_head_pose/README.md\` records why yaw
-and roll stayed open after #161: a clip's metadata cannot say whether it was mirrored, so
-"the person turned to *their* left" is unrecoverable from the file. A cue asks the player
-for that directly, in their own frame of reference, and the interval says exactly when
-they did it.
-
-## What is in here
-
-Each \`<nodeId>.<port>.ndjson[.gz]\` is a \`StreamRecord\` stream — \`{tick, t, value}\`
-per line, loadable with \`loadStream('${r.scenario}', '<nodeId>.<port>')\`. Only records
-whose \`t\` falls inside a cue interval are kept; the dead time between cues is dropped.
-The take's own \`tick\`/\`t\` are preserved, so the streams stay mutually aligned.
-
-| stream | records kept / recorded | size |
-|---|---|---|
-${streamRows}
-
-**No point clouds.** The converter rejects any take carrying a face mesh or a hand
-keypoint list rather than trimming it, and \`trainerTakeSession\` pins the recorded edges to
-the derived feature vectors so neither reaches the take. Note the emitted vectors do
-include four single-point *positions* (nose tip, palm centroid) — coordinates that locate
-a face in a frame, not shape that describes one.
-
-## The cues
-
-Times are seconds from \`t0\` (\`cues.json\` carries \`t0\` and the absolute times).
-
-| cue | window | held | verdict |
-|---|---|---|---|
-${rows}
-
-## Regenerating
-
-Record a take through the trainer, unzip it, then:
-
-\`\`\`
-npx vite-node scripts/trainer_take_to_fixture.ts -- <take-dir> ${r.scenario}
-\`\`\`
-`;
-}
-
-/** CLI. Kept below the exports so the module stays importable by tests. */
-function main(argv: string[]): void {
-  const args = argv.filter((a) => a !== '--');
+function main(): void {
+  // vite-node already strips the `--` separator before handing us argv, but a direct
+  // `node`/`tsx` invocation does not — filter it either way rather than depend on which.
+  const args = process.argv.slice(2).filter((a) => a !== '--');
   const dryRun = args.includes('--dry-run');
   const force = args.includes('--force');
   const positional = args.filter((a) => !a.startsWith('--'));
   const [takeDir, scenario] = positional;
+
   if (!takeDir || !scenario) {
     console.error('usage: vite-node scripts/trainer_take_to_fixture.ts -- <take-dir> <scenario> [--dry-run] [--force]');
     process.exit(2);
     return;
   }
+
   const fixturesRoot = join(process.cwd(), 'test', 'fixtures');
   const r = convertTake(takeDir, scenario, { dryRun, force, fixturesRoot });
   const where = join('test', 'fixtures', scenario);
@@ -466,7 +53,4 @@ function main(argv: string[]): void {
   }
 }
 
-// vite-node runs this as the entry module; a test importing it must not trigger the CLI.
-if (process.argv[1] && process.argv[1].includes('trainer_take_to_fixture')) {
-  main(process.argv.slice(2));
-}
+main();

--- a/scripts/trainer_take_to_fixture.ts
+++ b/scripts/trainer_take_to_fixture.ts
@@ -16,14 +16,23 @@
  *
  * ## Three things it refuses to do
  *
- * 1. **Emit face-mesh landmarks.** A 478-point mesh is facial geometry; blendshape
- *    coefficients and a head-pose triple are not, and neither reconstructs a face. The
- *    committed `video_head_pose` fixture already strips them by hand for exactly this
- *    reason. Here it is enforced: any value carrying a `landmarks` array is rejected
- *    outright rather than trimmed, because a converter that silently drops a field is a
- *    converter nobody checks. (`trainerTakeSession` now also pins `featureEdges` so the
- *    mesh never reaches the take in the first place — this is the second line of defence,
- *    and it is the one that guards what enters the repo.)
+ * 1. **Emit a face MESH or a hand keypoint list.** Any value carrying a `landmarks` or
+ *    `keypoints` array is rejected outright rather than trimmed, because a converter that
+ *    silently drops a field is a converter nobody checks. `trainerTakeSession` also pins
+ *    `featureEdges` so the mesh never reaches the take in the first place; this is the
+ *    second line of defence, and the one that guards what enters the repo.
+ *
+ *    **Be precise about what this does and does not claim.** It excludes *point clouds* —
+ *    the 478-point mesh and the 21-point hand keypoint list, which are shape and do
+ *    reconstruct a face. It does **not** claim the emitted vectors are free of every
+ *    landmark-derived number: four catalog features are positions computed from a single
+ *    point — `face.head.x` / `face.head.y` are the nose tip's normalized image coordinates
+ *    (`src/features/face_catalog.ts`), and `palm.x` / `palm.y` are the palm centroid. Two
+ *    coordinates of one point are the same class of thing as the head-pose matrix's
+ *    translation, which the committed `video_head_pose` fixture already carries by
+ *    deliberate decision. They locate a face in a frame; they do not describe it.
+ *    If that distinction ever stops being acceptable, the fix is a feature-id denylist
+ *    here, not a change to the array check.
  * 2. **Write outside `test/fixtures/`.** The output name is a bare scenario name, not a
  *    path.
  * 3. **Invent a clock.** Every emitted record keeps the take's own `tick` and `t`, so the
@@ -37,7 +46,7 @@
  * `<stem>.annotations.jsonl` and `<stem>.manifest.json`. `<scenario>` becomes
  * `test/fixtures/<scenario>/`.
  */
-import { readdirSync, readFileSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { readdirSync, readFileSync, existsSync, mkdirSync, writeFileSync, rmSync, statSync } from 'node:fs';
 import { join, basename } from 'node:path';
 import { gzipSync } from 'node:zlib';
 import { resolveIntervals } from '@/taglog/affordances/resolve';
@@ -45,6 +54,13 @@ import type { EdgeEvent, ResolvedInterval, TagKind, TagStatus } from '@/taglog/a
 
 /** Gzip anything at or above this many bytes, mirroring the existing committed fixtures. */
 const GZIP_THRESHOLD_BYTES = 200_000;
+
+/**
+ * Refuse a features file bigger than this rather than hit Node's ~512 MiB string cap
+ * with an opaque `ERR_STRING_TOO_LONG`. A take with the edges pinned is a few MB for a
+ * multi-minute routine; anything near this is a pre-pin take carrying the face mesh.
+ */
+const MAX_FEATURES_BYTES = 256 * 1024 * 1024;
 
 /** One line of `features.jsonl`, as written by `FeatureJsonlTap`. */
 interface FeatureLine {
@@ -125,14 +141,22 @@ export function carriesLandmarks(v: unknown): boolean {
 
 /** Find the take's stem from the files present, so the caller need not repeat it. */
 export function findStem(dir: string): string {
-  const names = readdirSync(dir);
-  const feat = names.find((n) => n.endsWith('.features.jsonl'));
-  if (!feat) {
+  const feats = readdirSync(dir).filter((n) => n.endsWith('.features.jsonl')).sort();
+  if (feats.length === 0) {
     throw new Error(
       `${dir}: no *.features.jsonl. Is this an unzipped take folder? A 'downloads' take is a .zip — unzip it first.`,
     );
   }
-  return basename(feat, '.features.jsonl');
+  if (feats.length > 1) {
+    // Downloads is where takes accumulate and the instruction here is "unzip it first",
+    // so two takes in one folder is an ordinary mistake. `readdirSync` order is not
+    // specified, so picking the first would convert an arbitrary one and say nothing.
+    throw new Error(
+      `${dir}: ${feats.length} takes found (${feats.map((f) => basename(f, '.features.jsonl')).join(', ')}). ` +
+        `Point this at one take folder, not a directory holding several.`,
+    );
+  }
+  return basename(feats[0], '.features.jsonl');
 }
 
 /**
@@ -206,6 +230,8 @@ export function insideAnyCue(tAbs: number, windows: readonly CueWindow[]): boole
 export interface ConvertOptions {
   /** Write nothing; just report what would be written. */
   dryRun?: boolean;
+  /** Replace an existing fixture directory. Off by default — see the overwrite guard. */
+  force?: boolean;
   /** Where `test/fixtures` lives (injected so tests can point at a temp dir). */
   fixturesRoot: string;
 }
@@ -248,6 +274,23 @@ export function convertTake(takeDir: string, scenario: string, opts: ConvertOpti
   // Group the feature stream by edge key, keeping only ticks inside a cue.
   const featPath = join(takeDir, `${stem}.features.jsonl`);
   if (!existsSync(featPath)) throw new Error(`${featPath} is missing`);
+  // The file is read whole, so it is bounded by Node's maximum string length
+  // (~512 MiB of chars). That limit is not theoretical here: it is reached by exactly
+  // the takes the landmark guard exists for. Every take recorded before `featureEdges`
+  // was pinned used the empty default, which `FeatureJsonlTap` reads as "record every
+  // edge" — including `camFace.face` and its 478 mesh points on every tick, ~36 KB per
+  // line. Such a take blows the string limit long before the guard can look at it, and
+  // `ERR_STRING_TOO_LONG` names neither the cause nor the fix. So check the size first
+  // and say the thing the guard would have said.
+  const featBytes = statSync(featPath).size;
+  if (featBytes > MAX_FEATURES_BYTES) {
+    throw new Error(
+      `${featPath} is ${(featBytes / 1024 / 1024).toFixed(0)} MB, past what this converter reads in one pass. ` +
+        `A take that large was almost certainly recorded before \`trainerTakeSession\` pinned \`featureEdges\`: ` +
+        `the empty default records EVERY edge, including the 478-point face mesh on \`camFace.face\`. ` +
+        `Re-record on a current build (a pinned take is a few MB), or pre-filter the file to the two vector edges.`,
+    );
+  }
   const byKey = new Map<string, StreamRecordOut[]>();
   const totals = new Map<string, number>();
   let lastT = t0;
@@ -271,6 +314,16 @@ export function convertTake(takeDir: string, scenario: string, opts: ConvertOpti
   sealOpenEnded(windows, lastT, t0);
 
   const outDir = join(opts.fixturesRoot, scenario);
+  if (!opts.dryRun && !opts.force && existsSync(outDir)) {
+    // Every committed fixture name matches the scenario regex, so a typo — or reusing the
+    // name of the fixture this take was meant to supersede — silently clobbered a
+    // hand-written README and its ground-truth table, which is the irreplaceable part.
+    throw new Error(
+      `${outDir} already exists. Converting would overwrite its streams and its README ` +
+        `(the ground-truth table is hand-written and not regenerable). Choose another scenario name, ` +
+        `or pass --force if replacing it is what you mean.`,
+    );
+  }
   if (!opts.dryRun) mkdirSync(outDir, { recursive: true });
 
   const streams: ConvertResult['streams'] = [];
@@ -284,7 +337,15 @@ export function convertTake(takeDir: string, scenario: string, opts: ConvertOpti
     // diffed and re-generated without spurious churn. The Python-generated fixtures
     // pass `mtime=0` explicitly for the same reason.
     const bytes = gzipped ? gzipSync(raw) : raw;
-    if (!opts.dryRun) writeFileSync(join(outDir, `${key}.ndjson${gzipped ? '.gz' : ''}`), bytes);
+    if (!opts.dryRun) {
+      writeFileSync(join(outDir, `${key}.ndjson${gzipped ? '.gz' : ''}`), bytes);
+      // Crossing the threshold on a regeneration would otherwise leave BOTH forms, and
+      // `loadStream` tries `.ndjson` before `.ndjson.gz` — so a re-recorded take that
+      // grew past the threshold would be silently ignored in favour of the stale plain
+      // file. Remove the counterpart rather than trusting whoever regenerates to notice.
+      const stale = join(outDir, `${key}.ndjson${gzipped ? '' : '.gz'}`);
+      if (existsSync(stale)) rmSync(stale);
+    }
     streams.push({ key, kept: records.length, total: totals.get(key) ?? 0, bytes: bytes.byteLength, gzipped });
   }
 
@@ -358,9 +419,11 @@ The take's own \`tick\`/\`t\` are preserved, so the streams stay mutually aligne
 |---|---|---|
 ${streamRows}
 
-**No landmark or keypoint geometry.** The converter rejects any take carrying it rather
-than trimming it, and \`trainerTakeSession\` pins the recorded edges to the derived feature
-vectors so it never reaches the take.
+**No point clouds.** The converter rejects any take carrying a face mesh or a hand
+keypoint list rather than trimming it, and \`trainerTakeSession\` pins the recorded edges to
+the derived feature vectors so neither reaches the take. Note the emitted vectors do
+include four single-point *positions* (nose tip, palm centroid) — coordinates that locate
+a face in a frame, not shape that describes one.
 
 ## The cues
 
@@ -384,15 +447,16 @@ npx vite-node scripts/trainer_take_to_fixture.ts -- <take-dir> ${r.scenario}
 function main(argv: string[]): void {
   const args = argv.filter((a) => a !== '--');
   const dryRun = args.includes('--dry-run');
+  const force = args.includes('--force');
   const positional = args.filter((a) => !a.startsWith('--'));
   const [takeDir, scenario] = positional;
   if (!takeDir || !scenario) {
-    console.error('usage: vite-node scripts/trainer_take_to_fixture.ts -- <take-dir> <scenario> [--dry-run]');
+    console.error('usage: vite-node scripts/trainer_take_to_fixture.ts -- <take-dir> <scenario> [--dry-run] [--force]');
     process.exit(2);
     return;
   }
   const fixturesRoot = join(process.cwd(), 'test', 'fixtures');
-  const r = convertTake(takeDir, scenario, { dryRun, fixturesRoot });
+  const r = convertTake(takeDir, scenario, { dryRun, force, fixturesRoot });
   const where = join('test', 'fixtures', scenario);
   console.log(`${dryRun ? '[dry run] would write' : 'wrote'} ${where}/`);
   console.log(`  take   ${r.stem}  (t0 = ${r.t0})`);

--- a/src/app/enroll/takeSession.ts
+++ b/src/app/enroll/takeSession.ts
@@ -5,7 +5,20 @@
  * - `pureVideo`: the CLEAN camera stream — no overlay, no guidance banner, no text.
  *   `plan.ts` distinguishes it from `overlayVideo`; only the pure stream is selected.
  * - `features`: the feature vectors the trainer itself learns from (`features.jsonl`),
- *   so a recorded take can be re-trained headlessly and its points projected.
+ *   so a recorded take can be re-trained headlessly and its points projected. The EDGES
+ *   are **pinned** to {@link FEATURE_VECTOR_EDGES} — the same constant `LiveVectorTap`
+ *   filters on, so the take contains exactly what the trainer learned from.
+ *
+ *   This is a fix, not a tidy-up. `featureEdges` is a subset filter where **empty means
+ *   every edge** (`FeatureJsonlTap` only builds a filter set when the list is non-empty),
+ *   and nothing in the app has ever written it — no Record-sheet control, no dial. So it
+ *   was always `[]`, and a training take recorded *every output port of every node*.
+ *   That includes `camFace.face`, which carries all 478 face-mesh landmarks per tick
+ *   (`blendshapesToFaceFrame`, `src/nodes/sources/webcam_face.ts`). Two consequences,
+ *   both bad: a multi-minute routine wrote hundreds of megabytes, and a **face mesh** —
+ *   biometric geometry, unlike the blendshape coefficients and pose the catalog derives —
+ *   sat in a file the player is invited to hand to a fixture converter. Pinning the edges
+ *   keeps the mesh out of the recording at the source rather than stripping it later.
  * - annotations ride along through the trainer's own tag source (cue intervals, verdict
  *   points) — see `annotations.ts`.
  *
@@ -15,22 +28,35 @@
  */
 import { DEFAULT_RECORDING_SESSION, type RecordingSession } from '../recording/schema';
 import { prefillName } from '../recording/naming';
+import { FEATURE_VECTOR_EDGES } from './liveVector';
 
 /** The instrument label a training take is filed under. */
 export const TRAINER_TAKE_INSTRUMENT = 'trainer';
 
 /**
  * The recording session a training take uses. The STREAMS are fixed (the clean camera
- * + the features + the annotations — never the overlay or audio), and the name is
- * always the trainer's; everything else the player has chosen — where recordings go,
- * the frame rate, the media formats — is inherited from `base` (their last Record-sheet
- * config, so a training take lands wherever their other takes do).
+ * + the features + the annotations — never the overlay or audio) and so are the feature
+ * EDGES; the name is always the trainer's. Everything else the player has chosen — where
+ * recordings go, the frame rate, the media formats — is inherited from `base` (their last
+ * Record-sheet config, so a training take lands wherever their other takes do).
+ *
+ * The split is: what the take *is* belongs to the trainer, because a downstream consumer
+ * (the fixture converter, a headless re-train) depends on it; where it *goes* belongs to
+ * the player.
  */
 export function trainerTakeSession(base: RecordingSession = DEFAULT_RECORDING_SESSION, now: Date = new Date()): RecordingSession {
   return {
     ...base,
     name: prefillName({ instrument: TRAINER_TAKE_INSTRUMENT, date: now }),
     singleFileWhenAlone: false,
-    streams: { ...base.streams, audio: false, overlayVideo: false, overlayAlpha: false, pureVideo: true, features: true },
+    streams: {
+      ...base.streams,
+      audio: false,
+      overlayVideo: false,
+      overlayAlpha: false,
+      pureVideo: true,
+      features: true,
+      featureEdges: [...FEATURE_VECTOR_EDGES],
+    },
   };
 }

--- a/test/trainer_recording.test.ts
+++ b/test/trainer_recording.test.ts
@@ -11,6 +11,7 @@ import { resolve } from 'node:path';
 import { createRunner, createSession, type Cue, type FeatureVector, type RunnerEvent } from '@/enroll';
 import { createTrainerTagSource, trainerTagDefs, TRAINER_TAGS } from '@/app/enroll/annotations';
 import { trainerTakeSession, TRAINER_TAKE_INSTRUMENT } from '@/app/enroll/takeSession';
+import { FEATURE_VECTOR_EDGES } from '@/app/enroll/liveVector';
 import { DEFAULT_RECORDING_SESSION } from '@/app/recording/schema';
 import { STARTER_CUES } from '@/app/enroll/starterCues';
 import { useTrainer } from '@/app/enroll/store';
@@ -175,6 +176,42 @@ describe('what a training take records', () => {
     expect(s.streams.audio).toBe(false);
     expect(s.streams.pureVideo).toBe(true);
     expect(s.name).toContain(TRAINER_TAKE_INSTRUMENT);
+  });
+
+  // `featureEdges` is a subset filter where EMPTY MEANS EVERY EDGE, and nothing in the
+  // app ever wrote it — so before the pin every training take recorded every output port
+  // of every node, including `camFace.face` and its 478 face-mesh landmarks per tick.
+  // These three tests are the guard on that; the first two are the ones that go red if
+  // the pin is removed.
+  it('pins the feature edges to the ones the trainer itself learns from, whatever the player last chose', () => {
+    const narrowed = {
+      ...DEFAULT_RECORDING_SESSION,
+      streams: { ...DEFAULT_RECORDING_SESSION.streams, features: true, featureEdges: ['handVec.vector'] },
+    };
+    const s = trainerTakeSession(narrowed);
+    expect(s.streams.featureEdges).toEqual([...FEATURE_VECTOR_EDGES]);
+    // The specific loss the pin prevents: the face vector surviving the player's filter.
+    expect(s.streams.featureEdges).toContain('faceVec.vector');
+  });
+
+  it('pins them over the shipped default, which is empty — and empty records the face mesh', () => {
+    // The default is `[]`, and this is the case that actually happened in production:
+    // no UI writes this field, so every take took the empty path and recorded every edge
+    // — `camFace.face` included, which is 478 landmarks per tick. A non-empty pin is the
+    // difference between a take that carries a face mesh and one that does not.
+    expect(DEFAULT_RECORDING_SESSION.streams.featureEdges).toEqual([]);
+    const s = trainerTakeSession(DEFAULT_RECORDING_SESSION);
+    expect(s.streams.featureEdges.length).toBeGreaterThan(0);
+    expect(s.streams.featureEdges).toEqual([...FEATURE_VECTOR_EDGES]);
+    expect(s.streams.featureEdges).not.toContain('camFace.face');
+  });
+
+  it('records exactly the edges the live tap reads — the two must not drift apart', () => {
+    // FEATURE_VECTOR_EDGES is the SSOT `LiveVectorTap` filters on. If a third vector node
+    // is added and only one of the two sites is updated, the trainer would learn from a
+    // signal its own recording does not contain (or vice versa).
+    const s = trainerTakeSession();
+    expect(new Set(s.streams.featureEdges)).toEqual(new Set(FEATURE_VECTOR_EDGES));
   });
 });
 

--- a/test/trainer_take_cli.test.ts
+++ b/test/trainer_take_cli.test.ts
@@ -1,0 +1,78 @@
+/**
+ * The converter CLI is REACHABLE (#160 / #163).
+ *
+ * This exists because it was not. The first version of the converter put the logic and
+ * the CLI in one module and guarded the entry point with
+ * `if (process.argv[1]?.includes('trainer_take_to_fixture'))`. Under `vite-node` — the
+ * documented way to run it — `argv[1]` is `node_modules/.bin/vite-node` and the script's
+ * own path never appears in `argv` at all, so the guard was always false. The documented
+ * command printed nothing and exited 0.
+ *
+ * Every unit test of the conversion logic passed throughout, because they import
+ * `convertTake` directly. That is precisely the gap CLAUDE.md's "a feature nobody can
+ * find is not shipped" rule names, and the only check that closes it is running the
+ * documented command as documented.
+ */
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { tmpdir } from 'node:os';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const STEM = 'trainer-2026-09-05T10-00-00';
+const T0 = 1000;
+
+/** A minimal but schema-faithful take on disk. */
+function makeTake(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'cli-take-'));
+  const ann = [
+    JSON.stringify({ anchor: true, t: T0, clock: 'media', wallClockISO: '2026-09-05T10:00:00.000Z', recStartPerf: 1e6, session: STEM, schema: 'thoremin.annotations/1' }),
+    JSON.stringify({ t: T0 + 1, tCorrected: T0 + 1, tag: 'cue:look-left', status: 'open', seq: 0, clock: 'media', src: 'auto' }),
+    JSON.stringify({ t: T0 + 3, tCorrected: T0 + 3, tag: 'cue:look-left', status: 'close', seq: 1, clock: 'media', src: 'auto' }),
+  ];
+  writeFileSync(join(dir, `${STEM}.annotations.jsonl`), ann.join('\n') + '\n');
+  const feats = Array.from({ length: 20 }, (_, i) =>
+    JSON.stringify({ tick: i, t: T0 + 1 + i * 0.05, key: 'faceVec.vector', value: { 'face.head.yaw': -20 + i } }),
+  );
+  writeFileSync(join(dir, `${STEM}.features.jsonl`), feats.join('\n') + '\n');
+  writeFileSync(join(dir, `${STEM}.manifest.json`), JSON.stringify({ t0: T0, fps: 30, streams: [] }));
+  return dir;
+}
+
+/** Run the CLI exactly as the docs say to, and return its stdout. */
+function runCli(args: string[]): string {
+  return execFileSync(
+    'npx',
+    ['vite-node', 'scripts/trainer_take_to_fixture.ts', '--', ...args],
+    { cwd: ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+  );
+}
+
+describe('the documented CLI invocation actually runs', () => {
+  it('produces a report on a real take, rather than silently doing nothing', () => {
+    const out = runCli([makeTake(), 'cli_reachability_probe', '--dry-run']);
+    // The specific regression: the old entry guard made this string empty.
+    expect(out.trim()).not.toBe('');
+    expect(out).toContain('[dry run] would write');
+    expect(out).toContain(STEM);
+    expect(out).toContain('look-left');
+    expect(out).toContain('faceVec.vector');
+  }, 60_000);
+
+  it('a dry run writes nothing, so this test cannot leave a fixture behind', () => {
+    runCli([makeTake(), 'cli_reachability_probe', '--dry-run']);
+    expect(existsSync(join(ROOT, 'test', 'fixtures', 'cli_reachability_probe'))).toBe(false);
+  }, 60_000);
+
+  it('exits non-zero with usage when given no arguments', () => {
+    let code = 0;
+    try {
+      execFileSync('npx', ['vite-node', 'scripts/trainer_take_to_fixture.ts'], { cwd: ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+    } catch (err) {
+      code = (err as { status?: number }).status ?? 0;
+    }
+    expect(code).toBe(2);
+  }, 60_000);
+});

--- a/test/trainer_take_to_fixture.test.ts
+++ b/test/trainer_take_to_fixture.test.ts
@@ -21,7 +21,9 @@ import {
   edgeEventsFromRows,
   insideAnyCue,
   findStem,
-} from '../scripts/trainer_take_to_fixture';
+  stripRawPositions,
+} from '../scripts/lib_trainer_take';
+import { FACE_OMIT } from '@/app/enroll/starterCues';
 import { resolveIntervals } from '@/taglog/affordances/resolve';
 import { valuesFromNDJSON } from '@/dag';
 
@@ -68,6 +70,48 @@ function makeTake(opts: {
 function outRoot(): string {
   return mkdtempSync(join(tmpdir(), 'fixtures-'));
 }
+
+describe('raw image-space coordinates are stripped, not merely undetected', () => {
+  // The array check cannot see these: a landmark coordinate flattened into the vector as
+  // a plain number lives in a `Record<string, number>` with no arrays anywhere. Over a
+  // take, `face.head.x`/`face.head.y` are a frame-by-frame nose-tip trajectory.
+  it('removes the raw-position ids the trainer itself omits, and keeps everything else', () => {
+    const ids = new Set(FACE_OMIT);
+    const v = { 'face.head.yaw': -21.4, 'face.head.pitch': 3.2, 'face.head.x': 0.4931, 'face.head.y': 0.5127 };
+    const { value, stripped } = stripRawPositions(v, ids);
+    expect(stripped.sort()).toEqual(['face.head.x', 'face.head.y']);
+    expect(value).toEqual({ 'face.head.yaw': -21.4, 'face.head.pitch': 3.2 });
+  });
+
+  it('leaves a value with no raw positions untouched, by identity', () => {
+    const v = { 'face.head.yaw': -21.4 };
+    const r = stripRawPositions(v, new Set(FACE_OMIT));
+    expect(r.value).toBe(v);
+    expect(r.stripped).toEqual([]);
+  });
+
+  it('strips them out of the WRITTEN fixture, and reports what it removed', () => {
+    const dir = makeTake({
+      cues: [['look-left', 1, 3]],
+      features: [['faceVec.vector', 2, { 'face.head.yaw': -25, 'face.head.x': 0.49, 'face.head.y': 0.51 }]],
+    });
+    const root = outRoot();
+    const r = convertTake(dir, 'stripped', { fixturesRoot: root });
+
+    const values = valuesFromNDJSON(readFileSync(join(root, 'stripped', 'faceVec.vector.ndjson'), 'utf8'));
+    expect(values).toEqual([{ 'face.head.yaw': -25 }]);
+
+    // Reported, never silent — the whole posture of this converter is that a dropped
+    // field must be visible to whoever reads the fixture later.
+    expect(r.strippedRawPositions).toEqual([
+      { id: 'face.head.x', records: 1 },
+      { id: 'face.head.y', records: 1 },
+    ]);
+    const meta = JSON.parse(readFileSync(join(root, 'stripped', 'meta.json'), 'utf8'));
+    expect(meta.strippedRawPositions).toHaveLength(2);
+    expect(readFileSync(join(root, 'stripped', 'README.md'), 'utf8')).toContain('face.head.x');
+  });
+});
 
 describe('landmark refusal — the guarantee about what enters the repo', () => {
   it('detects a face mesh however deeply it is nested', () => {
@@ -278,6 +322,24 @@ describe('refusals that protect the caller', () => {
     expect(existsSync(join(root, 'grew', 'faceVec.vector.ndjson.gz'))).toBe(true);
     // The stale plain file must be gone, or loadStream would keep returning it.
     expect(existsSync(join(root, 'grew', 'faceVec.vector.ndjson'))).toBe(false);
+  });
+
+  it('clears a superseded stream whose key disappears on regeneration', () => {
+    // Broader than the gzip flip: re-record with no hands in frame and `handVec.vector`
+    // is never emitted, so its file would survive and loadStream would keep serving the
+    // PREVIOUS take's hand data while meta.json correctly omits the key.
+    const root = outRoot();
+    const both = makeTake({
+      cues: [['a', 1, 3]],
+      features: [['faceVec.vector', 2, { v: 1 }], ['handVec.vector', 2, { h: 1 }]],
+    });
+    convertTake(both, 'shrank', { fixturesRoot: root });
+    expect(existsSync(join(root, 'shrank', 'handVec.vector.ndjson'))).toBe(true);
+
+    const faceOnly = makeTake({ cues: [['a', 1, 3]], features: [['faceVec.vector', 2, { v: 2 }]] });
+    const r = convertTake(faceOnly, 'shrank', { fixturesRoot: root, force: true });
+    expect(r.streams.map((s) => s.key)).toEqual(['faceVec.vector']);
+    expect(existsSync(join(root, 'shrank', 'handVec.vector.ndjson'))).toBe(false);
   });
 
   it('refuses a directory holding more than one take, naming them', () => {

--- a/test/trainer_take_to_fixture.test.ts
+++ b/test/trainer_take_to_fixture.test.ts
@@ -246,6 +246,48 @@ describe('refusals that protect the caller', () => {
     expect(() => convertTake(dir, 'truncated', { fixturesRoot: outRoot() })).toThrow(/line 2 is not JSON/);
   });
 
+  it('refuses to overwrite an existing fixture — the README is hand-written and not regenerable', () => {
+    // Every committed fixture name matches the scenario regex, so `video_head_pose` is a
+    // reachable typo — and its ground-truth table was established by reading traces
+    // against video frames. Losing it silently is the expensive failure.
+    const dir = makeTake({ cues: [['a', 1, 3]], features: [['faceVec.vector', 2, { v: 1 }]] });
+    const root = outRoot();
+    convertTake(dir, 'twice', { fixturesRoot: root });
+    expect(() => convertTake(dir, 'twice', { fixturesRoot: root })).toThrow(/already exists/);
+    // --force is the deliberate escape hatch.
+    expect(() => convertTake(dir, 'twice', { fixturesRoot: root, force: true })).not.toThrow();
+  });
+
+  it('removes the stale counterpart when a regeneration crosses the gzip threshold', () => {
+    // loadStream tries `<key>.ndjson` BEFORE `<key>.ndjson.gz`, so leaving both would make
+    // a re-recorded, larger take silently lose to the stale plain file.
+    const root = outRoot();
+    const small = makeTake({ cues: [['a', 1, 3]], features: [['faceVec.vector', 2, { v: 1 }]] });
+    const r1 = convertTake(small, 'grew', { fixturesRoot: root });
+    expect(r1.streams[0].gzipped).toBe(false);
+    expect(existsSync(join(root, 'grew', 'faceVec.vector.ndjson'))).toBe(true);
+
+    const big = makeTake({
+      cues: [['a', 1, 3]],
+      features: Array.from({ length: 6000 }, (_, i): [string, number, unknown] => [
+        'faceVec.vector', 1 + (i / 6000) * 2, { 'face.head.yaw': i * 0.001, 'face.head.pitch': i * 0.002 },
+      ]),
+    });
+    const r2 = convertTake(big, 'grew', { fixturesRoot: root, force: true });
+    expect(r2.streams[0].gzipped).toBe(true);
+    expect(existsSync(join(root, 'grew', 'faceVec.vector.ndjson.gz'))).toBe(true);
+    // The stale plain file must be gone, or loadStream would keep returning it.
+    expect(existsSync(join(root, 'grew', 'faceVec.vector.ndjson'))).toBe(false);
+  });
+
+  it('refuses a directory holding more than one take, naming them', () => {
+    // Downloads is where takes accumulate, and the instruction is "unzip it first".
+    // readdirSync order is unspecified, so picking one silently converts an arbitrary take.
+    const dir = makeTake({ cues: [['a', 1, 3]], features: [['faceVec.vector', 2, {}]] });
+    writeFileSync(join(dir, 'trainer-2026-08-24T09-00-00.features.jsonl'), '');
+    expect(() => findStem(dir)).toThrow(/2 takes found/);
+  });
+
   it('dry-run writes nothing', () => {
     const dir = makeTake({ cues: [['a', 1, 3]], features: [['faceVec.vector', 2, { v: 1 }]] });
     const root = outRoot();

--- a/test/trainer_take_to_fixture.test.ts
+++ b/test/trainer_take_to_fixture.test.ts
@@ -1,0 +1,298 @@
+/**
+ * The trainer-take → fixture converter (#160 / #163 / #146).
+ *
+ * Tested against a SYNTHESIZED take rather than a recorded one, deliberately: the point
+ * of the converter is that a take is machine-readable, so the test can build one from the
+ * same schemas the app writes and assert the join without a camera, a browser or a
+ * committed multi-megabyte input.
+ *
+ * The assertions that matter are the ones about what must NOT come out: no landmark
+ * geometry, nothing outside a cue window, and no invented clock.
+ */
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { gunzipSync } from 'node:zlib';
+import {
+  convertTake,
+  carriesLandmarks,
+  cueWindows,
+  edgeEventsFromRows,
+  insideAnyCue,
+  findStem,
+} from '../scripts/trainer_take_to_fixture';
+import { resolveIntervals } from '@/taglog/affordances/resolve';
+import { valuesFromNDJSON } from '@/dag';
+
+const STEM = 'trainer-2026-08-23T12-00-00';
+const T0 = 1000;
+
+/** Build a take folder on disk: the anchor + cue rows + a feature stream. */
+function makeTake(opts: {
+  /** [cue id, startOffset, endOffset] — offsets in seconds from t0. */
+  cues: [string, number, number][];
+  /** Feature records as [key, offsetSeconds, value]. */
+  features: [string, number, unknown][];
+  /** Leave the last cue unclosed. */
+  openEnded?: boolean;
+} = { cues: [['look-left', 1, 3], ['look-right', 5, 7]], features: [] }): string {
+  const dir = mkdtempSync(join(tmpdir(), 'take-'));
+  const ann: string[] = [
+    JSON.stringify({
+      anchor: true,
+      t: T0,
+      clock: 'media',
+      wallClockISO: '2026-08-23T12:00:00.000Z',
+      recStartPerf: 1_000_000,
+      session: STEM,
+      schema: 'thoremin.annotations/1',
+    }),
+  ];
+  let seq = 0;
+  for (const [cue, s, e] of opts.cues) {
+    ann.push(JSON.stringify({ t: T0 + s, tCorrected: T0 + s, tag: `cue:${cue}`, status: 'open', seq: seq++, clock: 'media', src: 'auto' }));
+    ann.push(JSON.stringify({ t: T0 + (s + e) / 2, tCorrected: T0 + (s + e) / 2, tag: 'verdict:enough', status: 'point', seq: seq++, clock: 'media', src: 'auto' }));
+    if (!opts.openEnded) {
+      ann.push(JSON.stringify({ t: T0 + e, tCorrected: T0 + e, tag: `cue:${cue}`, status: 'close', seq: seq++, clock: 'media', src: 'auto' }));
+    }
+  }
+  writeFileSync(join(dir, `${STEM}.annotations.jsonl`), ann.join('\n') + '\n');
+
+  const feats = opts.features.map(([key, off, value], i) => JSON.stringify({ tick: i, t: T0 + off, key, value }));
+  writeFileSync(join(dir, `${STEM}.features.jsonl`), feats.join('\n') + '\n');
+  writeFileSync(join(dir, `${STEM}.manifest.json`), JSON.stringify({ t0: T0, fps: 30, streams: [] }));
+  return dir;
+}
+
+function outRoot(): string {
+  return mkdtempSync(join(tmpdir(), 'fixtures-'));
+}
+
+describe('landmark refusal — the guarantee about what enters the repo', () => {
+  it('detects a face mesh however deeply it is nested', () => {
+    expect(carriesLandmarks({ present: true, blendshapes: { smile: 0.4 } })).toBe(false);
+    expect(carriesLandmarks({ present: true, landmarks: [{ x: 1, y: 2, z: 3 }] })).toBe(true);
+    expect(carriesLandmarks({ outer: { inner: { landmarks: [] } } })).toBe(true);
+    expect(carriesLandmarks([{ a: 1 }, { landmarks: [{ x: 0 }] }])).toBe(true);
+    // Hand keypoints are the same class of thing under a different name.
+    expect(carriesLandmarks({ hands: [{ keypoints: [{ x: 1, y: 2 }] }] })).toBe(true);
+  });
+
+  it('REFUSES the whole take rather than trimming the mesh out of it', () => {
+    const dir = makeTake({
+      cues: [['look-left', 1, 3]],
+      features: [
+        ['faceVec.vector', 2, { 'face.head.yaw': -20 }],
+        ['camFace.face', 2, { present: true, landmarks: [{ x: 0.5, y: 0.5, z: 0 }] }],
+      ],
+    });
+    expect(() => convertTake(dir, 'scratch', { fixturesRoot: outRoot() })).toThrow(/landmarks\/keypoints/);
+  });
+
+  it('the refusal names the edge and the fix, not just the failure', () => {
+    const dir = makeTake({
+      cues: [['look-left', 1, 3]],
+      features: [['camFace.face', 2, { landmarks: [{ x: 0, y: 0, z: 0 }] }]],
+    });
+    try {
+      convertTake(dir, 'scratch', { fixturesRoot: outRoot() });
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      const m = err instanceof Error ? err.message : String(err);
+      expect(m).toContain('camFace.face');
+      expect(m).toContain('featureEdges');
+    }
+  });
+});
+
+describe('slicing by cue interval', () => {
+  it('keeps only records inside a cue and drops the dead time between them', () => {
+    const dir = makeTake({
+      cues: [['look-left', 1, 3], ['look-right', 5, 7]],
+      features: [
+        ['faceVec.vector', 0.5, { 'face.head.yaw': 0 }], // before the first cue
+        ['faceVec.vector', 2, { 'face.head.yaw': -25 }], // inside cue 1
+        ['faceVec.vector', 4, { 'face.head.yaw': 0 }], // between cues
+        ['faceVec.vector', 6, { 'face.head.yaw': 30 }], // inside cue 2
+        ['faceVec.vector', 9, { 'face.head.yaw': 0 }], // after the last cue
+      ],
+    });
+    const root = outRoot();
+    const r = convertTake(dir, 'head_turns', { fixturesRoot: root });
+
+    expect(r.streams).toHaveLength(1);
+    expect(r.streams[0]).toMatchObject({ key: 'faceVec.vector', kept: 2, total: 5 });
+
+    const values = valuesFromNDJSON(readFileSync(join(root, 'head_turns', 'faceVec.vector.ndjson'), 'utf8'));
+    expect(values).toEqual([{ 'face.head.yaw': -25 }, { 'face.head.yaw': 30 }]);
+  });
+
+  it('preserves the take\'s own tick and t, so streams stay mutually aligned', () => {
+    const dir = makeTake({
+      cues: [['look-left', 1, 3]],
+      features: [
+        ['faceVec.vector', 2, { a: 1 }],
+        ['handVec.vector', 2, { b: 2 }],
+      ],
+    });
+    const root = outRoot();
+    convertTake(dir, 'aligned', { fixturesRoot: root });
+    const face = readFileSync(join(root, 'aligned', 'faceVec.vector.ndjson'), 'utf8').trim();
+    const hand = readFileSync(join(root, 'aligned', 'handVec.vector.ndjson'), 'utf8').trim();
+    // Absolute engine-clock time, not rebased to zero — that is what makes a join possible.
+    expect(JSON.parse(face).t).toBe(T0 + 2);
+    expect(JSON.parse(hand).t).toBe(T0 + 2);
+    expect(JSON.parse(face).tick).toBe(0);
+    expect(JSON.parse(hand).tick).toBe(1);
+  });
+
+  it('writes one file per edge, named so loadStream() finds it', () => {
+    const dir = makeTake({
+      cues: [['look-left', 1, 3]],
+      features: [['faceVec.vector', 2, { a: 1 }], ['handVec.vector', 2, { b: 2 }]],
+    });
+    const root = outRoot();
+    convertTake(dir, 'two_edges', { fixturesRoot: root });
+    const names = readdirSync(join(root, 'two_edges')).sort();
+    expect(names).toContain('faceVec.vector.ndjson');
+    expect(names).toContain('handVec.vector.ndjson');
+    expect(names).toContain('cues.json');
+    expect(names).toContain('meta.json');
+    expect(names).toContain('README.md');
+  });
+});
+
+describe('the cue index', () => {
+  it('records each cue as a take-relative window with its verdict', () => {
+    const dir = makeTake({
+      cues: [['look-left', 1, 3], ['look-right', 5, 7]],
+      features: [['faceVec.vector', 2, { a: 1 }], ['faceVec.vector', 6, { a: 2 }]],
+    });
+    const root = outRoot();
+    const r = convertTake(dir, 'cue_index', { fixturesRoot: root });
+    expect(r.cues).toEqual([
+      { cue: 'look-left', start: 1, end: 3, startAbs: T0 + 1, endAbs: T0 + 3, openEnded: false },
+      { cue: 'look-right', start: 5, end: 7, startAbs: T0 + 5, endAbs: T0 + 7, openEnded: false },
+    ]);
+    const cues = JSON.parse(readFileSync(join(root, 'cue_index', 'cues.json'), 'utf8'));
+    expect(cues.t0).toBe(T0);
+    expect(cues.verdicts.map((v: { cue: string }) => v.cue)).toEqual(['look-left', 'look-right']);
+  });
+
+  it('resolves intervals through taglog rather than re-pairing opens and closes itself', () => {
+    // The converter must agree with the exporters (Audacity/WebVTT/CSV) on where an
+    // interval starts and ends, which it does by calling the same resolver they do.
+    const rows = [
+      { t: T0 + 1, tCorrected: T0 + 1, tag: 'cue:a', status: 'open', seq: 0, clock: 'media', src: 'auto' },
+      { t: T0 + 3, tCorrected: T0 + 3, tag: 'cue:a', status: 'close', seq: 1, clock: 'media', src: 'auto' },
+    ];
+    const direct = cueWindows(resolveIntervals(edgeEventsFromRows(rows)), T0);
+    expect(direct).toEqual([{ cue: 'a', start: 1, end: 3, startAbs: T0 + 1, endAbs: T0 + 3, openEnded: false }]);
+  });
+
+  // A cue left open is the cue the take stopped DURING — the one whose data an abandoned
+  // take still has. taglog's resolver gives an unclosed open `end === start` unless told
+  // when the recording ended, and taking that literally would keep zero of its samples.
+  it('keeps the samples of a cue the take stopped during, and reports a real end time', () => {
+    const dir = makeTake({
+      cues: [['look-left', 1, 3]],
+      features: [
+        ['faceVec.vector', 0.5, { a: 'before' }],
+        ['faceVec.vector', 2, { a: 'during' }],
+        ['faceVec.vector', 6, { a: 'still-during' }],
+      ],
+      openEnded: true,
+    });
+    const root = outRoot();
+    const r = convertTake(dir, 'open_ended', { fixturesRoot: root });
+    expect(r.cues).toHaveLength(1);
+    expect(r.cues[0].openEnded).toBe(true);
+    // Sealed to the last record actually seen, not left as Infinity and not collapsed to 1.
+    expect(r.cues[0].end).toBe(6);
+    expect(Number.isFinite(r.cues[0].endAbs)).toBe(true);
+    // The pre-cue record is still excluded; both in-cue records survive.
+    const values = valuesFromNDJSON(readFileSync(join(root, 'open_ended', 'faceVec.vector.ndjson'), 'utf8'));
+    expect(values).toEqual([{ a: 'during' }, { a: 'still-during' }]);
+  });
+});
+
+describe('refusals that protect the caller', () => {
+  it('rejects a scenario name that is a path', () => {
+    const dir = makeTake({ cues: [['a', 1, 3]], features: [['faceVec.vector', 2, {}]] });
+    expect(() => convertTake(dir, '../escape', { fixturesRoot: outRoot() })).toThrow(/lowercase letters/);
+    expect(() => convertTake(dir, 'a/b', { fixturesRoot: outRoot() })).toThrow(/lowercase letters/);
+  });
+
+  it('says what to do when handed a zip instead of an unzipped folder', () => {
+    const empty = mkdtempSync(join(tmpdir(), 'empty-'));
+    expect(() => findStem(empty)).toThrow(/unzip/);
+  });
+
+  it('refuses a take with no cue intervals — there would be nothing to slice by', () => {
+    const dir = makeTake({ cues: [], features: [['faceVec.vector', 2, {}]] });
+    expect(() => convertTake(dir, 'nocues', { fixturesRoot: outRoot() })).toThrow(/no cue intervals/);
+  });
+
+  it('refuses when nothing fell inside a cue — the likeliest sign of a clock mismatch', () => {
+    const dir = makeTake({ cues: [['a', 1, 3]], features: [['faceVec.vector', 99, {}]] });
+    expect(() => convertTake(dir, 'nooverlap', { fixturesRoot: outRoot() })).toThrow(/share a clock/);
+  });
+
+  it('names the line number when the take is truncated mid-write', () => {
+    const dir = makeTake({ cues: [['a', 1, 3]], features: [['faceVec.vector', 2, {}]] });
+    const p = join(dir, `${STEM}.features.jsonl`);
+    writeFileSync(p, readFileSync(p, 'utf8') + '{"tick":1,"t":100,"key":"x","val\n');
+    expect(() => convertTake(dir, 'truncated', { fixturesRoot: outRoot() })).toThrow(/line 2 is not JSON/);
+  });
+
+  it('dry-run writes nothing', () => {
+    const dir = makeTake({ cues: [['a', 1, 3]], features: [['faceVec.vector', 2, { v: 1 }]] });
+    const root = outRoot();
+    const r = convertTake(dir, 'dry', { fixturesRoot: root, dryRun: true });
+    expect(r.streams[0].kept).toBe(1);
+    expect(existsSync(join(root, 'dry'))).toBe(false);
+  });
+});
+
+describe('the committed bytes', () => {
+  it('gzips a large stream and leaves a small one plain, both loadable the same way', () => {
+    const big: [string, number, unknown][] = [];
+    for (let i = 0; i < 4000; i++) {
+      big.push(['faceVec.vector', 1 + (i / 4000) * 2, { 'face.head.yaw': i * 0.001, 'face.head.pitch': i * 0.002 }]);
+    }
+    const dir = makeTake({ cues: [['look-left', 1, 3]], features: big });
+    const root = outRoot();
+    const r = convertTake(dir, 'big', { fixturesRoot: root });
+    expect(r.streams[0].gzipped).toBe(true);
+    const gz = join(root, 'big', 'faceVec.vector.ndjson.gz');
+    expect(existsSync(gz)).toBe(true);
+    const values = valuesFromNDJSON(gunzipSync(readFileSync(gz)).toString('utf8'));
+    expect(values).toHaveLength(4000);
+  });
+
+  it('is byte-reproducible — the same take converts to the same bytes twice', () => {
+    const dir = makeTake({
+      cues: [['look-left', 1, 3]],
+      features: Array.from({ length: 3000 }, (_, i): [string, number, unknown] => ['faceVec.vector', 1 + (i / 3000) * 2, { v: i }]),
+    });
+    const a = outRoot();
+    const b = outRoot();
+    const ra = convertTake(dir, 'repro', { fixturesRoot: a });
+    convertTake(dir, 'repro', { fixturesRoot: b });
+    const name = `faceVec.vector.ndjson${ra.streams[0].gzipped ? '.gz' : ''}`;
+    const fa = readFileSync(join(a, 'repro', name));
+    const fb = readFileSync(join(b, 'repro', name));
+    expect(fa.equals(fb)).toBe(true);
+  });
+});
+
+describe('insideAnyCue', () => {
+  it('is inclusive at both ends, so a record exactly on the boundary is kept', () => {
+    const w = [{ cue: 'a', start: 1, end: 3, startAbs: 1, endAbs: 3, openEnded: false }];
+    expect(insideAnyCue(0.999, w)).toBe(false);
+    expect(insideAnyCue(1, w)).toBe(true);
+    expect(insideAnyCue(3, w)).toBe(true);
+    expect(insideAnyCue(3.001, w)).toBe(false);
+  });
+});


### PR DESCRIPTION
Task 2 of four, and the high-leverage one. A trainer take already records the clean
camera, the feature vectors and a cue interval per instruction on one clock, with
recording on by default since #176. What was missing was the join.

## The bug found on the way in is the more important half

`featureEdges` is a subset filter where an **empty list means every edge**
(`FeatureJsonlTap` only builds a filter set when the list is non-empty), and **nothing
in the app has ever written it** — verified against `main`, not the working tree:

```
$ git grep -n "featureEdges" main -- src/ | grep -v "schema.ts\|session.ts"
(nothing)
```

So it was always `[]`, and a training take recorded *every output port of every node*.
That includes `camFace.face`, an edge in the default graph (`src/app/graph.ts:253`)
whose value carries **all 478 face-mesh landmarks per tick** (`blendshapesToFaceFrame`,
`src/nodes/sources/webcam_face.ts`). Two consequences, both bad:

- a multi-minute routine wrote hundreds of megabytes of `features.jsonl`
- a **face mesh** — biometric geometry, unlike the blendshape coefficients and the
  head-pose triple the catalog derives from it — sat in a file the player is invited to
  hand to a fixture converter

`trainerTakeSession` now pins the edges to `FEATURE_VECTOR_EDGES`, the constant
`LiveVectorTap` already filters on, so a take contains exactly what the trainer learned
from. The split: what a take **is** belongs to the trainer, because a downstream consumer
depends on it; where it **goes** stays the player's (location, fps and formats are still
inherited).

## The converter

`scripts/trainer_take_to_fixture.ts` resolves cue intervals through taglog's own
`resolveIntervals` — the same one the Audacity/WebVTT/CSV exporters use, so boundaries
agree rather than being re-derived — slices each edge to the records inside a cue, and
writes `test/fixtures/<scenario>/` in the layout `test/helpers/fixtures.ts` already
loads. It preserves the take's own `tick`/`t`, so streams stay mutually aligned.

Two behaviours the tests pin, both found by writing them:

- **It refuses a take carrying landmark or keypoint geometry** rather than trimming it.
  A converter that silently drops a field is one nobody checks, and this is the boundary
  that decides what enters a public repo. The pin is the first line of defence; this is
  the one that guards the repo.
- **A cue the take stopped during extends to the end of the recording**, not to a point.
  `resolveIntervals` returns `end === start` for an unclosed open unless told when
  recording stopped — so the naive reading discards every sample of the one cue an
  abandoned take still has.

## Why this pays off

`test/fixtures/video_head_pose/README.md` records why yaw and roll stayed open after
#161: nothing in a clip says whether it was mirrored, so *"the person turned to **their**
left"* is unrecoverable from the pixels. `starterCues.ts` already ships
look-left / look-right / tilt-left / tilt-right — cues phrased in the player's own frame
of reference. One two-minute session now yields a committed fixture that settles them.

That is #168 Q1's answer taken literally: *don't chase it from the old clip; let the
trainer produce the material.*

## Verification

- 1353 → **1374 tests**, all passing; `typecheck` clean; `catalog` unaffected (no node change)
- Tested against a **synthesized** take — the point of the converter is that a take is
  machine-readable, so the test needs no camera and no committed multi-megabyte input
- **All three guards mutation-tested**: reverting the landmark refusal fails 2 tests, the
  cue slice 3, the open-ended sealing 1

`docs/TESTING.md` also loses a false claim: it documents `meta.json`'s `graphSpecHash` as
an enforced staleness key. Nothing reads `meta.json` — two scripts write it, no test or
source file opens it, and the two face fixtures ship without one.

## What I still need from you

Nothing to merge this. To *use* it, one ~2-minute webcam session — I'll write the exact
steps in a follow-up comment once #146 is rewritten (task 4).

https://claude.ai/code/session_019MqaXSdxoS9hdavMAAMVvu