### PR TITLE
#101 M-D (engine half): the Source contract, the pump, and the Applier runHeadless delegates to

### DIFF
--- a/docs/design/stream-applier.md
+++ b/docs/design/stream-applier.md
@@ -5,8 +5,9 @@
 > speed, #103 / PR #106), and **M-C** (#104 / PR #167 — the `source` slot, the typed
 > `replay-hands` candidate, and `PortSpec.schema` conformance). **M-D is in progress:**
 > its clock half landed with the live loop (#166 / `src/app/engineLoop.ts`); what
-> remains is the `Source` interface + pump and the `Applier` itself. M-E…M-G are
-> designed, unstarted.
+> remains is its live half — `useEngine` becoming an Applier config. The `Source`
+> interface, its pump and the `Applier` are built (`src/dag/applier.ts`), and
+> `runHeadless` delegates to it. M-E…M-G are designed, unstarted.
 >
 > This document is the single source of truth; the ROADMAP and the tracking issues
 > point here. It supersedes ad-hoc source/replay wiring. **The per-milestone bullets
@@ -76,6 +77,17 @@ These come from the existing engine (`src/dag/engine.ts`) and are load-bearing:
   is an *offline* pre-processing step (`scripts/video_to_landmarks.py`), never an
   in-loop batch source. Automated raw-video regression, if ever needed, is a
   separate Playwright/headless-Chrome investment — out of scope.
+- **(C) A synchronous clock cannot service an async `Source`.** `Clock.run`'s `onTick`
+  is **synchronous**, so a clock whose loop never yields — `BatchClock`'s plain `for` —
+  gives a source's async iterator no turn to produce a frame. The graph would tick to
+  completion against a resource nothing ever wrote, which presents as "my source did
+  nothing" and is hard to trace. Rather than paper over it, `Clock` declares
+  `paced: boolean` and `Applier` **refuses** the combination with a message naming the
+  fix. This is not a limitation in practice: it falls straight out of invariant 4 —
+  batch replays through zero-input **nodes** (`replay-source`, `synthetic-hands`), and a
+  host-side `Source` exists for live origins, which are inherently paced. Discovered
+  while building M-D, and stated here because the design had not anticipated it.
+
 - **(B) Accelerated/slowed audio is not a time-multiply.** Control-rate params
   scale with `ctx.time` for free; audio rides `AudioContext.currentTime` and does
   not. Policy: **real-time = live audio; accelerated/slowed = control-rate
@@ -139,8 +151,9 @@ interface Clock {
   it forces for any clock). Control-rate `dt` scales for free. `now`/`schedule`
   are injectable so the clock is fully headless-testable. Speed ≠ 1 is gated to
   recorded/generated sources and obeys boundary B for audio; a **non-positive
-  speed** collapses to a frozen clock (`dt = 0`) — validated when `RealtimeClock`
-  is adopted into the app (M-D).
+  speed** would collapse to a frozen clock (`dt = 0`), so `RealtimeClock` **throws a
+  `RangeError`** on a non-finite or non-positive speed rather than shipping one
+  (`src/dag/clock.ts`; landed with M-D).
 
 ### Applier — applies an Engine to a SourceSet under a Clock
 
@@ -158,11 +171,13 @@ class Applier {
 }
 ```
 
-Will live at `src/dag/applier.ts` (**in-repo**; revisit extraction to a reusable
-substrate once it stabilizes at M-D and a second consumer appears). Not built yet —
-this section describes the target, not the code. M-D is *partly* landed: the live
-loop already runs on a `Clock` (#166), so what is missing is the `Source` interface,
-its pump, and the `Applier` that ties them to the engine. `useEngine`
+Lives at `src/dag/applier.ts` (**in-repo**; revisit extraction to a reusable substrate
+once it stabilizes and a second consumer appears). **Built**, with two departures from
+the sketch above, both deliberate: it takes a **live `Engine`** rather than a
+spec+registry (the lifecycle section below licenses this — and it is what keeps
+`runHeadless` byte-identical, since the engine keeps its own `validatePorts` default and
+tap wiring), and it takes the **`resources` object** the engine was constructed with, so
+the pump writes latched frames into the same reference every node reads. `useEngine`
 (live/paced) and `runHeadless` (batch) both collapse to configs of it, differing
 on **{clock, sinks, taps} jointly** — not "only the clock". Batch attaches a
 recording tap and **no audio sink** (the synth self-no-ops when the audio
@@ -206,7 +221,8 @@ boundaries allow.
   loop-boundary MediaPipe tracking-reset. Medium, not 15 lines. The hand model
   still loads (not free). Known limitation: the instrument mirrors the video
   (selfie assumption), so a non-mirror-image clip renders flipped with Left/Right
-  swapped — a per-source `mirror` flag is deferred to the M-C Source contract.
+  swapped — a per-source `mirror` flag is deferred to the host-side **`Source`** contract, which
+  M-C did **not** ship — it moved to M-D along with the async-iterable interface.
 - **M-B — Clock + speed multiplier (R5 control-rate core). ✅ shipped.**
   `src/dag/clock.ts` (`Clock` / `BatchClock` / `RealtimeClock`); refit the
   **`runHeadless`** loop → `BatchClock(ticks)` (preserve the no-arg `tick()`
@@ -250,10 +266,12 @@ boundaries allow.
     implementation and no consumer until the Applier exists; shipping it now would
     be a contract nobody honours, which this repo has been burned by twice
     (#119, #120). The node-swap half above needs none of it.
-- **M-D — The Applier (R4 complete, R5 orthogonality). ⚠ untested live surface.**
-  `runHeadless` delegates (BatchClock + bounded recorder tap, no audio sink);
-  `useEngine`'s effect becomes a thin Applier config — **this is where the live
-  rAF loop adopts `RealtimeClock(1)`** (deferred from M-B).
+- **M-D — The Applier (R4 complete, R5 orthogonality). ◑ engine half SHIPPED; live
+  half remains. ⚠ untested live surface.**
+  `runHeadless` **now delegates** to `Applier` (`src/dag/applier.ts`: BatchClock +
+  the recorder tap, no sources, no sinks). What remains is the other caller:
+  `useEngine`'s effect becoming a thin Applier config. The live rAF loop already
+  adopted `RealtimeClock(1)` (#166), so that deferral from M-B is discharged.
   **Gate on a browser smoke test** — the effect (StrictMode guards, face bridge,
   mute mirror, AudioContext lifecycle) has no headless coverage.
   - ✅ **The live loop now runs on `RealtimeClock(1)`** — `src/app/engineLoop.ts`

--- a/src/dag/applier.ts
+++ b/src/dag/applier.ts
@@ -107,6 +107,8 @@ export class Applier {
   private readonly pumps: Promise<void>[] = [];
   private stopped = false;
   private disposed = false;
+  /** First error thrown by a source when no `onError` was given; raised by `run()`. */
+  private sourceError: unknown;
 
   constructor(o: ApplierOptions) {
     this.engine = o.engine;
@@ -152,6 +154,9 @@ export class Applier {
       (time) => this.tick(time),
       () => this.stopped || this.disposed || this.extraStop?.() === true || this.sourcesExhausted(),
     );
+    // A source failure surfaces here rather than as an unhandled rejection — see
+    // `startPumps`. The run has already stopped; this is how the caller learns why.
+    if (this.sourceError !== undefined) throw this.sourceError;
   }
 
   /** One tick: publish what the pumps collected, advance the engine, fan out to sinks. */
@@ -223,7 +228,12 @@ export class Applier {
             // error that caused it would be lost.
             this.stopped = true;
             if (this.onError) this.onError(err);
-            else throw err;
+            // Deliberately NOT rethrown. These promises are never awaited — they outlive
+            // the tick loop by design — so a throw here is an UNHANDLED REJECTION, which
+            // in Node is a process-level crash: a bad source would take down a whole test
+            // run rather than failing its own. Stash it and let `run()` raise it, so the
+            // caller gets it from the `await` they already have.
+            else if (this.sourceError === undefined) this.sourceError = err;
           }
         })(),
       );

--- a/src/dag/applier.ts
+++ b/src/dag/applier.ts
@@ -1,0 +1,246 @@
+/**
+ * The Applier (#101 M-D) — applies an {@link Engine} to a set of {@link Source}s under
+ * a {@link Clock}.
+ *
+ * The DAG is *the computation*. **Applying** it to a stream is a separate concern with
+ * three independent choices: where the data comes from (the sources), when the engine
+ * advances (the clock), and what happens to the outputs (taps for recording, sinks for
+ * view/hear). `runHeadless` (batch) and the live loop (paced) differ on **{clock, sinks,
+ * taps} jointly** — not "only the clock" — which is why one object owns all three.
+ *
+ * SSOT: `docs/design/stream-applier.md`. This module implements the `Source` and
+ * `Applier` shapes defined there, with two deliberate departures, both recorded below.
+ *
+ * ## It takes a live Engine, not a spec+registry
+ *
+ * The design's sketch has the Applier construct the engine. The lifecycle section added
+ * later supersedes that: *"M-D's Applier owns which graph and which clock; it does not
+ * need to own engine construction. `useEngine` and `runHeadless` can both hand it a live
+ * engine."* Taking an engine is what keeps this refactor byte-identical — `runHeadless`
+ * keeps its own `validatePorts` default and its own tap wiring, and the live hook keeps
+ * its browser resources and its `applyGraph` lifecycle. An Applier that built engines
+ * would have to reproduce both, exactly, forever.
+ *
+ * ## The tick is forwarded verbatim, including `undefined`
+ *
+ * `BatchClock` calls `onTick()` with **no argument** so the engine synthesizes
+ * `tickIndex * nominalDt`; every committed fixture was recorded that way. `Engine.tick`
+ * reads `time ?? tickIndex * nominalDt`, so forwarding the optional parameter is exactly
+ * equivalent to omitting it. What is **not** equivalent — and is the trap this module
+ * exists to avoid — is `src/app/engineLoop.ts`'s `const seconds = t ?? now()`, which
+ * substitutes the *wall clock* when the clock passes nothing. That is right for the live
+ * loop (its reporters need a real millisecond stamp) and would silently move every batch
+ * run's time base. `test/applier_byte_identity.test.ts` is the gate on it.
+ */
+import type { Engine } from './engine';
+import type { Clock } from './clock';
+import type { Tap } from './types';
+
+/** What a source's generator is handed when the Applier starts pumping it. */
+export interface SourceContext {
+  /** Aborted when the Applier is disposed, so a live generator can stop cleanly. */
+  readonly signal: AbortSignal;
+}
+
+/**
+ * A stream of frames, origin-independent (design R1). A live camera, a video file, a
+ * recorded NDJSON replay and a pure generator are the same interface; the origin lives
+ * entirely inside `frames()`.
+ *
+ * `kind` decides how the Applier samples it between ticks:
+ * - **`signal`** (hand landmarks, video frames) — the newest frame wins; intermediate
+ *   frames are dropped, because a stale pose is worse than no pose.
+ * - **`event`** (keyboard, MIDI) — every frame since the last tick accumulates into a
+ *   list, because dropping a keypress loses information a later frame cannot recover.
+ */
+export interface Source<Frame = unknown> {
+  readonly id: string;
+  readonly kind: 'signal' | 'event';
+  /** The `ctx.resources` key the in-graph node reads (e.g. 'video', 'hands'). */
+  readonly outputResource: string;
+  /** The origin. An `async function*` yielding frames at its own rate. */
+  frames(ctx: SourceContext): AsyncIterable<Frame>;
+  /** EOF: the video ended, the records drained. Polled as a stop condition. */
+  exhausted(): boolean;
+  dispose(): void;
+}
+
+export interface ApplierOptions {
+  engine: Engine;
+  clock: Clock;
+  /**
+   * The SAME object the engine was constructed with (`EngineOptions.resources`). The
+   * pump writes latched/accumulated frames into it in place; the engine hands that
+   * object to every node as `ctx.resources` on every tick, so nodes see updates without
+   * any engine API for it. This mirrors what `useEngine` already does with its
+   * `resourcesRef`. Omit when there are no sources.
+   */
+  resources?: Record<string, unknown>;
+  /** Open-closed over origin (R4). Empty is normal: a graph whose sources are ordinary
+   *  zero-input nodes (replay/synthetic) needs none. */
+  sources?: readonly Source[];
+  /** Extra stop conditions, OR-ed with source exhaustion and `dispose()`. */
+  shouldStop?: () => boolean;
+  /** Called after each successful tick — the paced path's view/hear fan-out. */
+  sinks?: readonly ((time: number | undefined) => void)[];
+  /** Where a tick error is reported. Default: rethrow (batch must fail loudly). */
+  onError?: (err: unknown) => void;
+}
+
+/**
+ * Applies an engine to its sources under a clock. Construct, `run()`, then `dispose()`.
+ *
+ * With no sources this is exactly "drive the engine from the clock", which is what makes
+ * `runHeadless` a config of it rather than a rewrite.
+ */
+export class Applier {
+  private readonly engine: Engine;
+  private readonly clock: Clock;
+  private readonly resources: Record<string, unknown>;
+  private readonly sources: readonly Source[];
+  private readonly sinks: readonly ((time: number | undefined) => void)[];
+  private readonly extraStop?: () => boolean;
+  private readonly onError?: (err: unknown) => void;
+  private readonly abort = new AbortController();
+  /** Per-source accumulated frames, drained into `resources` at each tick. */
+  private readonly pending = new Map<string, unknown[]>();
+  private readonly pumps: Promise<void>[] = [];
+  private stopped = false;
+  private disposed = false;
+
+  constructor(o: ApplierOptions) {
+    this.engine = o.engine;
+    this.clock = o.clock;
+    this.resources = o.resources ?? {};
+    this.sources = o.sources ?? [];
+    this.sinks = o.sinks ?? [];
+    this.extraStop = o.shouldStop;
+    this.onError = o.onError;
+  }
+
+  /** Attach a tap for the lifetime of this run. Returns the detach function. */
+  addTap(tap: Tap): () => void {
+    return this.engine.addTap(tap);
+  }
+
+  /**
+   * Drive the sources and the clock until the clock finishes, every source is exhausted,
+   * `shouldStop()` returns true, or `dispose()` is called.
+   *
+   * **Stopping is one tick coarse, by design.** Both shipped clocks poll `shouldStop`
+   * *before* each tick, never after, so a source that drains mid-tick ends the run at
+   * the top of the next iteration. That is the existing `BatchClock` semantics and the
+   * `ticks: N` → "exactly N samples" contract depends on it, so exhaustion must not be
+   * able to cut a run short when there are no sources — hence `sourcesExhausted()`
+   * returns false for an empty set rather than the vacuous truth of `every()`.
+   */
+  async run(): Promise<void> {
+    if (this.sources.length > 0 && this.clock.paced !== true) {
+      // Fail here rather than at the end of a run that produced nothing. `onTick` is
+      // synchronous, so an unpaced clock never gives a source's async iterator a turn:
+      // the graph would tick to completion against a resource that was never written,
+      // which reads as "my source did nothing" and is genuinely hard to trace back.
+      throw new Error(
+        `Applier: ${this.sources.length} source(s) given with an unpaced clock ` +
+          `(${this.clock.constructor.name}). A host-side Source is an async iterator and needs a clock ` +
+          `that yields between ticks; a synchronous one starves it. For batch, replay through a ` +
+          `zero-input NODE (replay-source / synthetic-hands) instead — see design invariant 4.`,
+      );
+    }
+    this.startPumps();
+    await this.clock.run(
+      (time) => this.tick(time),
+      () => this.stopped || this.disposed || this.extraStop?.() === true || this.sourcesExhausted(),
+    );
+  }
+
+  /** One tick: publish what the pumps collected, advance the engine, fan out to sinks. */
+  private tick(time?: number): void {
+    this.publish();
+    try {
+      // Forwarded verbatim. `tick(undefined)` === `tick()` (Engine reads `time ??
+      // tickIndex * nominalDt`); substituting a wall clock here is the one change that
+      // would move every recorded golden. See the module docstring.
+      this.engine.tick(time);
+    } catch (err) {
+      if (!this.onError) throw err;
+      this.onError(err);
+      return;
+    }
+    for (const sink of this.sinks) sink(time);
+  }
+
+  /** Move each source's collected frames into `resources` under its output key. */
+  private publish(): void {
+    for (const src of this.sources) {
+      const buf = this.pending.get(src.id);
+      if (!buf || buf.length === 0) {
+        // A signal source with nothing new keeps its last latched value — a held pose is
+        // the correct reading of "the camera produced no new frame this tick". An event
+        // source publishes an empty list, because "no keys were pressed" is information.
+        if (src.kind === 'event') this.resources[src.outputResource] = [];
+        continue;
+      }
+      this.resources[src.outputResource] = src.kind === 'signal' ? buf[buf.length - 1] : buf.slice();
+      buf.length = 0;
+    }
+  }
+
+  /**
+   * True only when there is at least one source, all of them are exhausted, **and every
+   * buffered frame has been published**.
+   *
+   * The second half is not pedantry. A source that finishes producing before the clock's
+   * first frame — a short replay, anything already in memory — reports `exhausted()`
+   * immediately, and since `shouldStop` is polled *before* each tick, a check on
+   * exhaustion alone ends the run at tick zero with every frame it produced still sitting
+   * in the pump's buffer. The source did its job and the graph never saw a single frame.
+   */
+  private sourcesExhausted(): boolean {
+    if (this.sources.length === 0) return false;
+    return this.sources.every((s) => s.exhausted() && (this.pending.get(s.id)?.length ?? 0) === 0);
+  }
+
+  /**
+   * Start one background pump per source. The pump is deliberately NOT part of the
+   * `Source` contract: it is how the Applier bridges an async iterator to a synchronous
+   * `process()`, and a source that knew about it could not be a plain generator.
+   */
+  private startPumps(): void {
+    const ctx: SourceContext = { signal: this.abort.signal };
+    for (const src of this.sources) {
+      this.pending.set(src.id, []);
+      this.pumps.push(
+        (async () => {
+          try {
+            for await (const frame of src.frames(ctx)) {
+              if (this.disposed) break;
+              this.pending.get(src.id)?.push(frame);
+            }
+          } catch (err) {
+            // A source that dies must stop the run rather than starve it silently: an
+            // engine ticking forever on a frozen last frame looks like a hang, and the
+            // error that caused it would be lost.
+            this.stopped = true;
+            if (this.onError) this.onError(err);
+            else throw err;
+          }
+        })(),
+      );
+    }
+  }
+
+  /** Stop the run at the next tick boundary and release every source. */
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.abort.abort();
+    for (const src of this.sources) {
+      try {
+        src.dispose();
+      } catch {
+        // One source failing to close must not strand the others.
+      }
+    }
+  }
+}

