### PR TITLE
#209: a browser smoke harness — the built bundle boots headless, the engine is observed ticking, reachability is executable

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,68 @@
+# The browser smoke job (#209).
+#
+# ci.yml is the gate the repo documents (typecheck / test / build), and none of it
+# runs a browser. This job boots the BUILT bundle headless in Chromium and asks the
+# two questions the gate cannot: does the shipped app actually play (engine ticking,
+# audio up, overlay drawing, no uncaught error), and can a player reach every tool
+# and every settings section from a cold load — the shipping rule, executed.
+#
+# Its own job on purpose: it installs a browser and takes longer than the whole
+# vitest suite, so it must never slow the gate down or be skipped to keep the gate
+# fast. Like ci.yml it is advisory to the deploy — a red verdict beside the PR, not
+# a precondition. Whether it should gate anything (and whether #201's React-layer
+# type ratchet should live here) is the maintainer's call, not this file's.
+#
+# The harness is a self-contained sub-project (`smoke/`): its Playwright dependency
+# never enters the app's package.json or node_modules. Locally: `npm run smoke`.
+name: Browser smoke
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: built bundle, headless Chromium
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            smoke/package-lock.json
+
+      - name: Install the app (lockfile-exact)
+        run: npm ci
+
+      - name: Install the harness (lockfile-exact) and Chromium
+        run: |
+          npm --prefix smoke ci --no-audit --no-fund
+          npx --prefix smoke playwright install --with-deps chromium
+
+      - name: Build, serve and smoke the bundle
+        run: npm run smoke:run
+        env:
+          CI: "1"
+
+      - name: Keep the report and traces on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-report
+          path: |
+            smoke/playwright-report
+            smoke/test-results
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,8 @@ Thumbs.db
 # Generated/large test media (commit derived NDJSON fixtures, not raw video)
 /media/
 /node_modules
