### PR TITLE
#101 M-G: delayed edges — feedback the graph declares, instead of inferring from order

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -73,7 +73,7 @@ Two things worth knowing:
 [Get an API key](https://aistudio.google.com/app/apikey)
 
 
-## Nodes (37)
+## Nodes (38)
 
 ### Inputs (sources)
 _Where signals enter the graph._
@@ -283,6 +283,14 @@ Pick the first non-empty of two chord-tone streams (e.g. emotion triad vs pose c
 - **in:** a:number[], b:number[]
 - **out:** chord:number[]
 - **params:** —
+
+#### `delay` — Delay
+Emit the input value from N ticks ago; nothing until that much history exists.
+
+- **roles:** mapping
+- **in:** value:any
+- **out:** value:any
+- **params:** ticks (number=1)
 
 ### Music logic (tonal guidance)
 _Harmony kept in-key._

--- a/docs/design/stream-applier.md
+++ b/docs/design/stream-applier.md
@@ -348,10 +348,26 @@ boundaries allow.
   - ⏳ **`OfflineAudioContext` render-then-play** behind an explicit action. Not built:
     its value is a listening judgment (does the rendered take sound right?), which is a
     human-only check — tracked on #146 rather than blocking the mechanism above.
-  - ⏳ **The `delay` node + delayed-edge topoSort** (the only engine change on the whole
-    path), and migrating `StateReader` onto it. Not built: it is a purity improvement
-    over the working topo-order channel from M-F, and it is a real engine change, so it
-    earns its own PR and its own byte-identity check.
+  - ✅ **Delayed edges + the `delay` node.** `EdgeSpec.delayed` marks an edge as carrying
+    the source's value from the **previous** tick. `topoSort` skips such edges entirely,
+    so they impose no ordering and therefore cannot form a cycle — the same pair of nodes
+    that is illegal through an ordinary edge is legal through a delayed one, with no
+    special case in the sort. It also legalises a self-loop, which delayed is an
+    accumulator rather than a cycle. Reads come from a snapshot taken at the top of the
+    tick, NOT from `outputs`: `outputs` is deliberately never cleared (it is what
+    `getOutput` promises), so reading it gives this tick's value for a node that already
+    ran and last tick's for one that has not — a delay by accident of ordering, which is
+    precisely the trick this replaces.
+
+    The **`delay` node** (`src/nodes/mapping/delay.ts`) is the other tool and a different
+    one: it aligns streams by N ticks and has no effect on ordering at all. It cannot
+    break a cycle — the sort still sees its edges — which is the mistake worth naming.
+    Reach for the edge when the graph would otherwise be cyclic, the node when it would
+    not.
+
+    `StateReader` is deliberately NOT migrated yet: it works, it is used, and swapping its
+    backing is a separate change with its own blast radius. The delay mechanism it would
+    move onto now exists, which was the prerequisite.
   - ⏳ **Recorder backpressure** — folds into #88, not this milestone.
 
 ## M-C resolved: host-side Source for video, node-swap for frame-emitters

--- a/public/catalog.json
+++ b/public/catalog.json
@@ -396,6 +396,33 @@
     ]
   },
   {
+    "type": "delay",
+    "title": "Delay",
+    "description": "Emit the input value from N ticks ago; nothing until that much history exists.",
+    "roles": [
+      "mapping"
+    ],
+    "inputs": [
+      {
+        "name": "value",
+        "kind": "any"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "value",
+        "kind": "any"
+      }
+    ],
+    "params": [
+      {
+        "name": "ticks",
+        "type": "number",
+        "default": 1
+      }
+    ]
+  },
+  {
     "type": "expression-chord",
     "title": "Expression Chord",
     "description": "Facial expression → a voiced, rendered diatonic chord on the chord-source scale (active only in face \"chord\" mode).",

--- a/public/manual.html
+++ b/public/manual.html
@@ -42,7 +42,7 @@
           letter-spacing: .06em; border-radius: 999px; padding: .1rem .4rem; margin-left: .35rem; vertical-align: 1px; }
 </style></head><body><div class="wrap">
   <h1>θ Thoremin — Capabilities Manual</h1>
