### PR TITLE
#186 PR B: the body source — webcam-body, synthetic-body, replay-body, the body slot, skeleton overlay, Body panel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,11 +44,15 @@ Discussion #3. Key rules from it:
   swap *may* be surfaced, not that it must: the `source` slot has three real
   candidates and still gets no dropdown, because a replay or synthetic hand is a
   verification affordance, not an instrument a player picks between.)
-- **Two slots exist**: `mapping` (one candidate) and `source` (#104 —
-  `webcam-hands` / `synthetic-hands` / `replay-hands`). Select with
-  `?slot.<name>=<nodeType>`. `?slot.source=synthetic-hands` runs the whole
-  instrument with no camera and no MediaPipe — the fastest way to exercise the
-  graph without hardware.
+- **Three slots exist**: `mapping` (one candidate), `source` (#104 —
+  `webcam-hands` / `synthetic-hands` / `replay-hands`) and `body` (#186 —
+  `webcam-body` / `synthetic-body` / `replay-body`; a second camera branch, always
+  wired and gated off until the `body.enabled` dial, the Lab or a trainer cue wants
+  it, because hands and body are different instruments a player may run together).
+  Select with `?slot.<name>=<nodeType>`. `?slot.source=synthetic-hands` runs the
+  whole instrument with no camera and no MediaPipe — the fastest way to exercise
+  the graph without hardware; `?slot.body=synthetic-body` does the same for the
+  body path.
 - **`PortSpec.schema`** makes a port contract checkable (`kind` is only a label).
   The engine checks it in `tick()`'s output path under
   `EngineOptions.validatePorts` — off by default, **on** in `runHeadless`. It

--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -73,7 +73,7 @@ Two things worth knowing:
 [Get an API key](https://aistudio.google.com/app/apikey)
 
 
-## Nodes (32)
+## Nodes (35)
 
 ### Inputs (sources)
 _Where signals enter the graph._
@@ -93,6 +93,14 @@ MediaPipe FaceLandmarker blendshapes from the shared webcam (lazy-loaded, off by
 - **in:** —
 - **out:** face:face-frame, status:face-status
 - **params:** delegate (enum(GPU | CPU)="GPU")
+
+#### `webcam-body` — Webcam Body
+MediaPipe PoseLandmarker full-body pose (33 landmarks) from the shared webcam. Lazy-loaded, off by default.
+
+- **roles:** source
+- **in:** —
+- **out:** body:body-frame, status:body-status
+- **params:** model (enum(lite | full)="lite"), delegate (enum(GPU | CPU)="GPU"), minTrackingConfidence (number=0.5)
 
 #### `keyboard-source` — Keyboard Source
 Global keyboard input → held / pressed / released key events.
@@ -132,6 +140,22 @@ Replays a recorded hand-landmark stream, one frame per tick. Camera-free and det
 - **roles:** source
 - **in:** —
 - **out:** hands:hands-frame
+- **params:** frames (array=[]), loop (boolean=false)
+
+#### `synthetic-body` — Synthetic Body
+Camera-free animated full-body skeleton (bounce / sway / arms) for tests & demos.
+
+- **roles:** source
+- **in:** —
+- **out:** body:body-frame, status:body-status
+- **params:** width (number=640), height (number=480), bouncePeriod (number=0.5), bounceAmount (number=0.04), swayPeriod (number=2.4), armPeriod (number=3.2), kneeBend (number=0.3), torso (number=120)
+
+#### `replay-body` — Replay Body
+Replays a recorded full-body pose stream, one frame per tick. Camera-free and deterministic.
+
+- **roles:** source
+- **in:** —
+- **out:** body:body-frame, status:body-status
 - **params:** frames (array=[]), loop (boolean=false)
 
 ### Features
@@ -348,7 +372,7 @@ _Audio + the captured video with overlaid guides._
 Mirrored video + composable overlay elements (guides, landmarks, markers, cues).
 
 - **roles:** overlay
-- **in:** hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], chordScale:number[], chord:number[], faceFrame:face-frame, expression:face-expression, octaveShift:number, overlayConfig:overlay-config, faceVector:feature-vector, handVector:feature-vector
+- **in:** hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], chordScale:number[], chord:number[], faceFrame:face-frame, bodyFrame:body-frame, bodyStatus:body-status, expression:face-expression, octaveShift:number, overlayConfig:overlay-config, faceVector:feature-vector, handVector:feature-vector
 - **out:** —
-- **params:** video (object={}), scaleGuide (object={}), chordGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={}), fingerLines (object={}), faceLandmarks (object={}), timbreLevels (object={}), faceExpression (object={}), fingerBars (object={}), chordName (object={}), keyboardStrip (object={}), featureLab (object={}), tagHud (object={}), trainerHud (object={})
+- **params:** video (object={}), scaleGuide (object={}), chordGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={}), fingerLines (object={}), faceLandmarks (object={}), bodySkeleton (object={}), timbreLevels (object={}), faceExpression (object={}), fingerBars (object={}), chordName (object={}), keyboardStrip (object={}), featureLab (object={}), tagHud (object={}), trainerHud (object={})
 

--- a/docs/design/component-model.md
+++ b/docs/design/component-model.md
@@ -169,6 +169,7 @@ which is free — they are just a map on each node.
 |---|---|---|---|---|
 | `mapping` | `mapping` | `voice-mapping` | `voice-mapping` | no — one implementation |
 | `source` | `source` | `webcam-hands` | `webcam-hands`, `synthetic-hands`, `replay-hands` | no — see below |
+| `body` | `source` | `webcam-body` | `webcam-body`, `synthetic-body`, `replay-body` | no — same ruling; a second camera branch (#186), gated off until wanted, never a candidate of `source` (hands and body run together) |
 
 The `source` slot (#104) is the first with more than one real candidate, which
 makes it the first genuine test of "swapping is a config flip" — and it passes:

--- a/docs/design/lazy-loading.md
+++ b/docs/design/lazy-loading.md
@@ -91,7 +91,8 @@ Three idioms the existing sites need, stated so they are not re-derived:
 |---|---|---|
 | `lyria` (`src/nodes/output/lyria.ts`) | **adopts in #188 PR 3** | `createGenerativeEngine` seam; default lazily imports `lyria_engine.ts`, which reads the BYO key from the assistant's provider-key store. `LyriaEngine` leaves `browser.ts`'s static exports. |
 | `midi-out` | reference site, not migrated | Mutation-verified as is; migrate when a change touches it. Its `MidiPhase` maps to `LoadStatus` as `connecting → loading`, `unsupported/no-ports/denied → unavailable + reason`. |
-| `webcam-face`, `webcam-hands` | reference site, not migrated | Owned by the body-features work (#186); asked to adopt for the body model rather than write a fourth copy. |
+| `webcam-body` (`src/nodes/sources/webcam_body.ts`) | **adopted (#186 PR B)** | `createBodyLandmarker` seam on `ctx.resources`; default lazily imports tasks-vision. Keyed by the `body.model` dial (release on change); `gate` reports `unavailable` / `no-camera` until the shared `<video>` has frames, and the node releases-and-retries when they arrive. `active` while a body is detected. |
+| `webcam-face`, `webcam-hands` | reference site, not migrated | Same family as `webcam-body`; migrate when a change touches them. |
 | recording formats | reference site | Already a registry of `load()` thunks; the status here is per conversion, not per node. |
 | conductor assets (#187) | asked to adopt | Any score / model / sample fetched on first use. |
 | an in-browser generator (`generative-instruments.md` §3b) | must adopt | ~300 kB gzip of library and 12–18 MB of checkpoint, with a progress bar. |

--- a/public/catalog.json
+++ b/public/catalog.json
@@ -40,6 +40,14 @@
         "kind": "face-frame"
       },
       {
+        "name": "bodyFrame",
+        "kind": "body-frame"
+      },
+      {
+        "name": "bodyStatus",
+        "kind": "body-status"
+      },
+      {
         "name": "expression",
         "kind": "face-expression"
       },
@@ -100,6 +108,11 @@
       },
       {
         "name": "faceLandmarks",
+        "type": "object",
+        "default": {}
+      },
+      {
+        "name": "bodySkeleton",
         "type": "object",
         "default": {}
       },
@@ -1138,6 +1151,38 @@
     ]
   },
   {
+    "type": "replay-body",
+    "title": "Replay Body",
+    "description": "Replays a recorded full-body pose stream, one frame per tick. Camera-free and deterministic.",
+    "roles": [
+      "source"
+    ],
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "body",
+        "kind": "body-frame",
+        "description": "The latest full-body pose frame (33 landmarks; absent when nobody is in frame)."
+      },
+      {
+        "name": "status",
+        "kind": "body-status"
+      }
+    ],
+    "params": [
+      {
+        "name": "frames",
+        "type": "array",
+        "default": []
+      },
+      {
+        "name": "loop",
+        "type": "boolean",
+        "default": false
+      }
+    ]
+  },
+  {
     "type": "replay-hands",
     "title": "Replay Hands",
     "description": "Replays a recorded hand-landmark stream, one frame per tick. Camera-free and deterministic.",
@@ -1356,6 +1401,68 @@
       }
     ],
     "params": []
+  },
+  {
+    "type": "synthetic-body",
+    "title": "Synthetic Body",
+    "description": "Camera-free animated full-body skeleton (bounce / sway / arms) for tests & demos.",
+    "roles": [
+      "source"
+    ],
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "body",
+        "kind": "body-frame",
+        "description": "The latest full-body pose frame (33 landmarks; absent when nobody is in frame)."
+      },
+      {
+        "name": "status",
+        "kind": "body-status"
+      }
+    ],
+    "params": [
+      {
+        "name": "width",
+        "type": "number",
+        "default": 640
+      },
+      {
+        "name": "height",
+        "type": "number",
+        "default": 480
+      },
+      {
+        "name": "bouncePeriod",
+        "type": "number",
+        "default": 0.5
+      },
+      {
+        "name": "bounceAmount",
+        "type": "number",
+        "default": 0.04
+      },
+      {
+        "name": "swayPeriod",
+        "type": "number",
+        "default": 2.4
+      },
+      {
+        "name": "armPeriod",
+        "type": "number",
+        "default": 3.2
+      },
+      {
+        "name": "kneeBend",
+        "type": "number",
+        "default": 0.3
+      },
+      {
+        "name": "torso",
+        "type": "number",
+        "default": 120
+      }
+    ]
   },
   {
     "type": "synthetic-hands",
@@ -1590,6 +1697,43 @@
         "name": "gainGlide",
         "type": "number",
         "default": 0.08
+      }
+    ]
+  },
+  {
+    "type": "webcam-body",
+    "title": "Webcam Body",
+    "description": "MediaPipe PoseLandmarker full-body pose (33 landmarks) from the shared webcam. Lazy-loaded, off by default.",
+    "roles": [
+      "source"
+    ],
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "body",
+        "kind": "body-frame",
+        "description": "The latest full-body pose frame (33 landmarks; absent when nobody is in frame)."
+      },
+      {
+        "name": "status",
+        "kind": "body-status"
+      }
+    ],
+    "params": [
+      {
+        "name": "model",
+        "type": "enum(lite | full)",
+        "default": "lite"
+      },
+      {
+        "name": "delegate",
+        "type": "enum(GPU | CPU)",
+        "default": "GPU"
+      },
+      {
+        "name": "minTrackingConfidence",
+        "type": "number",
+        "default": 0.5
       }
     ]
   },

--- a/public/manual.html
+++ b/public/manual.html
@@ -42,7 +42,7 @@
           letter-spacing: .06em; border-radius: 999px; padding: .1rem .4rem; margin-left: .35rem; vertical-align: 1px; }
 </style></head><body><div class="wrap">
   <h1>θ Thoremin — Capabilities Manual</h1>
-  <p class="gen">Auto-generated from the node registry. 32 nodes.</p>
+  <p class="gen">Auto-generated from the node registry. 35 nodes.</p>
   <p class="guide">Looking for how to <b>use</b> the app — playing, instruments, shortcuts, the assistant, recording, annotations, the Feature Lab? → <a href="https://github.com/thorwhalen/thoremin/blob/main/docs/USER_GUIDE.md">the User Guide</a>. This page is the <b>node</b> catalog.</p>
   <p>Thoremin turns live sensor streams (webcam hand gestures, facial expressions and head pose, computer keyboard, MIDI out) into a live audiovisual stream — musical audio plus the captured video with overlaid guides. You build sounds by wiring small, typed <b>nodes</b> into a dataflow graph (DAG): inputs → features → mapping → music-logic → synthesis/generation → output. Every edge can be recorded and replayed.</p><p>The mapping layer spans a spectrum: <b>direct</b> (a gesture *is* a note/parameter — e.g. hand position → scale-snapped pitch) through <b>indirect</b> (a gesture expresses a high-level idea — e.g. openness → musical density steering an AI model), including <b>conductor</b> mode (direct a fixed piece's tempo and dynamics).</p><p>Everything runs <b>client-side</b>: gesture/face inference (MediaPipe), synthesis (Web Audio) and rendering (canvas) all happen in your browser. There is no backend — nothing you play, record, or annotate is uploaded anywhere. The only network calls are the ones you opt into by pasting your own API key (the AI assistant, and Lyria generative music), and those go straight from your browser to that provider.</p><p>This page catalogs the engine's building blocks — every node, its ports and its params. The DAG *is* the deployed instrument; a few nodes here (the generative and conductor-mode ones) are built and tested but are not wired into the default graph.</p>
   <h3>Example pipelines</h3>
@@ -106,6 +106,16 @@
       </dl>
     </div>
     <div class="node">
+      <h4><code>webcam-body</code> <span class="title">Webcam Body</span></h4>
+      <p>MediaPipe PoseLandmarker full-body pose (33 landmarks) from the shared webcam. Lazy-loaded, off by default.</p>
+      <dl>
+        <dt>roles</dt><dd>source</dd>
+        <dt>in</dt><dd>—</dd>
+        <dt>out</dt><dd>body:body-frame, status:body-status</dd>
+        <dt>params</dt><dd>model (enum(lite | full)="lite"), delegate (enum(GPU | CPU)="GPU"), minTrackingConfidence (number=0.5)</dd>
+      </dl>
+    </div>
+    <div class="node">
       <h4><code>keyboard-source</code> <span class="title">Keyboard Source</span></h4>
       <p>Global keyboard input → held / pressed / released key events.</p>
       <dl>
@@ -152,6 +162,26 @@
         <dt>roles</dt><dd>source</dd>
         <dt>in</dt><dd>—</dd>
         <dt>out</dt><dd>hands:hands-frame</dd>
+        <dt>params</dt><dd>frames (array=[]), loop (boolean=false)</dd>
+      </dl>
+    </div>
+    <div class="node">
+      <h4><code>synthetic-body</code> <span class="title">Synthetic Body</span></h4>
+      <p>Camera-free animated full-body skeleton (bounce / sway / arms) for tests &amp; demos.</p>
+      <dl>
+        <dt>roles</dt><dd>source</dd>
+        <dt>in</dt><dd>—</dd>
+        <dt>out</dt><dd>body:body-frame, status:body-status</dd>
+        <dt>params</dt><dd>width (number=640), height (number=480), bouncePeriod (number=0.5), bounceAmount (number=0.04), swayPeriod (number=2.4), armPeriod (number=3.2), kneeBend (number=0.3), torso (number=120)</dd>
+      </dl>
+    </div>
+    <div class="node">
+      <h4><code>replay-body</code> <span class="title">Replay Body</span></h4>
+      <p>Replays a recorded full-body pose stream, one frame per tick. Camera-free and deterministic.</p>
+      <dl>
+        <dt>roles</dt><dd>source</dd>
+        <dt>in</dt><dd>—</dd>
+        <dt>out</dt><dd>body:body-frame, status:body-status</dd>
         <dt>params</dt><dd>frames (array=[]), loop (boolean=false)</dd>
       </dl>
     </div></div></section>
@@ -406,9 +436,9 @@
       <p>Mirrored video + composable overlay elements (guides, landmarks, markers, cues).</p>
       <dl>
         <dt>roles</dt><dd>overlay</dd>
-        <dt>in</dt><dd>hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], chordScale:number[], chord:number[], faceFrame:face-frame, expression:face-expression, octaveShift:number, overlayConfig:overlay-config, faceVector:feature-vector, handVector:feature-vector</dd>
+        <dt>in</dt><dd>hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], chordScale:number[], chord:number[], faceFrame:face-frame, bodyFrame:body-frame, bodyStatus:body-status, expression:face-expression, octaveShift:number, overlayConfig:overlay-config, faceVector:feature-vector, handVector:feature-vector</dd>
         <dt>out</dt><dd>—</dd>
-        <dt>params</dt><dd>video (object={}), scaleGuide (object={}), chordGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={}), fingerLines (object={}), faceLandmarks (object={}), timbreLevels (object={}), faceExpression (object={}), fingerBars (object={}), chordName (object={}), keyboardStrip (object={}), featureLab (object={}), tagHud (object={}), trainerHud (object={})</dd>
+        <dt>params</dt><dd>video (object={}), scaleGuide (object={}), chordGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={}), fingerLines (object={}), faceLandmarks (object={}), bodySkeleton (object={}), timbreLevels (object={}), faceExpression (object={}), fingerBars (object={}), chordName (object={}), keyboardStrip (object={}), featureLab (object={}), tagHud (object={}), trainerHud (object={})</dd>
       </dl>
     </div></div></section>
 </div></body></html>