+
+# Browser smoke harness (self-contained sub-project, #209)
+smoke/node_modules/
+smoke/test-results/
+smoke/playwright-report/

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ npm run record     # regenerate test fixtures
 ```
 
 Chrome recommended. Audio starts only after a click (browser requirement).
+
+To run the browser smoke harness locally (`npm run smoke`) you also need Chromium, which the first run downloads through Playwright into its own cache; see `docs/TESTING.md` → Tier 5.
 `?source=video&video=<url>` runs the instrument camera-free from a pre-recorded
 clip.
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -53,6 +53,7 @@ while main auto-deployed to production.
 | `npm test` | **yes** | same |
 | `npm run build` | **yes** | same |
 | `npm run catalog` | **no** — still yours to run | run it locally after adding/renaming a node or changing a port/param, and commit the result |
+| `npm run smoke` | **yes**, as its own job | `.github/workflows/smoke.yml` — the browser smoke harness (#209): builds the bundle, serves it with `vite preview`, boots it headless in Chromium with `?slot.source=synthetic-hands`, and asserts the engine ticks, the audio graph comes up, the overlay draws, no page error fires, and every tool in `src/app/tools.ts` and every settings section is reachable from a cold load. Deliberately **not** part of `npm test`: it installs a browser and takes longer than the whole vitest suite. |
 | `npm run lint` | **no**, deliberately | `tsc --noEmit` over the *whole* tree, including the React layer the repo ships no `@types/react` for. It is red (19 errors as of 2026-08-17) and has been for a long time. Adding a known-red check would train everyone to ignore the X, which is worse than not having it. `npm run typecheck` (strict, `tsconfig.dag.json`) plus `npm run build` (which is what actually verifies the React layer) is the honest pair. |
 
 The CI job is *advisory to the deploy*, not a precondition for it: `deploy.yml` still
@@ -86,6 +87,26 @@ device I/O need a real browser + camera. They are build-checked and structured w
 feature detection + graceful fallback, but their end-to-end behaviour is verified by
 hand. This is a known gap — the Applier's M-D milestone is explicitly gated on a
 browser smoke test for exactly this reason.
+
+## Tier 5: the browser smoke harness (#209)
+
+Everything above runs in Node or jsdom. Nothing there can say whether the **built bundle, in a real browser, actually plays** — which is how #189's live loop was verified by hand and how a React-layer runtime error can ship green (#201). The smoke harness under `smoke/` closes that gap without touching the gate:
+
+```bash
+npm run smoke          # one command: installs the harness + Chromium (first time), builds, serves, runs
+npm run smoke:run      # just build + serve + run (after the first setup)
+```
+
+It is a **self-contained sub-project** (`smoke/package.json`, its own lockfile and `node_modules`), so `@playwright/test` never enters the app's `package.json` or the shared `node_modules`, and vitest (`test/**` only) never sees its `*.smoke.ts` files. It needs Chromium, which `npm run smoke:setup` downloads once (~150 MB, into Playwright's cache outside the repo).
+
+What it asserts, against the production build served at the deployed base path:
+
+- **boot**: `ready` → Tap to play → `live`; the live feature vector's time rises (clock → Applier → tick → nodes → tap all ran); the AudioContext is `running` behind a non-zero master gain; the merged voices are sounding; the overlay canvas changes between frames; no uncaught page error or `console.error` during the boot; the frozen `?engine=legacy` view still mounts.
+- **reachability**: every tool in `src/app/tools.ts` opens from the tools bar (panels show their close button, the palette its input, links resolve), and every settings section of the instrument editor expands to controls, reached the way a player reaches it (instruments → Edit → section). Both sweeps are data-driven from the shell's own registries, so a new tool or section is covered the day it is added.
+
+The app cooperates through one read-only probe, `window.thoremin` (`src/app/debugHandle.ts`): `getOutput(node, port)`, `liveVectorTime()`, `audio()`. It has no setters and reaches no secret; a person checking a live change gets the same handle in the devtools console. `engine_wiring.test.ts` pins that `useEngine` installs and uninstalls it.
+
+Whether the smoke job should gate the deploy, and whether #201's React-layer type ratchet should live beside it, are the maintainer's decisions; the harness is where such a check would go.
 
 ## On-disk fixture layout
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
     "record": "vite-node scripts/record_stream.ts",
     "catalog": "vite-node scripts/gen_catalog.ts",
     "voice": "vite-node scripts/cue_strings.ts | python3 scripts/gen_cue_voice.py",
-    "check:models": "tsx scripts/check_models.ts"
+    "check:models": "tsx scripts/check_models.ts",
+    "smoke": "npm run smoke:setup && npm run smoke:run",
+    "smoke:setup": "npm --prefix smoke ci --no-audit --no-fund && npx --prefix smoke playwright install chromium",
+    "smoke:run": "npx --prefix smoke playwright test -c smoke/playwright.config.ts"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^4.0.12",

--- a/smoke/package-lock.json
+++ b/smoke/package-lock.json
@@ -1,0 +1,58 @@
+{
+  "name": "thoremin-smoke",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "thoremin-smoke",
+      "devDependencies": {
+        "@playwright/test": "^1.56.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.63.0.tgz",
+      "integrity": "sha512-oxMK4vllB9RK5NQ2l1pq1IfOf2AvnEuj/vYGDj0H2nMtmtZpKtCwt/l00GEO6xjGfpBNAvjovvYdCm50dRQkpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0.tgz",
+      "integrity": "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0.tgz",
+      "integrity": "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    }
+  }
+}

--- a/smoke/package.json
+++ b/smoke/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "thoremin-smoke",
+  "private": true,
+  "description": "Browser smoke harness for thoremin (Playwright). Self-contained on purpose: its dependencies never touch the app's package.json or node_modules.",
+  "devDependencies": {
+    "@playwright/test": "^1.56.0"
+  }
+}

--- a/smoke/playwright.config.ts
+++ b/smoke/playwright.config.ts
@@ -1,0 +1,54 @@
+/**
+ * The browser smoke harness (#209): Playwright over the BUILT bundle.
+ *
+ * Self-contained on purpose. `smoke/` is its own npm project (its own package.json,
+ * lockfile and node_modules), so `@playwright/test` never enters the app's
+ * package.json or the shared node_modules, and `npm test` (vitest, `test/**` only)
+ * never sees these files. Run it with `npm run smoke` from the repo root; CI runs it
+ * as its own job (`.github/workflows/smoke.yml`).
+ *
+ * The web server is the production build served by `vite preview` — the same
+ * artefact `deploy.yml` ships — at the deployed base path (`/thoremin/`). The
+ * browser is Chromium with autoplay allowed, so "Tap to play" can start the
+ * AudioContext without a real gesture, and with a fake camera so `getUserMedia`
+ * would never block (the suite boots with `?slot.source=synthetic-hands`, which
+ * skips the camera entirely; the flags are a belt for a test that forgets to).
+ */
+import { defineConfig, devices } from '@playwright/test';
+
+const PORT = Number(process.env.SMOKE_PORT ?? 4173);
+/** The deployed base path (vite.config.ts `base`). */
+export const BASE_PATH = '/thoremin/';
+
+export default defineConfig({
+  testDir: './tests',
+  // `*.smoke.ts`, never `*.test.ts`: vitest's include is `test/**`, but a distinct
+  // suffix keeps the two suites unmistakable in an editor too.
+  testMatch: '**/*.smoke.ts',
+  fullyParallel: false,
+  workers: 1,
+  retries: process.env.CI ? 1 : 0,
+  timeout: 90_000,
+  expect: { timeout: 20_000 },
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : [['list']],
+  use: {
+    baseURL: `http://localhost:${PORT}${BASE_PATH}`,
+    trace: 'retain-on-failure',
+    ...devices['Desktop Chrome'],
+    launchOptions: {
+      args: [
+        '--autoplay-policy=no-user-gesture-required',
+        '--use-fake-ui-for-media-stream',
+        '--use-fake-device-for-media-stream',
+      ],
+    },
+  },
+  webServer: {
+    // Build first so the harness exercises exactly what ships, then serve it.
+    command: `npm run build && npx vite preview --port ${PORT} --strictPort`,
+    cwd: '..',
+    url: `http://localhost:${PORT}${BASE_PATH}`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 180_000,
+  },
+});