-  <p class="gen">Auto-generated from the node registry. 37 nodes.</p>
+  <p class="gen">Auto-generated from the node registry. 38 nodes.</p>
   <p class="guide">Looking for how to <b>use</b> the app — playing, instruments, shortcuts, the assistant, recording, annotations, the Feature Lab? → <a href="https://github.com/thorwhalen/thoremin/blob/main/docs/USER_GUIDE.md">the User Guide</a>. This page is the <b>node</b> catalog.</p>
   <p>Thoremin turns live sensor streams (webcam hand gestures, facial expressions and head pose, computer keyboard, MIDI out) into a live audiovisual stream — musical audio plus the captured video with overlaid guides. You build sounds by wiring small, typed <b>nodes</b> into a dataflow graph (DAG): inputs → features → mapping → music-logic → synthesis/generation → output. Every edge can be recorded and replayed.</p><p>The mapping layer spans a spectrum: <b>direct</b> (a gesture *is* a note/parameter — e.g. hand position → scale-snapped pitch) through <b>indirect</b> (a gesture expresses a high-level idea — e.g. openness → musical density steering an AI model), including <b>conductor</b> mode (direct a fixed piece's tempo and dynamics).</p><p>Everything runs <b>client-side</b>: gesture/face inference (MediaPipe), synthesis (Web Audio) and rendering (canvas) all happen in your browser. There is no backend — nothing you play, record, or annotate is uploaded anywhere. The only network calls are the ones you opt into by pasting your own API key (the AI assistant, and Lyria generative music), and those go straight from your browser to that provider.</p><p>This page catalogs the engine's building blocks — every node, its ports and its params. The DAG *is* the deployed instrument; a few nodes here are built and tested but are not wired into the default graph: the generative ones, and `transport` + `performance` (conductor mode's original clock and control mapping, kept for the non-conductor chain now that `conductor` + `score` are wired behind the Conductor dial, #187).</p>
   <h3>Example pipelines</h3>
@@ -335,6 +335,16 @@
         <dt>in</dt><dd>a:number[], b:number[]</dd>
         <dt>out</dt><dd>chord:number[]</dd>
         <dt>params</dt><dd>—</dd>
+      </dl>
+    </div>
+    <div class="node">
+      <h4><code>delay</code> <span class="title">Delay</span></h4>
+      <p>Emit the input value from N ticks ago; nothing until that much history exists.</p>
+      <dl>
+        <dt>roles</dt><dd>mapping</dd>
+        <dt>in</dt><dd>value:any</dd>
+        <dt>out</dt><dd>value:any</dd>
+        <dt>params</dt><dd>ticks (number=1)</dd>
       </dl>
     </div></div></section>
 <section><h3>Music logic (tonal guidance)</h3><p class="blurb">Harmony kept in-key.</p><div class="grid">

--- a/scripts/gen_catalog.ts
+++ b/scripts/gen_catalog.ts
@@ -21,7 +21,7 @@ const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const CATEGORIES: Array<{ name: string; blurb: string; types: string[] }> = [
   { name: 'Inputs (sources)', blurb: 'Where signals enter the graph.', types: ['webcam-hands', 'webcam-face', 'webcam-body', 'keyboard-source', 'store-controls', 'synthetic-hands', 'replay-source', 'replay-hands', 'synthetic-body', 'replay-body'] },
   { name: 'Features', blurb: 'Raw sensor data → normalized control signals.', types: ['hand-features', 'face-features', 'face-controls', 'face-expression', 'gesture-classifier', 'face-feature-vector', 'hand-feature-vector', 'body-feature-vector'] },
-  { name: 'Mapping (direct ↔ indirect)', blurb: 'Features → engine parameters, across the expression spectrum.', types: ['voice-mapping', 'indirect-map', 'keyboard-control', 'pick', 'one-euro', 'synth-merge', 'chord-select'] },
+  { name: 'Mapping (direct ↔ indirect)', blurb: 'Features → engine parameters, across the expression spectrum.', types: ['voice-mapping', 'indirect-map', 'keyboard-control', 'pick', 'one-euro', 'synth-merge', 'chord-select', 'delay'] },
   { name: 'Music logic (tonal guidance)', blurb: 'Harmony kept in-key.', types: ['chord', 'progression', 'expression-chord', 'pose-chord'] },
   { name: 'Conductor mode', blurb: 'Direct a fixed piece with gesture (tempo + dynamics).', types: ['conductor', 'transport', 'score', 'performance'] },
   { name: 'Synthesis & generation', blurb: 'Make sound — direct synthesis, steered AI music, or an external MIDI instrument.', types: ['webaudio-synth', 'lyria', 'midi-out'] },

--- a/src/dag/engine.ts
+++ b/src/dag/engine.ts
@@ -49,7 +49,7 @@ interface BuiltNode {
   /** input port name -> default value (from PortSpec.default), if any. */
   inputDefaults: Map<string, unknown>;
   /** incoming edges, grouped by target input port. */
-  incoming: Map<string, { node: string; port: string }>;
+  incoming: Map<string, { node: string; port: string; delayed?: boolean }>;
 }
 
 export interface EngineOptions {
@@ -140,6 +140,23 @@ export class Engine {
   private outputs = new Map<string, PortValues>();
   private taps: Tap[];
   private resourcesObject: Record<string, unknown>;
+  /**
+   * What every node had emitted by the end of the PREVIOUS tick — the source for
+   * {@link EdgeSpec.delayed} edges.
+   *
+   * Kept as a snapshot rather than by clearing `outputs`, because `outputs` is
+   * deliberately never cleared: it holds the *latest value a node produced*, which is
+   * what `getOutput` promises and what overlays, the StateReader and the UI read. A node
+   * that emits nothing this tick must keep showing its last value there.
+   */
+  private prevOutputs: Map<string, PortValues> = new Map();
+  /**
+   * Whether the compiled graph contains any delayed edge. When it does not — every graph
+   * shipped today — the per-tick snapshot below is skipped entirely, so a graph without
+   * feedback pays nothing for this feature and its recorded output is unchanged by
+   * construction rather than by testing. (It is tested anyway.)
+   */
+  private hasDelayedEdges = false;
   private nominalDt: number;
   private validatePorts: boolean;
   private log?: (msg: string) => void;
@@ -172,9 +189,10 @@ export class Engine {
     this.log = opts.log;
     this.registry = registry;
     this.spec = spec;
-    const { nodes, order } = compile(spec, registry, new Map());
+    const { nodes, order, hasDelayed } = compile(spec, registry, new Map());
     this.nodes = nodes;
     this.order = order;
+    this.hasDelayedEdges = hasDelayed;
     for (const id of nodes.keys()) this.outputs.set(id, {});
   }
 
@@ -257,7 +275,7 @@ export class Engine {
     const previousSpec = this.spec;
 
     // 1. PLAN — throws before anything is mutated.
-    const { nodes, order, fresh, kept } = compile(next, registry, previous);
+    const { nodes, order, fresh, kept, hasDelayed } = compile(next, registry, previous);
 
     // 2. PREPARE — init the new instances while the old graph keeps ticking.
     if (this.started) {
@@ -296,7 +314,14 @@ export class Engine {
     }
     this.nodes = nodes;
     this.order = order;
+    this.hasDelayedEdges = hasDelayed;
     this.outputs = outputs;
+    // Re-base the delayed-read snapshot on the committed outputs. Carrying the OLD
+    // snapshot across a swap would feed a rebuilt node a value from a graph that no
+    // longer exists; starting from `outputs` means a delayed edge reads what the kept
+    // nodes actually hold, and nothing for the fresh ones — the same one-tick hole a
+    // fresh node has on its ordinary inputs.
+    this.prevOutputs = new Map(outputs);
     this.spec = next;
     this.registry = registry;
     this.version += 1;
@@ -378,6 +403,11 @@ export class Engine {
     // caller bug; doing nothing is the safe reading of it.
     if (this.disposed) return;
     this.tickIndex += 1;
+    // Snapshot before anything runs, so every delayed read in this tick sees the same
+    // end-of-last-tick state regardless of evaluation order. Shallow: the port objects
+    // are the very ones the nodes emitted and are treated as immutable, as `getOutput`
+    // already assumes.
+    if (this.hasDelayedEdges) this.prevOutputs = new Map(this.outputs);
     const t = time ?? (this.tickIndex * this.nominalDt);
     const dt = this.tickIndex === 0 ? 0 : Math.max(0, t - this.lastTime);
     this.lastTime = t;
@@ -420,7 +450,12 @@ export class Engine {
     // Start from declared defaults so unconnected inputs are well-defined.
     for (const [port, def] of node.inputDefaults) inputs[port] = def;
     for (const [port, src] of node.incoming) {
-      const upstream = this.outputs.get(src.node);
+      // A delayed edge reads the snapshot taken at the top of this tick — i.e. what the
+      // source had emitted by the END of the previous one. Reading `this.outputs` would
+      // give whatever is there NOW, which for a node earlier in the order is this tick's
+      // value (no delay at all) and for a later one is last tick's (a delay by accident
+      // of ordering). The snapshot makes it one tick either way.
+      const upstream = (src.delayed ? this.prevOutputs : this.outputs).get(src.node);
       const v = upstream ? upstream[src.port] : undefined;
       if (v !== undefined) inputs[port] = v;
     }
@@ -504,7 +539,7 @@ function compile(
   spec: GraphSpec,
   registry: NodeRegistry,
   reusable: ReadonlyMap<string, BuiltNode>,
-): { nodes: Map<string, BuiltNode>; order: string[]; fresh: string[]; kept: string[] } {
+): { nodes: Map<string, BuiltNode>; order: string[]; fresh: string[]; kept: string[]; hasDelayed: boolean } {
   const nodes = new Map<string, BuiltNode>();
   const fresh: string[] = [];
   const kept: string[] = [];
@@ -562,10 +597,10 @@ function compile(
             `fan-in to one input is not allowed (use a merge node).`,
         );
       }
-      target.incoming.set(e.to.port, { node: e.from.node, port: e.from.port });
+      target.incoming.set(e.to.port, { node: e.from.node, port: e.from.port, delayed: e.delayed });
     }
 
-    return { nodes, order: topoSort(nodes, spec.edges), fresh, kept };
+    return { nodes, order: topoSort(nodes, spec.edges), fresh, kept, hasDelayed: spec.edges.some((e) => e.delayed === true) };
   } catch (err) {
     // Release anything this failed compile constructed. Reused instances belong
     // to the live graph and are deliberately left alone.
@@ -598,6 +633,14 @@ function topoSort(nodes: ReadonlyMap<string, BuiltNode>, edges: readonly EdgeSpe
     adj.set(id, new Set());
   }
   for (const e of edges) {
+    // A delayed edge carries LAST tick's value, so it imposes no ordering constraint on
+    // this one — it is deliberately invisible here. That is the whole mechanism: the same
+    // pair of nodes that would be a cycle through an ordinary edge is acyclic through a
+    // delayed one, with no special case in the sort itself.
+    //
+    // It also legalises the self-loop the next line rejects: `a.out -> a.in` delayed is a
+    // node reading its own previous output, which is an accumulator, not a cycle.
+    if (e.delayed) continue;
     if (e.from.node === e.to.node) {
       throw new Error(`Engine: self-loop on node "${e.from.node}" not allowed in v0`);
     }

--- a/src/dag/types.ts
+++ b/src/dag/types.ts
@@ -154,6 +154,20 @@ export interface NodeSpec {
 export interface EdgeSpec {
   from: { node: string; port: string };
   to: { node: string; port: string };
+  /**
+   * Carry the source port's value from the **previous** tick instead of this one.
+   *
+   * This is what lets a graph express feedback. The engine evaluates nodes once per tick
+   * in topological order, so an ordinary edge from a node that runs *later* would be a
+   * cycle — which `topoSort` rejects. A delayed edge is excluded from that dependency
+   * ordering entirely: it cannot create a cycle, because it does not constrain the order.
+   *
+   * The delay is **one tick, not a fixed duration**. Under a `RealtimeClock` at speed 1
+   * that is one frame; at another speed, or under a `BatchClock`, it is still one tick and
+   * therefore a different amount of wall time. Feedback built on it is frame-rate
+   * dependent by construction, which is a property to design around rather than a bug.
+   */
+  delayed?: boolean;
 }
 
 /** A complete, serializable description of a dataflow graph. */

--- a/src/nodes/index.ts
+++ b/src/nodes/index.ts
@@ -29,6 +29,7 @@ import { synthMergeNode } from './mapping/synth_merge';
 import { chordSelectNode } from './mapping/chord_select';
 import { pickNode } from './mapping/pick';
 import { oneEuroNode } from './mapping/one_euro';
+import { delayNode } from './mapping/delay';
 import { lyriaNode } from './output/lyria';
 import { chordNode } from './music/chord';
 import { expressionChordNode } from './music/expression_chord';
@@ -76,6 +77,7 @@ export { synthMergeNode } from './mapping/synth_merge';
 export { chordSelectNode } from './mapping/chord_select';
 export { pickNode } from './mapping/pick';
 export { oneEuroNode } from './mapping/one_euro';
+export { delayNode } from './mapping/delay';
 export { lyriaNode } from './output/lyria';
 export { chordNode, voiceChord } from './music/chord';
 export { expressionChordNode, CHORD_VOICE_ID_BASE, MAX_CHORD_VOICES } from './music/expression_chord';
@@ -111,6 +113,7 @@ export const CORE_NODES = [
   chordSelectNode,
   pickNode,
   oneEuroNode,
+  delayNode,
   lyriaNode,
   chordNode,
   expressionChordNode,

--- a/src/nodes/mapping/delay.ts
+++ b/src/nodes/mapping/delay.ts
@@ -1,0 +1,57 @@
+/**
+ * `delay` — emit the input from `ticks` ticks ago (#101 M-G).
+ *
+ * The companion to {@link EdgeSpec.delayed}, and deliberately a different tool:
+ *
+ * - A **delayed edge** exists to break a cycle. It is invisible to the topological sort,
+ *   so a graph can feed a value backwards without the engine rejecting it. One tick,
+ *   always, because that is what "the previous evaluation" means.
+ * - This **node** exists to align streams. It has no effect on ordering at all — it is an
+ *   ordinary node with an ordinary input — and it delays by however many ticks you ask
+ *   for. Use it when two paths through the graph have different lengths and you want them
+ *   to line up, or when you want a value's own past alongside its present.
+ *
+ * Reach for the edge when the graph would otherwise be cyclic; reach for the node when it
+ * would not. Using the node to break a cycle does not work (the sort still sees its
+ * edges), which is the mistake worth naming up front.
+ *
+ * Emits **nothing** until it has seen `ticks + 1` values, rather than emitting a seeded
+ * zero: a consumer can tell "no history yet" from "the value really was 0" only if the
+ * port stays absent, and `EngineOptions.validatePorts` treats an absent port as a fact
+ * about the node rather than an error.
+ */
+import { z } from 'zod';
+import { defineNode } from '@/dag';
+
+export const delayParams = z.object({
+  /** How many ticks back to emit. 1 = the previous tick. */
+  ticks: z.number().int().min(1).max(600).default(1),
+});
+
+export const delayNode = defineNode({
+  type: 'delay',
+  title: 'Delay',
+  description: 'Emit the input value from N ticks ago; nothing until that much history exists.',
+  roles: ['mapping'],
+  params: delayParams,
+  inputs: [{ name: 'value', kind: 'any' }],
+  outputs: [{ name: 'value', kind: 'any' }],
+  make: (params) => {
+    // A ring would be tidier; a plain array is clearer and `ticks` is bounded at 600
+    // (ten seconds at 60fps), so the shift is not worth optimising away.
+    const history: unknown[] = [];
+    return {
+      process: (inputs) => {
+        history.push(inputs.value);
+        if (history.length <= params.ticks) return {};
+        const out = history.shift();
+        // An absent input is recorded as absent and comes back out as absent, so a gap
+        // in the source stays a gap `ticks` later instead of becoming a repeat.
+        return out === undefined ? {} : { value: out };
+      },
+      dispose: () => {
+        history.length = 0;
+      },
+    };
+  },
+});

--- a/test/delayed_edges.test.ts
+++ b/test/delayed_edges.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Delayed edges and the `delay` node (#101 M-G) — the principled end of R3.
+ *
+ * The engine evaluates each node once per tick in topological order, so feeding a value
+ * backwards is a cycle, which `topoSort` rejects. M-F's `StateReader` got feedback anyway
+ * by exploiting that order: a zero-input source runs first, so reading a downstream node
+ * necessarily returned last tick's value. That works, and it is a trick — the delay is
+ * implied by position rather than declared, and it silently becomes a same-tick read if
+ * the reader ever stops being topologically first.
+ *
+ * A delayed edge declares it instead.
+ */
+import { describe, it, expect } from 'vitest';
+import { createHash } from 'node:crypto';
+import { Engine, createRegistry, defineNode, runHeadless, type GraphSpec } from '@/dag';
+import { delayNode, replaySourceNode, createCoreRegistry } from '@/nodes';
+import { loadStream } from './helpers/fixtures';
+import { z } from 'zod';
+
+/** Emits `seed` on the first tick, then whatever came back on `fed`, plus one. */
+const accumulator = defineNode({
+  type: 'accum', roles: ['source'], params: z.object({}),
+  inputs: [{ name: 'fed', kind: 'any' }],
+  outputs: [{ name: 'n', kind: 'any' }],
+  make: () => ({ process: (inputs) => ({ n: typeof inputs.fed === 'number' ? inputs.fed + 1 : 0 }) }),
+});
+
+const passthrough = defineNode({
+  type: 'pass', roles: ['mapping'], params: z.object({}),
+  inputs: [{ name: 'in', kind: 'any' }],
+  outputs: [{ name: 'out', kind: 'any' }],
+  process: (inputs) => (inputs.in === undefined ? {} : { out: inputs.in }),
+});
+
+describe('a delayed edge breaks a cycle the engine would otherwise reject', () => {
+  const registry = () => createRegistry([accumulator, passthrough, delayNode]);
+  const cyclic = (delayed: boolean): GraphSpec => ({
+    nodes: [
+      { id: 'a', type: 'accum', params: {} },
+      { id: 'p', type: 'pass', params: {} },
+    ],
+    edges: [
+      { from: { node: 'a', port: 'n' }, to: { node: 'p', port: 'in' } },
+      { from: { node: 'p', port: 'out' }, to: { node: 'a', port: 'fed' }, delayed },
+    ],
+  });
+
+  it('the SAME graph is a cycle without the flag and legal with it', async () => {
+    expect(() => new Engine(cyclic(false), registry(), {})).toThrow(/cycle/);
+    expect(() => new Engine(cyclic(true), registry(), {})).not.toThrow();
+  });
+
+  it('feeds back exactly one tick, so the accumulator counts', async () => {
+    const { recorder } = await runHeadless(cyclic(true), registry(), { ticks: 5, nominalDt: 1 / 30 });
+    // Tick 0 has no previous output, so `fed` is absent and the node seeds 0.
+    expect(recorder.values('a.n')).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it('legalises a self-loop, which is an accumulator rather than a cycle', async () => {
+    const spec: GraphSpec = {
+      nodes: [{ id: 'a', type: 'accum', params: {} }],
+      edges: [{ from: { node: 'a', port: 'n' }, to: { node: 'a', port: 'fed' }, delayed: true }],
+    };
+    const { recorder } = await runHeadless(spec, registry(), { ticks: 4, nominalDt: 1 / 30 });
+    expect(recorder.values('a.n')).toEqual([0, 1, 2, 3]);
+    // ...and the same edge without the flag is still refused.
+    expect(() => new Engine({ ...spec, edges: [{ ...spec.edges[0], delayed: false }] }, registry(), {})).toThrow(/self-loop/);
+  });
+
+  it('reads the SNAPSHOT, not whatever `outputs` happens to hold — proven against a source that already ran', async () => {
+    // This is the assertion that separates a declared delay from M-F's ordering trick,
+    // and getting it to discriminate takes care. With ONLY a delayed edge the two nodes
+    // are independent, so the sort orders them alphabetically and the reader may well run
+    // first — at which point `outputs` still holds last tick's value and reading the
+    // wrong map looks identical. A first attempt here passed with the delay removed.
+    //
+    // So the source is forced to run FIRST, by giving the reader an ordinary edge from it
+    // as well. Now `outputs.get('a')` is unambiguously THIS tick's value, and only the
+    // snapshot yields the previous one. `now` and `past` come from the same node on the
+    // same tick and must differ by exactly one.
+    const pair = defineNode({
+      type: 'pair', roles: ['mapping'], params: z.object({}),
+      inputs: [{ name: 'now', kind: 'any' }, { name: 'past', kind: 'any' }],
+      outputs: [{ name: 'both', kind: 'any' }],
+      process: (inputs) => ({ both: [inputs.now ?? null, inputs.past ?? null] }),
+    });
+    const spec: GraphSpec = {
+      nodes: [
+        { id: 'a', type: 'replay-source', params: { values: [10, 20, 30, 40] } },
+        { id: 'z', type: 'pair', params: {} },
+      ],
+      edges: [
+        { from: { node: 'a', port: 'value' }, to: { node: 'z', port: 'now' } },
+        { from: { node: 'a', port: 'value' }, to: { node: 'z', port: 'past' }, delayed: true },
+      ],
+    };
+    const { engine, recorder } = await runHeadless(spec, createRegistry([replaySourceNode, pair, delayNode]), {
+      ticks: 4, nominalDt: 1 / 30,
+    });
+    // The ordinary edge makes `a` a real dependency, so it is evaluated first.
+    expect(engine.evaluationOrder()).toEqual(['a', 'z']);
+    expect(recorder.values('z.both')).toEqual([
+      [10, null], // tick 0: no previous tick to read
+      [20, 10],
+      [30, 20],
+      [40, 30],
+    ]);
+  });
+});
+
+describe('the delay node aligns streams (it does NOT break cycles)', () => {
+  const registry = () => createRegistry([replaySourceNode, delayNode]);
+  const spec = (ticks: number): GraphSpec => ({
+    nodes: [
+      { id: 'src', type: 'replay-source', params: { values: [1, 2, 3, 4, 5] } },
+      { id: 'd', type: 'delay', params: { ticks } },
+    ],
+    edges: [{ from: { node: 'src', port: 'value' }, to: { node: 'd', port: 'value' } }],
+  });
+
+  it('delays by N ticks, emitting nothing until it has that much history', async () => {
+    const one = await runHeadless(spec(1), registry(), { ticks: 5, nominalDt: 1 / 30 });
+    expect(one.recorder.values('d.value')).toEqual([1, 2, 3, 4]);
+    const three = await runHeadless(spec(3), registry(), { ticks: 5, nominalDt: 1 / 30 });
+    expect(three.recorder.values('d.value')).toEqual([1, 2]);
+  });
+
+  it('cannot break a cycle — the sort still sees its edges', () => {
+    // The mistake worth naming: a delay NODE in a feedback path is still a cycle.
+    const cyclic: GraphSpec = {
+      nodes: [
+        { id: 'a', type: 'accum', params: {} },
+        { id: 'd', type: 'delay', params: { ticks: 1 } },
+      ],
+      edges: [
+        { from: { node: 'a', port: 'n' }, to: { node: 'd', port: 'value' } },
+        { from: { node: 'd', port: 'value' }, to: { node: 'a', port: 'fed' } },
+      ],
+    };
+    expect(() => new Engine(cyclic, createRegistry([accumulator, delayNode]), {})).toThrow(/cycle/);
+  });
+});
+
+describe('a graph with no delayed edge is untouched', () => {
+  it('reproduces the committed byte-identity digests exactly', async () => {
+    // The engine change adds a per-tick snapshot of `outputs`. Held against the same
+    // digests the Applier refactor was, because an engine change is exactly where a
+    // recorded stream could shift without any behavioural test noticing.
+    //
+    // Note what this does NOT prove: the snapshot is gated on the graph having a delayed
+    // edge, and that gate is a PERFORMANCE property, not a correctness one. Taking the
+    // snapshot unconditionally produces identical bytes — it is simply a Map copy per
+    // tick that no shipped graph needs. Removing the gate leaves this suite green, and
+    // saying so is better than implying a guard that is not there.
+    const GOLDEN: Record<string, string> = {
+      'feat.features.ndjson': '02e5f35fdfc3369e95d5d8a2820e081be5d3cad780c5d23c4770719bc1158527',
+      'map.params.ndjson': '4cc5a8d8e2a4bed20cc1b21e038dc09b3436c66632d799b7f7799d315fbd4329',
+      'src.value.ndjson': '386274e074a0041b005ee3d7e75709323bdbcaf255c2b5c29804ca621a9b39ef',
+    };
+    const hands = loadStream('video_hand_sweep', 'src.hands');
+    const spec: GraphSpec = {
+      nodes: [
+        { id: 'src', type: 'replay-source', params: { values: hands } },
+        { id: 'feat', type: 'hand-features', params: {} },
+        { id: 'map', type: 'voice-mapping', params: {} },
+      ],
+      edges: [
+        { from: { node: 'src', port: 'value' }, to: { node: 'feat', port: 'hands' } },
+        { from: { node: 'feat', port: 'features' }, to: { node: 'map', port: 'features' } },
+      ],
+    };
+    const { recorder } = await runHeadless(spec, createCoreRegistry(), { ticks: 60, nominalDt: 1 / 30 });
+    const actual: Record<string, string> = {};
+    for (const [name, text] of Object.entries(recorder.toFiles())) {
+      actual[name] = createHash('sha256').update(text).digest('hex');
+    }
+    expect(actual).toEqual(GOLDEN);
+  });
+});


### PR DESCRIPTION
The principled end of R3, and the design's *"only engine change on the whole path"*.
Headless throughout.

## What it replaces

M-F's `StateReader` gets feedback by **exploiting evaluation order**: a zero-input source
runs topologically first, so reading a downstream node necessarily returns last tick's
value. That works, and it is a trick — the delay is implied by *position* rather than
declared, and it silently becomes a same-tick read the moment the reader stops being first.

`EdgeSpec.delayed` declares it instead. `topoSort` skips such edges entirely, so they
impose no ordering and **cannot form a cycle**: the same pair of nodes that is illegal
through an ordinary edge is legal through a delayed one, with no special case in the sort.
It also legalises a self-loop — which, delayed, is an accumulator rather than a cycle.

## The subtle part: reads come from a snapshot, not from `outputs`

`outputs` is deliberately **never cleared** — it holds *the latest value a node produced*,
which is what `getOutput` promises and what overlays and the StateReader read.

So reading it for a delayed edge gives **this** tick's value for a node that already ran,
and **last** tick's for one that has not — a delay by accident of ordering, which is the
exact thing being replaced. A snapshot taken at the top of the tick makes it one tick
either way.

## Two tools, and the mistake worth naming

| | breaks a cycle? | delays by |
|---|---|---|
| **delayed edge** | yes — invisible to the sort | exactly one tick |
| **`delay` node** | **no** — the sort still sees its edges | N ticks |

Reach for the edge when the graph would otherwise be cyclic; the node when it would not.
A test asserts the node *cannot* break a cycle, because that is the natural wrong guess.

The node emits nothing until it has enough history rather than a seeded zero — a consumer
can tell "no history yet" from "the value really was 0" only if the port stays absent.

## Byte identity

Re-checked against the **same digests** the Applier refactor was held to. An engine change
is exactly where a recorded stream shifts without any behavioural test noticing.

## Two mutations survived the first pass, and both taught something

- **The snapshot test did not discriminate.** With *only* a delayed edge the two nodes are
  independent, so the sort ordered them alphabetically and the reader ran first — where
  `outputs` and the snapshot coincide. Rewritten to force the source to run first via an
  ordinary edge alongside the delayed one, so `now` and `past` come from the same node on
  the same tick and must differ by exactly one. It now fails under that mutation.
- **Gating the snapshot on `hasDelayedEdges` is a performance property, not a correctness
  one** — taking it unconditionally produces identical bytes. The test file says so rather
  than implying a guard that is not there.

## Not migrated, deliberately

`StateReader` still uses the ordering channel. It works and is used; swapping its backing
is a separate change with its own blast radius. The mechanism it would move onto now
exists, which was the prerequisite.

## Verification

1638 tests, typecheck, build clean. The **catalog guard caught the new node being unfiled**
and it now sits under Mapping — which is why `npm run catalog` is in the gate.

https://claude.ai/code/session_019MqaXSdxoS9hdavMAAMVvu