### PR TITLE
#101 M-F (the channel): the Applier publishes a StateReader, and takes resources from the engine

### DIFF
--- a/docs/design/stream-applier.md
+++ b/docs/design/stream-applier.md
@@ -178,14 +178,15 @@ once it stabilizes and a second consumer appears). **Built**, with two departure
 the sketch above, both deliberate: it takes a **live `Engine`** rather than a
 spec+registry (the lifecycle section below licenses this — and it is what keeps
 `runHeadless` byte-identical, since the engine keeps its own `validatePorts` default and
-tap wiring), and it takes the **`resources` object** the engine was constructed with, so
-the pump writes latched frames into the same reference every node reads. `useEngine`
+tap wiring), and it takes its **`resources` from the engine itself** (`Engine.resources`),
+so the pump writes latched frames into the very object every node reads — two references
+that are meant to be the same and silently are not is a failure with no symptom. `useEngine`
 (live/paced) and `runHeadless` (batch) both collapse to configs of it, differing
 on **{clock, sinks, taps} jointly** — not "only the clock". Batch attaches a
 recording tap and **no audio sink** (the synth self-no-ops when the audio
 resource is absent); paced attaches the AV sinks.
 
-The Applier also injects `resources.stateReader = { get: (n, p) => engine.getOutput(n, p) }`
+The Applier injects `resources.stateReader = { get: (n, p) => engine.getOutput(n, p) }`
 — the one-tick feedback channel for R3.
 
 ### State-feedback + composition
@@ -314,10 +315,21 @@ boundaries allow.
   - ⏳ **`replay-source-timed`** reading `StreamRecord.t` (index-by-tick stays canonical
     for CI goldens). Not built: it belongs in `src/nodes/sources/`, which another session
     is currently working in.
