### PR TITLE
PR 4 of #187: the Conductor tool — a shell entry point, a live readout, the beat over the video, and fermatas

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -342,7 +342,7 @@ _Direct a fixed piece with gesture (tempo + dynamics)._
 The beating hand becomes musical time: ictus detection + an adaptive oscillator (src/ictus) → beat, bpm, dynamics for the score. Off by default.
 
 - **roles:** feature, mapping
-- **in:** hands:hands-frame, config:conductor-config
+- **in:** hands:hands-frame, config:conductor-config, doc:score-doc
 - **out:** time:musical-time, beat:number, bpm:number, velocityScale:number, phase:number, dynamics:number, articulation:number, confidence:number, enabled:boolean
 - **params:** enabled (boolean=false), hand (enum(auto | right | left)="auto"), point (enum(wrist | indexTip)="wrist"), mirrorX (boolean=true), mirrorHandedness (boolean=true), beatsPerBar (number=4), servoBeats (number=1), fallbackBelowConfidence (number=0.3), fallbackBpmMin (number=50), fallbackBpmMax (number=160), dynMin (number=0.35), dynMax (number=1), phaseGain (number=0.5), periodGain (number=0.4)
 
@@ -404,7 +404,7 @@ _Audio + the captured video with overlaid guides._
 Mirrored video + composable overlay elements (guides, landmarks, markers, cues).
 
 - **roles:** overlay
-- **in:** hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], chordScale:number[], chord:number[], faceFrame:face-frame, bodyFrame:body-frame, bodyStatus:body-status, expression:face-expression, octaveShift:number, overlayConfig:overlay-config, faceVector:feature-vector, handVector:feature-vector, bodyVector:feature-vector
+- **in:** hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], chordScale:number[], chord:number[], faceFrame:face-frame, bodyFrame:body-frame, bodyStatus:body-status, conductorTime:musical-time, conductorEnabled:boolean, expression:face-expression, octaveShift:number, overlayConfig:overlay-config, faceVector:feature-vector, handVector:feature-vector, bodyVector:feature-vector
 - **out:** —
-- **params:** video (object={}), scaleGuide (object={}), chordGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={}), fingerLines (object={}), faceLandmarks (object={}), bodySkeleton (object={}), timbreLevels (object={}), faceExpression (object={}), fingerBars (object={}), chordName (object={}), keyboardStrip (object={}), featureLab (object={}), tagHud (object={}), trainerHud (object={})
+- **params:** video (object={}), scaleGuide (object={}), chordGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={}), fingerLines (object={}), faceLandmarks (object={}), bodySkeleton (object={}), conductorHud (object={}), timbreLevels (object={}), faceExpression (object={}), fingerBars (object={}), chordName (object={}), keyboardStrip (object={}), featureLab (object={}), tagHud (object={}), trainerHud (object={})
 

--- a/public/catalog.json
+++ b/public/catalog.json
@@ -156,6 +156,15 @@
         "kind": "body-status"
       },
       {
+        "name": "conductorTime",
+        "kind": "musical-time"
+      },
+      {
+        "name": "conductorEnabled",
+        "kind": "boolean",
+        "default": false
+      },
+      {
         "name": "expression",
         "kind": "face-expression"
       },
@@ -225,6 +234,11 @@
       },
       {
         "name": "bodySkeleton",
+        "type": "object",
+        "default": {}
+      },
+      {
+        "name": "conductorHud",
         "type": "object",
         "default": {}
       },
@@ -354,6 +368,10 @@
       {
         "name": "config",
         "kind": "conductor-config"
+      },
+      {
+        "name": "doc",
+        "kind": "score-doc"
       }
     ],
     "outputs": [

--- a/public/manual.html
+++ b/public/manual.html
@@ -404,7 +404,7 @@
       <p>The beating hand becomes musical time: ictus detection + an adaptive oscillator (src/ictus) → beat, bpm, dynamics for the score. Off by default.</p>
       <dl>
         <dt>roles</dt><dd>feature, mapping</dd>
-        <dt>in</dt><dd>hands:hands-frame, config:conductor-config</dd>
+        <dt>in</dt><dd>hands:hands-frame, config:conductor-config, doc:score-doc</dd>
         <dt>out</dt><dd>time:musical-time, beat:number, bpm:number, velocityScale:number, phase:number, dynamics:number, articulation:number, confidence:number, enabled:boolean</dd>
         <dt>params</dt><dd>enabled (boolean=false), hand (enum(auto | right | left)="auto"), point (enum(wrist | indexTip)="wrist"), mirrorX (boolean=true), mirrorHandedness (boolean=true), beatsPerBar (number=4), servoBeats (number=1), fallbackBelowConfidence (number=0.3), fallbackBpmMin (number=50), fallbackBpmMax (number=160), dynMin (number=0.35), dynMax (number=1), phaseGain (number=0.5), periodGain (number=0.4)</dd>
       </dl>
@@ -476,9 +476,9 @@
       <p>Mirrored video + composable overlay elements (guides, landmarks, markers, cues).</p>
       <dl>
         <dt>roles</dt><dd>overlay</dd>
-        <dt>in</dt><dd>hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], chordScale:number[], chord:number[], faceFrame:face-frame, bodyFrame:body-frame, bodyStatus:body-status, expression:face-expression, octaveShift:number, overlayConfig:overlay-config, faceVector:feature-vector, handVector:feature-vector, bodyVector:feature-vector</dd>
+        <dt>in</dt><dd>hands:hands-frame, features:hand-features, params:synth-params, scale:number[], scaleLeft:number[], chordScale:number[], chord:number[], faceFrame:face-frame, bodyFrame:body-frame, bodyStatus:body-status, conductorTime:musical-time, conductorEnabled:boolean, expression:face-expression, octaveShift:number, overlayConfig:overlay-config, faceVector:feature-vector, handVector:feature-vector, bodyVector:feature-vector</dd>
         <dt>out</dt><dd>—</dd>
-        <dt>params</dt><dd>video (object={}), scaleGuide (object={}), chordGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={}), fingerLines (object={}), faceLandmarks (object={}), bodySkeleton (object={}), timbreLevels (object={}), faceExpression (object={}), fingerBars (object={}), chordName (object={}), keyboardStrip (object={}), featureLab (object={}), tagHud (object={}), trainerHud (object={})</dd>
+        <dt>params</dt><dd>video (object={}), scaleGuide (object={}), chordGuide (object={}), indexGuide (object={}), landmarks (object={}), markers (object={}), fingerLines (object={}), faceLandmarks (object={}), bodySkeleton (object={}), conductorHud (object={}), timbreLevels (object={}), faceExpression (object={}), fingerBars (object={}), chordName (object={}), keyboardStrip (object={}), featureLab (object={}), tagHud (object={}), trainerHud (object={})</dd>
       </dl>
     </div></div></section>
 </div></body></html>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -32,6 +32,7 @@ import LabPanel from './LabPanel';
 import GesturesPanel from './GesturesPanel';
 import TrainerPanel from './TrainerPanel';
 import ScoreLoader from './ScoreLoader';