--- a/smoke/tests/boot.smoke.ts
+++ b/smoke/tests/boot.smoke.ts
@@ -1,0 +1,82 @@
+/**
+ * Boot smoke (#209): the built bundle, in a real browser, actually plays.
+ *
+ * Boots with `?slot.source=synthetic-hands` (no camera, no MediaPipe), taps to play,
+ * and asserts the four things no Node or jsdom gate can: the shell reaches `ready`
+ * then `live`; the engine TICKS (the live feature vector's time rises — which only
+ * happens if clock → Applier → tick → nodes → tap all ran); the audio graph is up (a
+ * running AudioContext behind a non-zero master gain); and the overlay canvas is
+ * drawing (its pixels change between two frames). Plus the check #201 asked for in
+ * spirit: no uncaught page error and no console error during the whole boot — a
+ * React-layer runtime failure would show up here even though nothing type-checks it.
+ */
+import { test, expect, type Page } from '@playwright/test';
+
+const SYNTHETIC = '?slot.source=synthetic-hands';
+
+/** Collect uncaught errors and console errors for the page's whole life. */
+function watchErrors(page: Page): { errors: string[] } {
+  const errors: string[] = [];
+  page.on('pageerror', (e) => errors.push(`pageerror: ${e.message}`));
+  page.on('console', (m) => {
+    if (m.type() === 'error') errors.push(`console.error: ${m.text()}`);
+  });
+  return { errors };
+}
+
+const status = (page: Page) => page.locator('text=Thoremin').locator('..').locator('div').last();
+
+test.describe('the built bundle boots and plays headless', () => {
+  test('ready → tap to play → live, with the engine ticking, audio up, overlay drawing, and no errors', async ({ page }) => {
+    const { errors } = watchErrors(page);
+    await page.goto(SYNTHETIC);
+
+    // The shell mounts and the engine initialises (no model to load with synthetic hands).
+    await expect(status(page)).toHaveText('ready', { timeout: 60_000 });
+    await expect(page.getByRole('button', { name: /tap to play/i })).toBeVisible();
+
+    // The probe exists before audio: the engine is built and ticking already.
+    const t0 = await page.evaluate(() => window.thoremin?.liveVectorTime() ?? -1);
+    expect(t0).toBeGreaterThanOrEqual(0);
+    await expect.poll(() => page.evaluate(() => window.thoremin!.liveVectorTime()), { timeout: 10_000 }).toBeGreaterThan(t0);
+
+    // Synthetic hands are present in the feature stream the mapping reads.
+    const hands = (await page.evaluate(() => window.thoremin!.getOutput('feat', 'features'))) as { right?: { present?: boolean }; left?: { present?: boolean } } | undefined;
+    expect(hands?.right?.present || hands?.left?.present).toBe(true);
+
+    // Tap to play: the audio graph comes up.
+    await page.getByRole('button', { name: /tap to play/i }).click();
+    await expect(status(page)).toHaveText('live');
+    await expect.poll(() => page.evaluate(() => window.thoremin!.audio().state), { timeout: 10_000 }).toBe('running');
+    const master = await page.evaluate(() => window.thoremin!.audio().masterGain);
+    expect(master).not.toBeNull();
+    expect(master!).toBeGreaterThan(0);
+
+    // The synth is sounding voices (the merged params feeding webaudio-synth).
+    await expect
+      .poll(
+        () => page.evaluate(() => ((window.thoremin!.getOutput('merge', 'params') as { voices?: Array<{ present: boolean; gain: number }> })?.voices ?? []).some((v) => v.present && v.gain > 0)),
+        { timeout: 10_000 },
+      )
+      .toBe(true);
+
+    // The overlay canvas is drawing: two samples half a second apart differ.
+    const snap = () => page.evaluate(() => document.querySelector('canvas')!.toDataURL('image/png').length + ':' + document.querySelector('canvas')!.toDataURL('image/png').slice(-64));
+    const a = await snap();
+    await page.waitForTimeout(500);
+    const b = await snap();
+    expect(b).not.toBe(a);
+
+    expect(errors, errors.join('\n')).toEqual([]);
+  });
+
+  test('the ?engine=legacy view still mounts (the frozen app is reachable, not rotted)', async ({ page }) => {
+    const { errors } = watchErrors(page);
+    await page.goto('?engine=legacy');
+    await expect(page.locator('body')).not.toBeEmpty();
+    await page.waitForTimeout(1500);
+    // The legacy app asks for a camera it will not get here; that is not an error we own.
+    const owned = errors.filter((e) => !/getUserMedia|NotAllowedError|NotFoundError|camera/i.test(e));
+    expect(owned, owned.join('\n')).toEqual([]);
+  });
+});

