### PR TITLE
#101 M-E: defineMergeNode — composition as an explicit typed node (R2)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -236,11 +236,20 @@ such — a bracketed `#n` in this list always means an issue.
 
 ### Engine / platform
 
-- **[#101] Stream Applier epic** (M8) — M-A, M-B and M-C have shipped, and M-D's clock
-  half landed with #166. **What remains of M-D** is the `Source` interface, its pump and
-  the `Applier` that `runHeadless` and `useEngine` both collapse into; M-E…M-G are
-  designed and unstarted. SSOT: [design/stream-applier.md](design/stream-applier.md) —
-  its per-milestone bullets, not its header, are the authority on status.
+- **[#101] Stream Applier epic** (M8) — **M-A…M-D have shipped.** Both callers are
+  Applier configs now (`runHeadless` #184, `useEngine` #189), and `runEngineLoop` retired
+  with M-D. **M-E is two-thirds landed**: `defineMergeNode` (R2 composition) and the
+  `event`-kind accumulate half; the timestamp-aware `replay-source-timed` remains, and it
+  belongs in `src/nodes/sources/`. M-F (state-feedback generators) and M-G (time-scaled
+  audio + a `delay` node) are designed and unstarted. SSOT:
+  [design/stream-applier.md](design/stream-applier.md) — its per-milestone bullets, not
+  its header, are the authority on status.
+
+  One thing worth knowing before touching the live loop: **M-D's stated gate, a browser
+  smoke test, does not exist** — this repo has no Playwright or e2e harness. What stands
+  in for it is a jsdom test that mounts the real hook and watches the loop run and stop.
+  AudioContext, MediaPipe and real rAF under load are still unverified, as a no-camera
+  item on #146.
 - **[#14] React Flow patcher UI** driven by Zod node configs (M6's remaining half).
   **Build is parked**; the open question is scope, not schedule — see #181.
 
@@ -279,7 +288,7 @@ these rather than inside them, so read the status column, not the milestone numb
 | **M5** | Conductor mode: immutable `score` node + `performance` overlay + humanization. | nodes built + tested (`transport` / `score` / `performance`); **not wired into the default graph**, which the manual and `docs/CATALOG.md` both say plainly. Stable but *undecided* — #180 asks for the decision: wire it (it would need a score, and there is no content pipeline), or retire it to node-library-only the way #128 retired the generative nodes. |
 | **M6** | `midi-out` + a React Flow patcher UI + deploy as a tw_platform static app. | partial — deploy done; `midi-out` shipped (#13 / PR #120) and made reachable (#137 / PR #147); the patcher (#14) is open, with its **scope** the actual open question (#181). |
 | **M7** | (optional) Pluggable Python feature service + self-hosted generative service behind the existing node facades. | optional, untouched. |
-| **M8** | **Stream Applier**: pluggable sources + batch-vs-paced execution + state-feedback generators. | in progress — M-A, M-B and M-C shipped; M-D half shipped (the live loop runs on the `Clock`, #166), its `Source` + pump + `Applier` remaining; M-E…M-G designed. See [design/stream-applier.md](design/stream-applier.md). |
+| **M8** | **Stream Applier**: pluggable sources + batch-vs-paced execution + state-feedback generators. | in progress — **M-A…M-D shipped** (both callers are Applier configs); M-E two-thirds landed (`defineMergeNode` + event accumulate; timed replay remains); M-F/M-G designed. See [design/stream-applier.md](design/stream-applier.md). |
 
 ### Open engine decisions (recorded; defaults taken)
 

--- a/docs/design/stream-applier.md
+++ b/docs/design/stream-applier.md
@@ -5,9 +5,11 @@
 > speed, #103 / PR #106), and **M-C** (#104 / PR #167 — the `source` slot, the typed
 > `replay-hands` candidate, and `PortSpec.schema` conformance). **M-D is in progress:**
 > its clock half landed with the live loop (#166 / `src/app/engineLoop.ts`); what
-> remains is its live half — `useEngine` becoming an Applier config. The `Source`
-> interface, its pump and the `Applier` are built (`src/dag/applier.ts`), and
-> `runHeadless` delegates to it. M-E…M-G are designed, unstarted.
+> **M-D is done** — both callers are Applier configs (`runHeadless` in #184,
+> `useEngine` in #189), and `runEngineLoop` retired with it. **M-E is partly landed**:
+> `defineMergeNode` (R2 composition) is built and the `event`-kind accumulate half came
+> with the Applier's pump; the timestamp-aware `replay-source-timed` remains. M-F and
+> M-G are designed, unstarted.
 >
 > This document is the single source of truth; the ROADMAP and the tracking issues
 > point here. It supersedes ad-hoc source/replay wiring. **The per-milestone bullets
@@ -266,12 +268,22 @@ boundaries allow.
     implementation and no consumer until the Applier exists; shipping it now would
     be a contract nobody honours, which this repo has been burned by twice
     (#119, #120). The node-swap half above needs none of it.
-- **M-D — The Applier (R4 complete, R5 orthogonality). ◑ engine half SHIPPED; live
-  half remains. ⚠ untested live surface.**
-  `runHeadless` **now delegates** to `Applier` (`src/dag/applier.ts`: BatchClock +
-  the recorder tap, no sources, no sinks). What remains is the other caller:
-  `useEngine`'s effect becoming a thin Applier config. The live rAF loop already
-  adopted `RealtimeClock(1)` (#166), so that deferral from M-B is discharged.
+- **M-D — The Applier (R4 complete, R5 orthogonality). ✅ SHIPPED (#184 + #189).**
+  Both callers are configs of it: `runHeadless` (BatchClock + the recorder tap, no
+  sources, no sinks) and `useEngine` (RealtimeClock + the three React bridges as sinks,
+  `disposed` as the stop condition). `runEngineLoop` — M-B's intermediate step — was
+  removed with it rather than left beside the Applier, after its guarantees were checked
+  off against `applier.test.ts` and the two missing ones ported.
+  - ⚠ **The browser smoke test the gate named does not exist** — this repo has no
+    Playwright or e2e harness. What stands in for it: the jsdom camera-free boot test
+    mounts the REAL hook and observes the loop *running* (engine time advances through
+    the live feature tap, which only fires inside `tick()`) and *stopping* (rAF stops
+    being re-armed on unmount). AudioContext, MediaPipe and real rAF under load remain
+    unreached; that residual is a no-camera item on #146.
+  - **Units are a boundary concern.** The React bridges take milliseconds; a `Clock`
+    reports seconds. Converted once in `useEngine` and guarded structurally — passing
+    seconds through turns a 400 ms gesture hold into 400 s and the dispatcher stops
+    firing with every unit test green (the same slip #164 fixed for the trainer).
   **Gate on a browser smoke test** — the effect (StrictMode guards, face bridge,
   mute mirror, AudioContext lifecycle) has no headless coverage.
   - ✅ **The live loop now runs on `RealtimeClock(1)`** — `src/app/engineLoop.ts`
@@ -290,9 +302,18 @@ boundaries allow.
     reconciles a *running* engine onto a new `GraphSpec`, keeping every unchanged
     node (see below). The Applier can therefore change its source/graph without
     reconstructing the engine and reloading the ML models.
-- **M-E — Composition + timestamp-aware replay (R2).** `defineMergeNode`; event
-  sources buffer→list; a **separate** time-based `replay-source-timed` reading
-  `StreamRecord.t` (index-by-tick stays canonical for CI goldens).
+- **M-E — Composition + timestamp-aware replay (R2). ◑ two of three landed.**
+  - ✅ **`defineMergeNode({type, kind, combine})`** (`src/dag/merge.ts`). The engine
+    rejects fan-in to one input port, so composition has to be an explicit typed node.
+    Kind-preserving, two inputs (`a`/`b`), one output (`merged`), pure. `combine` is
+    called on ticks where **one** side is absent — deciding what an absent side means is
+    the merge's job, not the engine's — but not when **both** are, so two silences merge
+    to silence rather than to `combine(undefined, undefined)`.
+  - ✅ **Event sources buffer→list** — landed with the Applier's pump (an `event` source
+    accumulates every frame since the last tick; a `signal` source latches the newest).
+  - ⏳ **`replay-source-timed`** reading `StreamRecord.t` (index-by-tick stays canonical
+    for CI goldens). Not built: it belongs in `src/nodes/sources/`, which another session
+    is currently working in.
 - **M-F — State-feedback generators (R3, `getOutput` option).**
   `stateGeneratorSource`; assert topo order + deterministic one-tick output; the
   fed-back snapshot appears in the recorded tap. #87 command-dispatch is the

--- a/src/dag/index.ts
+++ b/src/dag/index.ts
@@ -21,6 +21,8 @@ export type { ReplayOptions } from './recorder';
 export { BatchClock, RealtimeClock } from './clock';
 export type { Clock, RealtimeClockOptions } from './clock';
 export { Applier } from './applier';
+export { defineMergeNode, MERGE_INPUTS, MERGE_OUTPUT } from './merge';
+export type { MergeNodeSpec } from './merge';
 export type { ApplierOptions, Source, SourceContext } from './applier';
 
 import { Engine, type EngineOptions } from './engine';

--- a/src/dag/merge.ts
+++ b/src/dag/merge.ts
@@ -1,0 +1,92 @@
+/**
+ * `defineMergeNode` — the R2 composition primitive (#101 M-E).
+ *
+ * The engine **rejects fan-in to a single input port**: one edge per port, by design, so
+ * that a node's inputs are unambiguous and a graph's data flow is readable. That makes
+ * combining two streams an explicit, typed decision rather than an accident of wiring
+ * order — which is right, and which is also why merging needs a node.
+ *
+ * This is the factory for that node. Two same-kind inputs, one same-kind output, and a
+ * `combine` the caller supplies:
+ *
+ * ```ts
+ * const mergeHands = defineMergeNode({
+ *   type: 'merge-hands',
+ *   kind: 'hands-frame',
+ *   combine: (a, b) => (a ?? b),          // primary wins, secondary is the fallback
+ * });
+ * ```
+ *
+ * ## What `combine` is and is not called with
+ *
+ * It is called **every tick**, including ticks where one or both sides are `undefined` —
+ * a source that has not produced yet, a clip that ended, a node upstream of a slot that
+ * is not filled. Deciding what an absent side means is the merge's whole job, so it is
+ * the caller's to make: "primary wins", "sum them", "the newer one", "drop the frame".
+ * Handing `combine` only the both-present case would push that decision into the engine,
+ * where it cannot be right for every kind.
+ *
+ * The one case the factory keeps is **both absent**: it emits nothing, so a merge of two
+ * silent inputs is silent rather than a stream of `combine(undefined, undefined)`. A node
+ * that emits nothing on a port it declares is what `EngineOptions.validatePorts` exists
+ * to catch, and this is the honest reading of it — there was nothing to merge.
+ *
+ * ## Timestamps
+ *
+ * v0 merges on the **shared tick grid**: both inputs are whatever their edges carried on
+ * this tick. Sub-tick ordering is lost by design (latch-and-sample), which is why `event`
+ * sources accumulate into a list in the Applier rather than latching — the coalescing
+ * happens there, before the merge sees it. Timestamp-aware *resampling* to `ctx.time`
+ * belongs to the timed replay source, not here: a merge cannot resample what it is handed
+ * after the fact.
+ */
+import { z } from 'zod';
+import { defineNode } from './node';
+import type { NodeDef, PortValues, Role } from './types';
+
+/** The two input port names a merge node declares. Fixed so a graph reads the same
+ *  wherever a merge appears, and so tooling can recognise one. */
+export const MERGE_INPUTS = ['a', 'b'] as const;
+/** The single output port name. */
+export const MERGE_OUTPUT = 'merged' as const;
+
+export interface MergeNodeSpec<T> {
+  /** Node type id, e.g. `'merge-hands'`. */
+  type: string;
+  /** The port kind of both inputs and the output — a merge is kind-preserving. */
+  kind: string;
+  title?: string;
+  description?: string;
+  roles?: Role[];
+  /**
+   * Combine one tick's pair. Either side may be `undefined` (see the module docstring);
+   * returning `undefined` emits nothing for that tick.
+   */
+  combine(a: T | undefined, b: T | undefined): T | undefined;
+}
+
+/**
+ * Build a kind-preserving two-input merge node.
+ *
+ * Pure and stateless: the same pair always merges the same way, so a merged graph stays
+ * replayable and its recorded stream reproduces exactly.
+ */
+export function defineMergeNode<T = unknown>(spec: MergeNodeSpec<T>): NodeDef<Record<string, never>> {
+  return defineNode({
+    type: spec.type,
+    title: spec.title,
+    description: spec.description ?? `Merge two ${spec.kind} streams on the shared tick grid.`,
+    roles: spec.roles ?? ['mapping'],
+    inputs: MERGE_INPUTS.map((name) => ({ name, kind: spec.kind })),
+    outputs: [{ name: MERGE_OUTPUT, kind: spec.kind }],
+    params: z.object({}).passthrough() as never,
+    process: (inputs: PortValues): PortValues => {
+      const a = inputs[MERGE_INPUTS[0]] as T | undefined;
+      const b = inputs[MERGE_INPUTS[1]] as T | undefined;
+      // Both absent: nothing to merge, so emit nothing rather than manufacture a value.
+      if (a === undefined && b === undefined) return {};
+      const merged = spec.combine(a, b);
+      return merged === undefined ? {} : { [MERGE_OUTPUT]: merged };
+    },
+  });
+}

--- a/test/merge_node.test.ts
+++ b/test/merge_node.test.ts
@@ -1,0 +1,117 @@
+/**
+ * `defineMergeNode` — R2 composition (#101 M-E).
+ *
+ * The behaviours worth pinning are the ones about ABSENCE, because that is what a merge
+ * is actually for: two streams that do not both have something to say on every tick.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  defineMergeNode,
+  createRegistry,
+  runHeadless,
+  replayNode,
+  MERGE_INPUTS,
+  MERGE_OUTPUT,
+  type GraphSpec,
+} from '@/dag';
+import { replaySourceNode } from '@/nodes';
+
+/** Primary wins, secondary is the fallback — the composition case the design names. */
+const mergeNum = defineMergeNode<number>({
+  type: 'merge-num',
+  kind: 'number',
+  combine: (a, b) => a ?? b,
+});
+
+describe('the shape a merge declares', () => {
+  it('is kind-preserving: two inputs and one output, all the same kind', () => {
+    expect(mergeNum.inputs.map((p) => p.name)).toEqual([...MERGE_INPUTS]);
+    expect(mergeNum.outputs.map((p) => p.name)).toEqual([MERGE_OUTPUT]);
+    expect(new Set([...mergeNum.inputs, ...mergeNum.outputs].map((p) => p.kind))).toEqual(new Set(['number']));
+  });
+});
+
+describe('combining a tick', () => {
+  it('hands `combine` both sides, and emits what it returns', async () => {
+    const out = await replayNode(mergeNum.make({}), { a: [1, 2, 3], b: [10, 20, 30] }, { dt: 1 / 30 });
+    expect(out.map((r) => r[MERGE_OUTPUT])).toEqual([1, 2, 3]);
+  });
+
+  it('calls `combine` when ONE side is absent — deciding that is the merge\'s job, not the engine\'s', async () => {
+    // The b-only case: a primary that has not produced yet, or a clip that ended.
+    const seen: [unknown, unknown][] = [];
+    const spy = defineMergeNode<number>({
+      type: 'merge-spy', kind: 'number',
+      combine: (a, b) => { seen.push([a, b]); return a ?? b; },
+    });
+    const out = await replayNode(spy.make({}), { a: [undefined, 2], b: [10, 20] }, { dt: 1 / 30 });
+    expect(seen).toEqual([[undefined, 10], [2, 20]]);
+    expect(out.map((r) => r[MERGE_OUTPUT])).toEqual([10, 2]);
+  });
+
+  it('emits NOTHING when both sides are absent, rather than merging two silences', async () => {
+    // A node that emits on a port it declares when it has nothing is what validatePorts
+    // exists to catch. "There was nothing to merge" is the honest reading.
+    let called = 0;
+    const spy = defineMergeNode<number>({
+      type: 'merge-silent', kind: 'number',
+      combine: (a, b) => { called++; return a ?? b; },
+    });
+    const out = await replayNode(spy.make({}), { a: [undefined], b: [undefined] }, { dt: 1 / 30 });
+    expect(called).toBe(0);
+    expect(MERGE_OUTPUT in out[0]).toBe(false);
+  });
+
+  it('emits nothing when `combine` itself returns undefined — a merge may decline a tick', async () => {
+    const dropOdd = defineMergeNode<number>({
+      type: 'merge-drop', kind: 'number',
+      combine: (a) => (a !== undefined && a % 2 === 0 ? a : undefined),
+    });
+    const out = await replayNode(dropOdd.make({}), { a: [1, 2, 3, 4] }, { dt: 1 / 30 });
+    // Assert on KEY PRESENCE, not value. `{merged: undefined}` and `{}` both read as
+    // undefined, and they are not the same thing to the engine: declaring a port and
+    // emitting undefined on it is precisely what `EngineOptions.validatePorts` flags.
+    expect(out.map((r) => MERGE_OUTPUT in r)).toEqual([false, true, false, true]);
+    expect(out.map((r) => r[MERGE_OUTPUT])).toEqual([undefined, 2, undefined, 4]);
+  });
+});
+
+describe('in a real graph', () => {
+  it('merges two replayed streams the engine could not have fanned into one port', async () => {
+    // The reason this node exists: the engine rejects two edges into one input port, so
+    // composition has to be an explicit, typed node.
+    const registry = createRegistry([replaySourceNode, mergeNum]);
+    const spec: GraphSpec = {
+      nodes: [
+        { id: 'primary', type: 'replay-source', params: { values: [undefined, undefined, 7] } },
+        { id: 'backup', type: 'replay-source', params: { values: [1, 2, 3] } },
+        { id: 'mix', type: 'merge-num', params: {} },
+      ],
+      edges: [
+        { from: { node: 'primary', port: 'value' }, to: { node: 'mix', port: 'a' } },
+        { from: { node: 'backup', port: 'value' }, to: { node: 'mix', port: 'b' } },
+      ],
+    };
+    const { recorder } = await runHeadless(spec, registry, { ticks: 3, nominalDt: 1 / 30 });
+    // Falls back to the backup until the primary starts producing, then prefers it.
+    expect(recorder.values(`mix.${MERGE_OUTPUT}`)).toEqual([1, 2, 7]);
+  });
+
+  it('is pure: the same inputs merge identically on a second run', async () => {
+    const registry = createRegistry([replaySourceNode, mergeNum]);
+    const spec: GraphSpec = {
+      nodes: [
+        { id: 'a', type: 'replay-source', params: { values: [1, 2, 3] } },
+        { id: 'b', type: 'replay-source', params: { values: [9, 9, 9] } },
+        { id: 'mix', type: 'merge-num', params: {} },
+      ],
+      edges: [
+        { from: { node: 'a', port: 'value' }, to: { node: 'mix', port: 'a' } },
+        { from: { node: 'b', port: 'value' }, to: { node: 'mix', port: 'b' } },
+      ],
+    };
+    const one = await runHeadless(spec, registry, { ticks: 3, nominalDt: 1 / 30 });
+    const two = await runHeadless(spec, registry, { ticks: 3, nominalDt: 1 / 30 });
+    expect(one.recorder.toFiles()).toEqual(two.recorder.toFiles());
+  });
+});


### PR DESCRIPTION
M-E, two of its three parts. Headless throughout.

## Why composition needs a node at all

The engine **rejects fan-in to a single input port** — one edge per port, deliberately,
so a node's inputs are unambiguous. So combining two streams cannot be a wiring trick; it
has to be an explicit, typed node. `defineMergeNode` is the factory: kind-preserving, two
inputs (`a`/`b`), one output (`merged`), pure — so a merged graph stays replayable and its
recorded stream reproduces exactly.

## The decision worth reviewing

It is about **absence**, because that is what a merge is for — two streams that do not
both have something to say on every tick.

- `combine` **is** called when *one* side is absent. What an absent side means — "primary
  wins", "sum them", "the newer one", "drop the frame" — cannot be right for every kind,
  so it belongs to the caller. Handing `combine` only the both-present case would push
  that decision into the engine, where it would be wrong somewhere.
- `combine` is **not** called when *both* are absent. Two silences merge to silence rather
  than to `combine(undefined, undefined)`. A node that emits on a port it declares when it
  has nothing is exactly what `EngineOptions.validatePorts` exists to catch.

## The other two thirds of M-E

- **Event sources buffer→list** — already landed, with the Applier's pump in #184 (an
  `event` source accumulates every frame since the last tick; a `signal` source latches
  the newest). Now recorded as done rather than pending.
- **`replay-source-timed`** — **not built, deliberately.** It belongs in
  `src/nodes/sources/`, which another session is currently working in; building it here
  would have produced a conflict in someone else's worktree rather than progress. It stays
  open on #101 with its home named, ready to pick up once that directory is free.

## Docs

`stream-applier.md` and the ROADMAP now record M-D as shipped and M-E as two-thirds
landed — and both record the thing a status line would hide: **M-D's stated gate, a
browser smoke test, does not exist in this repo.** What stands in for it is the jsdom test
that mounts the real hook and watches the loop run and stop. AudioContext, MediaPipe and
real rAF under load stay unverified, as a no-camera item on #146.

## Verification

- **1417 tests**, typecheck, build, catalog clean; rebased on main
- All three merge guards mutation-tested (both-absent ✗, combine-returns-undefined ✗,
  one-side-absent ✗)
- One weak assertion of mine found and fixed: the "emits nothing" test read the port's
  *value*, and `{merged: undefined}` reads identically to `{}` — it stayed green with the
  guard removed. It now asserts **key presence**, which is the distinction the engine makes.

https://claude.ai/code/session_019MqaXSdxoS9hdavMAAMVvu