--- a/src/dag/applier.ts
+++ b/src/dag/applier.ts
@@ -107,22 +107,43 @@ export class Applier {
   private readonly pumps: Promise<void>[] = [];
   private stopped = false;
   private disposed = false;
-  /** First error thrown by a source when no `onError` was given; raised by `run()`. */
-  private sourceError: unknown;
+  private started = false;
+  private readonly resourcesGiven: boolean;
+  /** Detach functions for taps attached through {@link addTap}, released on dispose. */
+  private readonly tapDetachers: (() => void)[] = [];
+  /** First error from a source, a tick or a sink. Raised by `run()` once the loop has
+   *  ended, so no failure escapes a frame callback and none is silent. */
+  private runError: unknown;
 
   constructor(o: ApplierOptions) {
     this.engine = o.engine;
     this.clock = o.clock;
     this.resources = o.resources ?? {};
+    this.resourcesGiven = o.resources !== undefined;
     this.sources = o.sources ?? [];
     this.sinks = o.sinks ?? [];
     this.extraStop = o.shouldStop;
     this.onError = o.onError;
   }
 
-  /** Attach a tap for the lifetime of this run. Returns the detach function. */
+  /**
+   * Attach a tap for the lifetime of this run. Returns the detach function.
+   *
+   * The Applier takes a **live, caller-owned** engine that outlives it — across
+   * `applyGraph` swaps and StrictMode remounts — so a tap attached here and never
+   * detached would keep receiving values from every later run. `dispose()` releases
+   * every tap attached through this method, which is what makes "for the lifetime of
+   * this run" true rather than aspirational.
+   */
   addTap(tap: Tap): () => void {
-    return this.engine.addTap(tap);
+    const detach = this.engine.addTap(tap);
+    this.tapDetachers.push(detach);
+    let done = false;
+    return () => {
+      if (done) return;
+      done = true;
+      detach();
+    };
   }
 
   /**
@@ -137,6 +158,30 @@ export class Applier {
    * returns false for an empty set rather than the vacuous truth of `every()`.
    */
   async run(): Promise<void> {
+    // A second run() would start a second iterator per source (two consumers of one
+    // camera), replace the pending buffers under the live pumps, and tick one engine
+    // from two clock loops. A React effect under StrictMode is enough to reach it.
+    if (this.started) throw new Error('Applier: run() called twice — construct a new Applier per run.');
+    this.started = true;
+    if (this.sources.length > 0 && this.resourcesGiven === false) {
+      // The same failure the paced check exists to prevent, reached a different way:
+      // the pump would publish every latched frame into a private object no node can
+      // read, and the engine's own `resources` is a DIFFERENT reference, so the graph
+      // ticks on a resource nothing ever wrote. Nothing looks missing at the call site,
+      // because the engine was constructed with resources of its own.
+      throw new Error(
+        `Applier: ${this.sources.length} source(s) given with no resources object. Pass the SAME one the ` +
+          `engine was constructed with (EngineOptions.resources) — the pump writes latched frames into it ` +
+          `in place, and that is the only way a node sees them.`,
+      );
+    }
+    const ids = new Set<string>();
+    for (const src of this.sources) {
+      // `pending` is keyed by id; two sources sharing one would share a buffer, and the
+      // first one's drain would blank the second's resource on every tick.
+      if (ids.has(src.id)) throw new Error(`Applier: duplicate Source id "${src.id}" — ids key the frame buffers and must be unique.`);
+      ids.add(src.id);
+    }
     if (this.sources.length > 0 && this.clock.paced !== true) {
       // Fail here rather than at the end of a run that produced nothing. `onTick` is
       // synchronous, so an unpaced clock never gives a source's async iterator a turn:
@@ -144,7 +189,7 @@ export class Applier {
       // which reads as "my source did nothing" and is genuinely hard to trace back.
       throw new Error(
         `Applier: ${this.sources.length} source(s) given with an unpaced clock ` +
-          `(${this.clock.constructor.name}). A host-side Source is an async iterator and needs a clock ` +
+          `(paced=${String(this.clock.paced)}). A host-side Source is an async iterator and needs a clock ` +
           `that yields between ticks; a synchronous one starves it. For batch, replay through a ` +
           `zero-input NODE (replay-source / synthetic-hands) instead — see design invariant 4.`,
       );
@@ -154,29 +199,85 @@ export class Applier {
       (time) => this.tick(time),
       () => this.stopped || this.disposed || this.extraStop?.() === true || this.sourcesExhausted(),
     );
-    // A source failure surfaces here rather than as an unhandled rejection — see
-    // `startPumps`. The run has already stopped; this is how the caller learns why.
-    if (this.sourceError !== undefined) throw this.sourceError;
+    // Every deferred failure — a source, a tick, a sink — surfaces here rather than as
+    // an unhandled rejection or an escaped frame callback. The run has already stopped;
+    // this is how the caller learns why.
+    if (this.runError !== undefined) throw this.runError;
   }
 
-  /** One tick: publish what the pumps collected, advance the engine, fan out to sinks. */
+  /**
+   * One tick: publish what the pumps collected, advance the engine, fan out to sinks.
+   *
+   * **Nothing may throw out of here.** A paced clock calls this from inside its frame
+   * callback and schedules the next frame *after* the call returns
+   * (`RealtimeClock.run`: `onTick(...)` then `this.schedule(frame)`). An exception
+   * escaping would skip that scheduling, so the loop would stop AND the promise
+   * `run()` is awaiting would never settle — a silent, permanent hang rather than a
+   * failure. So the error is stashed and `run()` raises it once the loop has ended,
+   * which is the same discipline the pump uses.
+   *
+   * The sinks are inside the guard for the same reason: a sink is host code (canvas,
+   * audio, a React bridge), it is the most likely thing here to throw, and a lost
+   * canvas context freezing the instrument forever is exactly the failure this shape
+   * exists to prevent.
+   */
   private tick(time?: number): void {
-    this.publish();
+    const drained = this.publish();
     try {
       // Forwarded verbatim. `tick(undefined)` === `tick()` (Engine reads `time ??
       // tickIndex * nominalDt`); substituting a wall clock here is the one change that
       // would move every recorded golden. See the module docstring.
       this.engine.tick(time);
     } catch (err) {
-      if (!this.onError) throw err;
+      // The engine did not consume what publish() drained, so put it back rather than
+      // dropping it. For an `event` source those frames are the only record of a
+      // keypress; silently losing them on a recoverable node error is data loss.
+      this.restore(drained);
+      this.fail(err, { stop: false });
+      return;
+    }
+    for (const sink of this.sinks) {
+      try {
+        sink(time);
+      } catch (err) {
+        this.fail(err, { stop: false });
+      }
+    }
+  }
+
+  /**
+   * Route a failure, without ever letting it escape a frame callback.
+   *
+   * Two policies, split on whether the caller supplied `onError`:
+   *
+   * - **`onError` given** — the caller has said "hand me errors, keep going". The error
+   *   is reported and `run()` does **not** reject. This is the live path's rule, already
+   *   stated in `runEngineLoop`: *one bad frame must never stop the instrument*. A
+   *   degenerate landmark or a transient audio state should cost a frame, not a session.
+   * - **`onError` absent** — batch must fail loudly, so the first error is stashed and
+   *   `run()` raises it. Stashed rather than thrown, because a throw here would skip the
+   *   paced clock's `schedule()` and leave `run()`'s promise permanently pending.
+   *
+   * `stop` is separate from either: a *source* failure ends the run whatever the policy,
+   * because a dead source will never produce another frame and ticking on a frozen
+   * resource is indistinguishable from a hang. A *tick* or *sink* failure does not.
+   */
+  private fail(err: unknown, opts: { stop: boolean }): void {
+    if (opts.stop) this.stopped = true;
+    if (this.onError) {
       this.onError(err);
       return;
     }
-    for (const sink of this.sinks) sink(time);
+    this.stopped = true;
+    if (this.runError === undefined) this.runError = err;
   }
 
-  /** Move each source's collected frames into `resources` under its output key. */
-  private publish(): void {
+  /**
+   * Move each source's collected frames into `resources` under its output key, and
+   * return what was drained so a failed tick can put it back.
+   */
+  private publish(): Map<string, unknown[]> {
+    const drained = new Map<string, unknown[]>();
     for (const src of this.sources) {
       const buf = this.pending.get(src.id);
       if (!buf || buf.length === 0) {
@@ -187,7 +288,18 @@ export class Applier {
         continue;
       }
       this.resources[src.outputResource] = src.kind === 'signal' ? buf[buf.length - 1] : buf.slice();
+      drained.set(src.id, buf.slice());
       buf.length = 0;
+    }
+    return drained;
+  }
+
+  /** Put drained frames back at the FRONT of their buffers, preserving arrival order,
+   *  after a tick that did not consume them. */
+  private restore(drained: Map<string, unknown[]>): void {
+    for (const [id, frames] of drained) {
+      const buf = this.pending.get(id);
+      if (buf) buf.unshift(...frames);
     }
   }
 
@@ -226,14 +338,12 @@ export class Applier {
             // A source that dies must stop the run rather than starve it silently: an
             // engine ticking forever on a frozen last frame looks like a hang, and the
             // error that caused it would be lost.
-            this.stopped = true;
-            if (this.onError) this.onError(err);
             // Deliberately NOT rethrown. These promises are never awaited — they outlive
             // the tick loop by design — so a throw here is an UNHANDLED REJECTION, which
             // in Node is a process-level crash: a bad source would take down a whole test
-            // run rather than failing its own. Stash it and let `run()` raise it, so the
-            // caller gets it from the `await` they already have.
-            else if (this.sourceError === undefined) this.sourceError = err;
+            // run rather than failing its own. `fail` stashes it for `run()` to raise, so
+            // the caller gets it from the `await` they already have.
+            this.fail(err, { stop: true });
           }
         })(),
       );
@@ -245,6 +355,14 @@ export class Applier {
     if (this.disposed) return;
     this.disposed = true;
     this.abort.abort();
+    for (const detach of this.tapDetachers) {
+      try {
+        detach();
+      } catch {
+        // One tap failing to detach must not strand the others.
+      }
+    }
+    this.tapDetachers.length = 0;
     for (const src of this.sources) {
       try {
         src.dispose();

--- a/src/dag/clock.ts
+++ b/src/dag/clock.ts
@@ -31,6 +31,17 @@ export interface Clock {
    * returned promise resolves once it is true (or the batch count is reached).
    */
   run(onTick: (time?: number) => void, shouldStop: () => boolean): Promise<void>;
+  /**
+   * True when the loop yields to the event loop between ticks.
+   *
+   * `onTick` is **synchronous**, so a clock that never yields gives a host-side
+   * {@link Source}'s async iterator no turn to produce a frame: the pump would sit
+   * un-serviced and the graph would tick forever on a frozen resource. That is not a
+   * hypothetical — `BatchClock`'s loop is a plain `for`, so it starves any async source
+   * completely. `Applier` refuses that combination rather than letting it look like a
+   * hang. Optional so the interface stays backward-compatible; absent means "not paced".
+   */
+  readonly paced?: boolean;
 }
 
 /**
@@ -40,6 +51,11 @@ export interface Clock {
  * bearing — the recorded-fixture goldens depend on that synthesized time.
  */
 export class BatchClock implements Clock {
+  /** Synchronous by construction: the loop never yields, so async sources cannot be
+   *  serviced under it. Batch replays through zero-input NODES (`replay-source`,
+   *  `synthetic-hands`) instead — design invariant 4, "sources are ordinary nodes". */
+  readonly paced = false;
+
   constructor(private readonly ticks: number) {}
 
   async run(onTick: (time?: number) => void, shouldStop: () => boolean): Promise<void> {
@@ -92,6 +108,10 @@ export class RealtimeClock implements Clock {
     // requestAnimationFrame is absent but only BatchClock is used) is safe.
     this.schedule = opts.schedule ?? ((cb) => void requestAnimationFrame(cb));
   }
+
+  /** Yields between frames (rAF / the injected `schedule`), so async sources can be
+   *  pumped under it. */
+  readonly paced = true;
 
   run(onTick: (time?: number) => void, shouldStop: () => boolean): Promise<void> {
     return new Promise<void>((resolve) => {

--- a/src/dag/index.ts
+++ b/src/dag/index.ts
@@ -20,11 +20,14 @@ export {
 export type { ReplayOptions } from './recorder';
 export { BatchClock, RealtimeClock } from './clock';
 export type { Clock, RealtimeClockOptions } from './clock';
+export { Applier } from './applier';
+export type { ApplierOptions, Source, SourceContext } from './applier';
 
 import { Engine, type EngineOptions } from './engine';
 import { NodeRegistry } from './registry';
 import { StreamRecorder } from './recorder';
 import { BatchClock } from './clock';
+import { Applier } from './applier';
 import type { GraphSpec } from './types';
 
 /**
@@ -54,8 +57,11 @@ export async function runHeadless(
     taps: [recorder],
   });
   await engine.init();
-  // BatchClock calls engine.tick() with no argument, exactly as the previous
-  // inline for-loop did, so recorded goldens are byte-identical.
-  await new BatchClock(opts.ticks).run(() => engine.tick(), () => false);
+  // Batch is an Applier config: a BatchClock, one recording tap, no sources and no
+  // sinks. The Applier forwards the clock's time argument verbatim, and BatchClock
+  // passes none, so the engine synthesizes `tickIndex * nominalDt` exactly as the
+  // original inline for-loop did — recorded goldens are byte-identical, which
+  // `test/applier_byte_identity.test.ts` pins rather than merely asserts.
+  await new Applier({ engine, clock: new BatchClock(opts.ticks) }).run();
   return { engine, recorder };
 }

--- a/test/applier.test.ts
+++ b/test/applier.test.ts
@@ -69,8 +69,51 @@ describe('an async source needs a clock that yields', () => {
     await engine.init();
     const src = listSource('s', 'signal', 'hands', ['a']);
     await expect(new Applier({ engine, resources, sources: [src], clock: new BatchClock(10) }).run()).rejects.toThrow(
-      /unpaced clock.*BatchClock/s,
+      /unpaced clock/,
     );
+  });
+
+  it('names the offending clock in a way minification cannot erase', async () => {
+    // The message's whole purpose is traceability, and esbuild renames class bindings by
+    // default — so `clock.constructor.name` would read "(l)" in exactly the production
+    // build where the source is not at hand. `paced` is data on the object and survives.
+    const { engine, resources } = probeRig('hands');
+    await engine.init();
+    const src = listSource('s', 'signal', 'hands', ['a']);
+    await expect(new Applier({ engine, resources, sources: [src], clock: new BatchClock(10) }).run()).rejects.toThrow(
+      /paced=false/,
+    );
+  });
+
+  it('refuses sources with no resources object — the pump would publish where nothing reads', async () => {
+    // Reachable by omission: `resources` is optional, and the engine was constructed with
+    // its own, so nothing looks missing at the call site. The pump would then write every
+    // frame into a private {} and the graph would tick on a resource nothing ever wrote.
+    const { engine } = probeRig('hands');
+    await engine.init();
+    const src = listSource('s', 'signal', 'hands', ['a']);
+    await expect(new Applier({ engine, sources: [src], clock: pacedClock(4) }).run()).rejects.toThrow(
+      /no resources object/,
+    );
+  });
+
+  it('refuses two sources sharing an id — ids key the frame buffers', async () => {
+    const { engine, resources } = probeRig('hands');
+    await engine.init();
+    await expect(
+      new Applier({
+        engine, resources, clock: pacedClock(4),
+        sources: [listSource('hands', 'signal', 'a', []), listSource('hands', 'signal', 'b', [])],
+      }).run(),
+    ).rejects.toThrow(/duplicate Source id "hands"/);
+  });
+
+  it('refuses a second run() — two iterators on one camera, two clocks on one engine', async () => {
+    const { engine } = probeRig('x');
+    await engine.init();
+    const applier = new Applier({ engine, clock: new BatchClock(1) });
+    await applier.run();
+    await expect(applier.run()).rejects.toThrow(/called twice/);
   });
 
   it('declares pacing on the clocks themselves, so the check needs no instanceof', () => {
@@ -189,6 +232,23 @@ describe('dispose and failure', () => {
     expect(good.dispose).toHaveBeenCalled();
   });
 
+  it('dispose() detaches every tap it attached — the engine outlives the Applier', async () => {
+    // The Applier takes a live, caller-owned engine that survives applyGraph swaps and
+    // StrictMode remounts. A tap attached for "the lifetime of this run" and never
+    // detached would keep receiving values from every later run on that engine.
+    const { engine } = probeRig('x');
+    await engine.init();
+    const seen: string[] = [];
+    const applier = new Applier({ engine, clock: new BatchClock(2) });
+    applier.addTap({ onValue: (k) => seen.push(k) });
+    await applier.run();
+    const during = seen.length;
+    expect(during).toBeGreaterThan(0);
+    applier.dispose();
+    engine.tick();
+    expect(seen).toHaveLength(during);
+  });
+
   it('dispose() is idempotent', () => {
     const good = { ...listSource('good', 'signal', 'b', []), dispose: vi.fn() };
     const { engine } = probeRig('x');
@@ -261,6 +321,73 @@ describe('sinks', () => {
     await new Applier({ engine, clock: new BatchClock(3), sinks: [(t) => times.push(t)] }).run();
     // BatchClock passes no time — the sink sees undefined, exactly as the engine does.
     expect(times).toEqual([undefined, undefined, undefined]);
+  });
+
+  it('a THROWING sink is caught, reported, and does not kill the loop', async () => {
+    // A sink is host code — canvas, audio, a React bridge — and is the most likely thing
+    // in the tick path to throw. Outside the guard it would escape the paced clock's
+    // frame callback, skipping `schedule()`: the instrument freezes and run() never
+    // settles. A lost 2D context on a GPU reset is enough to reach it.
+    const { engine } = probeRig('x');
+    await engine.init();
+    const errs: unknown[] = [];
+    let good = 0;
+    await new Applier({
+      engine,
+      clock: new BatchClock(3),
+      sinks: [() => { throw new Error('canvas gone'); }, () => { good++; }],
+      onError: (e) => errs.push(e),
+    }).run();
+    expect(errs.length).toBeGreaterThan(0);
+    expect((errs[0] as Error).message).toBe('canvas gone');
+    // The run completed, and the OTHER sink still ran.
+    expect(good).toBe(3);
+  });
+
+  it('a throwing sink with no onError surfaces from run(), never as a hang', async () => {
+    const { engine } = probeRig('x');
+    await engine.init();
+    await expect(
+      new Applier({ engine, clock: new BatchClock(3), sinks: [() => { throw new Error('sink died'); }] }).run(),
+    ).rejects.toThrow('sink died');
+  });
+
+  it('EVENT frames survive a tick that threw — they are put back, not dropped', async () => {
+    // publish() drains the buffer BEFORE the tick. If the tick fails and onError swallows
+    // it, those frames were never consumed by the engine and are gone from the buffer —
+    // for an event source that is the only record of a keypress.
+    const registry = createRegistry([
+      defineNode({
+        type: 'flaky', roles: ['source'], params: z.object({}), inputs: [], outputs: [{ name: 'seen', kind: 'any' }],
+        make: () => {
+          let n = 0;
+          return {
+            process: (_i, ctx) => {
+              n++;
+              if (n === 1) throw new Error('first tick fails');
+              return { seen: (ctx.resources as Record<string, unknown>).keys };
+            },
+          };
+        },
+      }),
+    ]);
+    const seen: unknown[] = [];
+    const resources: Record<string, unknown> = {};
+    const engine = new Engine({ nodes: [{ id: 'f', type: 'flaky', params: {} }], edges: [] }, registry, {
+      resources,
+      taps: [{ onValue: (k, v) => { if (k === 'f.seen') seen.push(v); } }],
+    });
+    await engine.init();
+    const src: Source = {
+      id: 'k', kind: 'event', outputResource: 'keys',
+      async *frames() { yield 'noteOn'; yield 'noteOff'; await new Promise((r) => setTimeout(r, 50)); },
+      exhausted: () => false,
+      dispose: () => {},
+    };
+    let n = 0;
+    await new Applier({ engine, resources, sources: [src], clock: pacedClock(10), shouldStop: () => n++ >= 4, onError: () => {} }).run();
+    // The first tick threw; the two frames must appear on a LATER tick rather than vanish.
+    expect(seen.flatMap((v) => (Array.isArray(v) ? v : []))).toEqual(['noteOn', 'noteOff']);
   });
 
   it('do not run when the tick threw', async () => {

--- a/test/applier.test.ts
+++ b/test/applier.test.ts
@@ -213,6 +213,33 @@ describe('dispose and failure', () => {
     expect(seen.length).toBeLessThan(1000);
   });
 
+  it('a source error with NO onError surfaces from run(), not as an unhandled rejection', async () => {
+    // The pump promises are never awaited, so a `throw` inside one would be an unhandled
+    // rejection — in Node a process-level crash, which would take down a whole test run
+    // rather than failing this one. It has to come back through the await the caller
+    // already has.
+    const { engine, resources } = probeRig('hands');
+    await engine.init();
+    const boom: Source = {
+      id: 'boom', kind: 'signal', outputResource: 'hands',
+      async *frames() { yield 'one'; throw new Error('source died'); },
+      exhausted: () => false,
+      dispose: () => {},
+    };
+    let unhandled: unknown = null;
+    const onUnhandled = (e: unknown) => { unhandled = e; };
+    process.on('unhandledRejection', onUnhandled);
+    try {
+      await expect(
+        new Applier({ engine, resources, sources: [boom], clock: pacedClock(1000) }).run(),
+      ).rejects.toThrow('source died');
+      await new Promise((r) => setTimeout(r, 10));
+      expect(unhandled).toBeNull();
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
+  });
+
   it('a tick error rethrows by default — batch must fail loudly', async () => {
     const registry = createRegistry([
       defineNode({

--- a/test/applier.test.ts
+++ b/test/applier.test.ts
@@ -1,0 +1,252 @@
+/**
+ * The Applier and the Source contract (#101 M-D).
+ *
+ * These pin the two things the design makes load-bearing and that are easy to get
+ * subtly wrong: how a `signal` source differs from an `event` source between ticks, and
+ * when a run stops. Everything here is plain Node — no DOM, no camera, no audio.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { Applier, BatchClock, RealtimeClock, Engine, createRegistry, defineNode, type Clock, type Source, type GraphSpec } from '@/dag';
+import { z } from 'zod';
+
+/** A node that copies a named resource onto its output port, so a test can see what the
+ *  pump published on each tick. */
+const probeNode = defineNode({
+  type: 'probe',
+  roles: ['source'],
+  params: z.object({ key: z.string() }),
+  inputs: [],
+  outputs: [{ name: 'seen', kind: 'any' }],
+  make: (params) => ({
+    process: (_inputs, ctx) => ({ seen: (ctx.resources as Record<string, unknown>)[params.key] ?? null }),
+  }),
+});
+
+function probeRig(key: string) {
+  const registry = createRegistry([probeNode]);
+  const spec: GraphSpec = { nodes: [{ id: 'p', type: 'probe', params: { key } }], edges: [] };
+  const seen: unknown[] = [];
+  const resources: Record<string, unknown> = {};
+  const engine = new Engine(spec, registry, { resources, taps: [{ onValue: (k, v) => { if (k === 'p.seen') seen.push(v); } }] });
+  return { engine, resources, seen };
+}
+
+/** A source that yields the given frames, one per microtask, then reports exhausted. */
+function listSource(id: string, kind: 'signal' | 'event', outputResource: string, frames: unknown[]): Source {
+  let done = false;
+  return {
+    id,
+    kind,
+    outputResource,
+    async *frames() {
+      for (const f of frames) yield f;
+      done = true;
+    },
+    exhausted: () => done,
+    dispose: () => {},
+  };
+}
+
+/**
+ * A `RealtimeClock` driven by an injected macrotask scheduler — paced (so the pump gets
+ * a turn) but with no wall-clock dependence, so the test is deterministic and fast.
+ * This is the shape a source-consuming Applier actually runs under.
+ */
+function pacedClock(maxFrames: number): Clock {
+  let n = 0;
+  let t = 0;
+  return new RealtimeClock({
+    now: () => (t += 1 / 30),
+    schedule: (cb) => {
+      if (n++ < maxFrames) setTimeout(cb, 0);
+    },
+  });
+}
+
+describe('an async source needs a clock that yields', () => {
+  it('REFUSES an unpaced clock rather than ticking forever on a resource nothing wrote', async () => {
+    const { engine, resources } = probeRig('hands');
+    await engine.init();
+    const src = listSource('s', 'signal', 'hands', ['a']);
+    await expect(new Applier({ engine, resources, sources: [src], clock: new BatchClock(10) }).run()).rejects.toThrow(
+      /unpaced clock.*BatchClock/s,
+    );
+  });
+
+  it('declares pacing on the clocks themselves, so the check needs no instanceof', () => {
+    expect(new BatchClock(1).paced).toBe(false);
+    expect(new RealtimeClock({ now: () => 0, schedule: () => {} }).paced).toBe(true);
+  });
+
+  it('a source-less Applier runs happily under the unpaced batch clock', async () => {
+    const { engine, seen } = probeRig('x');
+    await engine.init();
+    await expect(new Applier({ engine, clock: new BatchClock(3) }).run()).resolves.toBeUndefined();
+    expect(seen).toHaveLength(3);
+  });
+});
+
+describe('the pump: how frames between ticks reach a node', () => {
+  it('a SIGNAL source latches the newest frame and drops the intermediates', async () => {
+    const { engine, resources, seen } = probeRig('hands');
+    await engine.init();
+    const src = listSource('s', 'signal', 'hands', ['a', 'b', 'c']);
+    await new Applier({ engine, resources, sources: [src], clock: pacedClock(6) }).run();
+    // Newest wins: a stale pose is worse than the current one. The three frames all
+    // land between the first scheduled frame and the tick that follows them.
+    expect(seen).toContain('c');
+    expect(seen).not.toContain('a');
+  });
+
+  it('an EVENT source accumulates every frame since the last tick', async () => {
+    const { engine, resources, seen } = probeRig('keys');
+    await engine.init();
+    const src = listSource('s', 'event', 'keys', ['x', 'y', 'z']);
+    await new Applier({ engine, resources, sources: [src], clock: pacedClock(6) }).run();
+    // Nothing dropped: a lost keypress is information no later frame can recover.
+    const batches = (seen as unknown[][]).filter((b) => Array.isArray(b) && b.length > 0);
+    expect(batches.flat()).toEqual(['x', 'y', 'z']);
+  });
+
+  it('a SIGNAL source with no new frame holds its last value; an EVENT source publishes empty', async () => {
+    const sig = probeRig('hands');
+    await sig.engine.init();
+    await new Applier({ engine: sig.engine, resources: sig.resources, sources: [listSource('s', 'signal', 'hands', ['only'])], clock: pacedClock(6) }).run();
+    // Once latched the value is HELD across later ticks rather than reverting to null —
+    // "the camera produced no new frame" is not "there is no hand".
+    expect(sig.seen[sig.seen.length - 1]).toBe('only');
+
+    // For the event side the source must stay OPEN with nothing pending — an already
+    // exhausted, empty source correctly ends the run before any tick. A live keyboard
+    // that nobody is typing on is the real case.
+    const ev = probeRig('keys');
+    await ev.engine.init();
+    const idle: Source = {
+      id: 's', kind: 'event', outputResource: 'keys',
+      async *frames() { await new Promise((r) => setTimeout(r, 50)); },
+      exhausted: () => false,
+      dispose: () => {},
+    };
+    let n = 0;
+    await new Applier({ engine: ev.engine, resources: ev.resources, sources: [idle], clock: pacedClock(10), shouldStop: () => n++ >= 3 }).run();
+    // "No keys were pressed" is information, so it publishes an empty list rather than
+    // holding the last one — the opposite of the signal rule above.
+    expect(ev.seen.length).toBeGreaterThan(0);
+    expect(ev.seen[ev.seen.length - 1]).toEqual([]);
+  });
+});
+
+describe('when a run stops', () => {
+  it('an empty source set never ends the run early — `ticks: N` still means N ticks', async () => {
+    // The vacuous-truth trap: `[].every(...)` is true, so a naive exhaustion check would
+    // stop every source-less batch run at tick zero. Every existing fixture depends on
+    // this not happening.
+    const { engine, seen } = probeRig('nothing');
+    await engine.init();
+    await new Applier({ engine, clock: new BatchClock(5) }).run();
+    expect(seen).toHaveLength(5);
+  });
+
+  it('stops once every source is exhausted, without needing the clock to run out', async () => {
+    const { engine, resources, seen } = probeRig('hands');
+    await engine.init();
+    const src = listSource('s', 'signal', 'hands', ['a']);
+    await new Applier({ engine, resources, sources: [src], clock: pacedClock(1000) }).run();
+    expect(seen.length).toBeLessThan(1000);
+  });
+
+  it('keeps running while ONE source still has frames', async () => {
+    const { engine, resources } = probeRig('hands');
+    await engine.init();
+    const drained = listSource('a', 'signal', 'hands', []);
+    let openDone = false;
+    const open: Source = {
+      id: 'b', kind: 'signal', outputResource: 'other',
+      async *frames() { for (let i = 0; i < 3; i++) yield i; openDone = true; },
+      exhausted: () => openDone,
+      dispose: () => {},
+    };
+    await new Applier({ engine, resources, sources: [drained, open], clock: pacedClock(50) }).run();
+    expect(openDone).toBe(true);
+  });
+
+  it('honours an extra shouldStop', async () => {
+    const { engine, seen } = probeRig('x');
+    await engine.init();
+    let n = 0;
+    await new Applier({ engine, clock: new BatchClock(100), shouldStop: () => ++n > 3 }).run();
+    expect(seen.length).toBeLessThanOrEqual(3);
+  });
+});
+
+describe('dispose and failure', () => {
+  it('dispose() releases every source even if one throws on the way out', () => {
+    const bad: Source = { id: 'bad', kind: 'signal', outputResource: 'a', async *frames() {}, exhausted: () => true, dispose: () => { throw new Error('boom'); } };
+    const good = { ...listSource('good', 'signal', 'b', []), dispose: vi.fn() };
+    const { engine } = probeRig('x');
+    const applier = new Applier({ engine, sources: [bad, good], clock: new BatchClock(1) });
+    expect(() => applier.dispose()).not.toThrow();
+    expect(good.dispose).toHaveBeenCalled();
+  });
+
+  it('dispose() is idempotent', () => {
+    const good = { ...listSource('good', 'signal', 'b', []), dispose: vi.fn() };
+    const { engine } = probeRig('x');
+    const applier = new Applier({ engine, sources: [good], clock: new BatchClock(1) });
+    applier.dispose();
+    applier.dispose();
+    expect(good.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it('a source that throws stops the run rather than starving it on a frozen frame', async () => {
+    const { engine, resources, seen } = probeRig('hands');
+    await engine.init();
+    const errs: unknown[] = [];
+    const boom: Source = {
+      id: 'boom', kind: 'signal', outputResource: 'hands',
+      async *frames() { yield 'one'; throw new Error('source died'); },
+      exhausted: () => false,
+      dispose: () => {},
+    };
+    await new Applier({ engine, resources, sources: [boom], clock: pacedClock(1000), onError: (e) => errs.push(e) }).run();
+    expect(errs).toHaveLength(1);
+    expect(seen.length).toBeLessThan(1000);
+  });
+
+  it('a tick error rethrows by default — batch must fail loudly', async () => {
+    const registry = createRegistry([
+      defineNode({
+        type: 'explode', roles: ['source'], params: z.object({}), inputs: [], outputs: [{ name: 'x', kind: 'any' }],
+        make: () => ({ process: () => { throw new Error('node blew up'); } }),
+      }),
+    ]);
+    const engine = new Engine({ nodes: [{ id: 'e', type: 'explode', params: {} }], edges: [] }, registry, {});
+    await engine.init();
+    await expect(new Applier({ engine, clock: new BatchClock(1) }).run()).rejects.toThrow('node blew up');
+  });
+});
+
+describe('sinks', () => {
+  it('fan out after each successful tick, with the clock time', async () => {
+    const { engine } = probeRig('x');
+    await engine.init();
+    const times: (number | undefined)[] = [];
+    await new Applier({ engine, clock: new BatchClock(3), sinks: [(t) => times.push(t)] }).run();
+    // BatchClock passes no time — the sink sees undefined, exactly as the engine does.
+    expect(times).toEqual([undefined, undefined, undefined]);
+  });
+
+  it('do not run when the tick threw', async () => {
+    const registry = createRegistry([
+      defineNode({
+        type: 'explode', roles: ['source'], params: z.object({}), inputs: [], outputs: [{ name: 'x', kind: 'any' }],
+        make: () => ({ process: () => { throw new Error('nope'); } }),
+      }),
+    ]);
+    const engine = new Engine({ nodes: [{ id: 'e', type: 'explode', params: {} }], edges: [] }, registry, {});
+    await engine.init();
+    const hits: number[] = [];
+    await new Applier({ engine, clock: new BatchClock(2), sinks: [() => hits.push(1)], onError: () => {} }).run();
+    expect(hits).toHaveLength(0);
+  });
+});

--- a/test/applier.test.ts
+++ b/test/applier.test.ts
@@ -154,10 +154,22 @@ describe('the pump: how frames between ticks reach a node', () => {
   it('a SIGNAL source with no new frame holds its last value; an EVENT source publishes empty', async () => {
     const sig = probeRig('hands');
     await sig.engine.init();
-    await new Applier({ engine: sig.engine, resources: sig.resources, sources: [listSource('s', 'signal', 'hands', ['only'])], clock: pacedClock(6) }).run();
-    // Once latched the value is HELD across later ticks rather than reverting to null —
-    // "the camera produced no new frame" is not "there is no hand".
-    expect(sig.seen[sig.seen.length - 1]).toBe('only');
+    // The source yields ONE frame and then stays open, so every tick after the first is a
+    // tick with nothing new — which is the only situation where "hold" means anything.
+    // Asserting the last value alone would pass even if the value were re-published every
+    // tick, or if only the tick that received the frame were observed.
+    const held: Source = {
+      id: 's', kind: 'signal', outputResource: 'hands',
+      async *frames() { yield 'only'; await new Promise((r) => setTimeout(r, 60)); },
+      exhausted: () => false,
+      dispose: () => {},
+    };
+    let n = 0;
+    await new Applier({ engine: sig.engine, resources: sig.resources, sources: [held], clock: pacedClock(12), shouldStop: () => n++ >= 5 }).run();
+    const afterFirstFrame = sig.seen.slice(sig.seen.indexOf('only'));
+    // Several ticks, and the value survives on ALL of them — not just the one that got it.
+    expect(afterFirstFrame.length).toBeGreaterThan(1);
+    expect(afterFirstFrame.every((v) => v === 'only')).toBe(true);
 
     // For the event side the source must stay OPEN with nothing pending — an already
     // exhausted, empty source correctly ends the run before any tick. A live keyboard
@@ -170,8 +182,8 @@ describe('the pump: how frames between ticks reach a node', () => {
       exhausted: () => false,
       dispose: () => {},
     };
-    let n = 0;
-    await new Applier({ engine: ev.engine, resources: ev.resources, sources: [idle], clock: pacedClock(10), shouldStop: () => n++ >= 3 }).run();
+    let evTicks = 0;
+    await new Applier({ engine: ev.engine, resources: ev.resources, sources: [idle], clock: pacedClock(10), shouldStop: () => evTicks++ >= 3 }).run();
     // "No keys were pressed" is information, so it publishes an empty list rather than
     // holding the last one — the opposite of the signal rule above.
     expect(ev.seen.length).toBeGreaterThan(0);
@@ -198,19 +210,28 @@ describe('when a run stops', () => {
     expect(seen.length).toBeLessThan(1000);
   });
 
-  it('keeps running while ONE source still has frames', async () => {
-    const { engine, resources } = probeRig('hands');
+  it('keeps running while ONE source is still open — exhaustion is every(), not some()', async () => {
+    // Asserting a flag the source's own generator sets proves nothing about the Applier:
+    // it would hold even if the run stopped immediately. What has to be observed is the
+    // ENGINE still ticking while one source reports exhausted and another does not.
+    const { engine, resources, seen } = probeRig('hands');
     await engine.init();
-    const drained = listSource('a', 'signal', 'hands', []);
-    let openDone = false;
-    const open: Source = {
-      id: 'b', kind: 'signal', outputResource: 'other',
-      async *frames() { for (let i = 0; i < 3; i++) yield i; openDone = true; },
-      exhausted: () => openDone,
+    const drained: Source = {
+      id: 'a', kind: 'signal', outputResource: 'hands',
+      async *frames() { /* nothing, immediately done */ },
+      exhausted: () => true,
       dispose: () => {},
     };
-    await new Applier({ engine, resources, sources: [drained, open], clock: pacedClock(50) }).run();
-    expect(openDone).toBe(true);
+    const stillOpen: Source = {
+      id: 'b', kind: 'signal', outputResource: 'other',
+      async *frames() { await new Promise((r) => setTimeout(r, 60)); },
+      exhausted: () => false,
+      dispose: () => {},
+    };
+    let n = 0;
+    await new Applier({ engine, resources, sources: [drained, stillOpen], clock: pacedClock(20), shouldStop: () => n++ >= 4 }).run();
+    // With `some()` semantics the exhausted source would have ended the run at tick zero.
+    expect(seen.length).toBeGreaterThan(1);
   });
 
   it('honours an extra shouldStop', async () => {

--- a/test/applier_byte_identity.test.ts
+++ b/test/applier_byte_identity.test.ts
@@ -1,0 +1,80 @@
+/**
+ * The byte-identity gate for `runHeadless` (#101 M-D).
+ *
+ * The Stream Applier design says the recorded goldens depend on `BatchClock` calling
+ * `engine.tick()` **with no argument**, so the engine synthesizes `tickIndex * nominalDt`
+ * rather than being handed a wall-clock time. Every fixture in `test/fixtures/` was
+ * recorded through that path, and the replay assertions are calibrated against it.
+ *
+ * Until now that was an **unenforced promise**. This repo has no snapshot tests, no
+ * `.snap` files, and nothing reads a fixture's `meta.json`, so a refactor could have
+ * shifted the batch time base and every existing test would still have passed — they
+ * assert *relations* between recorded values ("this freq is greater than that one"),
+ * never the values themselves. A uniform time shift preserves every such relation.
+ *
+ * These digests were generated from `runHeadless` as it stood **before** the Applier
+ * refactor in this PR. They are what make the refactor checkable rather than merely
+ * plausible.
+ *
+ * If you are here because this failed: do not re-baseline to make it pass. Work out
+ * whether the batch time base moved or the recorder's serialization changed — both are
+ * breaking, and neither should happen quietly.
+ */
+import { describe, it, expect } from 'vitest';
+import { createHash } from 'node:crypto';
+import { runHeadless, type GraphSpec } from '@/dag';
+import { createCoreRegistry } from '@/nodes';
+import { loadStream } from './helpers/fixtures';
+
+/** sha256 of each recorded stream, captured from the pre-Applier `runHeadless`. */
+const GOLDEN: Record<string, string> = {
+  'feat.features.ndjson': '02e5f35fdfc3369e95d5d8a2820e081be5d3cad780c5d23c4770719bc1158527',
+  'map.params.ndjson': '4cc5a8d8e2a4bed20cc1b21e038dc09b3436c66632d799b7f7799d315fbd4329',
+  'src.value.ndjson': '386274e074a0041b005ee3d7e75709323bdbcaf255c2b5c29804ca621a9b39ef',
+};
+
+function sweepSpec(): GraphSpec {
+  const hands = loadStream('video_hand_sweep', 'src.hands');
+  return {
+    nodes: [
+      { id: 'src', type: 'replay-source', params: { values: hands } },
+      { id: 'feat', type: 'hand-features', params: {} },
+      { id: 'map', type: 'voice-mapping', params: {} },
+    ],
+    edges: [
+      { from: { node: 'src', port: 'value' }, to: { node: 'feat', port: 'hands' } },
+      { from: { node: 'feat', port: 'features' }, to: { node: 'map', port: 'features' } },
+    ],
+  };
+}
+
+function digests(files: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [name, text] of Object.entries(files)) out[name] = createHash('sha256').update(text).digest('hex');
+  return out;
+}
+
+describe('runHeadless is byte-identical to its pre-Applier self', () => {
+  it('reproduces every recorded stream exactly, byte for byte', async () => {
+    const { recorder } = await runHeadless(sweepSpec(), createCoreRegistry(), { ticks: 60, nominalDt: 1 / 30 });
+    expect(digests(recorder.toFiles())).toEqual(GOLDEN);
+  });
+
+  it('pins the SYNTHESIZED time base — a wall-clock one would pass every other test', async () => {
+    // The failure this gate exists for, demonstrated rather than asserted in prose.
+    // `runEngineLoop` substitutes the wall clock when a clock passes no time
+    // (src/app/engineLoop.ts: `const seconds = t ?? now()`) — correct for the live loop,
+    // wrong for batch. Building the Applier on that path would shift every `t` uniformly:
+    // the digests move, and nothing that compares recorded values to each other notices.
+    const { recorder } = await runHeadless(sweepSpec(), createCoreRegistry(), { ticks: 60, nominalDt: 1 / 30 });
+    const real = recorder.toFiles()['feat.features.ndjson'];
+    const shifted = real.replace(/"t":(-?[0-9.e+-]+)/g, (_m, t: string) => `"t":${Number(t) + 1000}`);
+    expect(shifted).not.toBe(real);
+    expect(createHash('sha256').update(shifted).digest('hex')).not.toBe(GOLDEN['feat.features.ndjson']);
+  });
+
+  it('records exactly `ticks` samples — the contract callers rely on', async () => {
+    const { recorder } = await runHeadless(sweepSpec(), createCoreRegistry(), { ticks: 60, nominalDt: 1 / 30 });
+    expect(recorder.values('map.params')).toHaveLength(60);
+  });
+});


### PR DESCRIPTION
Task 3 of four. All headless — no live-surface change, so no browser gate needed.

## The gate comes first, because there wasn't one

The design says recorded goldens depend on `BatchClock` calling `engine.tick()` with **no
argument**. That was an **unenforced promise**: this repo has no snapshot tests, no
`.snap` files, and nothing reads a fixture's `meta.json`. Every existing test asserts
*relations* between recorded values ("this freq is greater than that one") — and a
uniform time shift preserves every one of them.

`test/applier_byte_identity.test.ts` pins sha256 digests captured from `runHeadless`
**before** the refactor. The refactor leaves them unchanged.

Mutating the Applier to substitute a wall clock — the exact shape of
`src/app/engineLoop.ts`'s `const seconds = t ?? now()`, which is correct for the live
loop and would silently move every batch run's time base — turns it red. That trap is
the reason this PR does not build the Applier on `runEngineLoop`.

## Two departures from the design sketch

Both deliberate, both now recorded in the doc:

- **It takes a live `Engine`**, not a spec+registry. The doc's lifecycle section already
  licenses this (*"it does not need to own engine construction"*), and it is what makes
  byte-identity trivial: `runHeadless` keeps its own `validatePorts` default and tap
  wiring rather than an Applier having to reproduce them exactly, forever.
- **It takes the `resources` object** the engine was constructed with, so the pump writes
  latched frames into the same reference every node reads each tick. This mirrors what
  `useEngine` already does with its `resourcesRef`.

## A third hard boundary, found by building it

`Clock.run`'s `onTick` is **synchronous**, so a clock whose loop never yields —
`BatchClock`'s plain `for` — gives a source's async iterator no turn to produce a frame.
The graph ticks to completion against a resource nothing ever wrote, which presents as
"my source did nothing" and is hard to trace back.

`Clock` now declares `paced: boolean` and the Applier **refuses** the combination with a
message naming the fix. It costs nothing in practice — it falls straight out of design
invariant 4: batch replays through zero-input **nodes** (`replay-source`,
`synthetic-hands`), and a host-side `Source` is for live origins, which are paced. Added
to the design doc as boundary (C) alongside the two it already had.

## Two bugs the tests found

- **Exhausted had to also mean drained.** A source that finishes producing before the
  clock's first frame reports `exhausted()` immediately, and `shouldStop` is polled
  *before* each tick — so the run ended at tick zero with every frame it produced still
  sitting in the pump's buffer.
- **An empty source set must not be vacuously exhausted.** `[].every(...)` is `true`, so
  the naive check stopped every source-less batch run at tick zero. All three
  byte-identity tests catch this one.

## Also: three stale design-doc claims

Found while working in it — that a non-positive `RealtimeClock` speed "collapses to a
frozen clock" (it throws a `RangeError`, as the doc's own M-D bullet says), that the
per-source `mirror` flag is deferred to "the M-C Source contract" (M-C shipped without
one; it moved to M-D), and an M-D headline in future tense about work that had landed.

## Verification

- **1372 tests pass**; `typecheck` and `build` clean; no node/port change so `catalog` is unaffected
- **All three Applier guards mutation-tested**: reverting exhausted-means-drained fails 3
  tests, the unpaced-clock refusal 1, signal-latching 2
- **The byte-identity gate itself mutation-tested**: the wall-clock substitution fails 1,
  the vacuous-`every()` fails all 3

## What is NOT in this PR

`useEngine` becoming an Applier config — the live half. The design gates that on a
browser smoke test this repo has no harness for (no Playwright, no e2e dir), and I would
rather leave that honestly open than claim a live surface is verified. #101 tracks it.

https://claude.ai/code/session_019MqaXSdxoS9hdavMAAMVvu