+import ConductorPanel from './ConductorPanel';
 import VersionBadge from './VersionBadge';
 
 /** A compact face-status chip, visible even when the controls panel is collapsed
@@ -148,6 +149,8 @@ export default function App({
 
       {/* Trainer mode (#160) — renders when its tool is the open one. */}
       <TrainerPanel />
+      {/* Conductor mode (#187) — renders when its tool is the open one. */}
+      <ConductorPanel />
       {/* The conductor's score (#187 PR 3): loads the selected piece when conducting is on. */}
       <ScoreLoader />
 

--- a/src/app/ConductorPanel.tsx
+++ b/src/app/ConductorPanel.tsx
@@ -1,0 +1,109 @@
+/**
+ * The Conductor tool panel (#187 PR 4) — the shell entry point for conducting.
+ *
+ * The shipping rule: a capability nobody can find is not shipped. Conductor mode has
+ * lived for a month as a settings section three clicks deep; this panel is the tools
+ * bar button that says "Conductor", opens on one click, and shows a player everything
+ * at once: a Start/Stop button (the `conductor.enabled` dial, through the single write
+ * path), the piece and the follower controls (the same `ConductorControls` section as
+ * the settings editor, so there is exactly one set of controls), and the live readout
+ * the settings section deliberately does not carry — what the follower is doing right
+ * now (waiting for a first stroke / running / holding), the tempo it is advancing at,
+ * the beat in the bar, its confidence and the dynamics — from the engine loop's
+ * reporter (`conductorStatus.ts`). The same beat is drawn over the video by the
+ * overlay's `conductorHud` element, so the panel can be closed while conducting.
+ */
+import { Music2, X } from 'lucide-react';
+import { dispatchDialSetIn } from './dispatchDial';
+import { ConductorControls } from './dials/panels/conductor';
+import { useDialsSettings } from './dials/useDialsSettings';
+import { useConductorStatus, type ConductorLive } from './conductorStatus';
+import { toolById } from './tools';
+import { useTools } from './toolsStore';
+import type { ConductorSettings } from '@/settings/schema';
+
+export const CONDUCTOR_TOOL_ID = 'conductor';
+
+/** What to tell the player, per follower state. */
+export function describeLive(live: ConductorLive): string {
+  if (!live.enabled) return 'Off. Press Start, then beat time with your hand.';
+  if (live.state === 'hold') return live.anchors === 0 ? 'Waiting for your first beat.' : 'Holding. Beat once to go on.';
+  if (live.state === 'ready') return live.anchors === 0 ? 'Waiting for your first beat.' : 'Finding your tempo...';
+  return `Following at ${Math.round(live.tempo)} bpm.`;
+}
+
+function LiveReadout({ live }: { live: ConductorLive }) {
+  const beat = live.beatInBar + 1;
+  return (
+    <div className="space-y-1.5 rounded-lg border border-white/10 bg-white/5 p-2 text-xs" data-testid="conductor-live" data-state={live.enabled ? live.state : 'off'}>
+      <div className="flex items-center justify-between">
+        <span className="text-white/80">{describeLive(live)}</span>
+        {live.enabled && live.state === 'running' && (
+          <span className="font-mono text-emerald-300">
+            {beat}/{live.beatsPerBar}
+          </span>
+        )}
+      </div>
+      <Meter label="Confidence" value={live.confidence} />
+      <Meter label="Dynamics" value={live.dynamics} />
+    </div>
+  );
+}
+
+function Meter({ label, value }: { label: string; value: number }) {
+  const pct = Math.round(Math.max(0, Math.min(1, value)) * 100);
+  return (
+    <div className="flex items-center gap-2 text-[10px] text-white/50">
+      <span className="w-16">{label}</span>
+      <div className="h-1.5 flex-1 overflow-hidden rounded bg-white/10">
+        <div className="h-full bg-emerald-400/70" style={{ width: `${pct}%` }} />
+      </div>
+      <span className="w-8 text-right font-mono">{pct}%</span>
+    </div>
+  );
+}
+
+export default function ConductorPanel() {
+  const open = useTools((s) => s.open) === CONDUCTOR_TOOL_ID;
+  const close = useTools((s) => s.close);
+  const { state } = useDialsSettings();
+  const live = useConductorStatus((s) => s.live);
+  if (!open) return null;
+
+  const tool = toolById(CONDUCTOR_TOOL_ID);
+  const enabled = ((state.effective.conductor ?? {}) as Partial<ConductorSettings>).enabled === true;
+
+  return (
+    <div className="absolute bottom-14 left-3 z-40 flex max-h-[calc(100dvh-5rem)] w-96 max-w-[calc(100vw-1.5rem)] flex-col overflow-hidden rounded-2xl border border-white/10 bg-black/70 backdrop-blur">
+      <div className="flex items-center gap-2 border-b border-white/10 px-3 py-2">
+        <Music2 className="h-3.5 w-3.5 shrink-0 text-emerald-300" aria-hidden />
+        <span className="flex-1 text-[11px] font-bold uppercase tracking-widest text-white/70">Conductor</span>
+        <button
+          onClick={close}
+          aria-label="Close the Conductor"
+          className="rounded p-1 text-white/60 transition hover:bg-white/10 hover:text-white"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+      <div className="space-y-3 overflow-auto p-4">
+        {tool && <p className="text-[10px] uppercase tracking-widest text-emerald-500/70">{tool.description}</p>}
+        <button
+          onClick={() => void dispatchDialSetIn('conductor.enabled', !enabled)}
+          className={`w-full rounded-lg px-3 py-2 text-sm font-semibold transition ${
+            enabled ? 'bg-white/10 text-white hover:bg-white/20' : 'bg-emerald-500 text-black hover:bg-emerald-400'
+          }`}
+        >
+          {enabled ? 'Stop conducting' : 'Start conducting'}
+        </button>
+        <LiveReadout live={live} />
+        <p className="text-[10px] leading-relaxed text-white/50">
+          Beat time in front of the camera: the bottom of each stroke is a beat, bigger strokes
+          are louder. The score waits for your first stroke, follows your tempo, and holds when
+          you stop.
+        </p>
+        <ConductorControls />
+      </div>
+    </div>
+  );
+}

--- a/src/app/ToolsBar.tsx
+++ b/src/app/ToolsBar.tsx
@@ -18,7 +18,7 @@
  * puts a stop button next to it — the state and its undo in the one place a player
  * already looks for "what else is here".
  */
-import { FlaskConical, Command, BookOpen, Hand, X, type LucideIcon } from 'lucide-react';
+import { FlaskConical, Command, BookOpen, Hand, Music2, X, type LucideIcon } from 'lucide-react';
 import { TOOLS, type Tool } from './tools';
 import { useTools } from './toolsStore';
 import { useControls } from './store';