--- a/scripts/gen_catalog.ts
+++ b/scripts/gen_catalog.ts
@@ -19,7 +19,7 @@ const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 
 // Layer grouping for the manual (type → category, in display order).
 const CATEGORIES: Array<{ name: string; blurb: string; types: string[] }> = [
-  { name: 'Inputs (sources)', blurb: 'Where signals enter the graph.', types: ['webcam-hands', 'webcam-face', 'keyboard-source', 'store-controls', 'synthetic-hands', 'replay-source', 'replay-hands'] },
+  { name: 'Inputs (sources)', blurb: 'Where signals enter the graph.', types: ['webcam-hands', 'webcam-face', 'webcam-body', 'keyboard-source', 'store-controls', 'synthetic-hands', 'replay-source', 'replay-hands', 'synthetic-body', 'replay-body'] },
   { name: 'Features', blurb: 'Raw sensor data → normalized control signals.', types: ['hand-features', 'face-features', 'face-controls', 'face-expression', 'gesture-classifier', 'face-feature-vector', 'hand-feature-vector'] },
   { name: 'Mapping (direct ↔ indirect)', blurb: 'Features → engine parameters, across the expression spectrum.', types: ['voice-mapping', 'indirect-map', 'keyboard-control', 'pick', 'one-euro', 'synth-merge', 'chord-select'] },
   { name: 'Music logic (tonal guidance)', blurb: 'Harmony kept in-key.', types: ['chord', 'progression', 'expression-chord', 'pose-chord'] },

--- a/src/app/dials/DialsControlsPanel.tsx
+++ b/src/app/dials/DialsControlsPanel.tsx
@@ -34,6 +34,7 @@ import { HandControls } from './panels/hand';
 import { FaceControls } from './panels/face';
 import { OverlayControls } from './panels/overlay';
 import { MidiControls } from './panels/midi';
+import { BodyControls } from './panels/body';
 
 export default function DialsControlsPanel() {
   const { state, set } = useDialsSettings();
@@ -65,6 +66,11 @@ export default function DialsControlsPanel() {
 
       <TopSection label="Face">
         <FaceControls />
+      </TopSection>
+
+      {/* Body tracking (#186): the pose source, off by default (the heaviest model). */}
+      <TopSection label="Body">
+        <BodyControls />
       </TopSection>
 
       <TopSection label="Overlay">

--- a/src/app/dials/panels/body.tsx
+++ b/src/app/dials/panels/body.tsx
@@ -1,0 +1,55 @@
+/**
+ * The BODY section of the settings panel (#186): the body-tracking on/off dial and
+ * the PoseLandmarker model choice. Body tracking is the most expensive model the
+ * graph can host, so it is a dial the player turns on — never a default — and the
+ * copy says what it costs. Both controls dispatch commands (the single write path).
+ */
+import { dispatchDialSet } from '../../dispatchDial';
+import { useDialsSettings } from '../useDialsSettings';
+import { selectCls } from '../primitives';
+import { BODY_MODELS } from '@/settings/schema';
+
+const MODEL_LABEL: Record<(typeof BODY_MODELS)[number], string> = {
+  lite: 'lite (fast, 6 MB)',
+  full: 'full (steadier, 9 MB)',
+};
+
+export function BodyControls() {
+  const { state } = useDialsSettings();
+  const v = state.effective;
+  const enabled = v['body.enabled'] as boolean;
+  const model = (v['body.model'] as (typeof BODY_MODELS)[number]) ?? 'lite';
+
+  return (
+    <div className="space-y-2">
+      <label className="flex items-center gap-2 text-xs">
+        <input
+          type="checkbox"
+          checked={enabled}
+          onChange={(e) => dispatchDialSet('body.enabled', e.target.checked)}
+        />
+        Track the body
+      </label>
+      <label className="flex items-center justify-between gap-2 text-xs">
+        Model
+        <select
+          className={selectCls}
+          value={model}
+          disabled={!enabled}
+          onChange={(e) => dispatchDialSet('body.model', e.target.value)}
+        >
+          {BODY_MODELS.map((m) => (
+            <option key={m} value={m}>
+              {MODEL_LABEL[m]}
+            </option>
+          ))}
+        </select>
+      </label>
+      <p className="text-[10px] leading-relaxed text-white/40">
+        Detects 33 full-body landmarks from the webcam and draws the skeleton on the
+        video. It is the source for body features (the Lab, the trainer) and the dance
+        pulse; the model downloads on first use.
+      </p>
+    </div>
+  );
+}

--- a/src/app/dials/panels/body.tsx
+++ b/src/app/dials/panels/body.tsx
@@ -10,8 +10,8 @@ import { selectCls } from '../primitives';
 import { BODY_MODELS } from '@/settings/schema';
 
 const MODEL_LABEL: Record<(typeof BODY_MODELS)[number], string> = {
-  lite: 'lite (fast, 6 MB)',
-  full: 'full (steadier, 9 MB)',
+  lite: 'lite (fast, 5.8 MB download)',
+  full: 'full (steadier on fast motion, 9.4 MB download)',
 };
 
 export function BodyControls() {

--- a/src/app/graph.ts
+++ b/src/app/graph.ts
@@ -353,8 +353,9 @@ export function defaultGraph(selection?: SlotSelection, registry?: NodeRegistry)
       { from: { node: 'chordSel', port: 'chord' }, to: { node: 'overlay', port: 'chord' } },
       // The raw face frame (mesh) + classified expression, for the face overlays.
       { from: { node: 'camFace', port: 'face' }, to: { node: 'overlay', port: 'faceFrame' } },
-      // The body skeleton + the body model's load state (#186). A synthetic/replay body
-      // emits no `status`, which the overlay treats as 'nothing to report'.
+      // The body skeleton + the body model's load state (#186). Every body candidate
+      // emits `status` (a synthetic/replay body is simply always loaded), so the swap
+      // stays edge-stable.
       { from: { node: 'camBody', port: 'body' }, to: { node: 'overlay', port: 'bodyFrame' } },
       { from: { node: 'camBody', port: 'status' }, to: { node: 'overlay', port: 'bodyStatus' } },
       { from: { node: 'faceExpr', port: 'expression' }, to: { node: 'overlay', port: 'expression' } },

--- a/src/app/graph.ts
+++ b/src/app/graph.ts
@@ -25,6 +25,7 @@
 import type { GraphSpec, NodeRegistry, Role } from '@/dag';
 import { MAPPING_SLOT_CONTRACT } from '@/nodes/mapping/mapping_contract';
 import { SOURCE_SLOT_CONTRACT } from '@/nodes/sources/source_contract';
+import { BODY_SLOT_CONTRACT } from '@/nodes/sources/body_contract';
 import type { SlotContract } from '@/nodes/slot_contract';
 
 /**
@@ -76,6 +77,21 @@ export const SLOTS: Record<string, SlotDef> = {
     default: 'webcam-hands',
     candidates: ['webcam-hands', 'synthetic-hands', 'replay-hands'],
     contract: SOURCE_SLOT_CONTRACT,
+  },
+  /**
+   * Where the full-body pose frames come from (#186). A SECOND slot rather than a
+   * candidate of `source`: hands and body are different instruments a player may
+   * run together, so the body branch is always wired (like the face branch) and
+   * gated off until the `body.enabled` dial, the Lab or a trainer cue wants it —
+   * `webcam-body` loads nothing until then. `?slot.body=synthetic-body` runs the
+   * whole body path with no camera and no model, headlessly or in the browser.
+   * No player-facing dropdown, for the same reason as `source`.
+   */
+  body: {
+    role: 'source',
+    default: 'webcam-body',
+    candidates: ['webcam-body', 'synthetic-body', 'replay-body'],
+    contract: BODY_SLOT_CONTRACT,
   },
 };
 
@@ -192,6 +208,7 @@ export function resolveSlot(
 export function defaultGraph(selection?: SlotSelection, registry?: NodeRegistry): GraphSpec {
   const mappingType = resolveSlot('mapping', selection, registry);
   const sourceType = resolveSlot('source', selection, registry);
+  const bodyType = resolveSlot('body', selection, registry);
   // The default source's params are MediaPipe's (model size, hand count) and mean
   // nothing to a replay or synthetic source. Rather than invent a shared params
   // contract for a slot whose candidates genuinely have nothing in common, a
@@ -204,6 +221,8 @@ export function defaultGraph(selection?: SlotSelection, registry?: NodeRegistry)
       { id: 'feat', type: 'hand-features', params: { mirrorX: true, mirrorHandedness: true } },
       // Face branch (idle until the player picks a face mapping in settings).
       { id: 'camFace', type: 'webcam-face', params: {} },
+      // Body branch (#186): idle (empty frame, no model) until body tracking is wanted.
+      { id: 'camBody', type: bodyType, params: {} },
       { id: 'faceFeat', type: 'face-features', params: { smoothing: 0.3 } },
       // Chord path: classify the expression, then play its diatonic triad.
       { id: 'faceExpr', type: 'face-expression', params: {} },
@@ -334,6 +353,10 @@ export function defaultGraph(selection?: SlotSelection, registry?: NodeRegistry)
       { from: { node: 'chordSel', port: 'chord' }, to: { node: 'overlay', port: 'chord' } },
       // The raw face frame (mesh) + classified expression, for the face overlays.
       { from: { node: 'camFace', port: 'face' }, to: { node: 'overlay', port: 'faceFrame' } },
+      // The body skeleton + the body model's load state (#186). A synthetic/replay body
+      // emits no `status`, which the overlay treats as 'nothing to report'.
+      { from: { node: 'camBody', port: 'body' }, to: { node: 'overlay', port: 'bodyFrame' } },
+      { from: { node: 'camBody', port: 'status' }, to: { node: 'overlay', port: 'bodyStatus' } },
       { from: { node: 'faceExpr', port: 'expression' }, to: { node: 'overlay', port: 'expression' } },
       // Live overlay element config from the UI store (toggle elements without rebuild).
       { from: { node: 'ui', port: 'overlay' }, to: { node: 'overlay', port: 'overlayConfig' } },

--- a/src/app/overlayControls.ts
+++ b/src/app/overlayControls.ts
@@ -69,6 +69,7 @@ export interface OverlayControlDesc {
 export const OVERLAY_CONTROLS: OverlayControlDesc[] = [
   { name: 'landmarks', label: 'Hand landmarks' },
   { name: 'faceLandmarks', label: 'Face mesh', needsFace: true },
+  { name: 'bodySkeleton', label: 'Body skeleton' },
   {
     // Feature Instrumentation Lab (#119) — owned by the LAB panel, not the instrument's
     // Overlay section: the Lab measures the instrument, so its config is a per-device

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -25,6 +25,9 @@ import {
   DEFAULT_FACE_CHORD,
   DEFAULT_FACE_EXPR,
   DEFAULT_MIDI,
+  DEFAULT_BODY,
+  BodySettingsSchema,
+  type BodySettings,
   FaceChordSchema,
   FaceExprSchema,
   HandMapSchema,
@@ -135,6 +138,9 @@ export interface ControlState {
    *  field (in {@link SETTINGS_KEYS}); read live by the `midi-out` node via
    *  `store-controls` → its `enabled`/`port` inputs. */
   midi: MidiSettings;
+  /** The body source (#186): on/off + model. A preset field; read live by `webcam-body`
+   *  through `ctx.resources.controls` (its gate, like the face's `faceMapping`). */
+  body: BodySettings;
   /**
    * The head/face CONTROL axis tuning (#76): per-axis gain (negative flips a
    * direction), deadzone, neutral zero and shared smoothing for the `face-controls`
@@ -371,6 +377,15 @@ export function mergeControls(persisted: unknown, current: ControlState): Contro
       midi = current.midi;
     }
   }
+  // Heal the body settings (#186): a pre-body blob has none → off, lite.
+  let body = current.body;
+  if (p.body) {
+    try {
+      body = BodySettingsSchema.parse({ ...DEFAULT_BODY, ...p.body });
+    } catch {
+      body = current.body;
+    }
+  }
   // Heal the face-control axes (#76): a pre-#76-dials blob has none → the shipped tuning;
   // a partial one is completed; a corrupt one falls back whole rather than leaving the
   // panel to dereference an undefined into a NaN slider.
@@ -404,7 +419,7 @@ export function mergeControls(persisted: unknown, current: ControlState): Contro
       gestures = current.gestures;
     }
   }
-  return { ...current, ...p, overlay, featureLab, trainerHud, faceMapping, faceChord, faceExpr, handMap, midi, faceControls, gestures };
+  return { ...current, ...p, overlay, featureLab, trainerHud, faceMapping, faceChord, faceExpr, handMap, midi, body, faceControls, gestures };
 }
 
 // localStorage in the browser; a no-op elsewhere (Node test runtime) so the
@@ -437,6 +452,7 @@ export const useControls = create<ControlState>()(
       featureLab: defaultFeatureLab(),
       handMap: defaultHandMap(),
       midi: { ...DEFAULT_MIDI },
+      body: { ...DEFAULT_BODY },
       faceControls: defaultFaceControls(),
       faceCalibration: null,
       gestures: defaultGesturePrefs(),

--- a/src/features/labConfig.ts
+++ b/src/features/labConfig.ts
@@ -104,6 +104,27 @@ export function demandWantsFace(demanded: DemandedGroups): boolean {
   return false;
 }
 
+/**
+ * The feature groups sourced from the BODY (#186), same exclusion as the face set.
+ * Empty until the body catalog lands; the gates below are then already correct.
+ */
+export const BODY_GROUP_IDS: readonly string[] = FEATURE_GROUPS.filter(
+  (g) => g.source === 'body' && g.id !== DERIVED_GROUP,
+).map((g) => g.id);
+
+/** Does the Lab need the body model loaded? (The face rule, for `webcam-body`.) */
+export function labWantsBody(cfg: FeatureLabConfig | undefined): boolean {
+  if (!cfg?.show) return false;
+  return cfg.groups.some((g) => BODY_GROUP_IDS.includes(g));
+}
+
+/** Does a live feature DEMAND (#163) need the body model loaded? */
+export function demandWantsBody(demanded: DemandedGroups): boolean {
+  if (!demanded) return false;
+  for (const g of demanded) if (BODY_GROUP_IDS.includes(g)) return true;
+  return false;
+}
+
 // ---- The compute gate the feature-vector nodes share ------------------------------
 
 /** The slice of the lab config the feature-vector nodes need off a control snapshot. */

--- a/src/features/types.ts
+++ b/src/features/types.ts
@@ -28,7 +28,7 @@ export type FeatureVector = Record<string, number>;
 export type Controllability = 'easy' | 'moderate' | 'involuntary';
 
 /** Which raw source a feature reads. */
-export type FeatureSource = 'face' | 'hand';
+export type FeatureSource = 'face' | 'hand' | 'body';
 
 /** The confound axes a feature can declare invariance to (#131): `scale` =
  *  camera distance, `position` = translation in the frame, `yaw`/`pitch`/`roll`

--- a/src/nodes/browser.ts
+++ b/src/nodes/browser.ts
@@ -8,6 +8,7 @@ import { createRegistry, type NodeRegistry } from '@/dag';
 import { CORE_NODES } from './index';
 import { webcamHandsNode } from './sources/webcam_hands';
 import { webcamFaceNode } from './sources/webcam_face';
+import { webcamBodyNode } from './sources/webcam_body';
 import { keyboardSourceNode } from './sources/keyboard';
 import { storeControlsNode } from './sources/store_controls';
 import { webAudioSynthNode } from './output/webaudio_synth';
@@ -16,6 +17,7 @@ import { midiOutNode } from './output/midi_out';
 
 export { webcamHandsNode } from './sources/webcam_hands';
 export { webcamFaceNode } from './sources/webcam_face';
+export { webcamBodyNode, bodyActive, resultToBodyFrame } from './sources/webcam_body';
 export { keyboardSourceNode } from './sources/keyboard';
 export { storeControlsNode } from './sources/store_controls';
 export { webAudioSynthNode } from './output/webaudio_synth';
@@ -34,6 +36,7 @@ export type { LyriaEngineOptions } from './output/lyria_engine';
 export const BROWSER_NODES = [
   webcamHandsNode,
   webcamFaceNode,
+  webcamBodyNode,
   keyboardSourceNode,
   storeControlsNode,
   webAudioSynthNode,

--- a/src/nodes/domain.ts
+++ b/src/nodes/domain.ts
@@ -466,3 +466,236 @@ export function makeHandKeypoints(spec: SyntheticHandSpec): Keypoint[] {
 
   return pts;
 }
+
+// ---- Body (full-body pose, #186) ---------------------------------------------
+
+/**
+ * MediaPipe PoseLandmarker landmark indices (the BlazePose 33-point topology).
+ * `BLM` mirrors {@link LM} for hands: the SSOT for "which index is the left
+ * wrist" shared by the live `webcam-body` source, the synthetic skeleton, the
+ * overlay skeleton and the body feature catalog. Order is MediaPipe's, verbatim.
+ */
+export const BLM = {
+  nose: 0,
+  left_eye_inner: 1,
+  left_eye: 2,
+  left_eye_outer: 3,
+  right_eye_inner: 4,
+  right_eye: 5,
+  right_eye_outer: 6,
+  left_ear: 7,
+  right_ear: 8,
+  mouth_left: 9,
+  mouth_right: 10,
+  left_shoulder: 11,
+  right_shoulder: 12,
+  left_elbow: 13,
+  right_elbow: 14,
+  left_wrist: 15,
+  right_wrist: 16,
+  left_pinky: 17,
+  right_pinky: 18,
+  left_index: 19,
+  right_index: 20,
+  left_thumb: 21,
+  right_thumb: 22,
+  left_hip: 23,
+  right_hip: 24,
+  left_knee: 25,
+  right_knee: 26,
+  left_ankle: 27,
+  right_ankle: 28,
+  left_heel: 29,
+  right_heel: 30,
+  left_foot_index: 31,
+  right_foot_index: 32,
+} as const;
+export type BodyLandmarkName = keyof typeof BLM;
+
+/** The 33 landmark names in index order (the offline pose script emits these). */
+export const BODY_LANDMARK_NAMES = Object.keys(BLM) as BodyLandmarkName[];
+
+export const BODY_LANDMARK_COUNT = 33;
+
+/**
+ * The skeleton's bones as landmark-index pairs (MediaPipe's `POSE_CONNECTIONS`
+ * minus the face triangle), for the overlay and for limb-length features.
+ */
+export const BODY_BONES: ReadonlyArray<readonly [number, number]> = [
+  [BLM.left_shoulder, BLM.right_shoulder],
+  [BLM.left_shoulder, BLM.left_elbow],
+  [BLM.left_elbow, BLM.left_wrist],
+  [BLM.right_shoulder, BLM.right_elbow],
+  [BLM.right_elbow, BLM.right_wrist],
+  [BLM.left_shoulder, BLM.left_hip],
+  [BLM.right_shoulder, BLM.right_hip],
+  [BLM.left_hip, BLM.right_hip],
+  [BLM.left_hip, BLM.left_knee],
+  [BLM.left_knee, BLM.left_ankle],
+  [BLM.right_hip, BLM.right_knee],
+  [BLM.right_knee, BLM.right_ankle],
+  [BLM.left_ankle, BLM.left_heel],
+  [BLM.left_heel, BLM.left_foot_index],
+  [BLM.right_ankle, BLM.right_heel],
+  [BLM.right_heel, BLM.right_foot_index],
+  [BLM.left_wrist, BLM.left_index],
+  [BLM.right_wrist, BLM.right_index],
+  [BLM.nose, BLM.left_eye],
+  [BLM.nose, BLM.right_eye],
+  [BLM.left_eye, BLM.left_ear],
+  [BLM.right_eye, BLM.right_ear],
+];
+
+/**
+ * One frame of full-body pose (#186). Produced by the browser `webcam-body`
+ * source, the camera-free `synthetic-body`, or a `replay-body` of a recorded
+ * stream (`scripts/video_to_pose.py`). `landmarks` are the 33 BlazePose points in
+ * PIXEL coordinates of the source frame (like a hand's `keypoints`); `world` is
+ * MediaPipe's metric, hip-centred set (metres) when the detector supplies it —
+ * the basis for scale-free angles and velocities; `visibility` is the per-point
+ * likelihood the landmark is in frame and unoccluded (0..1).
+ */
+export interface BodyFrame {
+  width: number;
+  height: number;
+  present: boolean;
+  /** 33 landmarks in pixel coordinates (empty when `present` is false). */
+  landmarks: Keypoint[];
+  /** 33 landmarks in metres, hip-midpoint origin. Optional (synthetic/older sources). */
+  world?: Keypoint[];
+  /** Per-landmark visibility 0..1, aligned with `landmarks`. */
+  visibility: number[];
+}
+
+/** Runtime shape of a {@link BodyFrame}, for the body slot's output port schema. */
+export const BodyFrameSchema = z.object({
+  width: z.number(),
+  height: z.number(),
+  present: z.boolean(),
+  landmarks: z.array(KeypointSchema),
+  world: z.array(KeypointSchema).optional(),
+  visibility: z.array(z.number()),
+});
+
+/** What a body source emits when nobody is in frame (never `undefined`). */
+export const EMPTY_BODY_FRAME: BodyFrame = {
+  width: 640,
+  height: 480,
+  present: false,
+  landmarks: [],
+  visibility: [],
+};
+
+/** Lifecycle + detection status of the live body model (mirrors {@link FaceStatus}). */
+export interface BodyStatus {
+  phase: 'idle' | 'loading' | 'ready' | 'error';
+  bodyDetected: boolean;
+}
+export const ABSENT_BODY_STATUS: BodyStatus = { phase: 'idle', bodyDetected: false };
+
+/** Fetch a body landmark by index (undefined when absent / out of range). */
+export function blm(frame: BodyFrame, index: number): Keypoint | undefined {
+  return frame.landmarks[index];
+}
+
+export interface SyntheticBodySpec {
+  /** Frame size in pixels. */
+  width: number;
+  height: number;
+  /** Hip-midpoint position, normalized 0..1 of the frame. */
+  cx: number;
+  cy: number;
+  /** Torso length (shoulder-mid to hip-mid) in pixels; every other length scales from it. */
+  torso: number;
+  /** Arm raise 0 (hanging) .. 1 (straight up), per side. */
+  leftArm: number;
+  rightArm: number;
+  /** Knee bend 0 (straight) .. 1 (deep squat), symmetric. */
+  kneeBend: number;
+  /** Lateral lean of the torso in radians (positive = towards frame right). */
+  lean: number;
+}
+
+/**
+ * Build a plausible upright 33-point skeleton facing the camera. Used by the
+ * synthetic body source and by tests, so the body pipeline never needs a camera.
+ * Geometry is in pixels (y down); `world` metres are derived by scaling the same
+ * layout to a 0.5 m torso about the hip midpoint (hip-centred, z = 0), which is
+ * what MediaPipe's world landmarks approximate for a frontal pose.
+ */
+export function makeBodyKeypoints(spec: SyntheticBodySpec): { landmarks: Keypoint[]; world: Keypoint[] } {
+  const { width, height, cx, cy, torso, leftArm, rightArm, kneeBend, lean } = spec;
+  const hx = cx * width;
+  const hy = cy * height;
+  const pts: Keypoint[] = new Array(BODY_LANDMARK_COUNT);
+  const set = (i: number, x: number, y: number) => {
+    pts[i] = { x, y };
+  };
+  const clamp = (v: number) => Math.max(0, Math.min(1, v));
+  // Torso: hips at (hx, hy); shoulders one torso length up, leaned by `lean`.
+  const sx = hx + Math.sin(lean) * torso;
+  const sy = hy - Math.cos(lean) * torso;
+  const shoulderHalf = 0.42 * torso;
+  const hipHalf = 0.3 * torso;
+  // Displayed-left of the image is the subject's RIGHT side; MediaPipe names
+  // sides by the subject, so right_* sits at smaller x when facing the camera.
+  set(BLM.left_shoulder, sx + shoulderHalf, sy);
+  set(BLM.right_shoulder, sx - shoulderHalf, sy);
+  set(BLM.left_hip, hx + hipHalf, hy);
+  set(BLM.right_hip, hx - hipHalf, hy);
+  // Head above the shoulder midpoint.
+  const headR = 0.22 * torso;
+  const nx = sx;
+  const ny = sy - 0.55 * torso;
+  set(BLM.nose, nx, ny);
+  set(BLM.left_eye_inner, nx + 0.25 * headR, ny - 0.3 * headR);
+  set(BLM.left_eye, nx + 0.4 * headR, ny - 0.3 * headR);
+  set(BLM.left_eye_outer, nx + 0.55 * headR, ny - 0.3 * headR);
+  set(BLM.right_eye_inner, nx - 0.25 * headR, ny - 0.3 * headR);
+  set(BLM.right_eye, nx - 0.4 * headR, ny - 0.3 * headR);
+  set(BLM.right_eye_outer, nx - 0.55 * headR, ny - 0.3 * headR);
+  set(BLM.left_ear, nx + headR, ny - 0.1 * headR);
+  set(BLM.right_ear, nx - headR, ny - 0.1 * headR);
+  set(BLM.mouth_left, nx + 0.3 * headR, ny + 0.4 * headR);
+  set(BLM.mouth_right, nx - 0.3 * headR, ny + 0.4 * headR);
+  // Arms: upper + forearm each 0.55 torso; `raise` swings the whole arm from
+  // hanging (angle 0, pointing down) to straight up (angle pi), outward of the body.
+  const arm = (side: 1 | -1, raise: number, shoulder: number, elbow: number, wrist: number, pinky: number, index: number, thumb: number) => {
+    const a = clamp(raise) * Math.PI; // 0 = down, pi = up
+    const dx = side * Math.sin(a) * 0.55 * torso;
+    const dy = Math.cos(a) * 0.55 * torso;
+    const s = pts[shoulder];
+    const e = { x: s.x + dx, y: s.y + dy };
+    const w = { x: e.x + dx, y: e.y + dy };
+    set(elbow, e.x, e.y);
+    set(wrist, w.x, w.y);
+    const hd = 0.12 * torso;
+    set(pinky, w.x + side * hd, w.y + dy * 0.2);
+    set(index, w.x + side * 0.6 * hd, w.y + dy * 0.25);
+    set(thumb, w.x - side * 0.4 * hd, w.y + dy * 0.15);
+  };
+  arm(1, leftArm, BLM.left_shoulder, BLM.left_elbow, BLM.left_wrist, BLM.left_pinky, BLM.left_index, BLM.left_thumb);
+  arm(-1, rightArm, BLM.right_shoulder, BLM.right_elbow, BLM.right_wrist, BLM.right_pinky, BLM.right_index, BLM.right_thumb);
+  // Legs: thigh + shin each 0.75 torso; a knee bend folds them (knee forward = +x
+  // offset outward, feet rise), keeping the feet under the hips.
+  const leg = (side: 1 | -1, hip: number, knee: number, ankle: number, heel: number, foot: number) => {
+    const b = clamp(kneeBend);
+    const h = pts[hip];
+    const kx = h.x + side * b * 0.3 * torso;
+    const ky = h.y + 0.75 * torso * (1 - 0.35 * b);
+    const ax = h.x;
+    const ay = ky + 0.75 * torso * (1 - 0.35 * b);
+    set(knee, kx, ky);
+    set(ankle, ax, ay);
+    set(heel, ax - side * 0.05 * torso, ay + 0.08 * torso);
+    set(foot, ax + side * 0.18 * torso, ay + 0.1 * torso);
+  };
+  leg(1, BLM.left_hip, BLM.left_knee, BLM.left_ankle, BLM.left_heel, BLM.left_foot_index);
+  leg(-1, BLM.right_hip, BLM.right_knee, BLM.right_ankle, BLM.right_heel, BLM.right_foot_index);
+  // World: the same layout in metres about the hip midpoint (0.5 m torso), y up
+  // flipped to MediaPipe's y-down convention is NOT applied — MediaPipe world
+  // coordinates keep y increasing downward like the image, so only translate + scale.
+  const k = 0.5 / torso;
+  const world: Keypoint[] = pts.map((q) => ({ x: (q.x - hx) * k, y: (q.y - hy) * k, z: 0 }));
+  return { landmarks: pts, world };
+}

--- a/src/nodes/domain.ts
+++ b/src/nodes/domain.ts
@@ -8,6 +8,7 @@
  */
 import { z } from 'zod';
 import type { SoundId } from '@/music/sounds';
+import type { LoadStatus } from '@/lazy';
 
 export interface Keypoint {
   x: number;
@@ -549,7 +550,7 @@ export const BODY_BONES: ReadonlyArray<readonly [number, number]> = [
 /**
  * One frame of full-body pose (#186). Produced by the browser `webcam-body`
  * source, the camera-free `synthetic-body`, or a `replay-body` of a recorded
- * stream (`scripts/video_to_pose.py`). `landmarks` are the 33 BlazePose points in
+ * stream (the planned `scripts/video_to_pose.py`, arriving with the body fixtures). `landmarks` are the 33 BlazePose points in
  * PIXEL coordinates of the source frame (like a hand's `keypoints`); `world` is
  * MediaPipe's metric, hip-centred set (metres) when the detector supplies it —
  * the basis for scale-free angles and velocities; `visibility` is the per-point
@@ -586,12 +587,16 @@ export const EMPTY_BODY_FRAME: BodyFrame = {
   visibility: [],
 };
 
-/** Lifecycle + detection status of the live body model (mirrors {@link FaceStatus}). */
-export interface BodyStatus {
-  phase: 'idle' | 'loading' | 'ready' | 'error';
-  bodyDetected: boolean;
-}
-export const ABSENT_BODY_STATUS: BodyStatus = { phase: 'idle', bodyDetected: false };
+/** The two live-capable PoseLandmarker variants (`heavy` is ~30 MB and ~5 fps in a
+ *  browser, so it is not offered). The one definition the dial schema, the store
+ *  snapshot and the `webcam-body` node all read. */
+export const BODY_MODELS = ['lite', 'full'] as const;
+export type BodyModel = (typeof BODY_MODELS)[number];
+
+/** The body model's lifecycle on the `status` port: the shared lazy-loading
+ *  vocabulary (#188, `src/lazy/status.ts`) — `active` while a body is detected. */
+export type BodyStatus = LoadStatus;
+export const ABSENT_BODY_STATUS: BodyStatus = { phase: 'off', message: 'Body tracking off' };
 
 /** Fetch a body landmark by index (undefined when absent / out of range). */
 export function blm(frame: BodyFrame, index: number): Keypoint | undefined {

--- a/src/nodes/index.ts
+++ b/src/nodes/index.ts
@@ -11,6 +11,8 @@ import { createRegistry, type NodeRegistry } from '@/dag';
 import { syntheticHandsNode } from './sources/synthetic_hands';
 import { replaySourceNode } from './sources/replay';
 import { replayHandsNode } from './sources/replay_hands';
+import { syntheticBodyNode } from './sources/synthetic_body';
+import { replayBodyNode } from './sources/replay_body';
 import { handFeaturesNode } from './features/hand_features';
 import { faceFeaturesNode } from './features/face_features';
 import { faceControlsNode } from './features/face_controls';
@@ -37,6 +39,9 @@ import { performanceNode } from './music/performance';
 export { syntheticHandsNode } from './sources/synthetic_hands';
 export { replaySourceNode } from './sources/replay';
 export { replayHandsNode } from './sources/replay_hands';
+export { syntheticBodyNode } from './sources/synthetic_body';
+export { replayBodyNode } from './sources/replay_body';
+export { BODY_SLOT_CONTRACT, BODY_SLOT_OUTPUT } from './sources/body_contract';
 export {
   SOURCE_SLOT_CONTRACT,
   SOURCE_SLOT_OUTPUT,
@@ -75,6 +80,8 @@ export const CORE_NODES = [
   syntheticHandsNode,
   replaySourceNode,
   replayHandsNode,
+  syntheticBodyNode,
+  replayBodyNode,
   handFeaturesNode,
   faceFeaturesNode,
   faceControlsNode,

--- a/src/nodes/output/canvas_overlay.ts
+++ b/src/nodes/output/canvas_overlay.ts
@@ -51,6 +51,10 @@ import { computeTagOverlay, type TagOverlayFrame, type TagOverlaySnapshot } from
 import { wrapLines, type TrainerHudSnapshot } from '@/enroll/hud';
 import { EFFECT_SHORT, type HandMap } from '../mapping/hand_map';
 import {
+  BODY_BONES,
+  BODY_LANDMARK_COUNT,
+  type BodyFrame,
+  type BodyStatus,
   FINGER_NAMES,
   kp,
   LM,
@@ -98,6 +102,8 @@ const Params = z.object({
   fingerLines: z.object({ show: z.boolean().default(false), showLabels: z.boolean().default(true) }).prefault({}),
   /** The detected face mesh (input feature) — available when a face mapping is on. */
   faceLandmarks: z.object({ show: z.boolean().default(true) }).prefault({}),
+  /** The full-body skeleton (#186) — drawn when body tracking is on; shows the load state. */
+  bodySkeleton: z.object({ show: z.boolean().default(true) }).prefault({}),
   /** Per-hand brightness/vibrato level bars (output feature). Opt-in. */
   timbreLevels: z.object({ show: z.boolean().default(false) }).prefault({}),
   /**
@@ -220,6 +226,8 @@ export type OverlayDialParams = z.infer<typeof OverlayDialSchema>;
 const RIGHT_COLOR = '#10b981';
 const LEFT_COLOR = '#3b82f6';
 const FACE_COLOR = '#22d3ee'; // cyan — distinct from hands (emerald/blue) + chord (gold)
+/** The body skeleton's colour (#186): distinct from hands/face/chord. */
+const BODY_COLOR = '#7dd3fc';
 const CHORD_COLOR = '#f5d142'; // warm gold
 
 /** Everything an overlay element needs to draw a frame. */
@@ -243,6 +251,10 @@ export interface OverlayView {
     octaveShift: number;
     chord?: number[];
     faceFrame?: FaceFrame;
+    /** The latest full-body pose (#186), for the skeleton element. */
+    bodyFrame?: BodyFrame;
+    /** The body model's lifecycle, so the skeleton element can say 'loading'. */
+    bodyStatus?: BodyStatus;
     expression?: ExpressionScores;
     /** Live hand map (note source + finger routing), for feature-accurate cues. */
     handMap?: HandMap;
@@ -573,6 +585,61 @@ const faceMesh: OverlayElement = {
       const sy = lm.y * H;
       g.moveTo(sx + r, sy);
       g.arc(sx, sy, r, 0, Math.PI * 2);
+    }
+    g.fill();
+    g.restore();
+  },
+};
+
+/**
+ * The full-body skeleton (#186): bones + joints of the latest body frame, mirrored
+ * like everything else in the scene. While the model is loading (or failed) it
+ * prints the state in the corner instead — the player's only feedback that the
+ * body toggle did something, since the status has no React chip of its own.
+ */
+const bodySkeleton: OverlayElement = {
+  name: 'bodySkeleton',
+  category: 'input',
+  draw(g, { W, H, inputs, params }) {
+    if (!params.bodySkeleton.show) return;
+    const status = inputs.bodyStatus;
+    const body = inputs.bodyFrame;
+    if (status && status.phase !== 'idle' && status.phase !== 'ready') {
+      g.save();
+      g.globalAlpha = 0.8;
+      g.fillStyle = BODY_COLOR;
+      g.font = '12px system-ui, sans-serif';
+      g.textAlign = 'left';
+      g.textBaseline = 'top';
+      g.fillText(status.phase === 'error' ? 'body model failed to load' : 'body model loading…', 12, H - 20);
+      g.restore();
+      return;
+    }
+    if (!body?.present || body.landmarks.length < BODY_LANDMARK_COUNT) return;
+    const sx = (i: number) => mirrorX(body.landmarks[i].x, body.width, W);
+    const sy = (i: number) => (body.landmarks[i].y / body.height) * H;
+    const vis = (i: number) => (body.visibility[i] ?? 1) >= 0.5;
+    g.save();
+    g.strokeStyle = BODY_COLOR;
+    g.lineWidth = 3;
+    g.lineCap = 'round';
+    g.globalAlpha = 0.7;
+    g.beginPath();
+    for (const [a, b] of BODY_BONES) {
+      if (!vis(a) || !vis(b)) continue;
+      g.moveTo(sx(a), sy(a));
+      g.lineTo(sx(b), sy(b));
+    }
+    g.stroke();
+    g.fillStyle = BODY_COLOR;
+    g.globalAlpha = 0.9;
+    g.beginPath();
+    for (let i = 0; i < BODY_LANDMARK_COUNT; i++) {
+      if (!vis(i)) continue;
+      const x = sx(i);
+      const y = sy(i);
+      g.moveTo(x + 4, y);
+      g.arc(x, y, 4, 0, Math.PI * 2);
     }
     g.fill();
     g.restore();
@@ -1560,6 +1627,7 @@ export const OVERLAY_ELEMENTS: readonly OverlayElement[] = [
   keyboardStripElement,
   indexFingerGuide,
   faceMesh,
+  bodySkeleton,
   landmarkDots,
   controlMarkers,
   fingerLinesElement,
@@ -1662,6 +1730,9 @@ export const canvasOverlayNode = defineNode<Params>({
     { name: 'chordScale', kind: 'number[]' },
     { name: 'chord', kind: 'number[]' },
     { name: 'faceFrame', kind: 'face-frame' },
+    // The body branch (#186): the latest pose + the model's load state, for the skeleton.
+    { name: 'bodyFrame', kind: 'body-frame' },
+    { name: 'bodyStatus', kind: 'body-status' },
     { name: 'expression', kind: 'face-expression' },
     { name: 'octaveShift', kind: 'number', default: 0 },
     { name: 'overlayConfig', kind: 'overlay-config' },
@@ -1730,6 +1801,8 @@ export const canvasOverlayNode = defineNode<Params>({
             octaveShift: typeof inputs.octaveShift === 'number' ? inputs.octaveShift : 0,
             chord: inputs.chord as number[] | undefined,
             faceFrame: inputs.faceFrame as FaceFrame | undefined,
+            bodyFrame: inputs.bodyFrame as BodyFrame | undefined,
+            bodyStatus: inputs.bodyStatus as BodyStatus | undefined,
             expression: inputs.expression as ExpressionScores | undefined,
             handMap: controls?.handMap,
             faceDegrees: controls?.faceExpr?.degrees,

--- a/src/nodes/output/canvas_overlay.ts
+++ b/src/nodes/output/canvas_overlay.ts
@@ -604,14 +604,16 @@ const bodySkeleton: OverlayElement = {
     if (!params.bodySkeleton.show) return;
     const status = inputs.bodyStatus;
     const body = inputs.bodyFrame;
-    if (status && status.phase !== 'idle' && status.phase !== 'ready') {
+    // Anything but off / ready / active is worth a word: loading, no camera, failed.
+    // Top-left, clear of the Lab panel and the trainer HUD that anchor to the bottom.
+    if (status && status.phase !== 'off' && status.phase !== 'ready' && status.phase !== 'active') {
       g.save();
       g.globalAlpha = 0.8;
       g.fillStyle = BODY_COLOR;
       g.font = '12px system-ui, sans-serif';
       g.textAlign = 'left';
       g.textBaseline = 'top';
-      g.fillText(status.phase === 'error' ? 'body model failed to load' : 'body model loading…', 12, H - 20);
+      g.fillText(`Body: ${status.message}`, 12, 12);
       g.restore();
       return;
     }

--- a/src/nodes/sources/body_contract.ts
+++ b/src/nodes/sources/body_contract.ts
@@ -1,0 +1,31 @@
+/**
+ * The **body** slot contract (#186): what a node must declare to fill `SLOTS.body`
+ * in `src/app/graph.ts`. Same shape as the hands `source` slot — a source is
+ * identified by the port it emits, and the schema makes the contract checkable
+ * rather than nominal (a candidate emitting nothing on `body` is a silent graph).
+ *
+ * Why a second slot rather than a second candidate of `source`: the `source`
+ * slot's output is `hands`, and a player may want hands AND body at once — they
+ * are different instruments, not alternatives. The body branch is therefore
+ * always wired (like the face branch) and gated off until something claims it,
+ * and this slot lets the same URL seam (`?slot.body=synthetic-body`) run the
+ * whole body path with no camera and no model.
+ */
+import type { PortSpec } from '@/dag';
+import { BodyFrameSchema } from '../domain';
+import type { SlotContract } from '../slot_contract';
+
+export const BODY_SLOT_OUTPUT: PortSpec = {
+  name: 'body',
+  kind: 'body-frame',
+  description: 'The latest full-body pose frame (33 landmarks; absent when nobody is in frame).',
+  schema: BodyFrameSchema,
+};
+
+export const BODY_SLOT_INPUTS: readonly PortSpec[] = [];
+
+export const BODY_SLOT_CONTRACT: SlotContract = {
+  role: 'source',
+  requiredInputs: [],
+  output: BODY_SLOT_OUTPUT,
+};

--- a/src/nodes/sources/replay_body.ts
+++ b/src/nodes/sources/replay_body.ts
@@ -26,7 +26,7 @@ export const replayBodyNode = defineNode<Params>({
   inputs: [],
   outputs: [
     BODY_SLOT_OUTPUT,
-    // A replay is always 'ready'; `bodyDetected` follows the replayed frame.
+    // A replay is always loaded: 'active' while the replayed frame has a body, else 'ready'.
     { name: 'status', kind: 'body-status' },
   ],
   params: Params,
@@ -34,7 +34,8 @@ export const replayBodyNode = defineNode<Params>({
     let n = 0;
     return {
       process() {
-        const ready = (present: boolean): BodyStatus => ({ phase: 'ready', bodyDetected: present });
+        const ready = (present: boolean): BodyStatus =>
+          present ? { phase: 'active', message: 'Replayed body' } : { phase: 'ready', message: 'Replay: nobody in frame' };
         if (frames.length === 0) return { body: EMPTY_BODY_FRAME, status: ready(false) };
         const i = loop ? n % frames.length : Math.min(n, frames.length - 1);
         n += 1;

--- a/src/nodes/sources/replay_body.ts
+++ b/src/nodes/sources/replay_body.ts
@@ -1,0 +1,46 @@
+/**
+ * `replay-body` node (#186) — replays a recorded {@link BodyFrame} stream, one
+ * frame per tick, on the body slot's `body` port. The typed sibling of
+ * `replay-hands` for the body slot: same semantics (counts its OWN frames so a
+ * swap into a running graph starts at frame 0; never reads a clock; emits the
+ * empty frame, never `undefined`, when it has nothing to replay).
+ */
+import { z } from 'zod';
+import { defineNode } from '@/dag';
+import { BodyFrameSchema, EMPTY_BODY_FRAME, type BodyFrame, type BodyStatus } from '../domain';
+import { BODY_SLOT_OUTPUT } from './body_contract';
+
+const Params = z.object({
+  /** The recorded frames, in tick order. */
+  frames: z.array(BodyFrameSchema).default([]),
+  /** Loop back to the start when exhausted (otherwise hold the last frame). */
+  loop: z.boolean().default(false),
+});
+type Params = z.infer<typeof Params>;
+
+export const replayBodyNode = defineNode<Params>({
+  type: 'replay-body',
+  roles: ['source'],
+  title: 'Replay Body',
+  description: 'Replays a recorded full-body pose stream, one frame per tick. Camera-free and deterministic.',
+  inputs: [],
+  outputs: [
+    BODY_SLOT_OUTPUT,
+    // A replay is always 'ready'; `bodyDetected` follows the replayed frame.
+    { name: 'status', kind: 'body-status' },
+  ],
+  params: Params,
+  make({ frames, loop }) {
+    let n = 0;
+    return {
+      process() {
+        const ready = (present: boolean): BodyStatus => ({ phase: 'ready', bodyDetected: present });
+        if (frames.length === 0) return { body: EMPTY_BODY_FRAME, status: ready(false) };
+        const i = loop ? n % frames.length : Math.min(n, frames.length - 1);
+        n += 1;
+        const frame = frames[i] as BodyFrame;
+        return { body: frame, status: ready(frame.present) };
+      },
+    };
+  },
+});

--- a/src/nodes/sources/store_controls.ts
+++ b/src/nodes/sources/store_controls.ts
@@ -12,7 +12,7 @@ import { defineNode } from '@/dag';
 import type { NodeContext } from '@/dag';
 import { generateScale, defaultChordSpecFor, type ScaleSpec, type ScaleTypeId } from '@/music/theory';
 import type { SoundId } from '@/music/sounds';
-import { legacyFaceToMapping, type FaceMapping } from '@/nodes/domain';
+import { legacyFaceToMapping, type BodyModel, type FaceMapping } from '@/nodes/domain';
 import type { FaceChord, FaceExpr } from '@/settings/schema';
 import type { FaceControlsDialParams } from '@/nodes/features/face_controls';
 import { TrainerHudParamsSchema, type OverlayDialParams, type TrainerHudParams } from '@/nodes/output/canvas_overlay';
@@ -73,7 +73,7 @@ export interface ControlSnapshot {
   /** The body source (#186): on/off + PoseLandmarker model. Read by `webcam-body` off
    *  the raw store (its gate, like `faceMapping` for the face) — not emitted as a port,
    *  because a slot candidate declares no inputs. */
-  body?: { enabled: boolean; model: 'lite' | 'full' };
+  body?: { enabled: boolean; model: BodyModel };
   /** The head/face CONTROL axis tuning (#76): per-axis gain / deadzone / neutral zero
    *  / smoothing. Fed to the `face-controls` node's `config` input as a live override
    *  of its build-time params, so re-tuning an axis needs no graph rebuild. */

--- a/src/nodes/sources/store_controls.ts
+++ b/src/nodes/sources/store_controls.ts
@@ -70,6 +70,10 @@ export interface ControlSnapshot {
   /** MIDI output (#137): on/off + target port name ('' = first available). Fed to
    *  the `midi-out` node's `enabled`/`port` inputs as live ports. */
   midi?: { enabled: boolean; port: string };
+  /** The body source (#186): on/off + PoseLandmarker model. Read by `webcam-body` off
+   *  the raw store (its gate, like `faceMapping` for the face) — not emitted as a port,
+   *  because a slot candidate declares no inputs. */
+  body?: { enabled: boolean; model: 'lite' | 'full' };
   /** The head/face CONTROL axis tuning (#76): per-axis gain / deadzone / neutral zero
    *  / smoothing. Fed to the `face-controls` node's `config` input as a live override
    *  of its build-time params, so re-tuning an axis needs no graph rebuild. */

--- a/src/nodes/sources/synthetic_body.ts
+++ b/src/nodes/sources/synthetic_body.ts
@@ -1,0 +1,78 @@
+/**
+ * `synthetic-body` node (#186) — a deterministic, camera-free source of
+ * {@link BodyFrame}s: an upright skeleton that bounces at a known period, sways,
+ * raises and lowers its arms and bends its knees. The body-pipeline analogue of
+ * `synthetic-hands`, and the ground truth for the pulse estimator: the bounce
+ * period is a param, so a test knows the answer before asking.
+ *
+ * Pure `process()` over `ctx.time`, so it is reproducible under the engine's
+ * injected clock (the determinism rule `test/body_slot.test.ts` enforces).
+ */
+import { z } from 'zod';
+import { defineNode } from '@/dag';
+import { BODY_LANDMARK_COUNT, makeBodyKeypoints, type BodyFrame, type BodyStatus } from '../domain';
+import { BODY_SLOT_OUTPUT } from './body_contract';
+
+const Params = z.object({
+  width: z.number().default(640),
+  height: z.number().default(480),
+  /** Seconds per vertical bounce (the pulse a test can measure). */
+  bouncePeriod: z.number().positive().default(0.5),
+  /** Bounce amplitude as a fraction of the frame height. */
+  bounceAmount: z.number().min(0).max(0.3).default(0.04),
+  /** Seconds per lateral sway cycle. */
+  swayPeriod: z.number().positive().default(2.4),
+  /** Seconds per arm raise/lower cycle. */
+  armPeriod: z.number().positive().default(3.2),
+  /** Knee bend depth 0..1 at the bottom of each bounce. */
+  kneeBend: z.number().min(0).max(1).default(0.3),
+  /** Torso length in pixels. */
+  torso: z.number().positive().default(120),
+});
+type Params = z.infer<typeof Params>;
+
+const osc = (t: number, period: number, phase = 0) => 0.5 + 0.5 * Math.sin((2 * Math.PI * t) / period + phase);
+
+export const syntheticBodyNode = defineNode<Params>({
+  type: 'synthetic-body',
+  roles: ['source'],
+  title: 'Synthetic Body',
+  description: 'Camera-free animated full-body skeleton (bounce / sway / arms) for tests & demos.',
+  inputs: [],
+  outputs: [
+    BODY_SLOT_OUTPUT,
+    // Every body candidate reports a status so the overlay edge stays valid across a
+    // swap; a synthetic body is always 'ready' and always present.
+    { name: 'status', kind: 'body-status' },
+  ],
+  params: Params,
+  process(_inputs, p, ctx) {
+    const t = ctx.time;
+    // A bounce is a |sin|-shaped dip: sharp at the bottom (the impact), which is
+    // what makes the deceleration-peak anchor detector's job well-posed.
+    const dip = Math.abs(Math.sin((Math.PI * t) / p.bouncePeriod));
+    const cy = 0.62 + p.bounceAmount * dip;
+    const sway = (osc(t, p.swayPeriod) - 0.5) * 0.25;
+    const { landmarks, world } = makeBodyKeypoints({
+      width: p.width,
+      height: p.height,
+      cx: 0.5 + sway * 0.4,
+      cy,
+      torso: p.torso,
+      leftArm: osc(t, p.armPeriod),
+      rightArm: osc(t, p.armPeriod, Math.PI),
+      kneeBend: p.kneeBend * dip,
+      lean: sway,
+    });
+    const frame: BodyFrame = {
+      width: p.width,
+      height: p.height,
+      present: true,
+      landmarks,
+      world,
+      visibility: new Array(BODY_LANDMARK_COUNT).fill(1),
+    };
+    const status: BodyStatus = { phase: 'ready', bodyDetected: true };
+    return { body: frame, status };
+  },
+});

--- a/src/nodes/sources/synthetic_body.ts
+++ b/src/nodes/sources/synthetic_body.ts
@@ -42,7 +42,7 @@ export const syntheticBodyNode = defineNode<Params>({
   outputs: [
     BODY_SLOT_OUTPUT,
     // Every body candidate reports a status so the overlay edge stays valid across a
-    // swap; a synthetic body is always 'ready' and always present.
+    // swap; a synthetic body is always present, so always 'active'.
     { name: 'status', kind: 'body-status' },
   ],
   params: Params,
@@ -72,7 +72,7 @@ export const syntheticBodyNode = defineNode<Params>({
       world,
       visibility: new Array(BODY_LANDMARK_COUNT).fill(1),
     };
-    const status: BodyStatus = { phase: 'ready', bodyDetected: true };
+    const status: BodyStatus = { phase: 'active', message: 'Synthetic body' };
     return { body: frame, status };
   },
 });

--- a/src/nodes/sources/tasks_vision.ts
+++ b/src/nodes/sources/tasks_vision.ts
@@ -1,0 +1,18 @@
+/**
+ * The one place the MediaPipe **tasks-vision** runtime is pinned (#186).
+ *
+ * `webcam-hands`, `webcam-face` and `webcam-body` share a single Emscripten
+ * runtime (two different MediaPipe wasm modules collide on the global `Module`,
+ * see `webcam_hands.ts`), so the wasm fileset URL is one constant, pinned to the
+ * installed `@mediapipe/tasks-vision` version so the runtime matches the imported
+ * JS API. Each source keeps its own model URL: the model is what differs.
+ *
+ * Nothing here touches the browser — it is data, safe to import from tests.
+ */
+export const TASKS_VISION_VERSION = '0.10.35';
+
+/** The wasm fileset every tasks-vision landmarker loads through `FilesetResolver`. */
+export const TASKS_VISION_WASM_BASE = `https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@${TASKS_VISION_VERSION}/wasm`;
+
+/** Google's model bucket — every `.task` file below lives under it. */
+export const MEDIAPIPE_MODELS_BASE = 'https://storage.googleapis.com/mediapipe-models';

--- a/src/nodes/sources/webcam_body.ts
+++ b/src/nodes/sources/webcam_body.ts
@@ -2,46 +2,59 @@
  * `webcam-body` source node (browser-only, #186) — runs MediaPipe
  * **PoseLandmarker** on the shared host `<video>` and outputs the latest
  * {@link BodyFrame} (33 BlazePose landmarks in pixels + metric world landmarks +
- * per-point visibility). The live counterpart of `scripts/video_to_pose.py`,
- * emitting the same frame shape so a recorded stream replays through the same
- * downstream nodes.
+ * per-point visibility). Its offline counterpart, a `scripts/video_to_pose.py`
+ * in the `video_to_landmarks.py` family, is planned with the body fixtures and
+ * will emit the same frame shape.
  *
- * It follows `webcam-face`, not `webcam-hands`, on every design point, because
- * the body is the most expensive model the graph can host and must cost nothing
- * until wanted:
+ * The body is the most expensive model the graph can host, so it must cost
+ * nothing until wanted. Rather than hand-roll a fourth copy of the load / release
+ * / late-arrival / failure-latch machine (`webcam-face` and `midi-out` each have
+ * one), this node is the first adopter of the catalogued pattern in `src/lazy`
+ * (#188, `docs/design/lazy-loading.md`):
  *
- * 1. **Off by default, lazy.** Nothing is downloaded at `init()`; the runtime and
- *    the model load on first *enable* — the `body.enabled` dial, the Feature Lab
- *    measuring a body group, or a trainer cue claiming one ({@link bodyActive}).
- * 2. **Lazy offload.** Disabling releases the landmarker so the hands model never
- *    competes with an idle body model for the tick budget.
- * 3. **Detached inference.** Its own `requestAnimationFrame` loop caches the
- *    latest frame; `process()` returns the cache, so the engine tick never waits
- *    on inference and the frame-drop guard sees a constant-cost node.
+ * 1. **Off by default, lazy.** Nothing loads at `init()`. `process()` calls
+ *    `want(enabled)` each tick; the loader (a dynamic `import()` of tasks-vision +
+ *    `PoseLandmarker.createFromOptions`, GPU then CPU) runs at most once per
+ *    request and never blocks the engine.
+ * 2. **Gated.** `enabled` is {@link bodyActive}: the `body.enabled` dial, the Lab
+ *    measuring a body group, or a trainer cue claiming one — the face rule. With
+ *    no camera frames the gate reports `unavailable` / `no-camera` instead of
+ *    downloading a model that could never detect anything, and retries by itself
+ *    the moment frames arrive.
+ * 3. **Keyed by model.** The dial picks `lite` / `full` live; a change releases the
+ *    current load (a superseded load is a late arrival, discarded on settle) and
+ *    the next tick starts the new one — including after a failed load, since a
+ *    release clears the failure latch.
+ * 4. **Detached inference.** Its own `requestAnimationFrame` loop caches the latest
+ *    frame while a landmarker is held; `process()` returns the cache.
  *
- * The runtime is the tasks-vision fileset the hands/face sources already load
- * (one Emscripten module, three tasks — see `tasks_vision.ts`); the only new
- * download is the pose model itself: `lite` 5.8 MB (default) or `full` 9.4 MB.
+ * The `status` port speaks the shared `LoadStatus` vocabulary, so the overlay's
+ * skeleton element (and any panel readout) can say "loading" / "needs the camera"
+ * / "failed" without knowing this node.
  */
 import { z } from 'zod';
 import { defineNode } from '@/dag';
 import type { NodeContext } from '@/dag';
 import type { DemandedGroups } from '@/features/demand';
 import { demandWantsBody, labWantsBody, type FeatureLabConfig } from '@/features/labConfig';
-import { ABSENT_BODY_STATUS, EMPTY_BODY_FRAME, type BodyFrame, type BodyStatus, type Keypoint } from '../domain';
+import { lazyResource, withActive, type LoadContext, type LoadResult, type LoadStatus } from '@/lazy';
+import {
+  BODY_MODELS,
+  EMPTY_BODY_FRAME,
+  type BodyFrame,
+  type BodyModel,
+  type Keypoint,
+} from '../domain';
 import { BODY_SLOT_OUTPUT } from './body_contract';
 import { MEDIAPIPE_MODELS_BASE, TASKS_VISION_WASM_BASE } from './tasks_vision';
-
-/** The two live-capable PoseLandmarker variants (heavy is ~30 MB and ~5 fps in a browser). */
-export const BODY_MODELS = ['lite', 'full'] as const;
-export type BodyModel = (typeof BODY_MODELS)[number];
 
 export function bodyModelUrl(model: BodyModel): string {
   return `${MEDIAPIPE_MODELS_BASE}/pose_landmarker/pose_landmarker_${model}/float16/latest/pose_landmarker_${model}.task`;
 }
 
 const Params = z.object({
-  /** Which pose model to download: `lite` (fast, default) or `full` (steadier on fast motion). */
+  /** Which pose model to download when the dial does not say: `lite` (fast, 5.8 MB)
+   *  or `full` (steadier on fast motion, 9.4 MB). The `body.model` dial overrides live. */
   model: z.enum(BODY_MODELS).default('lite'),
   /** Run inference on the GPU (WebGL) when available, else CPU. */
   delegate: z.enum(['GPU', 'CPU']).default('GPU'),
@@ -79,7 +92,7 @@ export function resultToBodyFrame(res: PoseLandmarkerResultLike, w: number, h: n
 }
 
 /** The minimal runtime surface of MediaPipe used here (browser-only, lazy). */
-interface PoseLandmarkerLike {
+export interface PoseLandmarkerLike {
   detectForVideo(video: HTMLVideoElement, timestampMs: number): PoseLandmarkerResultLike;
   close(): void;
 }
@@ -98,6 +111,44 @@ interface TasksVisionModule {
     ): Promise<PoseLandmarkerLike>;
   };
 }
+
+/** What the loader hands back: the landmarker and the model it was built for. */
+export interface BodyLandmarkerHandle {
+  landmarker: PoseLandmarkerLike;
+  model: BodyModel;
+}
+
+/** The loader seam: a host may inject one via `ctx.resources.createBodyLandmarker`
+ *  (tests, headless hosts); the default dynamically imports tasks-vision. */
+export type BodyLandmarkerFactory = (
+  opts: { model: BodyModel; delegate: 'GPU' | 'CPU'; minTrackingConfidence: number },
+  ctx: LoadContext,
+) => Promise<LoadResult<BodyLandmarkerHandle>>;
+
+const defaultFactory: BodyLandmarkerFactory = async (opts, lctx) => {
+  const vision = (await import('@mediapipe/tasks-vision')) as unknown as TasksVisionModule;
+  const fileset = await vision.FilesetResolver.forVisionTasks(TASKS_VISION_WASM_BASE);
+  if (lctx.signal.aborted) return { resource: null, reason: 'aborted' };
+  const options = (delegate: 'GPU' | 'CPU') => ({
+    baseOptions: { modelAssetPath: bodyModelUrl(opts.model), delegate },
+    numPoses: 1,
+    minTrackingConfidence: opts.minTrackingConfidence,
+    outputSegmentationMasks: false,
+    runningMode: 'VIDEO' as const,
+  });
+  let landmarker: PoseLandmarkerLike;
+  try {
+    landmarker = await vision.PoseLandmarker.createFromOptions(fileset, options(opts.delegate));
+  } catch (gpuErr) {
+    // GPU/WebGL unavailable on this client → the CPU delegate (the float16 model runs
+    // on CPU). If CPU was already chosen, the failure stands.
+    if (opts.delegate !== 'GPU') throw gpuErr;
+    if (lctx.signal.aborted) return { resource: null, reason: 'aborted' };
+    console.warn('[thoremin] body model GPU delegate failed; falling back to CPU', gpuErr);
+    landmarker = await vision.PoseLandmarker.createFromOptions(fileset, options('CPU'));
+  }
+  return { resource: { landmarker, model: opts.model }, message: `Body model (${opts.model}) ready` };
+};
 
 type BodyControlsGetter = () => {
   body?: { enabled?: boolean; model?: BodyModel };
@@ -120,6 +171,12 @@ export function bodyActive(
   return controls.body?.enabled === true;
 }
 
+/** The status reason when the node is wanted but the host has no camera frames. */
+export const NO_CAMERA_REASON = 'no-camera';
+
+const hasFrames = (video: HTMLVideoElement | undefined): boolean =>
+  !!video && video.readyState >= 2 && video.videoWidth > 0;
+
 export const webcamBodyNode = defineNode<Params>({
   type: 'webcam-body',
   roles: ['source'],
@@ -129,23 +186,36 @@ export const webcamBodyNode = defineNode<Params>({
   inputs: [],
   outputs: [
     BODY_SLOT_OUTPUT,
-    // Lifecycle + detection status, drawn by the overlay's body skeleton element
-    // so a player sees "loading" before the first skeleton appears.
+    // Lifecycle + detection status in the shared LoadStatus vocabulary (#188), drawn
+    // by the overlay's body skeleton element so a player sees "loading" / "needs the
+    // camera" / "failed" before the first skeleton appears.
     { name: 'status', kind: 'body-status' },
   ],
   params: Params,
   make(p) {
-    let landmarker: PoseLandmarkerLike | null = null;
-    /** The model the loaded (or loading) landmarker was created with. */
-    let loadedModel: BodyModel = p.model;
-    let loading = false;
-    let loadGen = 0;
-    let failedGen = -1;
     let latest: BodyFrame = EMPTY_BODY_FRAME;
     let raf: number | null = null;
     let disposed = false;
     let video: HTMLVideoElement | undefined;
     let lastVideoTime = -1;
+    let factory: BodyLandmarkerFactory | undefined;
+    /** The model the current (or in-flight) load targets — the keyed-request idiom. */
+    let requestedModel: BodyModel = p.model;
+
+    const resource = lazyResource<BodyLandmarkerHandle>({
+      load: (lctx) =>
+        (factory ?? defaultFactory)(
+          { model: requestedModel, delegate: p.delegate, minTrackingConfidence: p.minTrackingConfidence },
+          lctx,
+        ),
+      unload: (h) => h.landmarker.close(),
+      gate: () =>
+        hasFrames(video)
+          ? null
+          : { reason: NO_CAMERA_REASON, message: 'Body tracking needs the camera' },
+      label: 'body model',
+      log: (m) => console.warn(`[thoremin] ${m}`),
+    });
 
     const stopLoop = () => {
       if (raf !== null) {
@@ -154,29 +224,18 @@ export const webcamBodyNode = defineNode<Params>({
       }
     };
 
-    const offload = () => {
-      loadGen++;
-      failedGen = -1;
-      stopLoop();
-      landmarker?.close();
-      landmarker = null;
-      latest = EMPTY_BODY_FRAME;
-      lastVideoTime = -1;
-    };
-
     const loop = () => {
       if (disposed) return;
-      if (
-        landmarker &&
-        video &&
-        video.readyState >= 2 &&
-        video.videoWidth > 0 &&
-        video.currentTime !== lastVideoTime
-      ) {
+      const held = resource.current();
+      if (!held) {
+        raf = null;
+        return; // released: the loop ends itself; a re-request restarts it
+      }
+      if (video && hasFrames(video) && video.currentTime !== lastVideoTime) {
         lastVideoTime = video.currentTime;
         try {
           latest = resultToBodyFrame(
-            landmarker.detectForVideo(video, performance.now()),
+            held.landmarker.detectForVideo(video, performance.now()),
             video.videoWidth,
             video.videoHeight,
           );
@@ -187,57 +246,11 @@ export const webcamBodyNode = defineNode<Params>({
       raf = requestAnimationFrame(loop);
     };
 
-    const optionsFor = (model: BodyModel, delegate: 'GPU' | 'CPU') => ({
-      baseOptions: { modelAssetPath: bodyModelUrl(model), delegate },
-      numPoses: 1,
-      minTrackingConfidence: p.minTrackingConfidence,
-      outputSegmentationMasks: false,
-      runningMode: 'VIDEO' as const,
-    });
-
-    const ensureLoaded = (model: BodyModel) => {
-      if (landmarker || loading || disposed || failedGen === loadGen) return;
-      loading = true;
-      loadedModel = model;
-      const gen = loadGen;
-      void (async () => {
-        try {
-          const vision = (await import('@mediapipe/tasks-vision')) as unknown as TasksVisionModule;
-          const fileset = await vision.FilesetResolver.forVisionTasks(TASKS_VISION_WASM_BASE);
-          let lm: PoseLandmarkerLike;
-          try {
-            lm = await vision.PoseLandmarker.createFromOptions(fileset, optionsFor(model, p.delegate));
-          } catch (gpuErr) {
-            if (p.delegate !== 'GPU') throw gpuErr;
-            console.warn('[thoremin] body model GPU delegate failed; falling back to CPU', gpuErr);
-            lm = await vision.PoseLandmarker.createFromOptions(fileset, optionsFor(model, 'CPU'));
-          }
-          if (disposed || gen !== loadGen) {
-            lm.close();
-            return;
-          }
-          landmarker = lm;
-          failedGen = -1;
-          if (raf === null) raf = requestAnimationFrame(loop);
-        } catch (err) {
-          console.warn('[thoremin] body model failed to load', err);
-          failedGen = gen;
-        } finally {
-          loading = false;
-        }
-      })();
-    };
-
-    const statusOf = (enabled: boolean): BodyStatus => {
-      if (!enabled) return ABSENT_BODY_STATUS;
-      if (failedGen === loadGen) return { phase: 'error', bodyDetected: false };
-      if (landmarker) return { phase: 'ready', bodyDetected: latest.present };
-      return { phase: 'loading', bodyDetected: false };
-    };
-
     return {
       init(ctx: NodeContext) {
+        // Cheap: capture the shared <video> and any injected loader. No download.
         video = ctx.resources.video as HTMLVideoElement | undefined;
+        factory = ctx.resources.createBodyLandmarker as BodyLandmarkerFactory | undefined;
       },
       process(_inputs, ctx: NodeContext) {
         video = (ctx.resources.video as HTMLVideoElement | undefined) ?? video;
@@ -245,20 +258,37 @@ export const webcamBodyNode = defineNode<Params>({
         const getDemand = ctx.resources.featureDemand as (() => DemandedGroups) | undefined;
         const controls = getControls?.();
         const enabled = bodyActive(controls, getDemand?.() ?? null);
-        if (!enabled) {
-          if (landmarker || loading || failedGen === loadGen) offload();
-          return { body: EMPTY_BODY_FRAME, status: statusOf(false) };
+
+        if (enabled) {
+          const model: BodyModel = controls?.body?.model ?? p.model;
+          const st = resource.status();
+          // Keyed request: a model change supersedes whatever is held or loading
+          // (a late arrival is discarded on settle) and clears a failure latch.
+          if (model !== requestedModel) {
+            requestedModel = model;
+            resource.release();
+          } else if (st.phase === 'unavailable' && st.reason === NO_CAMERA_REASON && hasFrames(video)) {
+            // The camera arrived after the gate said no: retry now, not on toggle.
+            resource.release();
+          }
         }
-        // The dial picks the model live; a change while loaded releases the old model
-        // and the next tick loads the new one (no graph rebuild).
-        const model: BodyModel = controls?.body?.model ?? p.model;
-        if ((landmarker || loading) && model !== loadedModel) offload();
-        if (video) ensureLoaded(model);
-        return { body: latest, status: statusOf(true) };
+        resource.want(enabled);
+
+        const held = resource.current();
+        if (held) {
+          if (raf === null) raf = requestAnimationFrame(loop);
+        } else {
+          stopLoop();
+          latest = EMPTY_BODY_FRAME;
+          lastVideoTime = -1;
+        }
+        const status: LoadStatus = withActive(resource.status(), latest.present, 'Body detected');
+        return { body: held ? latest : EMPTY_BODY_FRAME, status };
       },
       dispose() {
         disposed = true;
-        offload();
+        stopLoop();
+        resource.dispose();
       },
     };
   },

--- a/src/nodes/sources/webcam_body.ts
+++ b/src/nodes/sources/webcam_body.ts
@@ -1,0 +1,265 @@
+/**
+ * `webcam-body` source node (browser-only, #186) — runs MediaPipe
+ * **PoseLandmarker** on the shared host `<video>` and outputs the latest
+ * {@link BodyFrame} (33 BlazePose landmarks in pixels + metric world landmarks +
+ * per-point visibility). The live counterpart of `scripts/video_to_pose.py`,
+ * emitting the same frame shape so a recorded stream replays through the same
+ * downstream nodes.
+ *
+ * It follows `webcam-face`, not `webcam-hands`, on every design point, because
+ * the body is the most expensive model the graph can host and must cost nothing
+ * until wanted:
+ *
+ * 1. **Off by default, lazy.** Nothing is downloaded at `init()`; the runtime and
+ *    the model load on first *enable* — the `body.enabled` dial, the Feature Lab
+ *    measuring a body group, or a trainer cue claiming one ({@link bodyActive}).
+ * 2. **Lazy offload.** Disabling releases the landmarker so the hands model never
+ *    competes with an idle body model for the tick budget.
+ * 3. **Detached inference.** Its own `requestAnimationFrame` loop caches the
+ *    latest frame; `process()` returns the cache, so the engine tick never waits
+ *    on inference and the frame-drop guard sees a constant-cost node.
+ *
+ * The runtime is the tasks-vision fileset the hands/face sources already load
+ * (one Emscripten module, three tasks — see `tasks_vision.ts`); the only new
+ * download is the pose model itself: `lite` 5.8 MB (default) or `full` 9.4 MB.
+ */
+import { z } from 'zod';
+import { defineNode } from '@/dag';
+import type { NodeContext } from '@/dag';
+import type { DemandedGroups } from '@/features/demand';
+import { demandWantsBody, labWantsBody, type FeatureLabConfig } from '@/features/labConfig';
+import { ABSENT_BODY_STATUS, EMPTY_BODY_FRAME, type BodyFrame, type BodyStatus, type Keypoint } from '../domain';
+import { BODY_SLOT_OUTPUT } from './body_contract';
+import { MEDIAPIPE_MODELS_BASE, TASKS_VISION_WASM_BASE } from './tasks_vision';
+
+/** The two live-capable PoseLandmarker variants (heavy is ~30 MB and ~5 fps in a browser). */
+export const BODY_MODELS = ['lite', 'full'] as const;
+export type BodyModel = (typeof BODY_MODELS)[number];
+
+export function bodyModelUrl(model: BodyModel): string {
+  return `${MEDIAPIPE_MODELS_BASE}/pose_landmarker/pose_landmarker_${model}/float16/latest/pose_landmarker_${model}.task`;
+}
+
+const Params = z.object({
+  /** Which pose model to download: `lite` (fast, default) or `full` (steadier on fast motion). */
+  model: z.enum(BODY_MODELS).default('lite'),
+  /** Run inference on the GPU (WebGL) when available, else CPU. */
+  delegate: z.enum(['GPU', 'CPU']).default('GPU'),
+  /** Below this tracking confidence the detector re-runs person detection (costlier, steadier). */
+  minTrackingConfidence: z.number().min(0).max(1).default(0.5),
+});
+type Params = z.infer<typeof Params>;
+
+interface LandmarkLike {
+  x: number;
+  y: number;
+  z?: number;
+  visibility?: number;
+}
+/** The minimal slice of a `PoseLandmarkerResult` this node reads. */
+export interface PoseLandmarkerResultLike {
+  landmarks: LandmarkLike[][];
+  worldLandmarks?: LandmarkLike[][];
+}
+
+/**
+ * Pure converter: a PoseLandmarker result → a {@link BodyFrame} in pixel
+ * coordinates of a `w`×`h` frame. Exported for headless tests; returns the empty
+ * frame (sized) when no pose was detected. Only the first pose is read.
+ */
+export function resultToBodyFrame(res: PoseLandmarkerResultLike, w: number, h: number): BodyFrame {
+  const pts = res.landmarks?.[0];
+  if (!pts || pts.length === 0) return { ...EMPTY_BODY_FRAME, width: w, height: h };
+  const landmarks: Keypoint[] = pts.map((p) => ({ x: p.x * w, y: p.y * h, z: p.z }));
+  const visibility = pts.map((p) => p.visibility ?? 1);
+  const wl = res.worldLandmarks?.[0];
+  const frame: BodyFrame = { width: w, height: h, present: true, landmarks, visibility };
+  if (wl && wl.length) frame.world = wl.map((p) => ({ x: p.x, y: p.y, z: p.z }));
+  return frame;
+}
+
+/** The minimal runtime surface of MediaPipe used here (browser-only, lazy). */
+interface PoseLandmarkerLike {
+  detectForVideo(video: HTMLVideoElement, timestampMs: number): PoseLandmarkerResultLike;
+  close(): void;
+}
+interface TasksVisionModule {
+  FilesetResolver: { forVisionTasks(wasmBase: string): Promise<unknown> };
+  PoseLandmarker: {
+    createFromOptions(
+      fileset: unknown,
+      opts: {
+        baseOptions: { modelAssetPath: string; delegate?: 'GPU' | 'CPU' };
+        numPoses?: number;
+        minTrackingConfidence?: number;
+        outputSegmentationMasks?: boolean;
+        runningMode?: 'IMAGE' | 'VIDEO';
+      },
+    ): Promise<PoseLandmarkerLike>;
+  };
+}
+
+type BodyControlsGetter = () => {
+  body?: { enabled?: boolean; model?: BodyModel };
+  featureLab?: FeatureLabConfig;
+};
+
+/**
+ * Should the body model be loaded and run? Any one of three consumers suffices —
+ * the `body.enabled` dial, the Lab measuring a body group, a trainer cue claiming
+ * one — exactly the rule `faceActive` states for the face, for the same reason:
+ * a measuring instrument must be able to observe without turning the sound on.
+ */
+export function bodyActive(
+  controls: ReturnType<BodyControlsGetter> | undefined,
+  demanded: DemandedGroups = null,
+): boolean {
+  if (demandWantsBody(demanded)) return true;
+  if (!controls) return false;
+  if (labWantsBody(controls.featureLab)) return true;
+  return controls.body?.enabled === true;
+}
+
+export const webcamBodyNode = defineNode<Params>({
+  type: 'webcam-body',
+  roles: ['source'],
+  title: 'Webcam Body',
+  description:
+    'MediaPipe PoseLandmarker full-body pose (33 landmarks) from the shared webcam. Lazy-loaded, off by default.',
+  inputs: [],
+  outputs: [
+    BODY_SLOT_OUTPUT,
+    // Lifecycle + detection status, drawn by the overlay's body skeleton element
+    // so a player sees "loading" before the first skeleton appears.
+    { name: 'status', kind: 'body-status' },
+  ],
+  params: Params,
+  make(p) {
+    let landmarker: PoseLandmarkerLike | null = null;
+    /** The model the loaded (or loading) landmarker was created with. */
+    let loadedModel: BodyModel = p.model;
+    let loading = false;
+    let loadGen = 0;
+    let failedGen = -1;
+    let latest: BodyFrame = EMPTY_BODY_FRAME;
+    let raf: number | null = null;
+    let disposed = false;
+    let video: HTMLVideoElement | undefined;
+    let lastVideoTime = -1;
+
+    const stopLoop = () => {
+      if (raf !== null) {
+        cancelAnimationFrame(raf);
+        raf = null;
+      }
+    };
+
+    const offload = () => {
+      loadGen++;
+      failedGen = -1;
+      stopLoop();
+      landmarker?.close();
+      landmarker = null;
+      latest = EMPTY_BODY_FRAME;
+      lastVideoTime = -1;
+    };
+
+    const loop = () => {
+      if (disposed) return;
+      if (
+        landmarker &&
+        video &&
+        video.readyState >= 2 &&
+        video.videoWidth > 0 &&
+        video.currentTime !== lastVideoTime
+      ) {
+        lastVideoTime = video.currentTime;
+        try {
+          latest = resultToBodyFrame(
+            landmarker.detectForVideo(video, performance.now()),
+            video.videoWidth,
+            video.videoHeight,
+          );
+        } catch {
+          /* transient inference error; keep the last frame */
+        }
+      }
+      raf = requestAnimationFrame(loop);
+    };
+
+    const optionsFor = (model: BodyModel, delegate: 'GPU' | 'CPU') => ({
+      baseOptions: { modelAssetPath: bodyModelUrl(model), delegate },
+      numPoses: 1,
+      minTrackingConfidence: p.minTrackingConfidence,
+      outputSegmentationMasks: false,
+      runningMode: 'VIDEO' as const,
+    });
+
+    const ensureLoaded = (model: BodyModel) => {
+      if (landmarker || loading || disposed || failedGen === loadGen) return;
+      loading = true;
+      loadedModel = model;
+      const gen = loadGen;
+      void (async () => {
+        try {
+          const vision = (await import('@mediapipe/tasks-vision')) as unknown as TasksVisionModule;
+          const fileset = await vision.FilesetResolver.forVisionTasks(TASKS_VISION_WASM_BASE);
+          let lm: PoseLandmarkerLike;
+          try {
+            lm = await vision.PoseLandmarker.createFromOptions(fileset, optionsFor(model, p.delegate));
+          } catch (gpuErr) {
+            if (p.delegate !== 'GPU') throw gpuErr;
+            console.warn('[thoremin] body model GPU delegate failed; falling back to CPU', gpuErr);
+            lm = await vision.PoseLandmarker.createFromOptions(fileset, optionsFor(model, 'CPU'));
+          }
+          if (disposed || gen !== loadGen) {
+            lm.close();
+            return;
+          }
+          landmarker = lm;
+          failedGen = -1;
+          if (raf === null) raf = requestAnimationFrame(loop);
+        } catch (err) {
+          console.warn('[thoremin] body model failed to load', err);
+          failedGen = gen;
+        } finally {
+          loading = false;
+        }
+      })();
+    };
+
+    const statusOf = (enabled: boolean): BodyStatus => {
+      if (!enabled) return ABSENT_BODY_STATUS;
+      if (failedGen === loadGen) return { phase: 'error', bodyDetected: false };
+      if (landmarker) return { phase: 'ready', bodyDetected: latest.present };
+      return { phase: 'loading', bodyDetected: false };
+    };
+
+    return {
+      init(ctx: NodeContext) {
+        video = ctx.resources.video as HTMLVideoElement | undefined;
+      },
+      process(_inputs, ctx: NodeContext) {
+        video = (ctx.resources.video as HTMLVideoElement | undefined) ?? video;
+        const getControls = ctx.resources.controls as BodyControlsGetter | undefined;
+        const getDemand = ctx.resources.featureDemand as (() => DemandedGroups) | undefined;
+        const controls = getControls?.();
+        const enabled = bodyActive(controls, getDemand?.() ?? null);
+        if (!enabled) {
+          if (landmarker || loading || failedGen === loadGen) offload();
+          return { body: EMPTY_BODY_FRAME, status: statusOf(false) };
+        }
+        // The dial picks the model live; a change while loaded releases the old model
+        // and the next tick loads the new one (no graph rebuild).
+        const model: BodyModel = controls?.body?.model ?? p.model;
+        if ((landmarker || loading) && model !== loadedModel) offload();
+        if (video) ensureLoaded(model);
+        return { body: latest, status: statusOf(true) };
+      },
+      dispose() {
+        disposed = true;
+        offload();
+      },
+    };
+  },
+});

--- a/src/nodes/sources/webcam_face.ts
+++ b/src/nodes/sources/webcam_face.ts
@@ -25,6 +25,7 @@
 import { z } from 'zod';
 import { defineNode } from '@/dag';
 import type { NodeContext } from '@/dag';
+import { MEDIAPIPE_MODELS_BASE, TASKS_VISION_WASM_BASE } from './tasks_vision';
 import { matrixToHeadPose, type FaceFrame, type FaceMapping, type FaceStatus } from '../domain';
 import type { DemandedGroups } from '@/features/demand';
 import { demandWantsFace, labWantsFace, type FeatureLabConfig } from '@/features/labConfig';
@@ -36,10 +37,8 @@ import { demandWantsFace, labWantsFace, type FeatureLabConfig } from '@/features
 // `face_landmarker.task` — the same model family `scripts/video_to_face.py`
 // uses, so live and recorded blendshapes are shape-compatible (same model,
 // identical blendshape names).
-const TASKS_VISION_VERSION = '0.10.35';
-const WASM_BASE = `https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@${TASKS_VISION_VERSION}/wasm`;
 const MODEL_URL =
-  'https://storage.googleapis.com/mediapipe-models/face_landmarker/face_landmarker/float16/1/face_landmarker.task';
+  `${MEDIAPIPE_MODELS_BASE}/face_landmarker/face_landmarker/float16/1/face_landmarker.task`;
 
 const Params = z.object({
   /** Run inference on the GPU (WebGL) when available, else CPU. */
@@ -231,7 +230,7 @@ export const webcamFaceNode = defineNode<Params>({
       void (async () => {
         try {
           const vision = (await import('@mediapipe/tasks-vision')) as unknown as TasksVisionModule;
-          const fileset = await vision.FilesetResolver.forVisionTasks(WASM_BASE);
+          const fileset = await vision.FilesetResolver.forVisionTasks(TASKS_VISION_WASM_BASE);
           let lm: FaceLandmarkerLike;
           try {
             lm = await vision.FaceLandmarker.createFromOptions(fileset, optionsFor(p.delegate));

--- a/src/nodes/sources/webcam_hands.ts
+++ b/src/nodes/sources/webcam_hands.ts
@@ -20,15 +20,14 @@ import { z } from 'zod';
 import { defineNode } from '@/dag';
 import { SOURCE_SLOT_OUTPUT } from './source_contract';
 import type { NodeContext } from '@/dag';
+import { MEDIAPIPE_MODELS_BASE, TASKS_VISION_WASM_BASE } from './tasks_vision';
 import type { Hand, Handedness, HandsFrame, Keypoint } from '../domain';
 
 // tasks-vision assets, loaded from a CDN on demand. The wasm fileset is pinned to
 // the installed `@mediapipe/tasks-vision` version (shared with `webcam-face`), and
 // the model is the float16 `hand_landmarker.task` (21 landmarks per hand).
-const TASKS_VISION_VERSION = '0.10.35';
-const WASM_BASE = `https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@${TASKS_VISION_VERSION}/wasm`;
 const MODEL_URL =
-  'https://storage.googleapis.com/mediapipe-models/hand_landmarker/hand_landmarker/float16/1/hand_landmarker.task';
+  `${MEDIAPIPE_MODELS_BASE}/hand_landmarker/hand_landmarker/float16/1/hand_landmarker.task`;
 
 const Params = z.object({
   // Retained for graph/preset compatibility; tasks-vision ships a single
@@ -143,7 +142,7 @@ export const webcamHandsNode = defineNode<Params>({
       async init(ctx: NodeContext) {
         video = ctx.resources.video as HTMLVideoElement | undefined;
         const vision = (await import('@mediapipe/tasks-vision')) as unknown as TasksVisionModule;
-        const fileset = await vision.FilesetResolver.forVisionTasks(WASM_BASE);
+        const fileset = await vision.FilesetResolver.forVisionTasks(TASKS_VISION_WASM_BASE);
         try {
           landmarker = await vision.HandLandmarker.createFromOptions(fileset, optionsFor('GPU'));
         } catch (gpuErr) {

--- a/src/settings/dials.ts
+++ b/src/settings/dials.ts
@@ -22,7 +22,7 @@ import { DEFAULT_EXPRESSION_SENSITIVITY, DEFAULT_EXPRESSION_TO_DEGREE } from '@/
 import { OverlayDialSchema } from '@/nodes/output/canvas_overlay';
 import { FaceControlsDialSchema, DEFAULT_FACE_CONTROLS_DIAL } from '@/nodes/features/face_controls';
 import { DEFAULT_HAND_MAP } from '@/nodes/mapping/hand_map';
-import { SettingsSchema, HandMapSchema, DEFAULT_FACE_CHORD, type Settings } from './schema';
+import { SettingsSchema, HandMapSchema, DEFAULT_FACE_CHORD, BODY_MODELS, DEFAULT_BODY, type Settings } from './schema';
 
 const ScaleEnum = z.enum(Object.keys(SCALE_TYPES) as [ScaleTypeId, ...ScaleTypeId[]]);
 const SoundEnum = z.enum(SOUND_IDS as [SoundId, ...SoundId[]]);
@@ -96,6 +96,12 @@ export const thoreminDials = defineDials(
     'midi.enabled': z.boolean().default(false).meta({ facets: ['MIDI'], title: 'MIDI output', description: 'Send the played voices to a Web MIDI output (external synth or DAW)' }),
     'midi.port': z.string().default('').meta({ facets: ['MIDI'], title: 'MIDI port', description: 'MIDI output port name (empty = first available)' }),
 
+    // The body source (#186): the most expensive model in the graph, so it is a dial
+    // the player turns on, never a default. `body.model` swaps the PoseLandmarker
+    // variant live (the node reloads when it changes).
+    'body.enabled': z.boolean().default(DEFAULT_BODY.enabled).meta({ facets: ['Body'], title: 'Body tracking', description: 'Track the full body (33 pose landmarks) from the webcam — the source for body features and the dance pulse' }),
+    'body.model': z.enum(BODY_MODELS).default(DEFAULT_BODY.model).meta({ facets: ['Body', 'advanced'], title: 'Body model', description: 'lite (fast, 6 MB) or full (steadier on fast motion, 9 MB)' }),
+
     // Complex/structured settings — rendered by bespoke widgets (the expression
     // table, the overlay accordion); carried as whole-object dial values.
     'faceExpr.sensitivity': z
@@ -168,6 +174,8 @@ export function settingsToLayer(s: Settings): Layer {
     'faceExpr.degrees': s.faceExpr.degrees,
     'midi.enabled': s.midi.enabled,
     'midi.port': s.midi.port,
+    'body.enabled': s.body.enabled,
+    'body.model': s.body.model,
     overlay: s.overlay,
     handMap: s.handMap,
     faceControls: s.faceControls,
@@ -201,6 +209,7 @@ export function layerToSettings(v: Record<string, unknown>): Settings {
     },
     faceExpr: { sensitivity: v['faceExpr.sensitivity'], degrees: v['faceExpr.degrees'] },
     midi: { enabled: v['midi.enabled'], port: v['midi.port'] },
+    body: { enabled: v['body.enabled'], model: v['body.model'] },
     overlay: v.overlay,
     handMap: v.handMap,
     faceControls: v.faceControls,

--- a/src/settings/schema.ts
+++ b/src/settings/schema.ts
@@ -13,7 +13,7 @@ import { z } from 'zod';
 import { SCALE_TYPES, type ScaleTypeId } from '@/music/theory';
 import { SOUND_IDS, type SoundId } from '@/music/sounds';
 import { VOICINGS, RENDERINGS, type VoicingId, type RenderingId } from '@/music/voicing';
-import { FACE_MAPPINGS, legacyFaceToMapping, type FaceMapping } from '@/nodes/domain';
+import { BODY_MODELS, FACE_MAPPINGS, legacyFaceToMapping, type FaceMapping } from '@/nodes/domain';
 import { OverlayDialSchema } from '@/nodes/output/canvas_overlay';
 import { FaceControlsDialSchema, DEFAULT_FACE_CONTROLS_DIAL } from '@/nodes/features/face_controls';
 import { DEFAULT_EXPRESSION_SENSITIVITY, DEFAULT_EXPRESSION_TO_DEGREE } from '@/music/expression';
@@ -151,8 +151,9 @@ export type MidiSettings = z.infer<typeof MidiSettingsSchema>;
 /** The shipped MIDI defaults: off, first available port. */
 export const DEFAULT_MIDI: MidiSettings = { enabled: false, port: '' };
 
-/** The body source (#186): on/off + which PoseLandmarker model to load. */
-export const BODY_MODELS = ['lite', 'full'] as const;
+/** The body source (#186): on/off + which PoseLandmarker model to load. `BODY_MODELS`
+ *  is the node's own list (`@/nodes/domain`), re-exported so the panel reads one SSOT. */
+export { BODY_MODELS };
 export const BodySettingsSchema = z.object({
   enabled: z.boolean(),
   model: z.enum(BODY_MODELS),

--- a/src/settings/schema.ts
+++ b/src/settings/schema.ts
@@ -151,6 +151,17 @@ export type MidiSettings = z.infer<typeof MidiSettingsSchema>;
 /** The shipped MIDI defaults: off, first available port. */
 export const DEFAULT_MIDI: MidiSettings = { enabled: false, port: '' };
 
+/** The body source (#186): on/off + which PoseLandmarker model to load. */
+export const BODY_MODELS = ['lite', 'full'] as const;
+export const BodySettingsSchema = z.object({
+  enabled: z.boolean(),
+  model: z.enum(BODY_MODELS),
+});
+export type BodySettings = z.infer<typeof BodySettingsSchema>;
+
+/** The shipped body defaults: off (the model is the most expensive in the graph), lite. */
+export const DEFAULT_BODY: BodySettings = { enabled: false, model: 'lite' };
+
 /** One hand's musical settings — mirrors VoiceControl in src/app/store.ts. */
 export const VoiceSettingsSchema = z.object({
   root: z.number().int().min(0).max(11),
@@ -192,6 +203,8 @@ export const SettingsSchema = z.object({
   handMap: HandMapSchema,
   // MIDI output (#137). `.default(...)` keeps pre-MIDI presets valid (off).
   midi: MidiSettingsSchema.default(DEFAULT_MIDI),
+  // The body source (#186). `.default(...)` keeps pre-body presets valid (off, lite).
+  body: BodySettingsSchema.default(DEFAULT_BODY),
   // The head/face CONTROL axes (#76): per-axis gain / deadzone / zero / smoothing for
   // the `face-controls` node. The schema is the node's own params, imported rather
   // than restated (see FaceControlsDialSchema) so the two can never drift.

--- a/test/app_graph.test.ts
+++ b/test/app_graph.test.ts
@@ -50,9 +50,24 @@ describe('production app graph', () => {
     expect(order.indexOf('merge')).toBeLessThan(order.indexOf('midiOut'));
     // Gesture classification taps the hand features, so it evaluates after them (#129).
     expect(order.indexOf('feat')).toBeLessThan(order.indexOf('gesture'));
+    // The body branch (#186) sits before the overlay that draws its skeleton.
+    expect(order.indexOf('camBody')).toBeLessThan(order.indexOf('overlay'));
     // 14 base nodes (#90 retired the kbd + kctrl nodes) + the two #119 feature-vector
-    // taps + the #13 midi-out sink + the #129 gesture-classifier tap.
-    expect(order).toHaveLength(18);
+    // taps + the #13 midi-out sink + the #129 gesture-classifier tap + the #186 body source.
+    expect(order).toHaveLength(19);
+  });
+
+  it('wires the body source to the overlay (skeleton + load state) — the #186 reachability guard', () => {
+    const edges = defaultGraph().edges;
+    const has = (fn: string, fp: string, tn: string, tp: string) =>
+      edges.some((e) => e.from.node === fn && e.from.port === fp && e.to.node === tn && e.to.port === tp);
+    // Without these two edges body tracking would run and show nothing: the toggle
+    // would look dead, which is the failure the shipping rule exists to catch.
+    expect(has('camBody', 'body', 'overlay', 'bodyFrame')).toBe(true);
+    expect(has('camBody', 'status', 'overlay', 'bodyStatus')).toBe(true);
+    // The body node is a slot candidate, so it declares NO inputs: its gate is the
+    // `body.enabled` dial read off the control store (see `bodyActive`), not a port.
+    expect(edges.filter((e) => e.to.node === 'camBody')).toEqual([]);
   });
 
   it('wires the face overlays (mesh + expression readout + both chord highlights)', () => {

--- a/test/body_panel.test.tsx
+++ b/test/body_panel.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+/**
+ * Body panel reachability (#186) — the UI half of the guard. The DAG-edge test
+ * (app_graph.test.ts) proves the body node's output reaches the overlay; this proves
+ * a player can FIND the control: the settings panel mounts a Body section with the
+ * tracking toggle, and the model selector is disabled until tracking is on. Without
+ * this, deleting the panel section keeps every other test green — the #119/#120
+ * failure mode the shipping rule exists for.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import DialsControlsPanel from '@/app/dials/DialsControlsPanel';
+import { BodyControls } from '@/app/dials/panels/body';
+
+afterEach(() => cleanup());
+
+describe('the settings panel mounts the Body section (#186 reachability)', () => {
+  it('renders a Body section', () => {
+    render(<DialsControlsPanel />);
+    expect(screen.getByText('Body')).toBeTruthy();
+  });
+});
+
+describe('BodyControls', () => {
+  it('renders the tracking toggle, off by default, with the model selector disabled and sized', () => {
+    render(<BodyControls />);
+    const toggle = screen.getByLabelText('Track the body') as HTMLInputElement;
+    expect(toggle.checked).toBe(false);
+    const select = screen.getByLabelText('Model') as HTMLSelectElement;
+    expect(select.disabled).toBe(true);
+    // The download cost is stated before the player triggers it (the lazy-loading rule).
+    expect(screen.getByText(/5\.8 MB/)).toBeTruthy();
+    expect(screen.getByText(/9\.4 MB/)).toBeTruthy();
+  });
+});

--- a/test/body_slot.test.ts
+++ b/test/body_slot.test.ts
@@ -133,7 +133,7 @@ describe('the payoff: the whole body path runs with no camera', () => {
     const engine = new Engine(defaultGraph({ source: 'synthetic-hands' }, reg), reg, { validatePorts: true });
     expect(() => engine.tick()).not.toThrow();
     expect(engine.getOutput('camBody', 'body')).toEqual(EMPTY_BODY_FRAME);
-    expect(engine.getOutput('camBody', 'status')).toEqual({ phase: 'idle', bodyDetected: false });
+    expect((engine.getOutput('camBody', 'status') as { phase: string }).phase).toBe('off');
   });
 
   it('a replay body with nothing to replay emits the empty frame, never nothing', () => {

--- a/test/body_slot.test.ts
+++ b/test/body_slot.test.ts
@@ -1,0 +1,228 @@
+/**
+ * The `body` slot (#186): the second slot with real candidates, and the first
+ * camera branch that is BOTH swappable and gated. Mirrors `test/source_slot.test.ts`
+ * clause for clause — contract, rejection, URL reachability, running-engine swap,
+ * the camera-free payoff, determinism — because the body slot exists so the whole
+ * body path can be exercised with no camera and no model.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { Engine, createRegistry, defineNode } from '@/dag';
+import { SLOTS, defaultGraph, parseSlotSelection, resolveSlot, sourceNeedsVideo } from '@/app/graph';
+import { createAppRegistry, BROWSER_NODES } from '@/nodes/browser';
+import { CORE_NODES } from '@/nodes';
+import { BODY_SLOT_CONTRACT, BODY_SLOT_OUTPUT } from '@/nodes/sources/body_contract';
+import { BLM, BODY_LANDMARK_COUNT, BodyFrameSchema, EMPTY_BODY_FRAME, type BodyFrame } from '@/nodes/domain';
+
+const appRegistry = () => createAppRegistry();
+
+/** Where each candidate's implementation lives, for the determinism guard below. */
+const CANDIDATE_SOURCES: Record<string, string> = {
+  'webcam-body': 'src/nodes/sources/webcam_body.ts',
+  'synthetic-body': 'src/nodes/sources/synthetic_body.ts',
+  'replay-body': 'src/nodes/sources/replay_body.ts',
+};
+
+describe('the body slot contract', () => {
+  it('every declared candidate really satisfies it', () => {
+    const reg = appRegistry();
+    for (const type of SLOTS.body.candidates) {
+      const def = reg.get(type);
+      expect(def.roles, `${type} must carry the source role`).toContain('source');
+      const out = def.outputs.find((p) => p.name === BODY_SLOT_OUTPUT.name);
+      expect(out, `${type} must emit "${BODY_SLOT_OUTPUT.name}"`).toBeTruthy();
+      expect(out!.kind).toBe(BODY_SLOT_OUTPUT.kind);
+      expect(out!.schema, `${type}'s body port must carry the contract schema`).toBe(BodyFrameSchema);
+      expect(def.inputs).toEqual([]);
+    }
+    expect(BODY_SLOT_CONTRACT.requiredInputs).toEqual([]);
+    expect(SLOTS.body.default).toBe('webcam-body');
+    expect(SLOTS.body.candidates.length).toBeGreaterThan(1);
+  });
+
+  it('rejects a node that is role:source but emits hands, not a body', () => {
+    const reg = appRegistry();
+    const warnings: string[] = [];
+    expect(resolveSlot('body', { body: 'synthetic-hands' }, reg, (m) => warnings.push(m))).toBe('webcam-body');
+    expect(warnings[0]).toContain('has no output port "body"');
+  });
+
+  it('rejects a wrong-kind body port', () => {
+    const reg = appRegistry();
+    reg.register(
+      defineNode({
+        type: 'bogus-body',
+        roles: ['source'],
+        inputs: [],
+        outputs: [{ name: 'body', kind: 'not-a-frame' }],
+        process: () => ({ body: null }),
+      }),
+    );
+    const warnings: string[] = [];
+    expect(resolveSlot('body', { body: 'bogus-body' }, reg, (m) => warnings.push(m))).toBe('webcam-body');
+    expect(warnings[0]).toContain('not "body-frame"');
+  });
+
+  it('is reachable from the URL, independently of the hands slot', () => {
+    expect(parseSlotSelection('?slot.body=synthetic-body')).toEqual({ body: 'synthetic-body' });
+    expect(parseSlotSelection('?slot.body=replay-body&slot.source=synthetic-hands')).toEqual({
+      body: 'replay-body',
+      source: 'synthetic-hands',
+    });
+  });
+
+  it('does not decide whether the host acquires a camera — that stays the hands slot’s call', () => {
+    const reg = appRegistry();
+    expect(sourceNeedsVideo({ body: 'synthetic-body' }, reg)).toBe(true);
+    expect(sourceNeedsVideo({ body: 'synthetic-body', source: 'synthetic-hands' }, reg)).toBe(false);
+  });
+});
+
+describe('swapping the body source in the real graph', () => {
+  it('replaces only the body node and leaves every edge valid', () => {
+    const reg = appRegistry();
+    const spec = defaultGraph({ body: 'synthetic-body' }, reg);
+    expect(spec.nodes.find((n) => n.id === 'camBody')?.type).toBe('synthetic-body');
+    expect(spec.nodes.find((n) => n.id === 'cam')?.type).toBe('webcam-hands');
+    expect(() => new Engine(spec, reg)).not.toThrow();
+    expect(spec.nodes).toHaveLength(defaultGraph().nodes.length);
+    expect(spec.edges).toEqual(defaultGraph().edges);
+  });
+
+  it('swaps on a RUNNING engine, keeping the hands and face models', async () => {
+    const reg = appRegistry();
+    const engine = new Engine(defaultGraph(), reg);
+    const change = await engine.applyGraph(defaultGraph({ body: 'synthetic-body' }, reg), reg);
+    expect(change.replaced).toEqual(['camBody']);
+    expect(change.added).toEqual([]);
+    expect(change.removed).toEqual([]);
+    expect(change.kept).toContain('cam');
+    expect(change.kept).toContain('camFace');
+  });
+});
+
+describe('the payoff: the whole body path runs with no camera', () => {
+  it('a synthetic body drives the real graph to a present, well-formed frame, headlessly', () => {
+    const reg = appRegistry();
+    const engine = new Engine(defaultGraph({ source: 'synthetic-hands', body: 'synthetic-body' }, reg), reg, {
+      validatePorts: true,
+    });
+    for (let i = 0; i < 30; i++) engine.tick(i / 30);
+    const frame = engine.getOutput('camBody', 'body') as BodyFrame;
+    expect(frame.present).toBe(true);
+    expect(frame.landmarks).toHaveLength(BODY_LANDMARK_COUNT);
+    expect(frame.world).toHaveLength(BODY_LANDMARK_COUNT);
+    expect(frame.visibility).toHaveLength(BODY_LANDMARK_COUNT);
+    // Upright and facing the camera: shoulders above hips, subject's left at larger x.
+    expect(frame.landmarks[BLM.left_shoulder].y).toBeLessThan(frame.landmarks[BLM.left_hip].y);
+    expect(frame.landmarks[BLM.left_shoulder].x).toBeGreaterThan(frame.landmarks[BLM.right_shoulder].x);
+    // Hip-centred world coordinates.
+    const hipMid = {
+      x: (frame.world![BLM.left_hip].x + frame.world![BLM.right_hip].x) / 2,
+      y: (frame.world![BLM.left_hip].y + frame.world![BLM.right_hip].y) / 2,
+    };
+    expect(Math.abs(hipMid.x)).toBeLessThan(1e-9);
+    expect(Math.abs(hipMid.y)).toBeLessThan(1e-9);
+  });
+
+  it('the live webcam-body node is a well-defined no-op with no camera and no dial', () => {
+    // The default graph, no resources at all: the body node must emit the EMPTY frame
+    // (never `undefined`) and an idle status, and must not try to load anything.
+    const reg = appRegistry();
+    const engine = new Engine(defaultGraph({ source: 'synthetic-hands' }, reg), reg, { validatePorts: true });
+    expect(() => engine.tick()).not.toThrow();
+    expect(engine.getOutput('camBody', 'body')).toEqual(EMPTY_BODY_FRAME);
+    expect(engine.getOutput('camBody', 'status')).toEqual({ phase: 'idle', bodyDetected: false });
+  });
+
+  it('a replay body with nothing to replay emits the empty frame, never nothing', () => {
+    const reg = appRegistry();
+    const engine = new Engine(defaultGraph({ source: 'synthetic-hands', body: 'replay-body' }, reg), reg, {
+      validatePorts: true,
+    });
+    expect(() => engine.tick()).not.toThrow();
+    expect((engine.getOutput('camBody', 'body') as BodyFrame).present).toBe(false);
+  });
+
+  it('the synthetic body bounces at its declared period (the pulse ground truth)', () => {
+    // hip-mid y over one period returns to its start; over half a period it does not.
+    const reg = appRegistry();
+    const period = 0.5;
+    const engine = new Engine(
+      { nodes: [{ id: 'b', type: 'synthetic-body', params: { bouncePeriod: period } }], edges: [] },
+      reg,
+    );
+    const hipY = (t: number) => {
+      engine.tick(t);
+      const f = engine.getOutput('b', 'body') as BodyFrame;
+      return (f.landmarks[BLM.left_hip].y + f.landmarks[BLM.right_hip].y) / 2;
+    };
+    const y0 = hipY(0.1);
+    const yHalf = hipY(0.1 + period / 2);
+    const yFull = hipY(0.1 + period);
+    expect(Math.abs(yFull - y0)).toBeLessThan(1e-6);
+    expect(Math.abs(yHalf - y0)).toBeGreaterThan(1);
+  });
+});
+
+describe('body source determinism (the seeded-RNG rule)', () => {
+  it('the candidate table covers every declared candidate', () => {
+    expect(Object.keys(CANDIDATE_SOURCES).sort()).toEqual([...SLOTS.body.candidates].sort());
+  });
+
+  const driveSource = (type: string, times: number[], params: unknown = {}): string => {
+    const reg = createRegistry([...CORE_NODES, ...BROWSER_NODES]);
+    const engine = new Engine({ nodes: [{ id: 's', type, params }], edges: [] }, reg, { validatePorts: true });
+    const out: unknown[] = [];
+    for (const t of times) {
+      engine.tick(t);
+      out.push(engine.getOutput('s', 'body'));
+    }
+    return JSON.stringify(out);
+  };
+
+  const FRAMES: BodyFrame[] = [11, 22, 33].map((w) => ({ ...EMPTY_BODY_FRAME, width: w, height: w }));
+  const paramsFor = (type: string) => (type === 'replay-body' ? { frames: FRAMES } : {});
+
+  it('BEHAVIOURAL: a finished-frame body source is a pure function of the ctx it is given', () => {
+    for (const type of SLOTS.body.candidates.filter((t) => t !== SLOTS.body.default)) {
+      const times = Array.from({ length: 20 }, (_, i) => i / 60);
+      expect(driveSource(type, times, paramsFor(type)), `${type} is not reproducible`).toBe(
+        driveSource(type, times, paramsFor(type)),
+      );
+    }
+  });
+
+  it('BEHAVIOURAL: a replay body ignores the clock entirely', () => {
+    const fast = Array.from({ length: 12 }, (_, i) => i / 60);
+    const slow = Array.from({ length: 12 }, (_, i) => 1000 + i / 5);
+    expect(driveSource('replay-body', fast, { frames: FRAMES })).toBe(driveSource('replay-body', slow, { frames: FRAMES }));
+  });
+
+  it('BEHAVIOURAL: a replay body swapped into a RUNNING graph starts at frame 0', async () => {
+    const reg = appRegistry();
+    const engine = new Engine(defaultGraph({ source: 'synthetic-hands', body: 'synthetic-body' }, reg), reg);
+    for (let i = 0; i < 50; i++) engine.tick();
+    const next = defaultGraph({ source: 'synthetic-hands', body: 'replay-body' }, reg);
+    next.nodes = next.nodes.map((n) => (n.id === 'camBody' ? { ...n, params: { frames: FRAMES } } : n));
+    expect((await engine.applyGraph(next, reg)).replaced).toEqual(['camBody']);
+    const widths: number[] = [];
+    for (let i = 0; i < 4; i++) {
+      engine.tick();
+      widths.push((engine.getOutput('camBody', 'body') as BodyFrame).width);
+    }
+    expect(widths).toEqual([11, 22, 33, 33]);
+  });
+
+  it('a cheap source grep backs the behavioural checks up', () => {
+    const AMBIENT = [/Math\.random/, /Date\.now/, /new Date\(/, /crypto\./];
+    for (const [type, file] of Object.entries(CANDIDATE_SOURCES)) {
+      const src = readFileSync(resolve(process.cwd(), file), 'utf8');
+      for (const pattern of AMBIENT) expect(src, `${type} must not use ${pattern}`).not.toMatch(pattern);
+      if (type !== SLOTS.body.default) {
+        expect(src, `${type} must not read the wall clock`).not.toMatch(/performance\.now/);
+      }
+    }
+  });
+});

--- a/test/overlay_elements.test.ts
+++ b/test/overlay_elements.test.ts
@@ -17,7 +17,10 @@ import { canvasOverlayNode, OVERLAY_ELEMENTS, OVERLAY_CATEGORIES } from '@/nodes
 import { OVERLAY_CONTROLS } from '@/app/overlayControls';
 import { DEFAULT_HAND_MAP } from '@/nodes/mapping/hand_map';
 import {
+  BLM,
+  makeBodyKeypoints,
   makeHandKeypoints,
+  type BodyFrame,
   type HandFeatures,
   type HandsFrame,
   type SynthParams,
@@ -230,6 +233,36 @@ describe('canvas-overlay composable elements', () => {
     expect(drawChord([48, 52, 57], { ...onlyChord, chordGuide: { show: false } }).count('stroke')).toBe(0); // off
     // C# (pitch class 1) is not in the scale {C,D,E,G,A} → no match.
     expect(drawChord([49]).count('stroke')).toBe(0);
+  });
+
+  it('bodySkeleton (Input, #186): bones + a dot per visible landmark, mirrored; nothing when absent', () => {
+    const { landmarks, world } = makeBodyKeypoints({ width: 640, height: 480, cx: 0.5, cy: 0.6, torso: 100, leftArm: 0.5, rightArm: 0.2, kneeBend: 0, lean: 0 });
+    const bodyFrame: BodyFrame = { width: 640, height: 480, present: true, landmarks, world, visibility: new Array(33).fill(1) };
+    const rc = drawWith(onlyElement('bodySkeleton'), { bodyFrame });
+    expect(rc.calls.filter((c) => c.m === 'arc')).toHaveLength(33);
+    expect(rc.calls.filter((c) => c.m === 'lineTo').length).toBeGreaterThan(10);
+    // Mirrored like every in-scene element: the subject's left shoulder (larger source x)
+    // is drawn at SMALLER canvas x.
+    const arcs = rc.calls.filter((c) => c.m === 'arc');
+    const ls = arcs[BLM.left_shoulder].args[0] as number;
+    const rs = arcs[BLM.right_shoulder].args[0] as number;
+    expect(ls).toBeLessThan(rs);
+    // Absent / toggled off / no frame → nothing.
+    expect(drawWith(onlyElement('bodySkeleton'), { bodyFrame: { ...bodyFrame, present: false, landmarks: [] } }).calls.filter((c) => c.m === 'arc')).toHaveLength(0);
+    expect(drawWith(onlyElement('bodySkeleton')).calls.filter((c) => c.m === 'arc')).toHaveLength(0);
+    expect(drawWith({ ...onlyElement('bodySkeleton'), bodySkeleton: { show: false } }, { bodyFrame }).calls.filter((c) => c.m === 'arc')).toHaveLength(0);
+    // A hidden landmark (visibility below 0.5) gets no dot.
+    const half = { ...bodyFrame, visibility: bodyFrame.visibility.map((v, i) => (i === BLM.nose ? 0.1 : v)) };
+    expect(drawWith(onlyElement('bodySkeleton'), { bodyFrame: half }).calls.filter((c) => c.m === 'arc')).toHaveLength(32);
+  });
+
+  it('bodySkeleton: prints the load state instead of a skeleton while the model loads or fails', () => {
+    const loading = drawWith(onlyElement('bodySkeleton'), { bodyStatus: { phase: 'loading', bodyDetected: false } });
+    expect(textsOf(loading).some((t) => /loading/.test(t))).toBe(true);
+    const failed = drawWith(onlyElement('bodySkeleton'), { bodyStatus: { phase: 'error', bodyDetected: false } });
+    expect(textsOf(failed).some((t) => /failed/.test(t))).toBe(true);
+    const idle = drawWith(onlyElement('bodySkeleton'), { bodyStatus: { phase: 'idle', bodyDetected: false } });
+    expect(textsOf(idle).some((t) => /body model/.test(t))).toBe(false);
   });
 
   it('faceLandmarks (Input): one dot per landmark when a present face frame has them', () => {

--- a/test/overlay_elements.test.ts
+++ b/test/overlay_elements.test.ts
@@ -257,12 +257,16 @@ describe('canvas-overlay composable elements', () => {
   });
 
   it('bodySkeleton: prints the load state instead of a skeleton while the model loads or fails', () => {
-    const loading = drawWith(onlyElement('bodySkeleton'), { bodyStatus: { phase: 'loading', bodyDetected: false } });
-    expect(textsOf(loading).some((t) => /loading/.test(t))).toBe(true);
-    const failed = drawWith(onlyElement('bodySkeleton'), { bodyStatus: { phase: 'error', bodyDetected: false } });
-    expect(textsOf(failed).some((t) => /failed/.test(t))).toBe(true);
-    const idle = drawWith(onlyElement('bodySkeleton'), { bodyStatus: { phase: 'idle', bodyDetected: false } });
-    expect(textsOf(idle).some((t) => /body model/.test(t))).toBe(false);
+    const loading = drawWith(onlyElement('bodySkeleton'), { bodyStatus: { phase: 'loading', message: 'Loading body model...' } });
+    expect(textsOf(loading)).toContain('Body: Loading body model...');
+    const failed = drawWith(onlyElement('bodySkeleton'), { bodyStatus: { phase: 'error', message: 'Could not load body model' } });
+    expect(textsOf(failed)).toContain('Body: Could not load body model');
+    const noCam = drawWith(onlyElement('bodySkeleton'), { bodyStatus: { phase: 'unavailable', reason: 'no-camera', message: 'Body tracking needs the camera' } });
+    expect(textsOf(noCam)).toContain('Body: Body tracking needs the camera');
+    for (const phase of ['off', 'ready', 'active'] as const) {
+      const quiet = drawWith(onlyElement('bodySkeleton'), { bodyStatus: { phase, message: 'x' } });
+      expect(textsOf(quiet).some((t) => t.startsWith('Body:'))).toBe(false);
+    }
   });
 
   it('faceLandmarks (Input): one dot per landmark when a present face frame has them', () => {

--- a/test/webcam_body.test.ts
+++ b/test/webcam_body.test.ts
@@ -1,34 +1,28 @@
 /**
  * `webcam-body` (#186), headlessly: the pure result → frame converter, the gate
  * that decides whether the (expensive) pose model is wanted, and the lazy-load
- * lifecycle driven through a mocked tasks-vision module — off by default, loads
- * on enable, swaps model on the dial, releases on disable.
+ * lifecycle through the injected loader seam (`ctx.resources.createBodyLandmarker`,
+ * the `src/lazy` pattern): off by default, `no-camera` until the video has frames
+ * (then a self-retry), loads the dial's model on enable, swaps model on change —
+ * also after a FAILED load — and releases on disable.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { NodeContext } from '@/dag';
-import { BLM, BODY_LANDMARK_COUNT, EMPTY_BODY_FRAME } from '@/nodes/domain';
+import { BLM, BODY_LANDMARK_COUNT, EMPTY_BODY_FRAME, type BodyFrame } from '@/nodes/domain';
 import { defaultFeatureLab } from '@/features/labConfig';
+import {
+  resultToBodyFrame,
+  bodyActive,
+  webcamBodyNode,
+  NO_CAMERA_REASON,
+  type BodyLandmarkerFactory,
+  type PoseLandmarkerLike,
+} from '@/nodes/sources/webcam_body';
 
-const created: Array<{ modelAssetPath: string; delegate?: string }> = [];
-const closed: number[] = [];
-vi.mock('@mediapipe/tasks-vision', () => ({
-  FilesetResolver: { forVisionTasks: async () => ({}) },
-  PoseLandmarker: {
-    createFromOptions: async (_fs: unknown, opts: { baseOptions: { modelAssetPath: string; delegate?: string } }) => {
-      created.push(opts.baseOptions);
-      const id = created.length;
-      return {
-        detectForVideo: () => ({ landmarks: [], worldLandmarks: [] }),
-        close: () => closed.push(id),
-      };
-    },
-  },
-}));
-
-// Imported after the mock is registered.
-const { resultToBodyFrame, bodyActive, webcamBodyNode, bodyModelUrl } = await import('@/nodes/sources/webcam_body');
-
-const flush = () => new Promise((r) => setTimeout(r, 0));
+const flush = async () => {
+  await new Promise((r) => setTimeout(r, 0));
+  await new Promise((r) => setTimeout(r, 0));
+};
 
 describe('resultToBodyFrame', () => {
   it('scales normalized landmarks to pixels, keeps z, visibility and world landmarks', () => {
@@ -64,9 +58,7 @@ describe('bodyActive (the gate)', () => {
   it('the dial turns it on', () => {
     expect(bodyActive({ body: { enabled: true } })).toBe(true);
   });
-  it('a demanded body group turns it on even with the dial off (the trainer path)', () => {
-    // No body groups are catalogued yet, so a demand for one cannot match; the rule
-    // still holds structurally: a non-body demand never turns the body on.
+  it('a non-body demand never turns it on', () => {
     expect(bodyActive({ body: { enabled: false } }, new Set(['face.geom']))).toBe(false);
   });
   it('the Lab measuring a non-body group does not turn it on', () => {
@@ -75,53 +67,135 @@ describe('bodyActive (the gate)', () => {
   });
 });
 
-describe('webcam-body lifecycle (mocked tasks-vision)', () => {
+describe('webcam-body lifecycle (injected loader)', () => {
+  const created: string[] = [];
+  const closed: string[] = [];
+  let failModel: string | null = null;
+
+  const factory: BodyLandmarkerFactory = async ({ model }) => {
+    if (model === failModel) throw new Error(`no ${model} for you`);
+    created.push(model);
+    const landmarker: PoseLandmarkerLike = {
+      detectForVideo: () => ({ landmarks: [], worldLandmarks: [] }),
+      close: () => closed.push(model),
+    };
+    return { resource: { landmarker, model } };
+  };
+
+  const liveVideo = { readyState: 2, videoWidth: 640, videoHeight: 480, currentTime: 0 } as unknown as HTMLVideoElement;
+  const deadVideo = { readyState: 0, videoWidth: 0, videoHeight: 0, currentTime: 0 } as unknown as HTMLVideoElement;
+  const ctxWith = (controls: unknown, video: HTMLVideoElement = liveVideo): NodeContext => ({
+    tick: 0,
+    time: 0,
+    dt: 0,
+    resources: { video, controls: () => controls, createBodyLandmarker: factory },
+  });
+  const phase = (out: Record<string, unknown>) => (out.status as { phase: string; reason?: string });
+
   beforeEach(() => {
     created.length = 0;
     closed.length = 0;
+    failModel = null;
     vi.stubGlobal('requestAnimationFrame', () => 1);
     vi.stubGlobal('cancelAnimationFrame', () => {});
   });
 
-  const video = { readyState: 0, videoWidth: 0, videoHeight: 0, currentTime: 0 } as unknown as HTMLVideoElement;
-  const ctxWith = (controls: unknown): NodeContext => ({
-    tick: 0,
-    time: 0,
-    dt: 0,
-    resources: { video, controls: () => controls },
-  });
-
-  it('loads nothing until enabled, loads the dial’s model on enable, swaps on change, releases on disable', async () => {
+  it('loads nothing until enabled; loads the dial’s model on enable; swaps on change; releases on disable', async () => {
     const h = webcamBodyNode.make(webcamBodyNode.params.parse({}));
     await h.init?.(ctxWith({ body: { enabled: false, model: 'lite' } }));
-    expect(created).toHaveLength(0);
     let out = h.process({}, ctxWith({ body: { enabled: false, model: 'lite' } }));
     expect(out.body).toEqual(EMPTY_BODY_FRAME);
-    expect(out.status).toEqual({ phase: 'idle', bodyDetected: false });
+    expect(phase(out).phase).toBe('off');
     expect(created).toHaveLength(0);
 
     out = h.process({}, ctxWith({ body: { enabled: true, model: 'lite' } }));
-    expect((out.status as { phase: string }).phase).toBe('loading');
+    expect(phase(out).phase).toBe('loading');
     await flush();
-    await flush();
-    expect(created).toHaveLength(1);
-    expect(created[0].modelAssetPath).toBe(bodyModelUrl('lite'));
+    expect(created).toEqual(['lite']);
     out = h.process({}, ctxWith({ body: { enabled: true, model: 'lite' } }));
-    expect((out.status as { phase: string }).phase).toBe('ready');
+    expect(phase(out).phase).toBe('ready');
 
-    // The dial picks `full`: the lite landmarker is released and full is loaded.
-    h.process({}, ctxWith({ body: { enabled: true, model: 'full' } }));
+    // The dial picks `full`: lite is released, full loads.
+    out = h.process({}, ctxWith({ body: { enabled: true, model: 'full' } }));
+    expect(phase(out).phase).toBe('loading');
     await flush();
-    await flush();
-    expect(closed).toEqual([1]);
-    expect(created).toHaveLength(2);
-    expect(created[1].modelAssetPath).toBe(bodyModelUrl('full'));
+    expect(closed).toEqual(['lite']);
+    expect(created).toEqual(['lite', 'full']);
 
-    // Disable: released, idle, nothing new created.
+    // Disable: released, off, nothing new created.
     out = h.process({}, ctxWith({ body: { enabled: false, model: 'full' } }));
-    expect(closed).toEqual([1, 2]);
-    expect(out.status).toEqual({ phase: 'idle', bodyDetected: false });
+    expect(closed).toEqual(['lite', 'full']);
+    expect(phase(out).phase).toBe('off');
     h.dispose?.();
     expect(created).toHaveLength(2);
+  });
+
+  it('a failed load is not re-hammered, and switching model retries (the review’s finding)', async () => {
+    failModel = 'lite';
+    const h = webcamBodyNode.make(webcamBodyNode.params.parse({}));
+    await h.init?.(ctxWith({ body: { enabled: true, model: 'lite' } }));
+    h.process({}, ctxWith({ body: { enabled: true, model: 'lite' } }));
+    await flush();
+    let out = h.process({}, ctxWith({ body: { enabled: true, model: 'lite' } }));
+    expect(phase(out).phase).toBe('error');
+    // Ticking on does not retry the failed model.
+    for (let i = 0; i < 5; i++) h.process({}, ctxWith({ body: { enabled: true, model: 'lite' } }));
+    await flush();
+    expect(created).toEqual([]);
+    // Picking the other model on the dial retries at once.
+    out = h.process({}, ctxWith({ body: { enabled: true, model: 'full' } }));
+    expect(phase(out).phase).toBe('loading');
+    await flush();
+    expect(created).toEqual(['full']);
+    expect(phase(h.process({}, ctxWith({ body: { enabled: true, model: 'full' } }))).phase).toBe('ready');
+    h.dispose?.();
+  });
+
+  it('with no camera frames it says so (no download), and retries by itself when frames arrive', async () => {
+    const h = webcamBodyNode.make(webcamBodyNode.params.parse({}));
+    await h.init?.(ctxWith({ body: { enabled: true, model: 'lite' } }, deadVideo));
+    let out = h.process({}, ctxWith({ body: { enabled: true, model: 'lite' } }, deadVideo));
+    expect(phase(out)).toMatchObject({ phase: 'unavailable', reason: NO_CAMERA_REASON });
+    await flush();
+    expect(created).toEqual([]);
+    // The camera comes up: the next tick loads without the player touching anything.
+    out = h.process({}, ctxWith({ body: { enabled: true, model: 'lite' } }, liveVideo));
+    expect(phase(out).phase).toBe('loading');
+    await flush();
+    expect(created).toEqual(['lite']);
+    h.dispose?.();
+  });
+
+  it('reports active while a body is detected', async () => {
+    const present: BodyFrame = { ...EMPTY_BODY_FRAME, present: true };
+    const detecting: BodyLandmarkerFactory = async ({ model }) => ({
+      resource: {
+        model,
+        landmarker: {
+          detectForVideo: () => ({
+            landmarks: [Array.from({ length: BODY_LANDMARK_COUNT }, () => ({ x: 0.5, y: 0.5, visibility: 1 }))],
+          }),
+          close: () => {},
+        },
+      },
+    });
+    // Run the rAF loop exactly ONCE when first scheduled (the loop re-arms itself, and a
+    // stub that always ran it would spin the microtask queue forever).
+    let armed = 0;
+    vi.stubGlobal('requestAnimationFrame', (cb: () => void) => {
+      if (armed++ === 0) queueMicrotask(cb);
+      return 1;
+    });
+    const h = webcamBodyNode.make(webcamBodyNode.params.parse({}));
+    const ctx: NodeContext = { tick: 0, time: 0, dt: 0, resources: { video: { ...liveVideo, currentTime: 1 }, controls: () => ({ body: { enabled: true } }), createBodyLandmarker: detecting } };
+    await h.init?.(ctx);
+    h.process({}, ctx);
+    await flush();
+    h.process({}, ctx); // schedules the loop
+    await flush();
+    const out = h.process({}, ctx);
+    expect((out.body as BodyFrame).present).toBe(present.present);
+    expect(phase(out).phase).toBe('active');
+    h.dispose?.();
   });
 });

--- a/test/webcam_body.test.ts
+++ b/test/webcam_body.test.ts
@@ -1,0 +1,127 @@
+/**
+ * `webcam-body` (#186), headlessly: the pure result → frame converter, the gate
+ * that decides whether the (expensive) pose model is wanted, and the lazy-load
+ * lifecycle driven through a mocked tasks-vision module — off by default, loads
+ * on enable, swaps model on the dial, releases on disable.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { NodeContext } from '@/dag';
+import { BLM, BODY_LANDMARK_COUNT, EMPTY_BODY_FRAME } from '@/nodes/domain';
+import { defaultFeatureLab } from '@/features/labConfig';
+
+const created: Array<{ modelAssetPath: string; delegate?: string }> = [];
+const closed: number[] = [];
+vi.mock('@mediapipe/tasks-vision', () => ({
+  FilesetResolver: { forVisionTasks: async () => ({}) },
+  PoseLandmarker: {
+    createFromOptions: async (_fs: unknown, opts: { baseOptions: { modelAssetPath: string; delegate?: string } }) => {
+      created.push(opts.baseOptions);
+      const id = created.length;
+      return {
+        detectForVideo: () => ({ landmarks: [], worldLandmarks: [] }),
+        close: () => closed.push(id),
+      };
+    },
+  },
+}));
+
+// Imported after the mock is registered.
+const { resultToBodyFrame, bodyActive, webcamBodyNode, bodyModelUrl } = await import('@/nodes/sources/webcam_body');
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+describe('resultToBodyFrame', () => {
+  it('scales normalized landmarks to pixels, keeps z, visibility and world landmarks', () => {
+    const pts = Array.from({ length: BODY_LANDMARK_COUNT }, (_, i) => ({ x: i / 33, y: 0.5, z: -0.1, visibility: 0.9 }));
+    const world = pts.map((p) => ({ x: p.x - 0.5, y: 0, z: 0 }));
+    const f = resultToBodyFrame({ landmarks: [pts], worldLandmarks: [world] }, 640, 480);
+    expect(f.present).toBe(true);
+    expect(f.width).toBe(640);
+    expect(f.landmarks).toHaveLength(BODY_LANDMARK_COUNT);
+    expect(f.landmarks[BLM.nose]).toEqual({ x: 0, y: 240, z: -0.1 });
+    expect(f.landmarks[BLM.right_foot_index].x).toBeCloseTo((32 / 33) * 640, 6);
+    expect(f.visibility[0]).toBe(0.9);
+    expect(f.world).toHaveLength(BODY_LANDMARK_COUNT);
+    expect(f.world![BLM.nose]).toEqual({ x: -0.5, y: 0, z: 0 });
+  });
+
+  it('returns the sized empty frame when nobody is detected', () => {
+    expect(resultToBodyFrame({ landmarks: [] }, 320, 240)).toEqual({ ...EMPTY_BODY_FRAME, width: 320, height: 240 });
+  });
+
+  it('defaults visibility to 1 when the detector omits it', () => {
+    const pts = Array.from({ length: BODY_LANDMARK_COUNT }, () => ({ x: 0.5, y: 0.5 }));
+    expect(resultToBodyFrame({ landmarks: [pts] }, 10, 10).visibility.every((v) => v === 1)).toBe(true);
+  });
+});
+
+describe('bodyActive (the gate)', () => {
+  it('is off with no controls, and off by default', () => {
+    expect(bodyActive(undefined)).toBe(false);
+    expect(bodyActive({ body: { enabled: false } })).toBe(false);
+    expect(bodyActive({})).toBe(false);
+  });
+  it('the dial turns it on', () => {
+    expect(bodyActive({ body: { enabled: true } })).toBe(true);
+  });
+  it('a demanded body group turns it on even with the dial off (the trainer path)', () => {
+    // No body groups are catalogued yet, so a demand for one cannot match; the rule
+    // still holds structurally: a non-body demand never turns the body on.
+    expect(bodyActive({ body: { enabled: false } }, new Set(['face.geom']))).toBe(false);
+  });
+  it('the Lab measuring a non-body group does not turn it on', () => {
+    const lab = { ...defaultFeatureLab(), show: true, groups: ['hand.position.raw'] };
+    expect(bodyActive({ body: { enabled: false }, featureLab: lab })).toBe(false);
+  });
+});
+
+describe('webcam-body lifecycle (mocked tasks-vision)', () => {
+  beforeEach(() => {
+    created.length = 0;
+    closed.length = 0;
+    vi.stubGlobal('requestAnimationFrame', () => 1);
+    vi.stubGlobal('cancelAnimationFrame', () => {});
+  });
+
+  const video = { readyState: 0, videoWidth: 0, videoHeight: 0, currentTime: 0 } as unknown as HTMLVideoElement;
+  const ctxWith = (controls: unknown): NodeContext => ({
+    tick: 0,
+    time: 0,
+    dt: 0,
+    resources: { video, controls: () => controls },
+  });
+
+  it('loads nothing until enabled, loads the dial’s model on enable, swaps on change, releases on disable', async () => {
+    const h = webcamBodyNode.make(webcamBodyNode.params.parse({}));
+    await h.init?.(ctxWith({ body: { enabled: false, model: 'lite' } }));
+    expect(created).toHaveLength(0);
+    let out = h.process({}, ctxWith({ body: { enabled: false, model: 'lite' } }));
+    expect(out.body).toEqual(EMPTY_BODY_FRAME);
+    expect(out.status).toEqual({ phase: 'idle', bodyDetected: false });
+    expect(created).toHaveLength(0);
+
+    out = h.process({}, ctxWith({ body: { enabled: true, model: 'lite' } }));
+    expect((out.status as { phase: string }).phase).toBe('loading');
+    await flush();
+    await flush();
+    expect(created).toHaveLength(1);
+    expect(created[0].modelAssetPath).toBe(bodyModelUrl('lite'));
+    out = h.process({}, ctxWith({ body: { enabled: true, model: 'lite' } }));
+    expect((out.status as { phase: string }).phase).toBe('ready');
+
+    // The dial picks `full`: the lite landmarker is released and full is loaded.
+    h.process({}, ctxWith({ body: { enabled: true, model: 'full' } }));
+    await flush();
+    await flush();
+    expect(closed).toEqual([1]);
+    expect(created).toHaveLength(2);
+    expect(created[1].modelAssetPath).toBe(bodyModelUrl('full'));
+
+    // Disable: released, idle, nothing new created.
+    out = h.process({}, ctxWith({ body: { enabled: false, model: 'full' } }));
+    expect(closed).toEqual([1, 2]);
+    expect(out.status).toEqual({ phase: 'idle', bodyDetected: false });
+    h.dispose?.();
+    expect(created).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
Part of #186 (PR B of the plan on the issue). The full-body pose source, reachable from a cold load.

**What lands**
- `BodyFrame` / `BodyFrameSchema` / `BLM` (33 BlazePose indices) / `BODY_BONES` / `makeBodyKeypoints` (a synthetic skeleton) in `src/nodes/domain.ts`.
- `src/nodes/sources/tasks_vision.ts`: the one pinned tasks-vision wasm base; `webcam-hands` and `webcam-face` now import it (the third copy was the moment to extract).
- `webcam-body`: MediaPipe `PoseLandmarker` (lite 5.8 MB default / full 9.4 MB), gated by `bodyActive` = `body.enabled` dial OR the Lab measuring a body group OR a trainer demand (the `faceActive` rule), lazy load on first enable, offload on disable, GPU→CPU fallback, failure latch, live model swap from the dial with no graph rebuild. Detached rAF inference loop like the other two sources.
- `synthetic-body` (bounces at a declared period — the pulse ground truth for PR F) and `replay-body`.
- `SLOTS.body` (`?slot.body=synthetic-body` runs the whole body path with no camera and no model), `BODY_SLOT_CONTRACT` with a checkable schema.
- Overlay: `bodySkeleton` element (bones + visible joints, mirrored) that prints "body model loading… / failed" from the node's `status` port while not ready.
- Dials `body.enabled`, `body.model` (schema + bijections + store heal); a Body section in the settings panel writing through `dispatchDialSet`.
- Catalog regenerated (35 nodes).

**Reachability (shipping rule).** Cold load → settings → Body → one checkbox: two clicks. The skeleton appears on the video when the model is ready. Guards: `test/app_graph.test.ts` asserts the two `camBody → overlay` edges exist and that the node has no inbound edges (a slot candidate declares no inputs; its gate is the dial read off the control store, the face pattern, not an `enabled` port).

**Tests.** `test/body_slot.test.ts` (contract, rejection, URL, running-engine swap keeping hands+face models, headless conformance, determinism, bounce period), `test/webcam_body.test.ts` (converter, gate, lifecycle off→on→model swap→off against a mocked tasks-vision), overlay skeleton tests, graph guard. Local: typecheck, 1448 tests / 112 files, build, catalog all green after rebasing on main (#192).

**Not in this PR (later PRs of the plan).** Body feature catalog (C), video fixtures (D), body→sound (E), pulse (F), song (G), pace (H). A React status chip for the body model needs a reporter in `useEngine.ts`, which #101 owns right now; the overlay's load-state text covers it until then.

https://claude.ai/code/session_01P8DbuQk8jQCt2P2vrgYJAP