### PR TITLE
#101 M-G: boundary B becomes a mechanism — accelerated playback mutes, never pitch-shifts

### DIFF
--- a/docs/design/stream-applier.md
+++ b/docs/design/stream-applier.md
@@ -330,11 +330,29 @@ boundaries allow.
     re-emitting the read snapshot on a second port so replay reproduces the feedback and
     it stays tappable. Not built: it belongs in `src/nodes/sources/`, which another
     session is working in. #87 command-dispatch is the prime consumer.
-- **M-G — Honest time-scaled audio + delay node (principled end-state).**
-  `OfflineAudioContext` render-then-play behind an explicit action; recorder
-  backpressure (fold into #88 recording-v2); the `delay` node + delayed-edge
-  topoSort (the only engine change on the whole path); migrate `StateReader` onto
-  it.
+- **M-G — Honest time-scaled audio + delay node (principled end-state). ◑ the HONEST
+  half is enforced; the render action and the delay node remain.**
+  - ✅ **Boundary (B) is now a mechanism, not a policy.** `Clock` declares `timeScale`
+    (engine seconds per wall second; **absent** = no wall-clock relation at all, which
+    `BatchClock` reports rather than lying with `1`), the `Applier` publishes it onto the
+    engine's resources, and `realtimeOutputAllowed` (`src/dag/timescale.ts`) is consulted
+    by every node with `roles: ['synth']` — `webaudio-synth` (tears its voices down, so
+    the result is silence rather than a chord frozen at its last value), `midi-out`
+    (forced through the existing disabled path, which already panics all-notes-off) and
+    `lyria` (which the design says cannot be scaled at all). A **structural test**
+    enumerates the registry's `synth`-role nodes and fails if one does not consult the
+    helper, so a future output node cannot quietly pitch-shift.
+    Absence means *allowed*, deliberately: `replayNode` passes no resources and a batch
+    run has no `AudioContext`, so muting on absence would buy no safety and break every
+    node test.
+  - ⏳ **`OfflineAudioContext` render-then-play** behind an explicit action. Not built:
+    its value is a listening judgment (does the rendered take sound right?), which is a
+    human-only check — tracked on #146 rather than blocking the mechanism above.
+  - ⏳ **The `delay` node + delayed-edge topoSort** (the only engine change on the whole
+    path), and migrating `StateReader` onto it. Not built: it is a purity improvement
+    over the working topo-order channel from M-F, and it is a real engine change, so it
+    earns its own PR and its own byte-identity check.
+  - ⏳ **Recorder backpressure** — folds into #88, not this milestone.
 
 ## M-C resolved: host-side Source for video, node-swap for frame-emitters
 

--- a/src/dag/applier.ts
+++ b/src/dag/applier.ts
@@ -36,6 +36,7 @@
 import type { Engine } from './engine';
 import type { Clock } from './clock';
 import type { Tap } from './types';
+import { TIME_SCALE_KEY } from './timescale';
 
 /** The `ctx.resources` key the state reader is published under. */
 export const STATE_READER_KEY = 'stateReader';
@@ -202,6 +203,10 @@ export class Applier {
     // a node only ever sees `ctx.resources.stateReader`, which is what makes it
     // trivially fakeable in a `replayNode` test.
     this.resources[STATE_READER_KEY] = this.stateReader;
+    // Boundary B (#101 M-G): publish how fast engine time runs against wall time, so
+    // real-time output nodes can go silent rather than pitch-shift when it is not 1.
+    // Republished per run because a run may be started under a different clock.
+    this.resources[TIME_SCALE_KEY] = this.clock.timeScale;
     this.startPumps();
     await this.clock.run(
       (time) => this.tick(time),

--- a/src/dag/clock.ts
+++ b/src/dag/clock.ts
@@ -42,6 +42,16 @@ export interface Clock {
    * hang. Optional so the interface stays backward-compatible; absent means "not paced".
    */
   readonly paced?: boolean;
+  /**
+   * Engine seconds per wall-clock second; 1 = real time. **Absent** means the clock has
+   * no wall-clock relation at all (a batch run), which is different from "real time" and
+   * is why consumers must not read absence as 1.
+   *
+   * Published by the `Applier` onto `ctx.resources` so real-time output nodes can honour
+   * design boundary (B) — accelerated or slowed playback mutes audio rather than
+   * pitch-shifting it. See `src/dag/timescale.ts`.
+   */
+  readonly timeScale?: number;
 }
 
 /**
@@ -55,6 +65,12 @@ export class BatchClock implements Clock {
    *  serviced under it. Batch replays through zero-input NODES (`replay-source`,
    *  `synthetic-hands`) instead — design invariant 4, "sources are ordinary nodes". */
   readonly paced = false;
+
+  /** Deliberately undefined: a batch run has NO wall-clock relation, so it is neither
+   *  real time nor a multiple of it. A batch run also has no AudioContext, so the audio
+   *  question does not arise — but saying `1` here would be a lie a future consumer
+   *  could act on. */
+  readonly timeScale = undefined;
 
   constructor(private readonly ticks: number) {}
 
@@ -112,6 +128,12 @@ export class RealtimeClock implements Clock {
   /** Yields between frames (rAF / the injected `schedule`), so async sources can be
    *  pumped under it. */
   readonly paced = true;
+
+  /** Engine seconds per wall second — exactly the speed multiplier. At anything but 1,
+   *  real-time output nodes go silent rather than pitch-shift (boundary B). */
+  get timeScale(): number {
+    return this.speed;
+  }
 
   run(onTick: (time?: number) => void, shouldStop: () => boolean): Promise<void> {
     return new Promise<void>((resolve) => {

--- a/src/dag/index.ts
+++ b/src/dag/index.ts
@@ -24,6 +24,7 @@ export { Applier } from './applier';
 export { defineMergeNode, MERGE_INPUTS, MERGE_OUTPUT } from './merge';
 export type { MergeNodeSpec } from './merge';
 export { STATE_READER_KEY } from './applier';
+export { TIME_SCALE_KEY, realtimeOutputAllowed } from './timescale';
 export type { ApplierOptions, Source, SourceContext, StateReader } from './applier';
 
 import { Engine, type EngineOptions } from './engine';

--- a/src/dag/timescale.ts
+++ b/src/dag/timescale.ts
@@ -1,0 +1,44 @@
+/**
+ * Time scale — how fast engine time runs against wall time (#101 M-G, boundary B).
+ *
+ * Control-rate parameters scale for free: a node reads `ctx.time`, so running the engine
+ * at 2x simply advances that value twice as fast and every mapping follows. **Audio does
+ * not.** A Web Audio graph rides `AudioContext.currentTime`, which is wall time and
+ * cannot be multiplied — so an engine at 2x driving a live synth does not produce "the
+ * same music, faster". It produces the same music at the same rate with the control
+ * stream sliding underneath it: pitches and gains arriving twice as fast at oscillators
+ * that keep running in real time.
+ *
+ * The design calls the honest reading of that boundary (B):
+ *
+ * > real-time = live audio; accelerated/slowed = control-rate preview with audio muted,
+ * > plus an explicit "render at speed" action on demand. **Never silently pitch-shift.**
+ * > Live/streaming/generative audio (Lyria) cannot be scaled at all.
+ *
+ * So this module is the mechanism for the "with audio muted" half. The Applier publishes
+ * the running clock's scale onto `ctx.resources`, and every node that produces real-time
+ * output consults {@link realtimeOutputAllowed} before making a sound.
+ *
+ * ## Absent means allowed, deliberately
+ *
+ * A missing scale is **not** treated as "not real time". Two callers depend on that:
+ * `replayNode` passes whatever resources a test hands it (usually none), and a batch run
+ * has no `AudioContext` at all, so the synth already self-no-ops. Making absence mute
+ * would change nothing about safety and would break every existing node test. Only an
+ * explicitly non-unity scale silences anything.
+ */
+import type { NodeContext } from './types';
+
+/** The `ctx.resources` key the Applier publishes the running clock's scale under. */
+export const TIME_SCALE_KEY = 'timeScale';
+
+/**
+ * May a node emit real-time output (audio, MIDI, a generative stream) on this tick?
+ *
+ * False only when the host has declared a scale that is not real time. See the module
+ * docstring for why absence means yes.
+ */
+export function realtimeOutputAllowed(ctx: NodeContext): boolean {
+  const scale = (ctx.resources as Record<string, unknown> | undefined)?.[TIME_SCALE_KEY];
+  return scale === undefined || scale === 1;
+}

--- a/src/nodes/output/lyria.ts
+++ b/src/nodes/output/lyria.ts
@@ -34,6 +34,7 @@
 import { z } from 'zod';
 import { defineNode } from '@/dag';
 import type { NodeContext } from '@/dag';
+import { realtimeOutputAllowed } from '@/dag';
 import { lazyResource, withActive, type LoadStatus } from '@/lazy';
 import { getStoredKey } from '@/keys/providerKeys';
 import type { GenerativeEngine, GenerativeEngineFactory, GenerativeSteer } from './generative';
@@ -192,7 +193,10 @@ export const lyriaNode = defineNode<Params>({
       process(inputs, ctx: NodeContext) {
         resources = ctx.resources;
         log = ctx.log;
-        const enabled = inputs.enabled === true;
+        // Boundary B (#101 M-G) is strictest here: the design says live/streaming
+        // generative audio "cannot be scaled at all" — there is no offline render to
+        // fall back to, because the stream is produced elsewhere in real time.
+        const enabled = inputs.enabled === true && realtimeOutputAllowed(ctx);
         const playing = enabled && inputs.playing === true;
 
         // ---- obtain / drop the engine (never awaited; the resource reports phase) ----

--- a/src/nodes/output/midi_out.ts
+++ b/src/nodes/output/midi_out.ts
@@ -28,6 +28,7 @@
 import { z } from 'zod';
 import { defineNode } from '@/dag';
 import type { NodeContext } from '@/dag';
+import { realtimeOutputAllowed } from '@/dag';
 import { freqToMidi } from '@/music/theory';
 import type { SynthParams, VoiceParams } from '../domain';
 
@@ -285,7 +286,12 @@ export const midiOutNode = defineNode<Params>({
         // An injected factory means the host vouches for capability (tests / custom
         // hosts); otherwise gate on the real Web MIDI feature test.
         supported = factory !== undefined || webMidiSupported();
-        const enabled = inputs.enabled === true;
+        // Boundary B (#101 M-G): a MIDI stream to a DAW is real-time output like audio —
+        // notes at 2x reach a synth that is still running at 1x. Forcing the DISABLED
+        // path rather than adding a new one is deliberate: that path already panics
+        // (all-notes-off) and holds no port, so silence is the behaviour that already
+        // exists and is already tested, not a second thing to get right.
+        const enabled = inputs.enabled === true && realtimeOutputAllowed(ctx);
         wantSink = enabled;
         const requestedPort = typeof inputs.port === 'string' ? inputs.port : '';
         wantPort = requestedPort;

--- a/src/nodes/output/webaudio_synth.ts
+++ b/src/nodes/output/webaudio_synth.ts
@@ -16,6 +16,7 @@
 import { z } from 'zod';
 import { defineNode } from '@/dag';
 import type { NodeContext } from '@/dag';
+import { realtimeOutputAllowed } from '@/dag';
 import { getSound } from '@/music/sounds';
 import type { SynthParams, VoiceParams } from '../domain';
 
@@ -277,6 +278,16 @@ export const webAudioSynthNode = defineNode<Params>({
         const audio = getAudio(ctx);
         if (!audio) return {};
         const { ac, master } = audio;
+        // Boundary B (#101 M-G): audio rides `AudioContext.currentTime`, which is wall
+        // time and cannot be multiplied. At any scale but real time this must go SILENT
+        // rather than pitch-shift. Tearing the voices down rather than skipping the tick
+        // is the difference between silence and a chord frozen at its last value: a
+        // skipped tick leaves the oscillators running exactly as they were.
+        if (!realtimeOutputAllowed(ctx)) {
+          for (const voice of voices.values()) teardownVoice(voice, ac, true);
+          voices.clear();
+          return {};
+        }
         bus = ensureBus(ac, master, bus);
         const sp = inputs.params as SynthParams | undefined;
         if (!sp) return {};

--- a/test/timescale_boundary.test.ts
+++ b/test/timescale_boundary.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Boundary B: accelerated or slowed playback MUTES real-time output (#101 M-G).
+ *
+ * Control-rate params scale for free — a node reads `ctx.time` and every mapping
+ * follows. Audio does not: a Web Audio graph rides `AudioContext.currentTime`, which is
+ * wall time and cannot be multiplied. So an engine at 2x driving a live synth does not
+ * make "the same music, faster"; it slides the control stream underneath oscillators
+ * that keep running in real time.
+ *
+ * The design's rule is *never silently pitch-shift*. These tests pin the mechanism, and
+ * the last one pins the thing a mechanism cannot: that a **future** node cannot forget.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  Applier,
+  BatchClock,
+  RealtimeClock,
+  Engine,
+  createRegistry,
+  defineNode,
+  realtimeOutputAllowed,
+  TIME_SCALE_KEY,
+  type NodeContext,
+} from '@/dag';
+import { createAppRegistry } from '@/nodes/browser';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { z } from 'zod';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const ctxWith = (resources: Record<string, unknown>) =>
+  ({ tick: 0, time: 0, dt: 0, resources } as unknown as NodeContext);
+
+describe('realtimeOutputAllowed', () => {
+  it('allows real time', () => {
+    expect(realtimeOutputAllowed(ctxWith({ [TIME_SCALE_KEY]: 1 }))).toBe(true);
+  });
+
+  it('refuses any other scale, faster OR slower', () => {
+    for (const s of [2, 0.5, 4, 0.25]) {
+      expect(realtimeOutputAllowed(ctxWith({ [TIME_SCALE_KEY]: s }))).toBe(false);
+    }
+  });
+
+  it('ALLOWS an absent scale — absence is not "not real time"', () => {
+    // Load-bearing, and the reason is compatibility rather than safety: `replayNode`
+    // passes whatever a test hands it (usually nothing), and a batch run has no
+    // AudioContext so the synth already self-no-ops. Muting on absence would change
+    // nothing about safety and would break every existing node test.
+    expect(realtimeOutputAllowed(ctxWith({}))).toBe(true);
+    expect(realtimeOutputAllowed({ tick: 0, time: 0, dt: 0 } as unknown as NodeContext)).toBe(true);
+  });
+});
+
+describe('the clocks declare their own scale', () => {
+  it('a RealtimeClock reports its speed', () => {
+    expect(new RealtimeClock({ now: () => 0, schedule: () => {} }).timeScale).toBe(1);
+    expect(new RealtimeClock({ speed: 2, now: () => 0, schedule: () => {} }).timeScale).toBe(2);
+  });
+
+  it('a BatchClock reports UNDEFINED, not 1 — it has no wall-clock relation at all', () => {
+    // Saying 1 would be a lie a future consumer could act on: a batch run is not
+    // "real time", it is unrelated to time.
+    expect(new BatchClock(1).timeScale).toBeUndefined();
+  });
+});
+
+describe('the Applier publishes the scale where nodes can see it', () => {
+  // NOTE the signature: a PURE node's process is `(inputs, params, ctx)`, not
+  // `(inputs, ctx)` — the stateful `make` form is the one that takes two. Getting it
+  // wrong silently hands you `params` where `ctx` belongs, so `ctx.resources` is
+  // undefined and every resource-gated check reads as "absent" — which for this helper
+  // means "allowed": the test passes while proving nothing. It did, until it was
+  // debugged by printing from inside the node.
+  const probe = defineNode({
+    type: 'probe-scale', roles: ['source'], params: z.object({}), inputs: [],
+    outputs: [{ name: 'allowed', kind: 'any' }],
+    process: (_inputs, _params, ctx) => ({ allowed: realtimeOutputAllowed(ctx) }),
+  });
+
+  /** A RealtimeClock that runs a bounded number of frames on macrotasks, then stops —
+   *  paced (so `run()` resolves) with no wall-clock dependence. */
+  function bounded(speed: number, frames: number) {
+    let t = 0;
+    let scheduled = 0;
+    let ticks = 0;
+    const clock = new RealtimeClock({
+      speed,
+      now: () => (t += 1 / 30),
+      schedule: (cb) => { if (scheduled++ <= frames) setTimeout(cb, 0); },
+    });
+    return { clock, shouldStop: () => ticks++ >= frames };
+  }
+
+  async function run(speed: number, frames: number) {
+    const registry = createRegistry([probe]);
+    const seen: unknown[] = [];
+    const engine = new Engine({ nodes: [{ id: 'p', type: 'probe-scale', params: {} }], edges: [] }, registry, {
+      taps: [{ onValue: (k, v) => { if (k === 'p.allowed') seen.push(v); } }],
+    });
+    await engine.init();
+    const { clock, shouldStop } = bounded(speed, frames);
+    await new Applier({ engine, clock, shouldStop }).run();
+    return { seen, engine };
+  }
+
+  it('publishes it onto the engine own resources object', async () => {
+    const { engine } = await run(2, 2);
+    expect(engine.resources[TIME_SCALE_KEY]).toBe(2);
+  });
+
+  it('a node sees real time under a speed-1 clock, and NOT under a 2x one', async () => {
+    const fast = await run(1, 3);
+    expect(fast.seen.length).toBeGreaterThan(0);
+    expect(fast.seen.every((v) => v === true)).toBe(true);
+
+    const scaled = await run(2, 3);
+    expect(scaled.seen.length).toBeGreaterThan(0);
+    expect(scaled.seen.every((v) => v === false)).toBe(true);
+  });
+});
+
+describe('every node that makes real-time output honours the boundary', () => {
+  // The mechanism above is only as good as its adoption, and adoption is exactly what a
+  // behavioural test cannot cover for a node that does not exist yet. `roles: ['synth']`
+  // is already the registry's own declaration of "this node produces real-time output",
+  // so it is the honest SSOT to enumerate — a new synth node that forgets the gate fails
+  // here rather than silently pitch-shifting in production. Same shape as the #147
+  // structural guards.
+  const registry = createAppRegistry();
+  const synthNodes = registry.list().filter((d) => (d.roles ?? []).includes('synth'));
+
+  it('finds the synth nodes (the guard is not vacuous)', () => {
+    expect(synthNodes.length).toBeGreaterThanOrEqual(3);
+    expect(synthNodes.map((d) => d.type).sort()).toEqual(
+      expect.arrayContaining(['lyria', 'midi-out', 'webaudio-synth']),
+    );
+  });
+
+  it('each one consults realtimeOutputAllowed', () => {
+    const files: Record<string, string> = {
+      'webaudio-synth': 'src/nodes/output/webaudio_synth.ts',
+      'midi-out': 'src/nodes/output/midi_out.ts',
+      lyria: 'src/nodes/output/lyria.ts',
+    };
+    const missingFile = synthNodes.map((d) => d.type).filter((t) => !(t in files));
+    expect(
+      missingFile,
+      `a node with role 'synth' has no entry in this test's file map — add it, and make ` +
+        `sure it honours boundary B: ${missingFile.join(', ')}`,
+    ).toEqual([]);
+
+    for (const [type, file] of Object.entries(files)) {
+      const src = readFileSync(resolve(ROOT, file), 'utf8').replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+      expect(src, `${type} (${file}) does not consult realtimeOutputAllowed`).toMatch(/realtimeOutputAllowed\(/);
+    }
+  });
+});


### PR DESCRIPTION
The **honest** half of "honest time-scaled audio". Headless throughout.

## Why this is the half worth landing first

Control-rate params scale for free — a node reads `ctx.time` and every mapping follows.
Audio does not: a Web Audio graph rides `AudioContext.currentTime`, which is wall time and
cannot be multiplied. An engine at 2x driving a live synth does **not** make the same music
faster; it slides the control stream underneath oscillators still running at 1x.

The design has said *"never silently pitch-shift"* since July. It was a policy with nothing
enforcing it — and unreachable besides, since nothing in the app sets a speed other than 1.
That is exactly the state in which a rule quietly stops being true.

## The mechanism

- **`Clock.timeScale`** — engine seconds per wall second. `RealtimeClock` reports its
  speed. `BatchClock` reports **`undefined`, not `1`**: a batch run has no wall-clock
  relation at all, and claiming real time would be a lie a future consumer could act on.
- **The `Applier` publishes it** onto the engine's own resources, beside the StateReader.
- **`realtimeOutputAllowed`** is consulted by every node with `roles: ['synth']`:

| node | what it does at a non-unity scale | why that shape |
|---|---|---|
| `webaudio-synth` | tears its voices down | a *skipped tick* leaves oscillators running as they were — a chord frozen at its last value, not silence |
| `midi-out` | forced through the **existing** disabled path | that path already panics (all-notes-off) and holds no port; reusing tested behaviour beats a second way to be silent. Notes at 2x reach a DAW still at 1x |
| `lyria` | same, and strictest | the design says live/streaming generative audio cannot be scaled at all — there is no offline render to fall back on |

**Absence means allowed, deliberately.** `replayNode` passes whatever a test hands it
(usually nothing), and a batch run has no `AudioContext` so the synth already self-no-ops.
Muting on absence would buy no safety and break every node test.

## The guard that matters is structural

A test enumerates the registry's `synth`-role nodes and fails if one does not consult the
helper. `roles: ['synth']` is already the registry's own declaration of "produces real-time
output", so it is the honest SSOT — a node added later cannot quietly pitch-shift, and a
node whose file the test does not know about fails **with instructions** rather than
passing.

**Five mutations verified**: the helper allowing any scale ✗, the Applier not publishing ✗,
`BatchClock` claiming real time ✗, and each of two synth nodes dropping the check ✗.

## Not in this PR — both recorded on #101 with reasons

- **`OfflineAudioContext` render-at-speed.** Its value is a *listening* judgment — does the
  rendered take sound right? That is a human-only check, so it goes on #146 rather than
  blocking the mechanism above. Per your steer: land what's workable.
- **The `delay` node + delayed-edge topoSort.** A real engine change, and a purity
  improvement over the working topo-order channel from M-F. It earns its own PR and its own
  byte-identity check rather than riding along here.

## One test bug worth naming

A **pure** node's `process` is `(inputs, params, ctx)`, not `(inputs, ctx)` — the stateful
`make` form is the two-argument one. Written the short way, my probe received `params`
where `ctx` belonged, so `ctx.resources` was undefined, the helper read "absent" and
returned *allowed* — the test passed while proving nothing. Found by printing from inside
the node rather than assuming. The corrected probe carries a comment so the next person
does not spend the same twenty minutes.

## Verification

1619 tests, typecheck, build, catalog clean; rebased on main.

https://claude.ai/code/session_019MqaXSdxoS9hdavMAAMVvu