-- **M-F — State-feedback generators (R3, `getOutput` option).**
-  `stateGeneratorSource`; assert topo order + deterministic one-tick output; the
-  fed-back snapshot appears in the recorded tap. #87 command-dispatch is the
-  prime consumer.
+- **M-F — State-feedback generators (R3, `getOutput` option). ◑ the channel is built;
+  the source is not.**
+  - ✅ **`resources.stateReader`** — the Applier publishes a `StateReader`
+    (`{ get(nodeId, port) }`, backed by `engine.getOutput`) onto the engine's own
+    resources, so a node reaches it as `ctx.resources.stateReader` and is trivially
+    fakeable in a `replayNode` test. Pinned by a test that a zero-input source reading a
+    DOWNSTREAM node observes tick **N-1**: the engine evaluates topo-first, so the
+    feedback falls out of evaluation order rather than needing a cycle the engine would
+    reject. Total by design — an absent node or port reads `undefined`, because a source
+    must tolerate a first-tick absence.
+  - ⏳ **`stateGeneratorSource`** — the node that consumes it: seed-derived randomness
+    (`seed + ctx.tick`, never `Math.random`, or recordings stop reproducing) and
+    re-emitting the read snapshot on a second port so replay reproduces the feedback and
+    it stays tappable. Not built: it belongs in `src/nodes/sources/`, which another
+    session is working in. #87 command-dispatch is the prime consumer.
 - **M-G — Honest time-scaled audio + delay node (principled end-state).**
   `OfflineAudioContext` render-then-play behind an explicit action; recorder
   backpressure (fold into #88 recording-v2); the `delay` node + delayed-edge

--- a/src/dag/applier.ts
+++ b/src/dag/applier.ts
@@ -36,6 +36,22 @@ import type { Engine } from './engine';
 import type { Clock } from './clock';
 import type { Tap } from './types';
 
+/** The `ctx.resources` key the state reader is published under. */
+export const STATE_READER_KEY = 'stateReader';
+
+/**
+ * Read the latest value a node emitted (R3, #101 M-F).
+ *
+ * Read from a **zero-input source** — which the engine evaluates topo-first — a
+ * downstream node's port yields its value from **tick N-1**. That is the feedback, and
+ * it is why this needs no cycle and no engine change. The delay is one *tick*, not a
+ * fixed duration, so under accelerated play it is not time-invariant; M-G's `delay` node
+ * is the principled end state and is a one-line swap of what backs `get`.
+ */
+export interface StateReader {
+  get(nodeId: string, port: string): unknown;
+}
+
 /** What a source's generator is handed when the Applier starts pumping it. */
 export interface SourceContext {
   /** Aborted when the Applier is disposed, so a live generator can stop cleanly. */
@@ -68,14 +84,6 @@ export interface Source<Frame = unknown> {
 export interface ApplierOptions {
   engine: Engine;
   clock: Clock;
-  /**
-   * The SAME object the engine was constructed with (`EngineOptions.resources`). The
-   * pump writes latched/accumulated frames into it in place; the engine hands that
-   * object to every node as `ctx.resources` on every tick, so nodes see updates without
-   * any engine API for it. This mirrors what `useEngine` already does with its
-   * `resourcesRef`. Omit when there are no sources.
-   */
-  resources?: Record<string, unknown>;
   /** Open-closed over origin (R4). Empty is normal: a graph whose sources are ordinary
    *  zero-input nodes (replay/synthetic) needs none. */
   sources?: readonly Source[];
@@ -105,10 +113,11 @@ export class Applier {
   /** Per-source accumulated frames, drained into `resources` at each tick. */
   private readonly pending = new Map<string, unknown[]>();
   private readonly pumps: Promise<void>[] = [];
+  /** Backed by the engine, and stable across ticks so a node can hold onto it. */
+  private readonly stateReader: StateReader;
   private stopped = false;
   private disposed = false;
   private started = false;
-  private readonly resourcesGiven: boolean;
   /** Detach functions for taps attached through {@link addTap}, released on dispose. */
   private readonly tapDetachers: (() => void)[] = [];
   /** First error from a source, a tick or a sink. Raised by `run()` once the loop has
@@ -118,11 +127,14 @@ export class Applier {
   constructor(o: ApplierOptions) {
     this.engine = o.engine;
     this.clock = o.clock;
-    this.resources = o.resources ?? {};
-    this.resourcesGiven = o.resources !== undefined;
+    // Taken FROM the engine, never passed alongside it. Handing the Applier a separate
+    // object invites the two to be different references — the pump then publishes where
+    // no node reads, and the only symptom is a graph that quietly sees nothing.
+    this.resources = o.engine.resources;
     this.sources = o.sources ?? [];
     this.sinks = o.sinks ?? [];
     this.extraStop = o.shouldStop;
+    this.stateReader = { get: (nodeId, port) => this.engine.getOutput(nodeId, port) };
     this.onError = o.onError;
   }
 
@@ -163,18 +175,6 @@ export class Applier {
     // from two clock loops. A React effect under StrictMode is enough to reach it.
     if (this.started) throw new Error('Applier: run() called twice — construct a new Applier per run.');
     this.started = true;
-    if (this.sources.length > 0 && this.resourcesGiven === false) {
-      // The same failure the paced check exists to prevent, reached a different way:
-      // the pump would publish every latched frame into a private object no node can
-      // read, and the engine's own `resources` is a DIFFERENT reference, so the graph
-      // ticks on a resource nothing ever wrote. Nothing looks missing at the call site,
-      // because the engine was constructed with resources of its own.
-      throw new Error(
-        `Applier: ${this.sources.length} source(s) given with no resources object. Pass the SAME one the ` +
-          `engine was constructed with (EngineOptions.resources) — the pump writes latched frames into it ` +
-          `in place, and that is the only way a node sees them.`,
-      );
-    }
     const ids = new Set<string>();
     for (const src of this.sources) {
       // `pending` is keyed by id; two sources sharing one would share a buffer, and the
@@ -194,6 +194,13 @@ export class Applier {
           `zero-input NODE (replay-source / synthetic-hands) instead — see design invariant 4.`,
       );
     }
+    // R3's one-tick feedback channel (#101 M-F). A zero-input source runs topo-FIRST,
+    // so when it reads a DOWNSTREAM node's output it gets that node's value from tick
+    // N-1 — the intended feedback, with no cycle and no engine change. Injected here
+    // rather than by each source because the engine is the Applier's to know about;
+    // a node only ever sees `ctx.resources.stateReader`, which is what makes it
+    // trivially fakeable in a `replayNode` test.
+    this.resources[STATE_READER_KEY] = this.stateReader;
     this.startPumps();
     await this.clock.run(
       (time) => this.tick(time),

--- a/src/dag/engine.ts
+++ b/src/dag/engine.ts
@@ -139,7 +139,7 @@ export class Engine {
   /** latest outputs per node: nodeId -> { port -> value }. */
   private outputs = new Map<string, PortValues>();
   private taps: Tap[];
-  private resources: Record<string, unknown>;
+  private resourcesObject: Record<string, unknown>;
   private nominalDt: number;
   private validatePorts: boolean;
   private log?: (msg: string) => void;
@@ -166,7 +166,7 @@ export class Engine {
 
   constructor(spec: GraphSpec, registry: NodeRegistry, opts: EngineOptions = {}) {
     this.taps = opts.taps ?? [];
-    this.resources = opts.resources ?? {};
+    this.resourcesObject = opts.resources ?? {};
     this.nominalDt = opts.nominalDt ?? 1 / 60;
     this.validatePorts = opts.validatePorts ?? false;
     this.log = opts.log;
@@ -364,7 +364,7 @@ export class Engine {
   }
 
   private makeContext(time: number, dt: number): NodeContext {
-    return { tick: Math.max(0, this.tickIndex), time, dt, resources: this.resources, log: this.log };
+    return { tick: Math.max(0, this.tickIndex), time, dt, resources: this.resourcesObject, log: this.log };
   }
 
   /**
@@ -439,6 +439,20 @@ export class Engine {
   /** Read the latest value produced on a node's output port (for overlays/UI). */
   getOutput(nodeId: string, port: string): unknown {
     return this.outputs.get(nodeId)?.[port];
+  }
+
+  /**
+   * The live host-resources object every node reads as `ctx.resources`.
+   *
+   * The SAME reference `makeContext` hands out on every tick, so a host that writes into
+   * it in place (the webcam feed, an Applier's pumped frames) is seen by nodes on the
+   * next tick with no engine API for it. Exposed so an `Applier` can take the engine's
+   * own object rather than being handed one separately: two references that are supposed
+   * to be the same object, and silently are not, is a failure with no symptom except a
+   * graph that reads nothing.
+   */
+  get resources(): Record<string, unknown> {
+    return this.resourcesObject;
   }
 
   /** The computed topological evaluation order (node ids). */

--- a/src/dag/index.ts
+++ b/src/dag/index.ts
@@ -23,7 +23,8 @@ export type { Clock, RealtimeClockOptions } from './clock';
 export { Applier } from './applier';
 export { defineMergeNode, MERGE_INPUTS, MERGE_OUTPUT } from './merge';
 export type { MergeNodeSpec } from './merge';
-export type { ApplierOptions, Source, SourceContext } from './applier';
+export { STATE_READER_KEY } from './applier';
+export type { ApplierOptions, Source, SourceContext, StateReader } from './applier';
 
 import { Engine, type EngineOptions } from './engine';
 import { NodeRegistry } from './registry';

--- a/test/applier.test.ts
+++ b/test/applier.test.ts
@@ -6,7 +6,7 @@
  * when a run stops. Everything here is plain Node — no DOM, no camera, no audio.
  */
 import { describe, it, expect, vi } from 'vitest';
-import { Applier, BatchClock, RealtimeClock, Engine, createRegistry, defineNode, type Clock, type Source, type GraphSpec } from '@/dag';
+import { Applier, BatchClock, RealtimeClock, Engine, createRegistry, defineNode, STATE_READER_KEY, type Clock, type Source, type StateReader, type GraphSpec } from '@/dag';
 import { z } from 'zod';
 
 /** A node that copies a named resource onto its output port, so a test can see what the
@@ -28,7 +28,7 @@ function probeRig(key: string) {
   const seen: unknown[] = [];
   const resources: Record<string, unknown> = {};
   const engine = new Engine(spec, registry, { resources, taps: [{ onValue: (k, v) => { if (k === 'p.seen') seen.push(v); } }] });
-  return { engine, resources, seen };
+  return { engine, seen };
 }
 
 /** A source that yields the given frames, one per microtask, then reports exhausted. */
@@ -65,10 +65,10 @@ function pacedClock(maxFrames: number): Clock {
 
 describe('an async source needs a clock that yields', () => {
   it('REFUSES an unpaced clock rather than ticking forever on a resource nothing wrote', async () => {
-    const { engine, resources } = probeRig('hands');
+    const { engine } = probeRig('hands');
     await engine.init();
     const src = listSource('s', 'signal', 'hands', ['a']);
-    await expect(new Applier({ engine, resources, sources: [src], clock: new BatchClock(10) }).run()).rejects.toThrow(
+    await expect(new Applier({ engine, sources: [src], clock: new BatchClock(10) }).run()).rejects.toThrow(
       /unpaced clock/,
     );
   });
@@ -77,32 +77,34 @@ describe('an async source needs a clock that yields', () => {
     // The message's whole purpose is traceability, and esbuild renames class bindings by
     // default — so `clock.constructor.name` would read "(l)" in exactly the production
     // build where the source is not at hand. `paced` is data on the object and survives.
-    const { engine, resources } = probeRig('hands');
+    const { engine } = probeRig('hands');
     await engine.init();
     const src = listSource('s', 'signal', 'hands', ['a']);
-    await expect(new Applier({ engine, resources, sources: [src], clock: new BatchClock(10) }).run()).rejects.toThrow(
+    await expect(new Applier({ engine, sources: [src], clock: new BatchClock(10) }).run()).rejects.toThrow(
       /paced=false/,
     );
   });
 
-  it('refuses sources with no resources object — the pump would publish where nothing reads', async () => {
-    // Reachable by omission: `resources` is optional, and the engine was constructed with
-    // its own, so nothing looks missing at the call site. The pump would then write every
-    // frame into a private {} and the graph would tick on a resource nothing ever wrote.
-    const { engine } = probeRig('hands');
+  it('publishes into the ENGINE\'s own resources — the two cannot be different objects', async () => {
+    // This replaced a guard. `resources` used to be a separate constructor option, so the
+    // Applier could publish into an object no node read — a graph ticking on a resource
+    // nothing ever wrote, with no symptom. Taking it from the engine makes that
+    // unrepresentable rather than merely detected, which is why the guard is gone.
+    const { engine, seen } = probeRig('hands');
     await engine.init();
-    const src = listSource('s', 'signal', 'hands', ['a']);
-    await expect(new Applier({ engine, sources: [src], clock: pacedClock(4) }).run()).rejects.toThrow(
-      /no resources object/,
-    );
+    const src = listSource('s', 'signal', 'hands', ['latched']);
+    await new Applier({ engine, sources: [src], clock: pacedClock(6) }).run();
+    // The probe node reads ctx.resources.hands, so seeing the frame proves the pump
+    // wrote where the engine reads.
+    expect(seen).toContain('latched');
   });
 
   it('refuses two sources sharing an id — ids key the frame buffers', async () => {
-    const { engine, resources } = probeRig('hands');
+    const { engine } = probeRig('hands');
     await engine.init();
     await expect(
       new Applier({
-        engine, resources, clock: pacedClock(4),
+        engine, clock: pacedClock(4),
         sources: [listSource('hands', 'signal', 'a', []), listSource('hands', 'signal', 'b', [])],
       }).run(),
     ).rejects.toThrow(/duplicate Source id "hands"/);
@@ -131,10 +133,10 @@ describe('an async source needs a clock that yields', () => {
 
 describe('the pump: how frames between ticks reach a node', () => {
   it('a SIGNAL source latches the newest frame and drops the intermediates', async () => {
-    const { engine, resources, seen } = probeRig('hands');
+    const { engine, seen } = probeRig('hands');
     await engine.init();
     const src = listSource('s', 'signal', 'hands', ['a', 'b', 'c']);
-    await new Applier({ engine, resources, sources: [src], clock: pacedClock(6) }).run();
+    await new Applier({ engine, sources: [src], clock: pacedClock(6) }).run();
     // Newest wins: a stale pose is worse than the current one. The three frames all
     // land between the first scheduled frame and the tick that follows them.
     expect(seen).toContain('c');
@@ -142,10 +144,10 @@ describe('the pump: how frames between ticks reach a node', () => {
   });
 
   it('an EVENT source accumulates every frame since the last tick', async () => {
-    const { engine, resources, seen } = probeRig('keys');
+    const { engine, seen } = probeRig('keys');
     await engine.init();
     const src = listSource('s', 'event', 'keys', ['x', 'y', 'z']);
-    await new Applier({ engine, resources, sources: [src], clock: pacedClock(6) }).run();
+    await new Applier({ engine, sources: [src], clock: pacedClock(6) }).run();
     // Nothing dropped: a lost keypress is information no later frame can recover.
     const batches = (seen as unknown[][]).filter((b) => Array.isArray(b) && b.length > 0);
     expect(batches.flat()).toEqual(['x', 'y', 'z']);
@@ -165,7 +167,7 @@ describe('the pump: how frames between ticks reach a node', () => {
       dispose: () => {},
     };
     let n = 0;
-    await new Applier({ engine: sig.engine, resources: sig.resources, sources: [held], clock: pacedClock(12), shouldStop: () => n++ >= 5 }).run();
+    await new Applier({ engine: sig.engine, sources: [held], clock: pacedClock(12), shouldStop: () => n++ >= 5 }).run();
     const afterFirstFrame = sig.seen.slice(sig.seen.indexOf('only'));
     // Several ticks, and the value survives on ALL of them — not just the one that got it.
     expect(afterFirstFrame.length).toBeGreaterThan(1);
@@ -183,7 +185,7 @@ describe('the pump: how frames between ticks reach a node', () => {
       dispose: () => {},
     };
     let evTicks = 0;
-    await new Applier({ engine: ev.engine, resources: ev.resources, sources: [idle], clock: pacedClock(10), shouldStop: () => evTicks++ >= 3 }).run();
+    await new Applier({ engine: ev.engine, sources: [idle], clock: pacedClock(10), shouldStop: () => evTicks++ >= 3 }).run();
     // "No keys were pressed" is information, so it publishes an empty list rather than
     // holding the last one — the opposite of the signal rule above.
     expect(ev.seen.length).toBeGreaterThan(0);
@@ -203,10 +205,10 @@ describe('when a run stops', () => {
   });
 
   it('stops once every source is exhausted, without needing the clock to run out', async () => {
-    const { engine, resources, seen } = probeRig('hands');
+    const { engine, seen } = probeRig('hands');
     await engine.init();
     const src = listSource('s', 'signal', 'hands', ['a']);
-    await new Applier({ engine, resources, sources: [src], clock: pacedClock(1000) }).run();
+    await new Applier({ engine, sources: [src], clock: pacedClock(1000) }).run();
     expect(seen.length).toBeLessThan(1000);
   });
 
@@ -214,7 +216,7 @@ describe('when a run stops', () => {
     // Asserting a flag the source's own generator sets proves nothing about the Applier:
     // it would hold even if the run stopped immediately. What has to be observed is the
     // ENGINE still ticking while one source reports exhausted and another does not.
-    const { engine, resources, seen } = probeRig('hands');
+    const { engine, seen } = probeRig('hands');
     await engine.init();
     const drained: Source = {
       id: 'a', kind: 'signal', outputResource: 'hands',
@@ -229,7 +231,7 @@ describe('when a run stops', () => {
       dispose: () => {},
     };
     let n = 0;
-    await new Applier({ engine, resources, sources: [drained, stillOpen], clock: pacedClock(20), shouldStop: () => n++ >= 4 }).run();
+    await new Applier({ engine, sources: [drained, stillOpen], clock: pacedClock(20), shouldStop: () => n++ >= 4 }).run();
     // With `some()` semantics the exhausted source would have ended the run at tick zero.
     expect(seen.length).toBeGreaterThan(1);
   });
@@ -240,6 +242,79 @@ describe('when a run stops', () => {
     let n = 0;
     await new Applier({ engine, clock: new BatchClock(100), shouldStop: () => ++n > 3 }).run();
     expect(seen.length).toBeLessThanOrEqual(3);
+  });
+});
+
+describe('the state reader — R3 one-tick feedback (#101 M-F)', () => {
+  it('publishes a stateReader on the engine\'s resources', async () => {
+    const { engine } = probeRig('x');
+    await engine.init();
+    await new Applier({ engine, clock: new BatchClock(1) }).run();
+    const sr = engine.resources[STATE_READER_KEY] as StateReader | undefined;
+    expect(typeof sr?.get).toBe('function');
+  });
+
+  it('reads the latest value a node emitted', async () => {
+    const registry = createRegistry([
+      defineNode({
+        type: 'counter', roles: ['source'], params: z.object({}), inputs: [], outputs: [{ name: 'n', kind: 'any' }],
+        make: () => { let n = 0; return { process: () => ({ n: n++ }) }; },
+      }),
+    ]);
+    const engine = new Engine({ nodes: [{ id: 'c', type: 'counter', params: {} }], edges: [] }, registry, {});
+    await engine.init();
+    await new Applier({ engine, clock: new BatchClock(3) }).run();
+    const sr = engine.resources[STATE_READER_KEY] as StateReader;
+    expect(sr.get('c', 'n')).toBe(2);
+    // A port or node that never emitted reads undefined rather than throwing — a source
+    // must tolerate a first-tick absence, which is only possible if this is total.
+    expect(sr.get('c', 'nope')).toBeUndefined();
+    expect(sr.get('nope', 'n')).toBeUndefined();
+  });
+
+  it('a zero-input source reading a DOWNSTREAM node gets tick N-1 — the feedback, with no cycle', async () => {
+    // The whole basis of R3: the engine evaluates topo-first, so when a source reads a
+    // node that runs after it, it necessarily sees the previous tick's value. If this
+    // ever returned the CURRENT tick, the graph would contain a cycle the engine rejects.
+    const observed: unknown[] = [];
+    const registry = createRegistry([
+      defineNode({
+        type: 'feedback-src', roles: ['source'], params: z.object({}), inputs: [], outputs: [{ name: 'out', kind: 'any' }],
+        make: () => ({
+          process: (_i, ctx) => {
+            const sr = (ctx.resources as Record<string, unknown>)[STATE_READER_KEY] as StateReader | undefined;
+            observed.push(sr?.get('sink', 'echo'));
+            return { out: ctx.tick };
+          },
+        }),
+      }),
+      defineNode({
+        type: 'echo-sink', roles: ['mapping'], params: z.object({}),
+        inputs: [{ name: 'in', kind: 'any' }], outputs: [{ name: 'echo', kind: 'any' }],
+        process: (inputs) => ({ echo: inputs.in }),
+      }),
+    ]);
+    const engine = new Engine({
+      nodes: [{ id: 'src', type: 'feedback-src', params: {} }, { id: 'sink', type: 'echo-sink', params: {} }],
+      edges: [{ from: { node: 'src', port: 'out' }, to: { node: 'sink', port: 'in' } }],
+    }, registry, {});
+    await engine.init();
+    await new Applier({ engine, clock: new BatchClock(4) }).run();
+    // Tick 0 sees nothing (the sink has not run); thereafter it sees the PREVIOUS tick.
+    expect(observed).toEqual([undefined, 0, 1, 2]);
+  });
+
+  it('is stable across ticks, so a node may hold onto it', async () => {
+    const { engine } = probeRig('x');
+    await engine.init();
+    const applier = new Applier({ engine, clock: new BatchClock(2) });
+    await applier.run();
+    const first = engine.resources[STATE_READER_KEY];
+    await new Applier({ engine, clock: new BatchClock(1) }).run();
+    // A second Applier over the same engine republishes an equivalent reader; what must
+    // not happen is the key vanishing between runs.
+    expect(engine.resources[STATE_READER_KEY]).toBeDefined();
+    expect(typeof (first as StateReader).get).toBe('function');
   });
 });
 
@@ -280,7 +355,7 @@ describe('dispose and failure', () => {
   });
 
   it('a source that throws stops the run rather than starving it on a frozen frame', async () => {
-    const { engine, resources, seen } = probeRig('hands');
+    const { engine, seen } = probeRig('hands');
     await engine.init();
     const errs: unknown[] = [];
     const boom: Source = {
@@ -289,7 +364,7 @@ describe('dispose and failure', () => {
       exhausted: () => false,
       dispose: () => {},
     };
-    await new Applier({ engine, resources, sources: [boom], clock: pacedClock(1000), onError: (e) => errs.push(e) }).run();
+    await new Applier({ engine, sources: [boom], clock: pacedClock(1000), onError: (e) => errs.push(e) }).run();
     expect(errs).toHaveLength(1);
     expect(seen.length).toBeLessThan(1000);
   });
@@ -299,7 +374,7 @@ describe('dispose and failure', () => {
     // rejection — in Node a process-level crash, which would take down a whole test run
     // rather than failing this one. It has to come back through the await the caller
     // already has.
-    const { engine, resources } = probeRig('hands');
+    const { engine } = probeRig('hands');
     await engine.init();
     const boom: Source = {
       id: 'boom', kind: 'signal', outputResource: 'hands',
@@ -312,7 +387,7 @@ describe('dispose and failure', () => {
     process.on('unhandledRejection', onUnhandled);
     try {
       await expect(
-        new Applier({ engine, resources, sources: [boom], clock: pacedClock(1000) }).run(),
+        new Applier({ engine, sources: [boom], clock: pacedClock(1000) }).run(),
       ).rejects.toThrow('source died');
       await new Promise((r) => setTimeout(r, 10));
       expect(unhandled).toBeNull();
@@ -406,7 +481,7 @@ describe('sinks', () => {
       dispose: () => {},
     };
     let n = 0;
-    await new Applier({ engine, resources, sources: [src], clock: pacedClock(10), shouldStop: () => n++ >= 4, onError: () => {} }).run();
+    await new Applier({ engine, sources: [src], clock: pacedClock(10), shouldStop: () => n++ >= 4, onError: () => {} }).run();
     // The first tick threw; the two frames must appear on a LATER tick rather than vanish.
     expect(seen.flatMap((v) => (Array.isArray(v) ? v : []))).toEqual(['noteOn', 'noteOff']);
   });


### PR DESCRIPTION
M-F's channel half. Headless throughout.

## Making a design claim true

`docs/design/stream-applier.md` has asserted since July that *"the Applier also injects
`resources.stateReader`"*. It did not — a doc claim ahead of the code, of the same family
as the ones the truth pass fixed. This makes it true, and it is R3's whole mechanism.

**Why it needs no cycle.** The engine evaluates topo-first, so a zero-input source reading
a **downstream** node's port necessarily sees that node's value from **tick N-1**. The
feedback falls out of evaluation order rather than out of a cycle the engine would reject.
The test pins the actual sequence — `[undefined, 0, 1, 2]` — rather than asserting the
mechanism in prose.

The reader is **total**: an absent node or port reads `undefined` rather than throwing,
because the design requires a state generator to tolerate a first-tick absence, and that
is only possible if reading one is not an error.

## A guard removed, because the failure is now unrepresentable

`Applier` had a `resources` constructor option that had to be *the same object* the engine
was built with. The adversarial review on #184 flagged the obvious problem: nothing checked
it, and the failure has no symptom — the pump publishes into an object no node reads, and
the graph ticks on a resource nothing ever wrote. I added a guard.

A guard is the wrong instrument when the failure can be made impossible instead. `Engine`
now exposes its live resources object, the Applier takes it, and the two cannot differ.
The guard and its test are deleted, replaced by a test of the invariant. It also removes
an option `useEngine` was passing redundantly.

## Not built, deliberately

**`stateGeneratorSource`** — the node that consumes the channel: seed-derived randomness
(`seed + ctx.tick`, never `Math.random`, or recordings stop reproducing) and re-emitting
the read snapshot on a second port so replay reproduces the feedback and it stays tappable.
It belongs in `src/nodes/sources/`, which another session is working in. Recorded on #101
with its home named, ready to pick up when that directory frees.

## Verification

- **1421 tests**, typecheck, build, catalog clean; rebased on main
- **The byte-identity gate still passes** — injecting a resources key changes no recorded
  output, because no shipped node reads it. Worth confirming explicitly since this touches
  `Engine` internals.
- All three new guards mutation-tested (reader-not-injected ✗, private-resources ✗,
  reader-returns-stale ✗)

https://claude.ai/code/session_019MqaXSdxoS9hdavMAAMVvu