### PR TITLE
#188: the catalogued lazy-loading pattern — src/lazy, the shared status readout, its design page

### DIFF
--- a/docs/design/lazy-loading.md
+++ b/docs/design/lazy-loading.md
@@ -12,8 +12,8 @@ Three sites already do this by hand, and each invented its own state machine and
 
 | Site | Heavy thing | Loader | Status words |
 |---|---|---|---|
-| `src/nodes/sources/webcam_hands.ts`, `webcam_face.ts` | MediaPipe tasks-vision (137 kB gzip + wasm + model) | `import('@mediapipe/tasks-vision')` in `init` / behind the face gate | `idle`, `loading`, `ready`, `error` |
-| `src/app/recording/formats.ts` → `flac.ts` | libflacjs (108 kB gzip) | `load()` per format entry, two lazy hops | a null blob plus an error |
+| `src/nodes/sources/webcam_face.ts` (and `webcam_hands.ts`, which loads the same way in `init` but reports no status) | MediaPipe tasks-vision (137 kB gzip + wasm + model) | `import('@mediapipe/tasks-vision')` behind the face gate | `idle`, `loading`, `ready`, `error` |
+| `src/app/recording/formats.ts` → `flac.ts` | libflacjs (352 kB raw, 108 kB gzip) | `load()` per format entry, two lazy hops | a null blob plus an error |
 | `src/nodes/output/midi_out.ts` → `midi_engine.ts` | WEBMIDI.js (17 kB gzip) + the MIDI permission | `ctx.resources.createMidiSink` or `import('./midi_engine')` | `off`, `unsupported`, `connecting`, `ready`, `no-ports`, `denied`, `error` |
 
 The bugs #147's adversarial review found in the third copy (an open for a superseded port attaching a device; a disabled node still holding a port) are bugs of exactly this state machine. A fourth hand-written copy would make them again. So the machine is extracted once, with each rule pinned by a test, and the status words are unified so one readout component can render any heavy node.
@@ -24,7 +24,7 @@ The bugs #147's adversarial review found in the third copy (an open for a supers
 
 A heavy node never imports its implementation statically. It declares a factory type, reads it from `ctx.resources.<name>` when the host injects one (tests, headless runs, custom hosts), and otherwise uses a module-level default whose body is a dynamic `import()` of a **browser-only sibling module** (`midi_engine.ts`, `lyria_engine.ts`). Two consequences that are easy to get wrong:
 
-- The sibling module is the only static importer of the vendor library, and **nothing in `src/nodes/index.ts` or `src/nodes/browser.ts` re-exports it**. A static re-export defeats the split: that is how `@google/genai` (207 kB raw, 38 kB gzip) sat in the main chunk until PR 3 of #188 removed the `LyriaEngine` export from `browser.ts`.
+- The sibling module is the only static importer of the vendor library, and **nothing in `src/nodes/index.ts` or `src/nodes/browser.ts` re-exports it**. A static re-export defeats the split: that is how `@google/genai` (207 kB raw, 38 kB gzip) sits in the main chunk today, through `browser.ts`'s `LyriaEngine` export; PR 3 of #188 removes it.
 - Loading is *requested* synchronously from `process()` and never awaited there. The node reads `current()` each tick and does its job when the thing is there.
 
 ### 2. Status port
