### PR TITLE
fix(#127): undo destroyed slider drags — apply a key delta, not the whole layer

### DIFF
--- a/src/app/commands/history.ts
+++ b/src/app/commands/history.ts
@@ -37,6 +37,15 @@
  *   skips drags entirely. That is arguably the correct coalescing — you rarely want to
  *   undo one pointer-move frame — but it is a consequence, not a decision anyone made,
  *   so it is stated rather than discovered.
+ *
+ *   It also had a sharp edge that took a sweep to find. Entries snapshot the WHOLE
+ *   editable layer, so applying `before` wholesale reverted *everything* written since
+ *   the dispatch — including those invisible drags, which could never be redone because
+ *   they were never recorded. Undo is therefore applied as a **key delta**
+ *   ({@link applyDelta}): only the keys the command itself changed are moved, and a
+ *   concurrent drag on any other key survives. Two decisions that were each correct
+ *   alone combined into silent data loss, which is the kind of thing only an adversarial
+ *   read finds.
  * - **Undo/redo apply via `setLayer`, outside dispatch.** So the middleware never sees
  *   its own writes and cannot record an undo of an undo. `redo` is what re-applies.
  */
@@ -132,6 +141,42 @@ export function layersEqual(a: Layer, b: Layer): boolean {
 }
 
 /**
+ * Move the CURRENT layer from `from` to `to`, touching only the keys those two differ on.
+ *
+ * The whole point is the keys they do NOT differ on: those are left exactly as the live
+ * layer has them. A history entry snapshots the whole editable layer either side of a
+ * dispatch, so writing `before` back wholesale also reverts everything written since —
+ * and slider drags are written outside dispatch on purpose (Decision B: routing a
+ * write-per-pointer-move through validation and a promise costs latency where latency is
+ * audible). Undo then silently destroyed the drag, with no way back, because a drag was
+ * never in the history to redo.
+ *
+ * Three cases, and the second and third are why this is not a spread:
+ *  - **changed** in both -> take `to`'s value
+ *  - **added** by the step (absent in `from`, present in `to`) -> set it
+ *  - **removed** by the step (present in `from`, absent in `to`) -> DELETE the key,
+ *    because writing `undefined` leaves the key present, and `'k' in layer` is the
+ *    difference between a dial that is unset and one explicitly set to nothing.
+ */
+function applyDelta(current: Layer, from: Layer, to: Layer): Layer {
+  const out = cloneLayer(current) as Record<string, unknown>;
+  const keys = new Set([...Object.keys(from), ...Object.keys(to)]);
+  for (const k of keys) {
+    const inFrom = k in from;
+    const inTo = k in to;
+    if (inFrom && inTo) {
+      if (!deepEqual((from as Record<string, unknown>)[k], (to as Record<string, unknown>)[k])) {
+        out[k] = cloneValue((to as Record<string, unknown>)[k]);
+      }
+      continue;
+    }
+    if (inTo) out[k] = cloneValue((to as Record<string, unknown>)[k]);
+    else delete out[k];
+  }
+  return out as Layer;
+}
+
+/**
  * Build an undo history over a dials-like store. `limit` bounds the undo stack; the
  * oldest entry is dropped when it is exceeded.
  */
@@ -162,14 +207,14 @@ export function createDialsHistory(
     undo() {
       const entry = undoStack.pop();
       if (!entry) return false;
-      store.setLayer(cloneLayer(entry.before));
+      store.setLayer(applyDelta(store.getState().layer, entry.after, entry.before));
       redoStack.push(entry);
       return true;
     },
     redo() {
       const entry = redoStack.pop();
       if (!entry) return false;
-      store.setLayer(cloneLayer(entry.after));
+      store.setLayer(applyDelta(store.getState().layer, entry.before, entry.after));
       undoStack.push(entry);
       return true;
     },

--- a/test/commands_middleware.test.ts
+++ b/test/commands_middleware.test.ts
@@ -167,6 +167,53 @@ describe('undo/redo over the dials layer (#127)', () => {
     expect(dialsStore.getState().effective['right.root']).toBe(5);
   });
 
+  // Decision B (docs + CLAUDE.md): a continuous range slider being DRAGGED writes the
+  // store directly, deliberately, because routing a write-per-pointer-move through Zod
+  // validation and a promise costs latency on the one interaction where latency is
+  // audible. #127 then chose to snapshot the WHOLE editable layer per dispatch rather
+  // than register per-command inverses, so a command added later gets undo for free.
+  //
+  // Each decision is right on its own. Together they lose data: undo wrote `entry.before`
+  // back wholesale, so every direct write made after the last dispatch was destroyed —
+  // silently, and with no way to get it back, since a drag was never in the history.
+  it('does not destroy direct writes made after the last dispatched command', async () => {
+    const { registry, history } = wiredRegistry();
+    await registry.dispatch('dial.set', { key: 'right.root', value: 5 });
+
+    // The drag: a direct store write, exactly as a slider does it.
+    dialsStore.setLayer({ ...dialsStore.getState().layer, 'right.detune': 42 });
+    expect(dialsStore.getState().layer['right.detune']).toBe(42);
+
+    history.undo();
+
+    // The command's own key reverts...
+    expect(dialsStore.getState().layer['right.root']).toBeUndefined();
+    // ...and the drag survives, because undo never touched that key.
+    expect(dialsStore.getState().layer['right.detune']).toBe(42);
+  });
+
+  it('redo also leaves untouched keys alone', async () => {
+    const { registry, history } = wiredRegistry();
+    await registry.dispatch('dial.set', { key: 'right.root', value: 5 });
+    history.undo();
+    dialsStore.setLayer({ ...dialsStore.getState().layer, 'right.detune': 7 });
+
+    history.redo();
+    expect(dialsStore.getState().effective['right.root']).toBe(5);
+    expect(dialsStore.getState().layer['right.detune']).toBe(7);
+  });
+
+  it('undo REMOVES a key the command added, rather than leaving it behind', async () => {
+    // The delta has to handle key creation, not just value change: `before` has no such
+    // key at all, so "write before's value" would write undefined and leave the key set.
+    const { registry, history } = wiredRegistry();
+    expect(dialsStore.getState().layer['left.root']).toBeUndefined();
+    await registry.dispatch('dial.set', { key: 'left.root', value: 9 });
+    expect('left.root' in dialsStore.getState().layer).toBe(true);
+    history.undo();
+    expect('left.root' in dialsStore.getState().layer).toBe(false);
+  });
+
   it('treats an atomic dial.patch as ONE undo entry', async () => {
     const { registry, history } = wiredRegistry();
     await registry.dispatch('dial.patch', {


### PR DESCRIPTION
Found by an adversarial sweep of the last ~10 PRs, and confirmed against shipped code.
Two decisions that are each correct on their own combine into silent data loss.

## The bug

- **Decision B** — a continuous range slider being *dragged* writes the store directly, on
  purpose: routing a write-per-pointer-move through Zod validation, the confirmation gate
  and a promise costs latency on the one interaction where latency is audible.
- **#127** — history snapshots the **whole editable layer** either side of a dispatch,
  rather than registering per-command inverses, so a command added later gets undo for
  free and `dial.patch` cannot be half-undone.

Together, `undo()` wrote `entry.before` back wholesale — reverting *everything* written
since that dispatch.

**What a player sees.** Set a sound from the Voice panel. Spend ten seconds dragging a
detune slider to taste. Press ⌘Z to undo the sound. The detune is gone — silently, and
unrecoverably, because a drag was never in the history to redo.

## The fix

Undo and redo now move only the keys the command itself changed. Keys the entry does not
mention keep whatever the live layer has, so a concurrent drag survives. `dial.patch` stays
atomic — its keys are all in the one entry and move together.

Three cases, and the last is why this is not a spread:

| | |
|---|---|
| changed in both | take the target's value |
| added by the step | set it |
| **removed** by the step | **delete the key**, not write `undefined` |

`'k' in layer` is the difference between a dial that is *unset* and one explicitly set to
nothing, and the dials store reads that distinction — writing `undefined` would leave the
key present and change the meaning.

## Verification

- Three regression tests, **all mutation-verified**: reverting undo to a wholesale replace
  fails one ✗, reverting redo fails one ✗, writing `undefined` instead of deleting fails
  three ✗.
- Full suite green; typecheck and build clean.

The module docstring described the old behaviour under "two properties to know". It now
records the edge and why the delta exists — that section is there precisely to stop this
being rediscovered.

https://claude.ai/code/session_019MqaXSdxoS9hdavMAAMVvu