--- a/smoke/tests/reachability.smoke.ts
+++ b/smoke/tests/reachability.smoke.ts
@@ -1,0 +1,94 @@
+/**
+ * Reachability smoke (#209): the shipping rule, executed.
+ *
+ * "A feature nobody can find is not shipped." Every PR answers *how many clicks from
+ * a cold load* in prose; this walks the answer in a real browser against the built
+ * bundle. Two sweeps, both data-driven from the shell's own registries so a new
+ * entry is covered the day it is added:
+ *
+ *   - every tool in `src/app/tools.ts` opens from the tools bar — a panel shows its
+ *     close button, the palette shows its input, a link resolves;
+ *   - every settings section of the instrument editor expands to real controls,
+ *     reached the way a player reaches it: instruments list → Edit → section.
+ *
+ * `tools.ts` is imported from the app source (it is plain data with no imports),
+ * so the list of tools here can never drift from the one the shell renders.
+ */
+import { test, expect, type Page } from '@playwright/test';
+import { TOOLS } from '../../src/app/tools';
+
+const SYNTHETIC = '?slot.source=synthetic-hands';
+
+/** What "open" looks like for each tool kind. Panels expose a close button named
+ *  after the tool (the pattern every panel follows); the palette is a cmdk input. */
+const OPEN_PROOF: Record<string, (page: Page, label: string) => Promise<void>> = {
+  panel: async (page, label) => {
+    await expect(page.getByRole('button', { name: new RegExp(`close the ${label}`, 'i') })).toBeVisible();
+  },
+  overlay: async (page) => {
+    await expect(page.locator('[cmdk-input], input[placeholder*="command" i], input[placeholder*="dial" i]').first()).toBeVisible();
+  },
+  link: async () => {},
+};
+
+test.describe('every tool in src/app/tools.ts opens from the tools bar', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(SYNTHETIC);
+    await expect(page.getByRole('button', { name: /tap to play/i })).toBeVisible({ timeout: 60_000 });
+  });
+
+  for (const tool of TOOLS) {
+    test(`${tool.id} (${tool.kind}): one click from a cold load`, async ({ page }) => {
+      const button = page.locator(`[data-tool="${tool.id}"]`);
+      await expect(button).toBeVisible();
+      await expect(button).toContainText(tool.label);
+      if (tool.kind === 'link') {
+        const href = await button.getAttribute('href');
+        expect(href, `${tool.id} has an href`).toBeTruthy();
+        const res = await page.request.get(new URL(href!, page.url()).toString());
+        expect(res.status(), `${href} resolves`).toBe(200);
+        return;
+      }
+      await button.click();
+      await OPEN_PROOF[tool.kind](page, tool.label);
+      // ...and closes again (a tool that traps the player is the mirror failure).
+      await page.keyboard.press('Escape');
+    });
+  }
+});
+
+/** The settings sections a player reaches through the instrument editor. Kept in
+ *  sync with DialsControlsPanel by the test itself: it reads every <details> the
+ *  editor renders and asserts each one it finds; this list is the floor. */
+const REQUIRED_SECTIONS = ['Sound', 'Hand', 'Face', 'Body', 'Overlay', 'MIDI', 'Generative', 'Keyboard'];
+
+test.describe('every settings section is reachable from a cold load', () => {
+  test('instruments → Edit → each section expands to controls', async ({ page }) => {
+    await page.goto(SYNTHETIC);
+    await expect(page.getByRole('button', { name: /tap to play/i })).toBeVisible({ timeout: 60_000 });
+
+    // The instruments panel is open on load; "Edit <name>" opens the dials editor.
+    const edit = page.getByRole('button', { name: /^Edit / }).first();
+    await expect(edit).toBeVisible();
+    await edit.click();
+
+    // Top-level sections carry `data-section` (TopSection); nested collapsibles do not.
+    const sections = page.locator('details[data-section]');
+    await expect(sections.first()).toBeVisible();
+    const labels = await sections.evaluateAll((els) => els.map((d) => d.getAttribute('data-section') ?? ''));
+    for (const required of REQUIRED_SECTIONS) expect(labels, `section "${required}" is in the editor`).toContain(required);
+
+    for (const label of labels) {
+      const section = page.locator(`details[data-section="${label}"]`);
+      if (!(await section.evaluate((d) => (d as HTMLDetailsElement).open))) await section.locator('> summary').click();
+      await expect(section).toHaveAttribute('open', '');
+      // A section is only reachable if it shows the player something to use.
+      await expect(section.locator('input, select, button, textarea, p, label').first()).toBeVisible();
+    }
+
+    // The Generative section specifically (#188): the switch and the transport are there.
+    const generative = page.locator('details[data-section="Generative"]');
+    await expect(generative.getByText('Generative layer', { exact: true })).toBeVisible();
+    await expect(generative.getByRole('button', { name: 'Play' })).toBeDisabled();
+  });
+});