@@ -31,6 +31,7 @@ const ICONS: Record<string, LucideIcon> = {
   lab: FlaskConical,
   commands: Command,
   gestures: Hand,
+  conductor: Music2,
   manual: BookOpen,
 };
 

--- a/src/app/conductorStatus.ts
+++ b/src/app/conductorStatus.ts
@@ -1,0 +1,104 @@
+/**
+ * conductorStatus — a tiny store the engine loop writes the live conductor state
+ * into (#187 PR 4), so the Conductor tool panel can show what the follower is doing:
+ * ready / running / hold, the tempo it is advancing at, where in the bar it is, how
+ * confident it is, and the dynamics. Ephemeral per-frame runtime state, exactly like
+ * `generativeStatus` and `midiStatus` — the DAG produces it; React only displays it.
+ *
+ * {@link makeConductorReporter} is the per-frame sink the host loop registers beside
+ * the other bridges in `useEngine.ts`: it reads the `conductor` node's `time`,
+ * `dynamics` and `enabled` outputs and reports only when something a player can SEE
+ * changed (the state, the whole beat, the tempo to the bpm, the confidence and
+ * dynamics to a twentieth), so the panel never re-renders 60×/s for a phase that
+ * merely crept.
+ */
+import { create } from 'zustand';
+import type { MusicalTime } from '@/ictus';
+
+export interface ConductorLive {
+  enabled: boolean;
+  state: MusicalTime['state'];
+  /** Beats per minute the score is advancing at (0 in hold / before the first stroke). */
+  tempo: number;
+  /** Whole beats since the start. */
+  beat: number;
+  beatInBar: number;
+  beatsPerBar: number;
+  /** 0..1. */
+  confidence: number;
+  /** 0..1. */
+  dynamics: number;
+  /** Anchors (strokes) the follower has accepted. */
+  anchors: number;
+}
+
+export const ABSENT_CONDUCTOR_LIVE: ConductorLive = {
+  enabled: false,
+  state: 'ready',
+  tempo: 0,
+  beat: 0,
+  beatInBar: 0,
+  beatsPerBar: 4,
+  confidence: 0,
+  dynamics: 0,
+  anchors: 0,
+};
+
+/** The node id the reporter reads — the `conductor` node in `graph.ts`. */
+export const CONDUCTOR_NODE_ID = 'conductor';
+
+export interface ConductorStatusState {
+  live: ConductorLive;
+  report(live: ConductorLive): void;
+  reset(): void;
+}
+
+export const useConductorStatus = create<ConductorStatusState>((set) => ({
+  live: ABSENT_CONDUCTOR_LIVE,
+  report: (live) => set({ live }),
+  reset: () => set({ live: ABSENT_CONDUCTOR_LIVE }),
+}));
+
+/** The one thing the reporter needs from an engine: a node output read. */
+export interface OutputReader {
+  getOutput(nodeId: string, port: string): unknown;
+}
+
+/** Quantise what the panel shows, so the change gate compares what a player sees. */
+export function conductorLiveKey(l: ConductorLive): string {
+  return `${l.enabled ? 1 : 0}|${l.state}|${Math.round(l.tempo)}|${l.beat}|${l.beatInBar}|${l.beatsPerBar}|${Math.round(l.confidence * 20)}|${Math.round(l.dynamics * 20)}|${l.anchors}`;
+}
+
+/**
+ * Build the per-frame sink: read the conductor node's outputs, report them to
+ * {@link useConductorStatus} when something visible changed. Pure over the reader, so
+ * it is testable with a stub engine.
+ */
+export function makeConductorReporter(
+  engine: OutputReader,
+  store: Pick<ConductorStatusState, 'report'> = useConductorStatus.getState(),
+  nodeId: string = CONDUCTOR_NODE_ID,
+): () => void {
+  let lastKey = '';
+  return () => {
+    const time = engine.getOutput(nodeId, 'time') as MusicalTime | undefined;
+    if (!time) return;
+    const dynamics = engine.getOutput(nodeId, 'dynamics');
+    const enabled = engine.getOutput(nodeId, 'enabled');
+    const live: ConductorLive = {
+      enabled: enabled === true,
+      state: time.state,
+      tempo: Number.isFinite(time.tempo) ? time.tempo : 0,
+      beat: Math.floor(time.beat),
+      beatInBar: time.beatInBar,
+      beatsPerBar: time.beatsPerBar,
+      confidence: time.confidence,
+      dynamics: typeof dynamics === 'number' ? dynamics : 0,
+      anchors: time.anchors,
+    };
+    const key = conductorLiveKey(live);
+    if (key === lastKey) return;
+    lastKey = key;
+    store.report(live);
+  };
+}

--- a/src/app/graph.ts
+++ b/src/app/graph.ts
@@ -435,6 +435,11 @@ export function defaultGraph(selection?: SlotSelection, registry?: NodeRegistry)
       { from: { node: 'conductor', port: 'enabled' }, to: { node: 'score', port: 'enabled' } },
       // The loaded piece (#187 PR 3): a ScoreDoc from the store, or nothing (the demo scale).
       { from: { node: 'ui', port: 'scoreDoc' }, to: { node: 'score', port: 'doc' } },
+      // The same piece feeds the conductor its meter and fermatas (PR 4), and the
+      // conductor's musical time + enable flag reach the overlay's beat HUD.
+      { from: { node: 'ui', port: 'scoreDoc' }, to: { node: 'conductor', port: 'doc' } },
+      { from: { node: 'conductor', port: 'time' }, to: { node: 'overlay', port: 'conductorTime' } },
+      { from: { node: 'conductor', port: 'enabled' }, to: { node: 'overlay', port: 'conductorEnabled' } },
       // The conducted score joins the hand voices and both face chords at the merge, so
       // the master mute and the synth/MIDI/overlay taps cover it for free.
       { from: { node: 'score', port: 'params' }, to: { node: 'merge', port: 'd' } },