@@ -40,14 +40,14 @@ Every heavy node emits a `status` output of type `LoadStatus` (`src/lazy/status.
 | `active` | loaded and doing its job right now (playing, sending, detecting) — `withActive(status, isActive)` |
 | `error` | the load or the resource failed; `message` is human-readable; disable then enable retries |
 
-Node-specific detail goes in `reason`, never in a new phase. The two existing nodes keep their own status shapes (both are pinned by tests); the shared readout adapts them. New heavy nodes speak `LoadStatus` directly.
+Node-specific detail goes in `reason` (a cause for `unavailable` / `error`, or a qualifier for `loading` such as `permission` when the wait is a browser prompt rather than a download), and node-specific *data* goes in `detail` (the MIDI port list that comes back with a `no-ports` result, for the selector to offer). Never a new phase. The two existing nodes keep their own status shapes (both are pinned by tests); their panels adapt them. New heavy nodes speak `LoadStatus` directly.
 
 ### 3. UI affordance
 
-`src/app/LoadStatusReadout.tsx` renders a `LoadStatus` as the dot + message the MIDI panel already draws (`PHASE_DOT` generalised), with a progress bar while `loading` and progress is known. Two rules travel with it:
+`src/app/LoadStatusReadout.tsx` renders a `LoadStatus` as the dot + message the MIDI panel already draws (`PHASE_DOT` generalised), with a progress bar only while `loading` *and* the loader has reported progress (a permission prompt never shows a stuck bar). Two rules belong to the **panel** that mounts it, not to the component:
 
-- Where the capability cannot exist on this host (`unavailable` with `unsupported`), render the reason instead of a dead toggle (the MIDI section's precedent).
-- A multi-megabyte download is labelled as such *before* the player triggers it (the ffmpeg.wasm rule in `recording-v2.md`). The readout shows progress; the enable control says the size.
+- Where the capability cannot exist on this host (`unavailable` with `unsupported`), the panel renders the reason instead of a dead toggle (the MIDI section's precedent). `reason` and the phase are exposed as data attributes so a panel test can pin that.
+- A multi-megabyte download is labelled as such *before* the player triggers it (the rule `formats.ts` states for an ffmpeg.wasm format, and `component-model.md`'s recording section). The readout shows progress; the enable control says the size.
 
 ## The module: `src/lazy/`
 
@@ -57,6 +57,7 @@ import { lazyResource, withActive } from '@/lazy';
 const engine = lazyResource<GenerativeEngine>({
   load: (ctx) => (injectedFactory ?? defaultFactory)(opts, ctx),  // the seam
   unload: (e) => void e.stop(),
+  gate: () => (webMidiSupported() ? null : { reason: 'unsupported' }), // optional sync pre-check
   label: 'generative engine',
   log: ctx.log,
 });
@@ -70,13 +71,19 @@ return { status: withActive(engine.status(), playing, 'Playing') };
 
 Five rules, each a test in `test/lazy_resource.test.ts`:
 
-1. **Request once.** `request()` on every tick starts at most one load.
-2. **A late arrival is discarded.** A load that resolves after `release()` / `dispose()` is unloaded on arrival, never attached, and the loader's `AbortSignal` fires so a download can stop early.
-3. **A failure is not re-hammered.** After `unavailable` / `error`, `request()` is a no-op until `release()`.
+1. **Request once.** `request()` on every tick starts at most one load, including while an older, released load is still settling.
+2. **A late arrival is discarded.** A load that resolves after `release()` / `dispose()` is unloaded on arrival, never attached, touches nothing that belongs to a newer load, and the loader's `AbortSignal` fires so a download can stop early.
+3. **A failure is not re-hammered.** After `unavailable` / `error` (from the loader or the `gate`), `request()` is a no-op until `release()`.
 4. **Re-enable retries.** `release()` clears the failure, so disable → enable is the player's "try again".
-5. **Never throw.** A rejecting (or synchronously throwing) loader becomes an `error` status.
+5. **Never throw.** A rejecting (or synchronously throwing) loader becomes an `error` status; an `unload` that throws is logged, never propagated.
 
 Pure and Node-safe: no DAG import, no DOM, no vendor library. `src/dag/` is untouched; a node composes the resource inside `make()`.
+
+Three idioms the existing sites need, stated so they are not re-derived:
+
+- **A keyed request** (`midi-out`'s live `port` input): compare the key to the one the current load targets and `release()` on change *before* `want()`; the superseded open is then a late arrival by rule 2.
+- **A thing that runs after attach** (`webcam-face`'s detection loop): the loader returns `{ landmarker, stop }` and `unload` calls `stop()`; a loader with a heavy second step (the GPU → CPU fallback) checks `ctx.signal.aborted` between the steps.
+- **A synchronous capability gate** (`webMidiSupported()`): the `gate` option, so an unsupported host reports `unavailable` on the same tick with nothing imported and no one-tick "Loading…" flash.
 
 ## Adopters
 

--- a/docs/design/lazy-loading.md
+++ b/docs/design/lazy-loading.md
@@ -1,0 +1,96 @@
+# Lazy loading as a catalogued pattern
+
+> Status: design record (2026-09-09), issue [#188](https://github.com/thorwhalen/thoremin/issues/188). The maintainer's rule, verbatim: *"We don't want to load everything at once, but only what is needed when it's needed."* This page is the pattern that rule became, and the module that implements it (`src/lazy/`). The wider context (where generative AI fits inside an instrument) is [`generative-instruments.md`](generative-instruments.md) §5.
+
+## The rule
+
+A heavy thing (a vendor SDK, an ML model, a wasm runtime, a network session, an encoder) is **never in the main chunk and never loaded before a player asks for it**, and while it loads, the instrument keeps playing and the UI says what is happening. A player who never enables a capability never pays for it, in bytes or in permission prompts.
+
+## Why a pattern and not a convention
+
+Three sites already do this by hand, and each invented its own state machine and its own status words:
+
+| Site | Heavy thing | Loader | Status words |
+|---|---|---|---|
+| `src/nodes/sources/webcam_hands.ts`, `webcam_face.ts` | MediaPipe tasks-vision (137 kB gzip + wasm + model) | `import('@mediapipe/tasks-vision')` in `init` / behind the face gate | `idle`, `loading`, `ready`, `error` |
+| `src/app/recording/formats.ts` → `flac.ts` | libflacjs (108 kB gzip) | `load()` per format entry, two lazy hops | a null blob plus an error |
+| `src/nodes/output/midi_out.ts` → `midi_engine.ts` | WEBMIDI.js (17 kB gzip) + the MIDI permission | `ctx.resources.createMidiSink` or `import('./midi_engine')` | `off`, `unsupported`, `connecting`, `ready`, `no-ports`, `denied`, `error` |
+
+The bugs #147's adversarial review found in the third copy (an open for a superseded port attaching a device; a disabled node still holding a port) are bugs of exactly this state machine. A fourth hand-written copy would make them again. So the machine is extracted once, with each rule pinned by a test, and the status words are unified so one readout component can render any heavy node.
+
+## The three parts
+
+### 1. Loader seam
+
+A heavy node never imports its implementation statically. It declares a factory type, reads it from `ctx.resources.<name>` when the host injects one (tests, headless runs, custom hosts), and otherwise uses a module-level default whose body is a dynamic `import()` of a **browser-only sibling module** (`midi_engine.ts`, `lyria_engine.ts`). Two consequences that are easy to get wrong:
+
+- The sibling module is the only static importer of the vendor library, and **nothing in `src/nodes/index.ts` or `src/nodes/browser.ts` re-exports it**. A static re-export defeats the split: that is how `@google/genai` (207 kB raw, 38 kB gzip) sat in the main chunk until PR 3 of #188 removed the `LyriaEngine` export from `browser.ts`.
+- Loading is *requested* synchronously from `process()` and never awaited there. The node reads `current()` each tick and does its job when the thing is there.
+
+### 2. Status port
+
+Every heavy node emits a `status` output of type `LoadStatus` (`src/lazy/status.ts`):
+
+| phase | meaning |
+|---|---|
+| `off` | not requested: the enable input is false; nothing loaded, nothing held |
+| `unavailable` | requested, but this host cannot provide it; `reason` says why (`unsupported`, `no-key`, `denied`, `no-ports`, …) |
+| `loading` | the SDK / model / wasm / session is being fetched or opened; `progress` 0..1 when known |
+| `ready` | loaded and usable, idle |
+| `active` | loaded and doing its job right now (playing, sending, detecting) — `withActive(status, isActive)` |
+| `error` | the load or the resource failed; `message` is human-readable; disable then enable retries |
+
+Node-specific detail goes in `reason`, never in a new phase. The two existing nodes keep their own status shapes (both are pinned by tests); the shared readout adapts them. New heavy nodes speak `LoadStatus` directly.
+
+### 3. UI affordance
+
+`src/app/LoadStatusReadout.tsx` renders a `LoadStatus` as the dot + message the MIDI panel already draws (`PHASE_DOT` generalised), with a progress bar while `loading` and progress is known. Two rules travel with it:
+
+- Where the capability cannot exist on this host (`unavailable` with `unsupported`), render the reason instead of a dead toggle (the MIDI section's precedent).
+- A multi-megabyte download is labelled as such *before* the player triggers it (the ffmpeg.wasm rule in `recording-v2.md`). The readout shows progress; the enable control says the size.
+
+## The module: `src/lazy/`
+
+```ts
+import { lazyResource, withActive } from '@/lazy';
+
+const engine = lazyResource<GenerativeEngine>({
+  load: (ctx) => (injectedFactory ?? defaultFactory)(opts, ctx),  // the seam
+  unload: (e) => void e.stop(),
+  label: 'generative engine',
+  log: ctx.log,
+});
+
+// in process(), every tick, never awaited:
+engine.want(inputs.enabled === true);
+const e = engine.current();
+if (e && playing) { /* drive it */ }
+return { status: withActive(engine.status(), playing, 'Playing') };
+```
+
+Five rules, each a test in `test/lazy_resource.test.ts`:
+
+1. **Request once.** `request()` on every tick starts at most one load.
+2. **A late arrival is discarded.** A load that resolves after `release()` / `dispose()` is unloaded on arrival, never attached, and the loader's `AbortSignal` fires so a download can stop early.
+3. **A failure is not re-hammered.** After `unavailable` / `error`, `request()` is a no-op until `release()`.
+4. **Re-enable retries.** `release()` clears the failure, so disable → enable is the player's "try again".
+5. **Never throw.** A rejecting (or synchronously throwing) loader becomes an `error` status.
+
+Pure and Node-safe: no DAG import, no DOM, no vendor library. `src/dag/` is untouched; a node composes the resource inside `make()`.
+
+## Adopters
+
+| Node / site | Status | Notes |
+|---|---|---|
+| `lyria` (`src/nodes/output/lyria.ts`) | **adopts in #188 PR 3** | `createGenerativeEngine` seam; default lazily imports `lyria_engine.ts`, which reads the BYO key from the assistant's provider-key store. `LyriaEngine` leaves `browser.ts`'s static exports. |
+| `midi-out` | reference site, not migrated | Mutation-verified as is; migrate when a change touches it. Its `MidiPhase` maps to `LoadStatus` as `connecting → loading`, `unsupported/no-ports/denied → unavailable + reason`. |
+| `webcam-face`, `webcam-hands` | reference site, not migrated | Owned by the body-features work (#186); asked to adopt for the body model rather than write a fourth copy. |
+| recording formats | reference site | Already a registry of `load()` thunks; the status here is per conversion, not per node. |
+| conductor assets (#187) | asked to adopt | Any score / model / sample fetched on first use. |
+| an in-browser generator (`generative-instruments.md` §3b) | must adopt | ~300 kB gzip of library and 12–18 MB of checkpoint, with a progress bar. |
+
+## What this is not
+
+- Not a plugin or discovery mechanism; the registry stays a hand-listed array (`component-model.md`, correction 2).
+- Not a replacement for Vite's code splitting; it is what makes the split *reach* the node (the seam) and *visible* to the player (the status).
+- Not a cache: whether a model is cached across sessions is the browser's business (HTTP cache, or the Cache API in a later step), not this module's.

--- a/src/app/LoadStatusReadout.tsx
+++ b/src/app/LoadStatusReadout.tsx
@@ -1,0 +1,56 @@
+/**
+ * LoadStatusReadout — the one honest readout for any lazily-loaded heavy node (#188).
+ *
+ * Renders a {@link LoadStatus} the way the MIDI section (#137) renders its own phase:
+ * a status dot (coloured and pulsing per phase), the node's message, and — new here —
+ * a progress bar while `loading` when the loader reports progress (a model or wasm
+ * download). The phase vocabulary is `src/lazy/status.ts`; a node that still speaks its
+ * own words (`midi-out`, `webcam-face`) is adapted by its panel, not by this component.
+ *
+ * `enabled` is the node's enable control: when it is off the readout says so, whatever
+ * stale status a torn-down engine last reported.
+ */
+import type { LoadPhase, LoadStatus } from '@/lazy';
+
+/** Status-dot colour + whether it pulses, per phase. Same palette as the MIDI panel. */
+const PHASE_DOT: Record<LoadPhase, string> = {
+  off: 'bg-white/30',
+  unavailable: 'bg-amber-400',
+  loading: 'bg-amber-400 animate-pulse',
+  ready: 'bg-emerald-400',
+  active: 'bg-emerald-400 animate-pulse',
+  error: 'bg-rose-500',
+};
+
+export interface LoadStatusReadoutProps {
+  status: LoadStatus;
+  /** The node's enable control. Off → "…off" regardless of `status`. */
+  enabled: boolean;
+  /** What to say when disabled (defaults to "Off"). */
+  offMessage?: string;
+}
+
+export function LoadStatusReadout({ status, enabled, offMessage = 'Off' }: LoadStatusReadoutProps) {
+  const phase: LoadPhase = enabled ? status.phase : 'off';
+  const message = enabled ? status.message : offMessage;
+  const showProgress = enabled && phase === 'loading' && typeof status.progress === 'number';
+  return (
+    <div className="space-y-1" data-load-phase={phase} data-load-reason={enabled ? status.reason : undefined}>
+      <div className="flex items-center gap-2 text-[11px] text-white/70">
+        <span className={`inline-block h-2 w-2 rounded-full ${PHASE_DOT[phase]}`} aria-hidden />
+        <span>{message}</span>
+      </div>
+      {showProgress && (
+        <div
+          className="h-1 w-full overflow-hidden rounded bg-white/10"
+          role="progressbar"
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={Math.round((status.progress as number) * 100)}
+        >
+          <div className="h-full bg-amber-400" style={{ width: `${Math.round((status.progress as number) * 100)}%` }} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lazy/index.ts
+++ b/src/lazy/index.ts
@@ -1,0 +1,10 @@
+/**
+ * `src/lazy` — the catalogued lazy-loading pattern (#188): a heavy node loads its
+ * SDK / model / wasm / session only when asked, through an injectable loader, and
+ * reports where it is on a `status` port in one shared vocabulary. See
+ * `docs/design/lazy-loading.md` for the rule and the adopters table.
+ */
+export { lazyResource } from './resource';
+export type { LazyResource, LazyResourceOptions, Loader, LoadContext, LoadResult } from './resource';
+export { withActive } from './status';
+export type { LoadPhase, LoadStatus } from './status';

--- a/src/lazy/resource.ts
+++ b/src/lazy/resource.ts
@@ -1,0 +1,169 @@
+/**
+ * `lazyResource` — the one state machine behind every "load the heavy thing only
+ * when asked, and say where you are" node (#188).
+ *
+ * Extracted, not invented. `webcam-face`, `midi-out` and the recording formats each
+ * hand-roll the same five rules, and the bugs #147's adversarial review found were
+ * bugs in that hand-rolling (a superseded open attaching a device; a disabled node
+ * holding a port). The rules, each pinned by a test in `test/lazy_resource.test.ts`:
+ *
+ *   1. **Request once.** `request()` on every tick starts at most one load.
+ *   2. **A late arrival is discarded.** A load that resolves after `release()` or
+ *      `dispose()` is unloaded on arrival, never attached.
+ *   3. **A failure is not re-hammered.** After `unavailable` / `error`, `request()`
+ *      is a no-op until `release()` — one bad key must not open a socket per frame.
+ *   4. **Re-enable retries.** `release()` clears the failure, so disable → enable is
+ *      the player's "try again".
+ *   5. **Never throw.** A rejecting loader becomes an `error` status; `process()`
+ *      runs every frame and one throw would take the instrument down.
+ *
+ * The API is synchronous on purpose: a node's `process()` calls `want(enabled)` and
+ * `current()` each tick and never awaits. The *loader* is the seam — a host-injected
+ * factory in tests and custom hosts, a dynamic `import()` of a browser-only sibling
+ * module by default (`midi_engine.ts`, `lyria_engine.ts`). Pure and Node-safe: no
+ * DAG, no DOM, no vendor import.
+ */
+import type { LoadStatus } from './status';
+
+/** What a loader resolves: the thing, or an actionable reason it cannot be had. */
+export type LoadResult<T> =
+  | { resource: T; message?: string }
+  | { resource: null; reason: string; message?: string };
+
+/** What a loader receives. `signal` aborts when the request is released mid-load, so
+ *  a loader that can stop a download early should; `progress` drives the readout. */
+export interface LoadContext {
+  signal: AbortSignal;
+  progress: (fraction: number) => void;
+}
+
+export type Loader<T> = (ctx: LoadContext) => Promise<LoadResult<T>>;
+
+export interface LazyResourceOptions<T> {
+  /** The seam: the injected factory, or the default `() => import(...)`. */
+  load: Loader<T>;
+  /** Close / dispose the held thing (also called on a late arrival). */
+  unload?: (resource: T) => void;
+  /** A noun for the default messages ("MIDI output", "generative engine"). */
+  label?: string;
+  /** Where a failure is reported once (the node's `ctx.log`, or `console.warn`). */
+  log?: (msg: string) => void;
+}
+
+export interface LazyResource<T> {
+  /** Start loading if nothing is loaded, loading, or failed since the last release. */
+  request(): void;
+  /** Drop the held thing (or the in-flight load) and clear any failure. */
+  release(): void;
+  /** `request()` when `enabled`, else `release()` — the per-tick line. */
+  want(enabled: boolean): void;
+  /** The loaded thing, synchronously, or null. */
+  current(): T | null;
+  /** The status-port value. `ready` when `current()` is non-null. */
+  status(): LoadStatus;
+  /** Release and refuse every later arrival. Terminal. */
+  dispose(): void;
+}
+
+const _messages = (label: string) => ({
+  off: `${label} off`,
+  loading: `Loading ${label}...`,
+  ready: `${label} ready`,
+  unavailable: `${label} is not available here`,
+  error: `Could not load ${label}`,
+});
+
+export function lazyResource<T>(opts: LazyResourceOptions<T>): LazyResource<T> {
+  const label = opts.label ?? 'resource';
+  const msg = _messages(label);
+  const unload = opts.unload ?? (() => {});
+
+  let held: T | null = null;
+  let loading = false;
+  let attempted = false; // a load settled (any outcome) since the last release
+  let disposed = false;
+  let gen = 0; // bumped by release(): a load from an older generation is a late arrival
+  let controller: AbortController | null = null;
+  let status: LoadStatus = { phase: 'off', message: msg.off };
+  let progress = 0;
+
+  type Outcome = { kind: 'result'; res: LoadResult<T> } | { kind: 'error'; error: unknown };
+
+  const settle = (myGen: number, outcome: Outcome): void => {
+    loading = false;
+    if (myGen !== gen || disposed) {
+      // Rule 2: released or disposed while loading — never attach, never mark attempted
+      // (so the NEXT request after the release starts fresh instead of staying wedged).
+      if (outcome.kind === 'result' && outcome.res.resource !== null) unload(outcome.res.resource);
+      return;
+    }
+    attempted = true;
+    if (outcome.kind === 'error') {
+      const detail = outcome.error instanceof Error ? outcome.error.message : String(outcome.error);
+      status = { phase: 'error', reason: 'error', message: detail ? `${msg.error}: ${detail}` : msg.error };
+      opts.log?.(`[lazy] ${label}: ${detail}`);
+      return;
+    }
+    const res = outcome.res;
+    if (res.resource === null) {
+      const { reason, message } = res as { resource: null; reason: string; message?: string };
+      status = { phase: 'unavailable', reason, message: message ?? msg.unavailable };
+      return;
+    }
+    held = res.resource;
+    status = { phase: 'ready', message: res.message ?? msg.ready };
+  };
+
+  return {
+    request() {
+      if (disposed || held || loading || attempted) return;
+      loading = true;
+      progress = 0;
+      const myGen = gen;
+      controller = new AbortController();
+      status = { phase: 'loading', message: msg.loading, progress };
+      const ctx: LoadContext = {
+        signal: controller.signal,
+        progress: (f) => {
+          if (myGen !== gen) return;
+          progress = Math.min(1, Math.max(0, f));
+          if (status.phase === 'loading') status = { ...status, progress };
+        },
+      };
+      let p: Promise<LoadResult<T>>;
+      try {
+        p = Promise.resolve(opts.load(ctx));
+      } catch (err) {
+        // Rule 5: a loader that throws synchronously is a rejected load, not our throw.
+        p = Promise.reject(err);
+      }
+      p.then(
+        (res) => settle(myGen, { kind: 'result', res }),
+        (error) => settle(myGen, { kind: 'error', error }),
+      );
+    },
+    release() {
+      gen++;
+      controller?.abort();
+      controller = null;
+      loading = false;
+      attempted = false; // Rule 4
+      if (held !== null) {
+        const h = held;
+        held = null;
+        unload(h);
+      }
+      status = { phase: 'off', message: msg.off };
+    },
+    want(enabled) {
+      if (enabled) this.request();
+      else if (held !== null || loading || attempted) this.release();
+    },
+    current: () => held,
+    status: () => status,
+    dispose() {
+      this.release();
+      disposed = true;
+    },
+  };
+}

--- a/src/lazy/resource.ts
+++ b/src/lazy/resource.ts
@@ -27,8 +27,8 @@ import type { LoadStatus } from './status';
 
 /** What a loader resolves: the thing, or an actionable reason it cannot be had. */
 export type LoadResult<T> =
-  | { resource: T; message?: string }
-  | { resource: null; reason: string; message?: string };
+  | { resource: T; message?: string; detail?: unknown }
+  | { resource: null; reason: string; message?: string; detail?: unknown };
 
 /** What a loader receives. `signal` aborts when the request is released mid-load, so
  *  a loader that can stop a download early should; `progress` drives the readout. */
@@ -44,6 +44,14 @@ export interface LazyResourceOptions<T> {
   load: Loader<T>;
   /** Close / dispose the held thing (also called on a late arrival). */
   unload?: (resource: T) => void;
+  /**
+   * A synchronous capability check run by `request()` BEFORE the loader: return a
+   * reason (+ message) when this host can never provide the thing (no Web MIDI, no
+   * WebGPU), and the status is `unavailable` on the same tick with nothing imported
+   * — no one-tick "Loading..." flash, no vendor code fetched where it cannot work.
+   * Return null to proceed. Re-checked on every fresh request (after a release).
+   */
+  gate?: () => { reason: string; message?: string; detail?: unknown } | null;
   /** A noun for the default messages ("MIDI output", "generative engine"). */
   label?: string;
   /** Where a failure is reported once (the node's `ctx.log`, or `console.warn`). */
@@ -85,18 +93,32 @@ export function lazyResource<T>(opts: LazyResourceOptions<T>): LazyResource<T> {
   let gen = 0; // bumped by release(): a load from an older generation is a late arrival
   let controller: AbortController | null = null;
   let status: LoadStatus = { phase: 'off', message: msg.off };
-  let progress = 0;
 
   type Outcome = { kind: 'result'; res: LoadResult<T> } | { kind: 'error'; error: unknown };
 
+  /** Rule 5 extends to teardown: a `close()` that throws (a landmarker, a port) is
+   *  logged, never propagated into `process()` or left as an unhandled rejection. */
+  const safeUnload = (resource: T): void => {
+    try {
+      unload(resource);
+    } catch (err) {
+      opts.log?.(`[lazy] ${label}: unload failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  };
+
   const settle = (myGen: number, outcome: Outcome): void => {
-    loading = false;
     if (myGen !== gen || disposed) {
       // Rule 2: released or disposed while loading — never attach, never mark attempted
-      // (so the NEXT request after the release starts fresh instead of staying wedged).
-      if (outcome.kind === 'result' && outcome.res.resource !== null) unload(outcome.res.resource);
+      // (so the NEXT request after the release starts fresh instead of staying wedged),
+      // and touch NOTHING else: `loading` / `controller` belong to whatever load the
+      // current generation may have in flight. (Clearing `loading` here was the bug the
+      // review of this module found: it let a second load start beside the first and
+      // let a disabled node attach a resource — the #147 bug class, re-made.)
+      if (outcome.kind === 'result' && outcome.res.resource !== null) safeUnload(outcome.res.resource);
       return;
     }
+    loading = false;
+    controller = null;
     attempted = true;
     if (outcome.kind === 'error') {
       const detail = outcome.error instanceof Error ? outcome.error.message : String(outcome.error);
@@ -106,27 +128,35 @@ export function lazyResource<T>(opts: LazyResourceOptions<T>): LazyResource<T> {
     }
     const res = outcome.res;
     if (res.resource === null) {
-      const { reason, message } = res as { resource: null; reason: string; message?: string };
-      status = { phase: 'unavailable', reason, message: message ?? msg.unavailable };
+      const { reason, message, detail } = res as { resource: null; reason: string; message?: string; detail?: unknown };
+      status = { phase: 'unavailable', reason, message: message ?? msg.unavailable, detail };
       return;
     }
     held = res.resource;
-    status = { phase: 'ready', message: res.message ?? msg.ready };
+    status = { phase: 'ready', message: res.message ?? msg.ready, detail: res.detail };
   };
 
   return {
     request() {
       if (disposed || held || loading || attempted) return;
+      const blocked = opts.gate?.();
+      if (blocked) {
+        attempted = true;
+        status = { phase: 'unavailable', reason: blocked.reason, message: blocked.message ?? msg.unavailable, detail: blocked.detail };
+        return;
+      }
       loading = true;
-      progress = 0;
       const myGen = gen;
-      controller = new AbortController();
-      status = { phase: 'loading', message: msg.loading, progress };
+      const myController = new AbortController();
+      controller = myController;
+      // `progress` stays absent until the loader reports one: a readout must not draw a
+      // stuck 0% bar for a permission prompt or a socket that cannot say how far it is.
+      status = { phase: 'loading', message: msg.loading };
       const ctx: LoadContext = {
-        signal: controller.signal,
+        signal: myController.signal,
         progress: (f) => {
-          if (myGen !== gen) return;
-          progress = Math.min(1, Math.max(0, f));
+          if (myGen !== gen || myController.signal.aborted) return;
+          const progress = Math.min(1, Math.max(0, f));
           if (status.phase === 'loading') status = { ...status, progress };
         },
       };
@@ -140,7 +170,7 @@ export function lazyResource<T>(opts: LazyResourceOptions<T>): LazyResource<T> {
       p.then(
         (res) => settle(myGen, { kind: 'result', res }),
         (error) => settle(myGen, { kind: 'error', error }),
-      );
+      ).catch((err) => opts.log?.(`[lazy] ${label}: settle failed: ${String(err)}`));
     },
     release() {
       gen++;
@@ -151,13 +181,13 @@ export function lazyResource<T>(opts: LazyResourceOptions<T>): LazyResource<T> {
       if (held !== null) {
         const h = held;
         held = null;
-        unload(h);
+        safeUnload(h);
       }
       status = { phase: 'off', message: msg.off };
     },
     want(enabled) {
       if (enabled) this.request();
-      else if (held !== null || loading || attempted) this.release();
+      else if (held !== null || loading || attempted || controller !== null) this.release();
     },
     current: () => held,
     status: () => status,

--- a/src/lazy/status.ts
+++ b/src/lazy/status.ts
@@ -1,0 +1,48 @@
+/**
+ * The shared status vocabulary every lazily-loaded heavy resource speaks (#188).
+ *
+ * Three nodes already report a lifecycle phase on a port so the UI can be honest
+ * about *why* they are silent: `webcam-face` (`idle | loading | ready | error`),
+ * `midi-out` (`off | unsupported | connecting | ready | no-ports | denied | error`)
+ * and the recording formats (a null blob plus an error). Each invented its own
+ * words. This module is the one vocabulary the next heavy node uses instead, and
+ * what one shared readout component renders — see `docs/design/lazy-loading.md`.
+ *
+ * Node-specific detail lives in `reason`, never in a new phase: a blocked MIDI
+ * permission and a missing API key are both `unavailable`, with reasons `denied`
+ * and `no-key`, so a UI that has never heard of the node still knows to show the
+ * reason instead of a dead toggle.
+ */
+
+/** Where a heavy resource is in its life. Ordered roughly as a player meets them. */
+export type LoadPhase =
+  /** Not requested: nothing loaded, nothing held. The enable control is off. */
+  | 'off'
+  /** Requested, but this host cannot provide it. `reason` says why, actionably. */
+  | 'unavailable'
+  /** The implementation (SDK, model, wasm, session) is being fetched or opened. */
+  | 'loading'
+  /** Loaded and usable; idle. */
+  | 'ready'
+  /** Loaded and doing its job right now (playing, sending, detecting). */
+  | 'active'
+  /** The load or the resource failed. A later disable + enable retries. */
+  | 'error';
+
+/** What a heavy node reports on its `status` port each tick. */
+export interface LoadStatus {
+  phase: LoadPhase;
+  /** Short, human-readable explanation of the phase, always present. */
+  message: string;
+  /** Machine-readable cause for `unavailable` / `error` (`no-key`, `denied`, `unsupported`, …). */
+  reason?: string;
+  /** 0..1 while `loading`, when the loader can report it (a multi-megabyte download). */
+  progress?: number;
+}
+
+/** A `ready` status becomes `active` while the node is doing its job; anything else is
+ *  returned unchanged. Keeps "is it working" a one-line composition in `process()`. */
+export function withActive(status: LoadStatus, active: boolean, activeMessage?: string): LoadStatus {
+  if (status.phase !== 'ready' || !active) return status;
+  return { ...status, phase: 'active', message: activeMessage ?? status.message };
+}

--- a/src/lazy/status.ts
+++ b/src/lazy/status.ts
@@ -34,10 +34,16 @@ export interface LoadStatus {
   phase: LoadPhase;
   /** Short, human-readable explanation of the phase, always present. */
   message: string;
-  /** Machine-readable cause for `unavailable` / `error` (`no-key`, `denied`, `unsupported`, …). */
+  /** Machine-readable cause for `unavailable` / `error` (`no-key`, `denied`, `unsupported`, …),
+   *  and optionally a qualifier for `loading` (`permission`: waiting on a browser prompt,
+   *  which wants different player instructions than a download). */
   reason?: string;
   /** 0..1 while `loading`, when the loader can report it (a multi-megabyte download). */
   progress?: number;
+  /** Node-specific data that travels with the phase — the MIDI port list that comes
+   *  back WITH a `no-ports` / `port-not-found` result, for a selector to offer. Typed by
+   *  the node, opaque here. */
+  detail?: unknown;
 }
 
 /** A `ready` status becomes `active` while the node is doing its job; anything else is

--- a/test/lazy_resource.test.ts
+++ b/test/lazy_resource.test.ts
@@ -155,6 +155,103 @@ describe('lazyResource', () => {
     expect(d.calls).toHaveLength(2);
   });
 
+  it('rule 1+2 (review catch, stale settle first): the old load resolving does not clear the new load or let want(false) skip the release', async () => {
+    // Per-call resolvers, so the OLD load can settle while the NEW one is in flight.
+    const resolvers: Array<(r: LoadResult<string>) => void> = [];
+    const signals: AbortSignal[] = [];
+    const unloaded: string[] = [];
+    const r = lazyResource<string>({
+      load: (ctx) => {
+        signals.push(ctx.signal);
+        return new Promise((res) => resolvers.push(res));
+      },
+      unload: (s) => unloaded.push(s),
+    });
+    r.want(true); // A
+    r.want(false);
+    r.want(true); // B
+    expect(resolvers).toHaveLength(2);
+    resolvers[0]({ resource: 'A' }); // A settles late, B still loading
+    await flush();
+    expect(unloaded).toEqual(['A']);
+    expect(r.status().phase).toBe('loading'); // B's phase, untouched by A's settle
+    r.want(true); // must NOT start a third load
+    expect(resolvers).toHaveLength(2);
+    r.want(false); // must release B even though nothing is held yet
+    expect(signals[1].aborted).toBe(true);
+    resolvers[1]({ resource: 'B' });
+    await flush();
+    expect(r.current()).toBeNull(); // the enable control is off: nothing attached
+    expect(r.status().phase).toBe('off');
+    expect(unloaded).toEqual(['A', 'B']);
+  });
+
+  it('progress is absent until the loader reports one (no stuck 0% bar for a permission prompt)', () => {
+    const d = deferredLoader<string>();
+    const r = lazyResource({ load: d.load });
+    r.request();
+    expect(r.status()).toEqual({ phase: 'loading', message: 'Loading resource...' });
+    expect('progress' in r.status()).toBe(false);
+    d.calls[0].progress(0.5);
+    expect(r.status().progress).toBe(0.5);
+  });
+
+  it('rule 5 (teardown): an unload that throws is logged, never thrown from release()/want() or left unhandled', async () => {
+    const d = deferredLoader<string>();
+    const logs: string[] = [];
+    const r = lazyResource({
+      load: d.load,
+      unload: () => {
+        throw new Error('close failed');
+      },
+      label: 'port',
+      log: (m) => logs.push(m),
+    });
+    r.request();
+    d.resolve({ resource: 'p' });
+    await flush();
+    expect(() => r.want(false)).not.toThrow();
+    expect(logs).toEqual(['[lazy] port: unload failed: close failed']);
+    // Late arrival path too.
+    r.request();
+    r.release();
+    d.resolve({ resource: 'late' });
+    await flush();
+    expect(logs).toHaveLength(2);
+  });
+
+  it('gate: a synchronous capability check reports unavailable on the same tick, imports nothing, and re-checks after release', () => {
+    let supported = false;
+    const d = deferredLoader<string>();
+    const r = lazyResource({
+      load: d.load,
+      gate: () => (supported ? null : { reason: 'unsupported', message: 'No Web MIDI here' }),
+    });
+    r.request();
+    expect(r.status()).toEqual({ phase: 'unavailable', reason: 'unsupported', message: 'No Web MIDI here', detail: undefined });
+    expect(d.calls).toHaveLength(0);
+    r.request();
+    expect(d.calls).toHaveLength(0); // rule 3 applies to a gated result too
+    r.release();
+    supported = true;
+    r.request();
+    expect(d.calls).toHaveLength(1);
+  });
+
+  it('detail travels with the result in both branches (the MIDI port list that comes back WITH no-ports)', async () => {
+    const d = deferredLoader<string>();
+    const r = lazyResource({ load: d.load });
+    r.request();
+    d.resolve({ resource: null, reason: 'no-ports', detail: { ports: ['IAC Driver'] } });
+    await flush();
+    expect(r.status().detail).toEqual({ ports: ['IAC Driver'] });
+    r.release();
+    r.request();
+    d.resolve({ resource: 'sink', detail: { ports: ['IAC Driver', 'Synth'] } });
+    await flush();
+    expect(r.status()).toMatchObject({ phase: 'ready', detail: { ports: ['IAC Driver', 'Synth'] } });
+  });
+
   it('unload is called for a held resource on release, and only once', async () => {
     const d = deferredLoader<string>();
     const unloaded: string[] = [];

--- a/test/lazy_resource.test.ts
+++ b/test/lazy_resource.test.ts
@@ -1,0 +1,181 @@
+/**
+ * The five rules of `lazyResource` (#188), each pinned so the next heavy node does
+ * not re-make the bugs the hand-rolled copies made: request once, discard a late
+ * arrival, do not re-hammer a failure, retry on re-enable, never throw. Plus the
+ * status vocabulary and `withActive`.
+ */
+import { describe, it, expect } from 'vitest';
+import { lazyResource, withActive, type LoadResult, type LoadContext } from '@/lazy';
+
+/** A loader whose resolution the test controls. */
+function deferredLoader<T>() {
+  let resolve!: (r: LoadResult<T>) => void;
+  let reject!: (e: unknown) => void;
+  const calls: LoadContext[] = [];
+  const load = (ctx: LoadContext) => {
+    calls.push(ctx);
+    return new Promise<LoadResult<T>>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+  };
+  return { load, calls, resolve: (r: LoadResult<T>) => resolve(r), reject: (e: unknown) => reject(e) };
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+describe('lazyResource', () => {
+  it('rule 1: request() on every tick starts exactly one load, and reports loading then ready', async () => {
+    const d = deferredLoader<{ id: number }>();
+    const r = lazyResource({ load: d.load, label: 'thing' });
+    expect(r.status()).toEqual({ phase: 'off', message: 'thing off' });
+    for (let i = 0; i < 30; i++) r.request();
+    expect(d.calls).toHaveLength(1);
+    expect(r.status().phase).toBe('loading');
+    expect(r.current()).toBeNull();
+    d.resolve({ resource: { id: 1 } });
+    await flush();
+    expect(r.current()).toEqual({ id: 1 });
+    expect(r.status()).toEqual({ phase: 'ready', message: 'thing ready' });
+    r.request(); // already held: no second load
+    expect(d.calls).toHaveLength(1);
+  });
+
+  it('rule 2: a load that resolves after release() is unloaded on arrival, never attached', async () => {
+    const d = deferredLoader<string>();
+    const unloaded: string[] = [];
+    const r = lazyResource({ load: d.load, unload: (s) => unloaded.push(s) });
+    r.request();
+    expect(d.calls[0].signal.aborted).toBe(false);
+    r.release();
+    expect(d.calls[0].signal.aborted).toBe(true);
+    d.resolve({ resource: 'late' });
+    await flush();
+    expect(r.current()).toBeNull();
+    expect(unloaded).toEqual(['late']);
+    expect(r.status().phase).toBe('off');
+    // ...and the next request starts a FRESH load rather than staying wedged.
+    r.request();
+    expect(d.calls).toHaveLength(2);
+  });
+
+  it('rule 2 (dispose): a load resolving after dispose() is unloaded, and dispose is terminal', async () => {
+    const d = deferredLoader<string>();
+    const unloaded: string[] = [];
+    const r = lazyResource({ load: d.load, unload: (s) => unloaded.push(s) });
+    r.request();
+    r.dispose();
+    d.resolve({ resource: 'late' });
+    await flush();
+    expect(unloaded).toEqual(['late']);
+    r.request();
+    expect(d.calls).toHaveLength(1);
+    expect(r.current()).toBeNull();
+  });
+
+  it('rule 3: an unavailable result is reported with its reason and not re-requested every tick', async () => {
+    const d = deferredLoader<string>();
+    const r = lazyResource({ load: d.load, label: 'engine' });
+    r.request();
+    d.resolve({ resource: null, reason: 'no-key', message: 'Add an API key to enable the engine' });
+    await flush();
+    expect(r.status()).toEqual({ phase: 'unavailable', reason: 'no-key', message: 'Add an API key to enable the engine' });
+    for (let i = 0; i < 10; i++) r.request();
+    expect(d.calls).toHaveLength(1);
+  });
+
+  it('rule 4: release() after a failure clears it, so disable -> enable retries', async () => {
+    const d = deferredLoader<string>();
+    const r = lazyResource({ load: d.load });
+    r.request();
+    d.resolve({ resource: null, reason: 'denied' });
+    await flush();
+    r.release();
+    r.request();
+    expect(d.calls).toHaveLength(2);
+    d.resolve({ resource: 'ok' });
+    await flush();
+    expect(r.current()).toBe('ok');
+  });
+
+  it('rule 5: a rejecting loader becomes an error status (logged once) and nothing throws', async () => {
+    const d = deferredLoader<string>();
+    const logs: string[] = [];
+    const r = lazyResource({ load: d.load, label: 'model', log: (m) => logs.push(m) });
+    r.request();
+    d.reject(new Error('network down'));
+    await flush();
+    expect(r.status()).toEqual({ phase: 'error', reason: 'error', message: 'Could not load model: network down' });
+    expect(logs).toEqual(['[lazy] model: network down']);
+    r.request(); // not re-hammered
+    expect(d.calls).toHaveLength(1);
+  });
+
+  it('rule 5: a loader that throws synchronously is an error, not a throw from request()', async () => {
+    const r = lazyResource<string>({
+      load: () => {
+        throw new Error('boom');
+      },
+    });
+    expect(() => r.request()).not.toThrow();
+    await flush();
+    expect(r.status().phase).toBe('error');
+  });
+
+  it('reports loader progress while loading, clamped to 0..1, and ignores progress from a released load', async () => {
+    const d = deferredLoader<string>();
+    const r = lazyResource({ load: d.load });
+    r.request();
+    d.calls[0].progress(0.25);
+    expect(r.status()).toMatchObject({ phase: 'loading', progress: 0.25 });
+    d.calls[0].progress(7);
+    expect(r.status().progress).toBe(1);
+    r.release();
+    d.calls[0].progress(0.5);
+    expect(r.status().phase).toBe('off');
+  });
+
+  it('want(enabled) is the per-tick line: enabling requests, disabling releases, toggling retries', async () => {
+    const d = deferredLoader<string>();
+    const unloaded: string[] = [];
+    const r = lazyResource({ load: d.load, unload: (s) => unloaded.push(s) });
+    r.want(false);
+    r.want(false);
+    expect(d.calls).toHaveLength(0);
+    r.want(true);
+    r.want(true);
+    expect(d.calls).toHaveLength(1);
+    d.resolve({ resource: 'a' });
+    await flush();
+    expect(r.current()).toBe('a');
+    r.want(false);
+    expect(unloaded).toEqual(['a']);
+    expect(r.current()).toBeNull();
+    r.want(true);
+    expect(d.calls).toHaveLength(2);
+  });
+
+  it('unload is called for a held resource on release, and only once', async () => {
+    const d = deferredLoader<string>();
+    const unloaded: string[] = [];
+    const r = lazyResource({ load: d.load, unload: (s) => unloaded.push(s) });
+    r.request();
+    d.resolve({ resource: 'held' });
+    await flush();
+    r.release();
+    r.release();
+    r.dispose();
+    expect(unloaded).toEqual(['held']);
+  });
+});
+
+describe('withActive', () => {
+  it('promotes ready to active, with an optional message, and leaves every other phase alone', () => {
+    const ready = { phase: 'ready' as const, message: 'engine ready' };
+    expect(withActive(ready, true, 'Playing')).toEqual({ phase: 'active', message: 'Playing' });
+    expect(withActive(ready, true)).toEqual({ phase: 'active', message: 'engine ready' });
+    expect(withActive(ready, false)).toBe(ready);
+    const loading = { phase: 'loading' as const, message: 'Loading' };
+    expect(withActive(loading, true)).toBe(loading);
+  });
+});

--- a/test/load_status_readout.test.tsx
+++ b/test/load_status_readout.test.tsx
@@ -24,8 +24,8 @@ describe('LoadStatusReadout', () => {
 
   it('says off (and reports phase off) when the enable control is off, whatever the status', () => {
     const stale: LoadStatus = { phase: 'error', message: 'Could not load' };
-    render(<LoadStatusReadout status={stale} enabled={false} offMessage="Generative layer off" />);
-    const el = screen.getByText('Generative layer off');
+    render(<LoadStatusReadout status={stale} enabled={false} offMessage="Generative off" />);
+    const el = screen.getByText('Generative off');
     expect(phaseOf(el)).toBe('off');
     expect(screen.queryByText('Could not load')).toBeNull();
   });

--- a/test/load_status_readout.test.tsx
+++ b/test/load_status_readout.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+/**
+ * The shared lazy-load readout (#188): renders every phase of the shared vocabulary
+ * honestly — the message, the phase as a data attribute a panel test can pin, the
+ * reason for `unavailable`, a progress bar only while loading with known progress,
+ * and "off" whenever the enable control is off regardless of stale status.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { LoadStatusReadout } from '@/app/LoadStatusReadout';
+import type { LoadStatus } from '@/lazy';
+
+afterEach(cleanup);
+
+const phaseOf = (el: HTMLElement) => el.closest('[data-load-phase]')?.getAttribute('data-load-phase');
+
+describe('LoadStatusReadout', () => {
+  it('shows the message and phase for a ready / active status', () => {
+    render(<LoadStatusReadout status={{ phase: 'active', message: 'Playing' }} enabled />);
+    const el = screen.getByText('Playing');
+    expect(phaseOf(el)).toBe('active');
+    expect(screen.queryByRole('progressbar')).toBeNull();
+  });
+
+  it('says off (and reports phase off) when the enable control is off, whatever the status', () => {
+    const stale: LoadStatus = { phase: 'error', message: 'Could not load' };
+    render(<LoadStatusReadout status={stale} enabled={false} offMessage="Generative layer off" />);
+    const el = screen.getByText('Generative layer off');
+    expect(phaseOf(el)).toBe('off');
+    expect(screen.queryByText('Could not load')).toBeNull();
+  });
+
+  it('exposes the reason for an unavailable status so a panel can react (a key prompt, a hint)', () => {
+    render(
+      <LoadStatusReadout status={{ phase: 'unavailable', reason: 'no-key', message: 'Add a Gemini API key' }} enabled />,
+    );
+    const el = screen.getByText('Add a Gemini API key');
+    expect(el.closest('[data-load-reason]')?.getAttribute('data-load-reason')).toBe('no-key');
+  });
+
+  it('renders a progress bar only while loading with known progress', () => {
+    const { rerender } = render(<LoadStatusReadout status={{ phase: 'loading', message: 'Loading model', progress: 0.4 }} enabled />);
+    expect(screen.getByRole('progressbar').getAttribute('aria-valuenow')).toBe('40');
+    rerender(<LoadStatusReadout status={{ phase: 'loading', message: 'Connecting' }} enabled />);
+    expect(screen.queryByRole('progressbar')).toBeNull();
+  });
+});

--- a/tsconfig.dag.json
+++ b/tsconfig.dag.json
@@ -7,7 +7,7 @@
     "noUnusedParameters": true,
     "types": ["node", "vitest/globals"]
   },
-  "include": ["src/dag", "src/nodes", "src/music", "src/features", "src/settings", "src/taglog", "src/enroll", "src/app/graph.ts", "src/app/featureDemand.ts", "src/app/enroll", "src/app/lab", "test", "scripts"],
+  "include": ["src/dag", "src/lazy", "src/nodes", "src/music", "src/features", "src/settings", "src/taglog", "src/enroll", "src/app/graph.ts", "src/app/featureDemand.ts", "src/app/enroll", "src/app/lab", "test", "scripts"],
   "//exclude": "The jsdom SHELL tests are .tsx (they render React components) and this project ships no @types/react by design — same reason the React app layer is excluded. Vitest still runs them; Vite/esbuild type-erases the JSX.",
   "exclude": ["test/**/*.test.tsx", "src/app/enroll/**/*.tsx"]
 }


### PR DESCRIPTION
PR 2 of #188 (`docs/design/generative-instruments.md` §5, landing in #190's predecessor PR).

**The rule**, from the maintainer: load only what is needed, when it is needed. Three sites already do it by hand (`webcam_face.ts`, `recording/formats.ts`, `midi_out.ts`), each with its own state machine and its own status words, and the bugs #147's review found were bugs in that hand-rolling. This extracts the machine once.

## What lands

- `src/lazy/resource.ts` — `lazyResource<T>()`: a synchronous API a node's `process()` calls every tick (`want(enabled)`, `current()`, `status()`) over an injectable async loader (the seam: a host-injected factory, or the default dynamic `import()` of a browser-only sibling). Five rules, each a test: request once; a late arrival is discarded (and the loader's `AbortSignal` fires); a failure is not re-hammered; re-enable retries; never throw (a rejecting loader, a synchronously throwing loader, or a throwing `unload` all become status + a log line). Plus a synchronous `gate` for capability checks (no "Loading…" flash on Safari for Web MIDI) and a `detail` payload (the MIDI port list that comes back *with* a `no-ports` result).
- `src/lazy/status.ts` — the one phase vocabulary (`off | unavailable | loading | ready | active | error`, `reason`, `progress`, `detail`) and `withActive`.
- `src/app/LoadStatusReadout.tsx` — the MIDI panel's dot + message generalised, with a progress bar only when the loader reported progress.
- `docs/design/lazy-loading.md` — the pattern page: the three parts, the module, the adopters table (lyria adopts next; `midi-out` / `webcam-face` are reference sites, not migrated; #186 and #187 are asked to adopt), and the three idioms the existing sites need (keyed request, run-after-attach, sync gate).

## Review

Adversarial review (separate agent, refute-by-default): 8 findings. The serious one: a load superseded by `release()` + a new `request()` cleared the in-flight flag on its stale settle, so a second load could start beside the first and `want(false)` could skip the release — a **disabled node attached a resource and reported ready**, the exact #147 bug class this module exists to retire. Fixed (a stale settle touches nothing of a newer load), pinned by two interleaving tests, and mutation-checked: restoring the bug fails the suite. The rest (progress absent until reported, unload never throws, gate, detail, five unbacked doc claims) fixed.

## Reachability

No user-facing surface, on purpose: this is a module and a rule. Its first adopter (`lyria`, next PR) is what a player meets.

## Gates

`npm run typecheck` clean; `npm test` 111 files / 1430 tests; `npm run build` green. No nodes or ports changed, so no catalog regeneration.

Refs #188.

https://claude.ai/code/session_01Gzvj7aM4hNkdDx3iwLYcXA