--- a/src/app/debugHandle.ts
+++ b/src/app/debugHandle.ts
@@ -1,0 +1,64 @@
+/**
+ * The read-only debug handle the engine host publishes on `window.thoremin` (#209).
+ *
+ * Every gate in this repo runs in Node or jsdom; the one thing they cannot answer is
+ * whether the BUILT bundle, in a real browser, actually plays. The browser smoke
+ * harness (`smoke/`) answers it by asking the running app three things it could not
+ * otherwise observe without scraping pixels: is the engine ticking (the live feature
+ * vector's time advances), is the audio graph up (the AudioContext is running), and
+ * what is a node emitting right now (`getOutput`). A person verifying a live change
+ * by hand gets the same handle in the devtools console.
+ *
+ * Read-only by construction: getters over the engine and the resources bag, no
+ * setters, nothing that writes a dial or the store (the command registry is the one
+ * write path, #87). It exposes no secrets — the key store is not reachable from it.
+ * Installed by `useEngine` when the engine is ready and removed on teardown, so a
+ * torn-down engine is never reachable through a stale handle.
+ */
+import { readLiveVector } from './enroll/liveVector';
+
+/** The slice of the engine the handle needs — the same read the per-frame bridges use. */
+export interface OutputReader {
+  getOutput(nodeId: string, port: string): unknown;
+}
+
+export interface ThoreminDebugHandle {
+  /** A node's latest output on a port, or undefined before the first tick. */
+  getOutput(nodeId: string, port: string): unknown;
+  /** The live feature vector's engine time in ms, or 0 before the first tick — rises
+   *  only if clock → Applier → tick → nodes → tap all ran. */
+  liveVectorTime(): number;
+  /** The host audio graph, if the player has tapped to play. */
+  audio(): { state: AudioContextState | null; masterGain: number | null };
+}
+
+export const DEBUG_HANDLE_KEY = 'thoremin';
+
+declare global {
+  interface Window {
+    [DEBUG_HANDLE_KEY]?: ThoreminDebugHandle;
+  }
+}
+
+/** Build the handle over an engine and the host resources bag. Pure; testable. */
+export function makeDebugHandle(engine: OutputReader, resources: Record<string, unknown>): ThoreminDebugHandle {
+  return Object.freeze({
+    getOutput: (nodeId: string, port: string) => engine.getOutput(nodeId, port),
+    liveVectorTime: () => readLiveVector()?.t ?? 0,
+    audio: () => {
+      const ac = resources.audioContext as AudioContext | undefined;
+      const master = resources.masterGain as GainNode | undefined;
+      return { state: ac?.state ?? null, masterGain: master?.gain.value ?? null };
+    },
+  });
+}
+
+/** Publish the handle on `window` (a no-op outside a browser). Returns the uninstaller. */
+export function installDebugHandle(engine: OutputReader, resources: Record<string, unknown>): () => void {
+  if (typeof window === 'undefined') return () => {};
+  const handle = makeDebugHandle(engine, resources);
+  window[DEBUG_HANDLE_KEY] = handle;
+  return () => {
+    if (window[DEBUG_HANDLE_KEY] === handle) delete window[DEBUG_HANDLE_KEY];
+  };
+}