--- a/src/app/overlayControls.ts
+++ b/src/app/overlayControls.ts
@@ -70,6 +70,7 @@ export const OVERLAY_CONTROLS: OverlayControlDesc[] = [
   { name: 'landmarks', label: 'Hand landmarks' },
   { name: 'faceLandmarks', label: 'Face mesh', needsFace: true },
   { name: 'bodySkeleton', label: 'Body skeleton' },
+  { name: 'conductorHud', label: 'Conductor beat' },
   {
     // Feature Instrumentation Lab (#119) — owned by the LAB panel, not the instrument's
     // Overlay section: the Lab measures the instrument, so its config is a per-device

--- a/src/app/tools.ts
+++ b/src/app/tools.ts
@@ -90,6 +90,13 @@ export const TOOLS: readonly Tool[] = [
     kind: 'panel',
   },
   {
+    id: 'conductor',
+    label: 'Conductor',
+    description:
+      'Conduct a score with your hand: beat time in front of the camera and the piece follows your tempo and dynamics.',
+    kind: 'panel',
+  },
+  {
     id: 'trainer',
     label: 'Trainer',
     description:

--- a/src/app/useEngine.ts
+++ b/src/app/useEngine.ts
@@ -39,6 +39,7 @@ import { useFaceStatus } from './faceStatus';
 import { useMidiStatus } from './midiStatus';
 import { useGenerativeStatus, makeGenerativeReporter } from './generativeStatus';
 import { installDebugHandle } from './debugHandle';
+import { useConductorStatus, makeConductorReporter } from './conductorStatus';
 import { useGestureStatus, type HandPoses } from './gestureStatus';
 import { createGestureDispatcher } from './gestureDispatch';
 import type { FaceStatus } from '@/nodes';
@@ -361,6 +362,9 @@ export function useThoreminEngine(source: SourceSpec = DEFAULT_SOURCE, slots: Sl
         // section can render an honest readout (loading / ready / playing / needs a
         // key). Change-gated inside the reporter, like the others.
         const reportGenerative = makeGenerativeReporter(engine);
+        // Bridge the `conductor` node's musical time to React (#187), for the Conductor
+        // tool panel's live readout. Change-gated inside the reporter, like the others.
+        const reportConductor = makeConductorReporter(engine);
 
         // #101 M-D, live half: this effect is now an {@link Applier} config. Batch
         // (`runHeadless`) and paced (here) differ on **{clock, sinks, taps} jointly**,
@@ -400,7 +404,7 @@ export function useThoreminEngine(source: SourceSpec = DEFAULT_SOURCE, slots: Sl
           // No `resources` here: #192 made the Applier take them from the engine, so the
           // two can never be different objects. Passing one was harmless at runtime (it
           // was the same reference) but it was a type error nothing could see — see below.
-          sinks: [toMs(reportFace), toMs(reportMidi), toMs(reportGesture), toMs(reportGenerative)],
+          sinks: [toMs(reportFace), toMs(reportMidi), toMs(reportGesture), toMs(reportGenerative), toMs(reportConductor)],
           shouldStop: () => disposed,
           onError: (err) => {
             // Same disposition `runEngineLoop` had: log and keep going. A degenerate
@@ -434,6 +438,7 @@ export function useThoreminEngine(source: SourceSpec = DEFAULT_SOURCE, slots: Sl
       useMidiStatus.getState().reset();
       useGestureStatus.getState().reset();
       useGenerativeStatus.getState().reset();
+      useConductorStatus.getState().reset();
       uninstallDebug();
       // A rebuilt engine must not auto-start a paid stream from a stale transport flag.
       useControls.getState().setSteerPlaying(false);

--- a/src/nodes/features/conductor.ts
+++ b/src/nodes/features/conductor.ts
@@ -27,6 +27,14 @@
  * freezes: `bpm` reads 0 and the score sustains whatever is sounding. Disabling resets
  * the beat to 0, so re-enabling starts the piece from the top on a clean downbeat.
  *
+ * The score (PR 3/4): the loaded `ScoreDoc` on the `doc` input supplies the meter
+ * (beats per bar from its time signature, so `beatInBar` counts the way the piece is
+ * written) and its **fermatas**: when the beat would cross a fermata, it stops exactly
+ * there and holds — `bpm` 0, the note sustains, the HUD says "holding" — until the
+ * conductor's next stroke, the preparatory beat that releases a fermata in every
+ * shipped system (§6.3). Without a document the dial's `beatsPerBar` is used and there
+ * are no fermatas.
+ *
  * The dial. {@link ConductorDialSchema} IS this node's params (the `faceControls`
  * pattern): the `conductor` dial re-exports it, the `config` input overrides the
  * build-time params live per tick, and `commands/paths.ts` derives a `dial.setIn`
@@ -44,6 +52,7 @@ import { defineNode } from '@/dag';
 import type { NodeContext } from '@/dag';
 import { beatAt, createIctus, wrapPhase, type Ictus, type IctusState, type MusicalTime } from '@/ictus';
 import { LM, type Hand, type HandsFrame } from '../domain';
+import { beatsPerBarAt, ScoreDocSchema, type ScoreDoc } from '@/score/schema';
 
 export const CONDUCTOR_HANDS = ['auto', 'right', 'left'] as const;
 export type ConductorHand = (typeof CONDUCTOR_HANDS)[number];
@@ -146,6 +155,8 @@ export const conductorNode = defineNode<Params>({
   inputs: [
     { name: 'hands', kind: 'hands-frame' },
     { name: 'config', kind: 'conductor-config' },
+    // The loaded piece (#187 PR 3/4): its time signature and fermatas. Optional.
+    { name: 'doc', kind: 'score-doc' },
   ],
   outputs: [
     { name: 'time', kind: 'musical-time', schema: MusicalTimeSchema },
@@ -166,10 +177,32 @@ export const conductorNode = defineNode<Params>({
     /** The beat the score reads: integrated here, phase-servoed onto the ictus. */
     let beatOut = 0;
     let wasEnabled = false;
+    // The document's fermatas (sorted beats) and meter, re-read when the doc object changes.
+    let docRef: unknown = null;
+    let fermatas: number[] = [];
+    let docMeter: ((beat: number) => number) | null = null;
+    /** Fermata hold: the beat we stopped at, and the anchor count when we stopped (a
+     *  NEW stroke — one more anchor — releases it). */
+    let fermataAt: number | null = null;
+    let fermataAnchors = 0;
     // Speed-based fallback: EW speed of the tracked point and a decaying envelope of it.
     let lastPt: { t: number; x: number; y: number } | null = null;
     let speedEw = 0;
     let speedEnv = 0;
+
+    const resolveDoc = (raw: unknown): void => {
+      if (raw === docRef) return;
+      docRef = raw;
+      fermatas = [];
+      docMeter = null;
+      fermataAt = null;
+      if (!raw || typeof raw !== 'object') return;
+      const parsed = ScoreDocSchema.safeParse(raw);
+      if (!parsed.success) return;
+      const doc = parsed.data as ScoreDoc;
+      fermatas = [...doc.fermatas].sort((a, b) => a - b);
+      docMeter = (beat) => beatsPerBarAt(doc, beat);
+    };
 
     const resolveConfig = (raw: unknown): Params => {
       if (raw === lastConfigRef) return cfg;
@@ -215,6 +248,8 @@ export const conductorNode = defineNode<Params>({
     return {
       process(inputs, ctx: NodeContext) {
         const c = resolveConfig(inputs.config);
+        resolveDoc(inputs.doc);
+        const beatsPerBar = docMeter ? docMeter(beatOut) : c.beatsPerBar;
         if (!c.enabled) {
           if (wasEnabled) {
             ictus = null;
@@ -222,9 +257,10 @@ export const conductorNode = defineNode<Params>({
             speedEw = 0;
             speedEnv = 0;
             beatOut = 0;
+            fermataAt = null;
             wasEnabled = false;
           }
-          return emit(idleTime(ctx.time, c.beatsPerBar), 0, 0, 0.5, false, c);
+          return emit(idleTime(ctx.time, beatsPerBar), 0, 0, 0.5, false, c);
         }
         if (!wasEnabled || !ictus) {
           ictus = createIctus({
@@ -255,7 +291,11 @@ export const conductorNode = defineNode<Params>({
         // 2. Blend the inferred tempo with the speed fallback by confidence; integrate.
         const fallbackBpm = c.fallbackBpmMin + (c.fallbackBpmMax - c.fallbackBpmMin) * (speedEnv > 0 ? clamp01(speedEw / speedEnv) : 0);
         let bpm: number;
-        if (s.state === 'hold' || s.anchors === 0) {
+        // A fermata releases on the NEXT stroke after it was reached.
+        if (fermataAt !== null && s.anchors > fermataAnchors) fermataAt = null;
+        if (fermataAt !== null) {
+          bpm = 0;
+        } else if (s.state === 'hold' || s.anchors === 0) {
           // Holding, or no stroke seen yet (the preparatory beat has not come): frozen.
           bpm = 0;
         } else {
@@ -269,10 +309,22 @@ export const conductorNode = defineNode<Params>({
             const err = wrapPhase(advanced - beatAt(s, ctx.time));
             corrected = advanced - w * err * Math.min(1, ctx.dt / (c.servoBeats * s.period));
           }
-          beatOut = Math.max(beatOut, corrected);
+          let next = Math.max(beatOut, corrected);
+          // 4. Fermatas: stop exactly on one the beat would cross, and hold there.
+          for (const f of fermatas) {
+            if (f > beatOut && f <= next) {
+              next = f;
+              fermataAt = f;
+              fermataAnchors = s.anchors;
+              bpm = 0;
+              break;
+            }
+          }
+          beatOut = next;
         }
 
         const wholeBeat = Math.floor(beatOut);
+        const bpb = docMeter ? docMeter(beatOut) : c.beatsPerBar;
         const time: MusicalTime = {
           t: ctx.time,
           beat: beatOut,
@@ -281,9 +333,10 @@ export const conductorNode = defineNode<Params>({
           period: bpm > 0 ? 60 / bpm : Infinity,
           confidence: s.confidence,
           nextBeatAt: bpm > 0 ? ctx.time + ((1 - (beatOut - wholeBeat)) * 60) / bpm : Infinity,
-          beatsPerBar: c.beatsPerBar,
-          beatInBar: ((wholeBeat % c.beatsPerBar) + c.beatsPerBar) % c.beatsPerBar,
-          state: s.state,
+          beatsPerBar: bpb,
+          beatInBar: ((wholeBeat % bpb) + bpb) % bpb,
+          // A fermata reads as a hold to every consumer (the HUD, the panel, the score).
+          state: fermataAt !== null ? 'hold' : s.state,
           anchors: s.anchors,
         };
         return emit(time, bpm, s.dynamics, s.articulation, true, c);

--- a/src/nodes/output/canvas_overlay.ts
+++ b/src/nodes/output/canvas_overlay.ts
@@ -23,6 +23,7 @@
  * Canvas + video are injected via `ctx.resources`. Pure drawing; no port output.
  */
 import { z } from 'zod';
+import type { MusicalTime } from '@/ictus';
 import { defineNode } from '@/dag';
 import type { NodeContext } from '@/dag';
 import {
@@ -104,6 +105,10 @@ const Params = z.object({
   faceLandmarks: z.object({ show: z.boolean().default(true) }).prefault({}),
   /** The full-body skeleton (#186) — drawn when body tracking is on; shows the load state. */
   bodySkeleton: z.object({ show: z.boolean().default(true) }).prefault({}),
+  /** The conductor's beat over the video (#187): a phase ring that fills through each
+   *  beat and flashes on it, the beat-in-bar count, the tempo, and the follower's state
+   *  (waiting / holding). Draws only while conducting is on. */
+  conductorHud: z.object({ show: z.boolean().default(true) }).prefault({}),
   /** Per-hand brightness/vibrato level bars (output feature). Opt-in. */
   timbreLevels: z.object({ show: z.boolean().default(false) }).prefault({}),
   /**
@@ -228,6 +233,8 @@ const LEFT_COLOR = '#3b82f6';
 const FACE_COLOR = '#22d3ee'; // cyan — distinct from hands (emerald/blue) + chord (gold)
 /** The body skeleton's colour (#186): distinct from hands/face/chord. */
 const BODY_COLOR = '#7dd3fc';
+/** The conductor HUD's ring colour (#187). */
+const CONDUCTOR_COLOR = '#34d399';
 const CHORD_COLOR = '#f5d142'; // warm gold
 
 /** Everything an overlay element needs to draw a frame. */
@@ -255,6 +262,9 @@ export interface OverlayView {
     bodyFrame?: BodyFrame;
     /** The body model's lifecycle, so the skeleton element can say 'loading'. */
     bodyStatus?: BodyStatus;
+    /** The conductor's musical time (#187) and whether conducting is on, for the HUD. */
+    conductorTime?: MusicalTime;
+    conductorEnabled?: boolean;
     expression?: ExpressionScores;
     /** Live hand map (note source + finger routing), for feature-accurate cues. */
     handMap?: HandMap;
@@ -597,6 +607,67 @@ const faceMesh: OverlayElement = {
  * prints the state in the corner instead — the player's only feedback that the
  * body toggle did something, since the status has no React chip of its own.
  */
+/**
+ * The conductor's beat (#187): a ring at the top centre that fills through the beat
+ * (the phase), flashes white on the beat, and carries the beat-in-bar count with the
+ * tempo under it; "waiting for your first beat" and "holding" as words when the
+ * follower is not running. The same information the Conductor panel shows, on the
+ * video, so a player conducting with the panel closed still sees the follower answer.
+ */
+const conductorHud: OverlayElement = {
+  name: 'conductorHud',
+  category: 'output',
+  draw(g, { W, inputs, params }) {
+    if (!params.conductorHud.show) return;
+    if (!inputs.conductorEnabled) return;
+    const t = inputs.conductorTime;
+    if (!t) return;
+    const cx = W / 2;
+    const cy = 44;
+    const r = 18;
+    const running = t.state === 'running' && t.tempo > 0;
+    g.save();
+    g.lineWidth = 3;
+    g.strokeStyle = 'rgba(255,255,255,0.25)';
+    g.beginPath();
+    g.arc(cx, cy, r, 0, Math.PI * 2);
+    g.stroke();
+    if (running) {
+      // The phase arc, and a flash in the first tenth of the beat.
+      const phase = Math.max(0, Math.min(1, t.phase));
+      g.strokeStyle = CONDUCTOR_COLOR;
+      g.beginPath();
+      g.arc(cx, cy, r, -Math.PI / 2, -Math.PI / 2 + phase * Math.PI * 2);
+      g.stroke();
+      if (phase < 0.1) {
+        g.globalAlpha = 1 - phase / 0.1;
+        g.fillStyle = 'white';
+        g.beginPath();
+        g.arc(cx, cy, r - 4, 0, Math.PI * 2);
+        g.fill();
+        g.globalAlpha = 1;
+      }
+    }
+    g.fillStyle = 'white';
+    g.textAlign = 'center';
+    g.textBaseline = 'middle';
+    g.font = 'bold 13px system-ui, sans-serif';
+    const beat = ((Math.floor(t.beat) % t.beatsPerBar) + t.beatsPerBar) % t.beatsPerBar + 1;
+    g.fillText(running ? `${beat}` : t.state === 'hold' ? '||' : '…', cx, cy);
+    g.font = '11px system-ui, sans-serif';
+    g.fillStyle = 'rgba(255,255,255,0.75)';
+    const label = running
+      ? `${Math.round(t.tempo)} bpm · ${beat}/${t.beatsPerBar}`
+      : t.anchors === 0
+        ? 'waiting for your first beat'
+        : t.state === 'hold'
+          ? 'holding'
+          : 'finding your tempo';
+    g.fillText(label, cx, cy + r + 12);
+    g.restore();
+  },
+};
+
 const bodySkeleton: OverlayElement = {
   name: 'bodySkeleton',
   category: 'input',
@@ -1631,6 +1702,8 @@ export const OVERLAY_ELEMENTS: readonly OverlayElement[] = [
   faceMesh,
   bodySkeleton,
   landmarkDots,
+  // The conductor's beat HUD (#187): an in-scene output element above the markers.
+  conductorHud,
   controlMarkers,
   fingerLinesElement,
   timbreLevels,
@@ -1735,6 +1808,9 @@ export const canvasOverlayNode = defineNode<Params>({
     // The body branch (#186): the latest pose + the model's load state, for the skeleton.
     { name: 'bodyFrame', kind: 'body-frame' },
     { name: 'bodyStatus', kind: 'body-status' },
+    // The conductor (#187): its musical time + enable flag, for the beat HUD.
+    { name: 'conductorTime', kind: 'musical-time' },
+    { name: 'conductorEnabled', kind: 'boolean', default: false },
     { name: 'expression', kind: 'face-expression' },
     { name: 'octaveShift', kind: 'number', default: 0 },
     { name: 'overlayConfig', kind: 'overlay-config' },
@@ -1806,6 +1882,8 @@ export const canvasOverlayNode = defineNode<Params>({
             faceFrame: inputs.faceFrame as FaceFrame | undefined,
             bodyFrame: inputs.bodyFrame as BodyFrame | undefined,
             bodyStatus: inputs.bodyStatus as BodyStatus | undefined,
+            conductorTime: inputs.conductorTime as MusicalTime | undefined,
+            conductorEnabled: inputs.conductorEnabled === true,
             expression: inputs.expression as ExpressionScores | undefined,
             handMap: controls?.handMap,
             faceDegrees: controls?.faceExpr?.degrees,

--- a/test/app_graph.test.ts
+++ b/test/app_graph.test.ts
@@ -231,6 +231,11 @@ describe('production app graph', () => {
     // The loaded piece reaches the score live from the store (PR 3): a ScoreDoc that
     // could be loaded but never played is the #120 failure mode again.
     expect(has('ui', 'scoreDoc', 'score', 'doc')).toBe(true);
+    // PR 4: the piece's meter and fermatas reach the conductor; the conductor's musical
+    // time and enable flag reach the overlay's beat HUD (a HUD nothing feeds draws nothing).
+    expect(has('ui', 'scoreDoc', 'conductor', 'doc')).toBe(true);
+    expect(has('conductor', 'time', 'overlay', 'conductorTime')).toBe(true);
+    expect(has('conductor', 'enabled', 'overlay', 'conductorEnabled')).toBe(true);
     const inbound = edges.filter((e) => e.to.node === 'conductor').map((e) => e.to.port);
     expect(inbound).toContain('config');
     expect(inbound).toContain('hands');

--- a/test/app_shell.test.ts
+++ b/test/app_shell.test.ts
@@ -23,6 +23,7 @@ const SURFACES: Record<string, string> = {
   commands: 'CommandPaletteOverlay',
   gestures: 'GesturesPanel',
   trainer: 'TrainerPanel',
+  conductor: 'ConductorPanel',
 };
 
 describe('app shell', () => {

--- a/test/conductor_node.test.ts
+++ b/test/conductor_node.test.ts
@@ -89,6 +89,44 @@ describe('conductor node on the 4/4 fixture (stated 70 bpm)', () => {
     expect(outs[n - 1].beat as number).toBeLessThan(outs[149].beat as number);
   });
 
+  it('a fermata in the loaded score stops the beat exactly there and holds until the next stroke', async () => {
+    // A document whose only content is a fermata at beat 4, in 3/4.
+    const doc = {
+      v: 1,
+      title: 'fermata test',
+      source: 'builtin',
+      parts: [{ id: 'p', name: 'p', percussion: false, notes: [{ midi: 60, start: 0, duration: 12, velocity: 1 }] }],
+      tempoMap: [],
+      timeSignatures: [{ beat: 0, numerator: 3, denominator: 4 }],
+      dynamics: [],
+      fermatas: [4],
+      lengthBeats: 12,
+    };
+    const h = conductorNode.make(conductorNode.params.parse({ enabled: true, ...RECORDED }));
+    const outs = await replayNode(h, { hands: frames, doc: frames.map(() => doc) }, { dt: 1 / FPS });
+    const beats = outs.map((o) => o.beat as number);
+    const times = outs.map((o) => o.time as { state: string; beatsPerBar: number; anchors: number });
+    // The meter comes from the score, not the dial.
+    expect(times.every((t) => t.beatsPerBar === 3)).toBe(true);
+    // The beat reaches 4 and stops there for a while (hold), then goes on.
+    const firstAt4 = beats.findIndex((b) => b >= 4);
+    expect(firstAt4).toBeGreaterThan(0);
+    expect(beats[firstAt4]).toBe(4);
+    expect(times[firstAt4].state).toBe('hold');
+    expect(outs[firstAt4].bpm).toBe(0);
+    let heldTicks = 0;
+    let k = firstAt4;
+    while (k < beats.length && beats[k] === 4) {
+      heldTicks++;
+      k++;
+    }
+    // Held across at least a few frames, and released only by a NEW stroke.
+    expect(heldTicks).toBeGreaterThan(2);
+    expect(k).toBeLessThan(beats.length);
+    expect(times[k].anchors).toBeGreaterThan(times[firstAt4].anchors);
+    expect(beats[beats.length - 1]).toBeGreaterThan(4);
+  });
+
   it('disabled: the beat is frozen, enabled is false and velocityScale is 0', async () => {
     const h = conductorNode.make(conductorNode.params.parse({ enabled: false, ...RECORDED }));
     const outs = await replayNode(h, { hands: frames.slice(0, 120) }, { dt: 1 / FPS });

--- a/test/conductor_status.test.ts
+++ b/test/conductor_status.test.ts
@@ -1,0 +1,56 @@
+/**
+ * The conductor status reporter (#187 PR 4): the per-frame sink that bridges the
+ * `conductor` node's outputs to the tool panel's store. It reads through a stub
+ * engine, reports only when something a player can see changed (state, whole beat,
+ * tempo to the bpm, confidence/dynamics to a twentieth), and ignores a missing node.
+ */
+import { describe, it, expect } from 'vitest';
+import { makeConductorReporter, conductorLiveKey, type ConductorLive } from '@/app/conductorStatus';
+import type { MusicalTime } from '@/ictus';
+
+function time(over: Partial<MusicalTime>): MusicalTime {
+  return { t: 0, beat: 0, phase: 0, tempo: 0, period: Infinity, confidence: 0, nextBeatAt: Infinity, beatsPerBar: 4, beatInBar: 0, state: 'ready', anchors: 0, ...over };
+}
+
+describe('makeConductorReporter', () => {
+  it('reports the first read, then only visible changes', () => {
+    const outputs: Record<string, unknown> = { time: time({ state: 'running', tempo: 70.2, beat: 3.1, beatInBar: 3, confidence: 0.51, anchors: 4 }), dynamics: 0.4, enabled: true };
+    const engine = { getOutput: (_n: string, port: string) => outputs[port] };
+    const reports: ConductorLive[] = [];
+    const tick = makeConductorReporter(engine, { report: (l) => reports.push(l) });
+    tick();
+    expect(reports).toHaveLength(1);
+    expect(reports[0]).toMatchObject({ enabled: true, state: 'running', beat: 3, beatInBar: 3, anchors: 4 });
+    expect(reports[0].tempo).toBeCloseTo(70.2, 5);
+    // A creep inside the same visible bucket: no report.
+    outputs.time = time({ state: 'running', tempo: 70.4, beat: 3.6, beatInBar: 3, confidence: 0.52, anchors: 4 });
+    outputs.dynamics = 0.415;
+    tick();
+    expect(reports).toHaveLength(1);
+    // The next whole beat: a report.
+    outputs.time = time({ state: 'running', tempo: 70.4, beat: 4.0, beatInBar: 0, confidence: 0.52, anchors: 5 });
+    tick();
+    expect(reports).toHaveLength(2);
+    expect(reports[1].beat).toBe(4);
+    // Hold: a report.
+    outputs.time = time({ state: 'hold', tempo: 0, beat: 4.0, beatInBar: 0, confidence: 0.3, anchors: 5 });
+    tick();
+    expect(reports[2].state).toBe('hold');
+    expect(reports[2].tempo).toBe(0);
+  });
+
+  it('ignores a missing node and never throws', () => {
+    const engine = { getOutput: () => undefined };
+    const reports: ConductorLive[] = [];
+    const tick = makeConductorReporter(engine, { report: (l) => reports.push(l) });
+    expect(() => tick()).not.toThrow();
+    expect(reports).toHaveLength(0);
+  });
+
+  it('the change key quantises the way the panel displays', () => {
+    const a: ConductorLive = { enabled: true, state: 'running', tempo: 70.2, beat: 3, beatInBar: 3, beatsPerBar: 4, confidence: 0.51, dynamics: 0.4, anchors: 4 };
+    expect(conductorLiveKey(a)).toBe(conductorLiveKey({ ...a, tempo: 70.4, confidence: 0.52, dynamics: 0.415 }));
+    expect(conductorLiveKey(a)).not.toBe(conductorLiveKey({ ...a, tempo: 71 }));
+    expect(conductorLiveKey(a)).not.toBe(conductorLiveKey({ ...a, enabled: false }));
+  });
+});

--- a/test/conductor_tool.test.tsx
+++ b/test/conductor_tool.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+/**
+ * The Conductor tool (#187 PR 4) — reachability and honesty of the shell surface.
+ * `tools_shell.test.tsx` proves every registered tool has a labelled button;
+ * `app_shell.test.ts` proves App.tsx mounts a surface for it. This proves the surface
+ * does what the button promises: closed until its tool is open; a Start button that
+ * writes the `conductor.enabled` dial through the command path; a live readout that
+ * says what the follower is doing (off / waiting / following at N bpm / holding) from
+ * the status store the engine loop reports into; and the same piece + follower
+ * controls as the settings section, so there is one set of controls, not two.
+ */
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, act } from '@testing-library/react';
+import ConductorPanel, { describeLive } from '@/app/ConductorPanel';
+import { useTools } from '@/app/toolsStore';
+import { useConductorStatus, ABSENT_CONDUCTOR_LIVE } from '@/app/conductorStatus';
+import { dialsStore } from '@/app/dials/settingsStore';
+import { TOOLS } from '@/app/tools';
+import type { ConductorSettings } from '@/settings/schema';
+
+const conductor = () => dialsStore.getState().effective.conductor as ConductorSettings;
+const drain = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+beforeEach(() => {
+  useTools.setState({ open: null });
+  useConductorStatus.getState().reset();
+});
+afterEach(() => cleanup());
+
+describe('the Conductor tool', () => {
+  it('is registered as a panel tool with a label a player can read', () => {
+    const tool = TOOLS.find((t) => t.id === 'conductor');
+    expect(tool?.kind).toBe('panel');
+    expect(tool?.label).toBe('Conductor');
+    expect(tool?.description).toMatch(/beat time/i);
+  });
+
+  it('is closed until its tool is open', () => {
+    const { container } = render(<ConductorPanel />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('opens with a Start button that turns conducting on through the dial, and Stop turns it off', async () => {
+    useTools.setState({ open: 'conductor' });
+    render(<ConductorPanel />);
+    expect(conductor().enabled).toBe(false);
+    fireEvent.click(screen.getByText('Start conducting'));
+    await drain();
+    expect(conductor().enabled).toBe(true);
+    expect(screen.getByText('Stop conducting')).toBeTruthy();
+    fireEvent.click(screen.getByText('Stop conducting'));
+    await drain();
+    expect(conductor().enabled).toBe(false);
+  });
+
+  it('shows the live follower state from the status store', () => {
+    useTools.setState({ open: 'conductor' });
+    render(<ConductorPanel />);
+    expect(screen.getByTestId('conductor-live').getAttribute('data-state')).toBe('off');
+    act(() => useConductorStatus.getState().report({ ...ABSENT_CONDUCTOR_LIVE, enabled: true, state: 'running', tempo: 72.4, beatInBar: 2, beatsPerBar: 4, confidence: 0.8, dynamics: 0.5, anchors: 9, beat: 10 }));
+    expect(screen.getByText('Following at 72 bpm.')).toBeTruthy();
+    expect(screen.getByText('3/4')).toBeTruthy();
+    act(() => useConductorStatus.getState().report({ ...ABSENT_CONDUCTOR_LIVE, enabled: true, state: 'hold', anchors: 9 }));
+    expect(screen.getByText(/Holding/)).toBeTruthy();
+    act(() => useConductorStatus.getState().report({ ...ABSENT_CONDUCTOR_LIVE, enabled: true, state: 'ready', anchors: 0 }));
+    expect(screen.getByText(/Waiting for your first beat/)).toBeTruthy();
+  });
+
+  it('carries the same piece and follower controls as the settings section', () => {
+    useTools.setState({ open: 'conductor' });
+    render(<ConductorPanel />);
+    expect(screen.getByLabelText('Piece')).toBeTruthy();
+    expect(screen.getByLabelText('Beating hand')).toBeTruthy();
+  });
+
+  it('describeLive covers every state', () => {
+    expect(describeLive(ABSENT_CONDUCTOR_LIVE)).toMatch(/Off/);
+    expect(describeLive({ ...ABSENT_CONDUCTOR_LIVE, enabled: true, state: 'ready', anchors: 2 })).toMatch(/Finding/);
+    expect(describeLive({ ...ABSENT_CONDUCTOR_LIVE, enabled: true, state: 'hold', anchors: 0 })).toMatch(/first beat/);
+  });
+});

--- a/test/engine_wiring.test.ts
+++ b/test/engine_wiring.test.ts
@@ -64,7 +64,7 @@ describe('useEngine drives the live loop from the Clock seam', () => {
     const c = code(useEngine);
     expect(c).toMatch(/\* 1000/);
     // Each bridge goes through the converter rather than being passed raw.
-    expect(c).toMatch(/sinks:\s*\[\s*toMs\(reportFace\),\s*toMs\(reportMidi\),\s*toMs\(reportGesture\),\s*toMs\(reportGenerative\)\s*\]/);
+    expect(c).toMatch(/sinks:\s*\[\s*toMs\(reportFace\),\s*toMs\(reportMidi\),\s*toMs\(reportGesture\),\s*toMs\(reportGenerative\),\s*toMs\(reportConductor\)\s*\]/);
   });
 
   it('publishes the read-only debug handle when the engine is ready, and removes it on teardown (#209)', () => {

--- a/test/overlay_elements.test.ts
+++ b/test/overlay_elements.test.ts
@@ -235,6 +235,22 @@ describe('canvas-overlay composable elements', () => {
     expect(drawChord([49]).count('stroke')).toBe(0);
   });
 
+  it('conductorHud (Output, #187): a phase ring + count + tempo while conducting; nothing when off', () => {
+    const running = { t: 1, beat: 5.25, phase: 0.25, tempo: 70, period: 60 / 70, confidence: 0.8, nextBeatAt: 1.6, beatsPerBar: 4, beatInBar: 1, state: 'running', anchors: 6 };
+    const rc = drawWith(onlyElement('conductorHud'), { conductorTime: running, conductorEnabled: true });
+    const arcs = rc.calls.filter((c) => c.m === 'arc');
+    expect(arcs.length).toBeGreaterThanOrEqual(2); // the ring and the phase arc
+    const texts = rc.calls.filter((c) => c.m === 'fillText').map((c) => String(c.args[0]));
+    expect(texts).toContain('2'); // beat 5 in 4/4 is the second beat of the bar
+    expect(texts.some((t) => /70 bpm/.test(t))).toBe(true);
+    // Holding: the words say so, no phase arc.
+    const held = drawWith(onlyElement('conductorHud'), { conductorTime: { ...running, state: 'hold', tempo: 0 }, conductorEnabled: true });
+    expect(held.calls.filter((c) => c.m === 'fillText').map((c) => String(c.args[0]))).toContain('holding');
+    // Off: nothing at all.
+    expect(drawWith(onlyElement('conductorHud'), { conductorTime: running, conductorEnabled: false }).calls.filter((c) => c.m === 'arc')).toHaveLength(0);
+    expect(drawWith(onlyElement('conductorHud'), { conductorEnabled: true }).calls.filter((c) => c.m === 'arc')).toHaveLength(0);
+  });
+
   it('bodySkeleton (Input, #186): bones + a dot per visible landmark, mirrored; nothing when absent', () => {
     const { landmarks, world } = makeBodyKeypoints({ width: 640, height: 480, cx: 0.5, cy: 0.6, torso: 100, leftArm: 0.5, rightArm: 0.2, kneeBend: 0, lean: 0 });
     const bodyFrame: BodyFrame = { width: 640, height: 480, present: true, landmarks, world, visibility: new Array(33).fill(1) };


### PR DESCRIPTION
Fourth build PR of #187 (plan in the issue). **Stacked on #213** (base `conductor/score`; retarget to `main` when it lands).

## What

- **The tool**: `src/app/tools.ts` gains `conductor` (kind `panel`); `ToolsBar` shows it with a note icon; `ConductorPanel.tsx` mounts at the app root with **Start / Stop** (writes `conductor.enabled` through `dispatchDialSetIn`), a **live readout** (waiting for a first stroke / following at N bpm with beat-in-bar / holding, plus confidence and dynamics meters), and the same `ConductorControls` section as the settings editor embedded (one set of controls, not two).
- **`conductorStatus.ts`**: the per-frame reporter that bridges the `conductor` node's `time` / `dynamics` / `enabled` outputs to a zustand store, change-gated on what a player can see. Registered as an engine sink beside the generative one: **a two-line touch of `useEngine.ts`** (the sink list, and the teardown reset), flagged here because that file belongs to the #101 session; nothing else there changes.
- **The beat over the video**: overlay element `conductorHud` (phase ring filling through the beat, a flash on it, beat-in-bar, tempo, and the words for waiting / holding) from two new overlay inputs, `conductor.time → overlay.conductorTime` and `conductor.enabled → overlay.conductorEnabled`. A dial like every element (`overlay.conductorHud.show`), in the Overlay section.
- **Fermatas and meter from the score**: `ui.scoreDoc → conductor.doc`. `beatInBar` follows the piece's time signature; when the beat would cross a written fermata it stops exactly there and holds (bpm 0, the note sustains, HUD says *holding*) until the next stroke — the preparatory-beat release of §6.3. The shipped Beethoven 5 has two in the first five bars.
- The pure scheduler the plan listed under PR 4 moves to PR 5 with its consumer (the orchestra); shipping it unused would be a stub.

## Reachability

**One click** from a cold load: the *Conductor* button in the tools bar. Start is the first thing in the panel.

## Tests

`conductor_tool` (jsdom: registered as a panel tool; closed until open; Start/Stop write the dial; the readout per state; the shared controls), `conductor_status` (change gate over a stub engine; missing node), `overlay_elements` (the HUD's draws while running / holding / off), `conductor_node` (fermata: the beat stops at 4 in a 3/4 document, holds, releases on a new stroke; meter from the score), `app_graph` (the three new edges), `app_shell` and `engine_wiring` extended.

## Gates

`npm run typecheck` ✓ · `npm test` 135 files / 1654 tests ✓ · `npm run build` ✓ · `npm run catalog` ✓ (committed).

What only a webcam can judge (on #146): whether the fermata release feels right on a real preparatory beat, and the HUD's legibility while conducting.

https://claude.ai/code/session_01RHpQekkMVnGHsSXyPHdaL4