### PR TITLE
docs: CLAUDE.md pointed at a module #189 deleted — fix the row, and guard the class

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,12 +219,12 @@ So, when you add a user-facing capability:
 
 | Area | Path |
 |------|------|
-| DAG engine (framework-agnostic) | `src/dag/` (`engine.ts`, `types.ts`, `registry.ts`, `recorder.ts`, `clock.ts`) |
+| DAG engine (framework-agnostic) | `src/dag/` (`engine.ts`, `types.ts`, `registry.ts`, `recorder.ts`, `clock.ts`, `applier.ts`, `merge.ts`) |
 | Node library | `src/nodes/{sources,features,mapping,music,output}/` |
 | Default graph wiring + the `SLOTS` table (role-typed swap points) | `src/app/graph.ts` |
 | **Slot contracts** — what a candidate must declare to fill a slot | `src/nodes/slot_contract.ts`, `src/nodes/mapping/mapping_contract.ts`, `src/nodes/sources/source_contract.ts` |
 | React↔DAG bridge (webcam, AudioContext, recorder, slot selection) | `src/app/useEngine.ts` |
-| Live frame loop — the app's `Clock` adoption (tick + per-frame reporters + frame-drop guard) | `src/app/engineLoop.ts` |
+| Live frame loop — an `Applier` config: `RealtimeClock`, the React bridges as sinks (through the seconds→ms converter), `disposed` as the stop condition | `src/app/useEngine.ts` (the effect), `src/dag/applier.ts` |
 | Live control store (zustand+persist) — the hot per-tick mirror | `src/app/store.ts` |
 | Music theory + **sounds** (timbre presets) | `src/music/` (`theory.ts`, `sounds.ts`, `voicing.ts`, `expression.ts`) |
 | Overlay (compose elements here) | `src/nodes/output/canvas_overlay.ts` |

--- a/test/claude_md_paths.test.ts
+++ b/test/claude_md_paths.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Every repo path CLAUDE.md names must exist.
+ *
+ * CLAUDE.md's "Where things live" table is the map a fresh agent navigates by, and a row
+ * pointing at a deleted file is worse than no row: it sends someone looking for a module
+ * that moved, and it reads as authoritative. It happens by omission — you delete a module
+ * in a PR about something else and the map is not part of the diff. It happened in #189,
+ * which removed `src/app/engineLoop.ts` and left the row behind.
+ *
+ * The check is deliberately dumb: extract every backticked `src|test|scripts|docs/...`
+ * path and assert it resolves. That is enough to catch the whole class, and it costs
+ * nothing to keep true.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * Paths CLAUDE.md names in order to say they do NOT exist.
+ *
+ * `src/music/instruments.ts` is the one: the "sound vs instrument" section exists because
+ * both words were taken, and it says plainly *"There is no `src/music/instruments.ts`. If
+ * you are looking for the timbre enum, it is `src/music/sounds.ts`."* A path audit that
+ * "fixed" that by creating the file, or by deleting the sentence, would destroy the
+ * warning. Listed here so the exception is explicit rather than a silent regex hole.
+ */
+const DELIBERATELY_ABSENT = new Set(['src/music/instruments.ts']);
+
+function citedPaths(md: string): string[] {
+  const out = new Set<string>();
+  for (const m of md.matchAll(/`((?:src|test|scripts|docs)\/[A-Za-z0-9_./-]+)`/g)) {
+    const p = m[1];
+    // Trailing punctuation inside the backticks, and directory citations, are fine.
+    out.add(p.replace(/[.,]$/, ''));
+  }
+  return [...out].sort();
+}
+
+describe('CLAUDE.md is a map you can navigate by', () => {
+  const md = readFileSync(resolve(ROOT, 'CLAUDE.md'), 'utf8');
+  const cited = citedPaths(md);
+
+  it('cites a meaningful number of paths (the extractor still works)', () => {
+    // Guards the guard: a regex that silently matched nothing would make every
+    // assertion below vacuously true.
+    expect(cited.length).toBeGreaterThan(30);
+  });
+
+  it('every path it names exists, except the ones it names to say they do not', () => {
+    const missing = cited.filter((p) => !DELIBERATELY_ABSENT.has(p) && !existsSync(resolve(ROOT, p)));
+    expect(missing, `CLAUDE.md points at paths that do not exist:\n  ${missing.join('\n  ')}`).toEqual([]);
+  });
+
+  it('the deliberate absences are still absent — the warning is only useful while true', () => {
+    for (const p of DELIBERATELY_ABSENT) {
+      expect(existsSync(resolve(ROOT, p)), `${p} now exists; CLAUDE.md says it does not`).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
Small, and it closes a class.

#189 removed `src/app/engineLoop.ts` and left its "Where things live" row behind. That
table is the map a fresh agent navigates by, so a row pointing at a deleted file is worse
than no row — it sends someone looking for a module that moved, and it reads as
authoritative. My omission: the map was not part of that diff.

The row now describes what actually runs the live loop — an `Applier` config in
`useEngine`'s effect — and names the seconds→ms converter, since that is the part anyone
touching it needs to know. The DAG-engine row gains `applier.ts` and `merge.ts`.

## The guard is the point

`test/claude_md_paths.test.ts` extracts every backticked `src|test|scripts|docs/...` path
from CLAUDE.md and asserts it resolves. Deliberately dumb — that is enough to catch the
whole class, and it costs nothing to keep true.

**One exception, listed explicitly rather than left as a regex hole.**
`src/music/instruments.ts` is named in CLAUDE.md in order to say it does *not* exist ("if
you are looking for the timbre enum, it is `src/music/sounds.ts`"). That section exists
because both words were taken, and a path audit that "fixed" it by creating the file — or
by deleting the sentence — would destroy the warning. A third test asserts the deliberate
absences are still absent, because the warning is only useful while true.

## Verification

- Both guards mutation-tested, including **guard-the-guard**: an extractor matching nothing
  would make the whole file vacuously green, so a minimum-count assertion fails if the
  regex stops working.
- Full suite green; typecheck and build clean.

Found by thoremin-0908 while reviewing. I verified it against git before changing anything
rather than editing on the report alone.

https://claude.ai/code/session_019MqaXSdxoS9hdavMAAMVvu