--- a/src/app/dials/primitives.tsx
+++ b/src/app/dials/primitives.tsx
@@ -110,7 +110,9 @@ export function TopSection({
   children: ReactNode;
 }) {
   return (
-    <details open={defaultOpen} className="group border-t border-white/10 pt-3 [&[open]>summary>span.mk]:rotate-90">
+    // `data-section` is the stable hook the browser smoke harness walks (#209): the
+    // rendered label is CSS-uppercased and nested collapsibles share the element type.
+    <details open={defaultOpen} data-section={label} className="group border-t border-white/10 pt-3 [&[open]>summary>span.mk]:rotate-90">
       <summary className="flex cursor-pointer select-none items-center gap-1.5 text-[11px] font-bold uppercase tracking-widest text-white/70 transition hover:text-white">
         <span className="mk inline-block transition-transform">▸</span>
         {label}

--- a/src/app/useEngine.ts
+++ b/src/app/useEngine.ts
@@ -38,6 +38,7 @@ import { tagStreamSource, tagOverlayResource } from './tagging/runtime';
 import { useFaceStatus } from './faceStatus';
 import { useMidiStatus } from './midiStatus';
 import { useGenerativeStatus, makeGenerativeReporter } from './generativeStatus';
+import { installDebugHandle } from './debugHandle';
 import { useGestureStatus, type HandPoses } from './gestureStatus';
 import { createGestureDispatcher } from './gestureDispatch';
 import type { FaceStatus } from '@/nodes';
@@ -130,6 +131,7 @@ export function useThoreminEngine(source: SourceSpec = DEFAULT_SOURCE, slots: Sl
 
   useEffect(() => {
     let disposed = false;
+    let uninstallDebug: () => void = () => {};
     // The acquired stream is held here (not read back off video.srcObject) so
     // cleanup can always stop the exact stream this run acquired. Under React
     // StrictMode the effect runs mount→cleanup→mount; an aborted run must stop
@@ -273,6 +275,9 @@ export function useThoreminEngine(source: SourceSpec = DEFAULT_SOURCE, slots: Sl
           return;
         }
         engineRef.current = engine;
+        // The read-only `window.thoremin` probe the browser smoke harness (and a person
+        // at the devtools console) reads the live loop through (#209). Removed on teardown.
+        uninstallDebug = installDebugHandle(engine, resources);
         setStatus('ready');
 
         // The selection may have changed during the model load, while the
@@ -429,6 +434,7 @@ export function useThoreminEngine(source: SourceSpec = DEFAULT_SOURCE, slots: Sl
       useMidiStatus.getState().reset();
       useGestureStatus.getState().reset();
       useGenerativeStatus.getState().reset();
+      uninstallDebug();
       // A rebuilt engine must not auto-start a paid stream from a stale transport flag.
       useControls.getState().setSteerPlaying(false);
       sessionRecRef.current?.dispose();

--- a/test/debug_handle.test.ts
+++ b/test/debug_handle.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+/**
+ * The `window.thoremin` debug handle (#209): read-only, reports the live loop
+ * through the same reads the per-frame bridges use, installs on `window` and
+ * uninstalls only its own handle — so a torn-down engine is never reachable through
+ * a stale probe, and a newer engine's handle is never removed by an older teardown.
+ * The browser smoke harness depends on this shape; `engine_wiring.test.ts` pins that
+ * `useEngine` actually installs it.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { makeDebugHandle, installDebugHandle, DEBUG_HANDLE_KEY } from '@/app/debugHandle';
+import { LiveVectorTap, resetLiveVector } from '@/app/enroll/liveVector';
+
+afterEach(() => {
+  delete window[DEBUG_HANDLE_KEY];
+  resetLiveVector();
+});
+
+const fakeEngine = (outputs: Record<string, unknown> = {}) => ({
+  getOutput: (id: string, port: string) => outputs[`${id}.${port}`],
+});
+
+describe('makeDebugHandle', () => {
+  it('reads node outputs, the audio graph, and the live vector time', () => {
+    const h = makeDebugHandle(fakeEngine({ 'gen.status': { phase: 'off' } }), {
+      audioContext: { state: 'running' },
+      masterGain: { gain: { value: 0.4 } },
+    });
+    expect(h.getOutput('gen', 'status')).toEqual({ phase: 'off' });
+    expect(h.audio()).toEqual({ state: 'running', masterGain: 0.4 });
+    expect(h.liveVectorTime()).toBe(0);
+    // The live vector tap is what the smoke harness watches rising.
+    const tap = new LiveVectorTap();
+    tap.onValue?.('handVec.vector', {}, { tick: 3, time: 0.1, dt: 1 / 30, resources: {} });
+    expect(h.liveVectorTime()).toBeGreaterThan(0);
+  });
+
+  it('reports a null audio graph before tap-to-play', () => {
+    expect(makeDebugHandle(fakeEngine(), {}).audio()).toEqual({ state: null, masterGain: null });
+  });
+
+  it('is frozen: no way to write through it', () => {
+    const h = makeDebugHandle(fakeEngine(), {});
+    expect(Object.isFrozen(h)).toBe(true);
+    expect(Object.keys(h).sort()).toEqual(['audio', 'getOutput', 'liveVectorTime']);
+  });
+});
+
+describe('installDebugHandle', () => {
+  it('publishes on window and the uninstaller removes only its own handle', () => {
+    const un1 = installDebugHandle(fakeEngine({ 'a.b': 1 }), {});
+    expect(window[DEBUG_HANDLE_KEY]?.getOutput('a', 'b')).toBe(1);
+    const un2 = installDebugHandle(fakeEngine({ 'a.b': 2 }), {});
+    expect(window[DEBUG_HANDLE_KEY]?.getOutput('a', 'b')).toBe(2);
+    un1(); // an older teardown must not remove the newer engine's handle
+    expect(window[DEBUG_HANDLE_KEY]?.getOutput('a', 'b')).toBe(2);
+    un2();
+    expect(window[DEBUG_HANDLE_KEY]).toBeUndefined();
+  });
+});

--- a/test/engine_wiring.test.ts
+++ b/test/engine_wiring.test.ts
@@ -67,6 +67,15 @@ describe('useEngine drives the live loop from the Clock seam', () => {
     expect(c).toMatch(/sinks:\s*\[\s*toMs\(reportFace\),\s*toMs\(reportMidi\),\s*toMs\(reportGesture\),\s*toMs\(reportGenerative\)\s*\]/);
   });
 
+  it('publishes the read-only debug handle when the engine is ready, and removes it on teardown (#209)', () => {
+    // The browser smoke harness observes the live loop through `window.thoremin`.
+    // If this call is dropped the harness goes red for a reason nobody can see in
+    // the app; if the uninstall is dropped a torn-down engine stays reachable.
+    const c = code(useEngine);
+    expect(c).toMatch(/uninstallDebug = installDebugHandle\(engine, resources\)/);
+    expect(c).toMatch(/uninstallDebug\(\)/);
+  });
+
   it('releases the Applier on unmount, so its taps do not outlive the run', () => {
     // The engine is caller-owned and survives StrictMode remounts; a tap the Applier
     // attached and never detached would keep receiving values from every later run.


### PR DESCRIPTION
Closes #209.

Every gate in this repo runs in Node or jsdom. This is the first thing that boots the **built bundle in a real browser** and asks what those gates cannot.

## What it proves, per run

- **Boot** (`smoke/tests/boot.smoke.ts`): with `?slot.source=synthetic-hands` (no camera, no MediaPipe) the shell reaches `ready`, Tap to play makes it `live`; the engine **ticks** (the live feature vector's time rises — only true if clock → Applier → tick → nodes → tap all ran); the **audio graph is up** (AudioContext `running` behind a non-zero master gain) and the merged voices are sounding; the **overlay draws** (canvas differs between frames); **no uncaught page error or `console.error`** during the boot — the runtime half of what #201 is about; and the frozen `?engine=legacy` view still mounts.
- **Reachability** (`smoke/tests/reachability.smoke.ts`): the shipping rule executed. Every tool in `src/app/tools.ts` opens from the tools bar (panels show their close button, the palette its input, the manual link resolves), and every settings section — Sound, Hand, Face, Body, Overlay, MIDI, Generative, Keyboard — expands to controls, reached the way a player reaches it (instruments → Edit → section). Both sweeps read the shell's own registries, so a new tool or section is covered the day it is added.

## How, and what it costs

- **Self-contained** `smoke/` sub-project (its own `package.json`, lockfile and `node_modules`): `@playwright/test` never enters the app's `package.json` or the shared `node_modules`; vitest (`test/**`) and the strict typecheck never see `*.smoke.ts`. **No new runtime dependency.**
- **One command:** `npm run smoke` (installs the harness + Chromium on first use, then builds, serves with `vite preview` at the deployed base path, runs). `npm run smoke:run` after setup.
- **Its own CI job** (`.github/workflows/smoke.yml`), advisory like `ci.yml`, never on the `npm test` path.
- The app cooperates through one read-only probe, **`window.thoremin`** (`src/app/debugHandle.ts`: `getOutput`, `liveVectorTime`, `audio`), installed by `useEngine` when ready and removed on teardown (pinned by `engine_wiring.test.ts`); a person checking a live change gets the same handle in the devtools console. And a `data-section` hook on the settings sections, because the rendered label is CSS-uppercased.

## Not decided here

#201's React-layer type ratchet and whether the smoke job gates the deploy are the maintainer's; the harness is where such a check would go.

## Verified

Locally: 8/8 smoke tests pass in ~25 s (`npm run smoke:run`). `npm run typecheck` clean · `npm test` 129 files / 1615 tests · `npm run build` green · `npm run catalog` no diff. Adversarial review: see the comment below.

https://claude.ai/code/session_01Gzvj7aM4hNkdDx3iwLYcXA