### PR TITLE
docs: the Stream Applier is delivered — make #101's record true, and give its leftovers homes

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -123,8 +123,16 @@ in the player's terms, which is exactly the missing frame of reference.
 | **M-A** camera-free pre-recorded video source (`?source=video`) | #102 | #105 | shipped |
 | **M-B** `Clock` abstraction + speed multiplier | #103 | #106 | shipped (`BatchClock` fully tested; the live `RealtimeClock` adoption landed later, in #166) |
 | **M-C** `source` slot + typed `replay-hands` + `PortSpec.schema` conformance | #104 | #167 | **shipped** — `?slot.source=synthetic-hands` runs the whole instrument with no camera and no MediaPipe |
-| **M-D** (first half) live loop on the `Clock` + `?slot.<name>=` selection | #101 | #166 | shipped — `src/app/engineLoop.ts` (since removed in #189); the `Source` interface, its pump and the `Applier` remain |
+| **M-D** the `Applier` — both callers are configs of it | #101 | #166, #184, #189 | shipped — `runHeadless` (BatchClock + recorder tap) and `useEngine` (RealtimeClock + the React bridges as sinks). `runEngineLoop`, the intermediate step, retired with it |
+| **M-E** `defineMergeNode` (R2) + `event`-kind accumulation | #101 | #191, #184 | shipped — the engine rejects fan-in to one port, so composition is an explicit typed node |
+| **M-F** the `StateReader` feedback channel (R3) | #101 | #192 | shipped — the Applier publishes it on the engine's own resources |
+| **M-G** boundary (B) enforced + delayed edges + the `delay` node | #101 | #210, #214 | shipped — accelerated playback **mutes** rather than pitch-shifting, enforced by a structural guard over every `synth`-role node; feedback is now *declared* by `EdgeSpec.delayed` rather than inferred from evaluation order |
 | **#51** graph lifecycle: re-wire a running engine | #51 | #165 | shipped — `Engine.applyGraph` reconciles onto a new `GraphSpec` without rebuilding audio or reloading models |
+
+**#101 is closed.** Three pieces were deliberately not built and have homes elsewhere:
+`replay-source-timed` and `stateGeneratorSource` (#215), the `OfflineAudioContext`
+render-at-speed action (#146 B9 — its value is a listening judgment), and recorder
+backpressure (#88).
 
 ---
 
@@ -236,20 +244,18 @@ such — a bracketed `#n` in this list always means an issue.
 
 ### Engine / platform
 
-- **[#101] Stream Applier epic** (M8) — **M-A…M-D have shipped.** Both callers are
-  Applier configs now (`runHeadless` #184, `useEngine` #189), and `runEngineLoop` retired
-  with M-D. **M-E is two-thirds landed**: `defineMergeNode` (R2 composition) and the
-  `event`-kind accumulate half; the timestamp-aware `replay-source-timed` remains, and it
-  belongs in `src/nodes/sources/`. M-F (state-feedback generators) and M-G (time-scaled
-  audio + a `delay` node) are designed and unstarted. SSOT:
-  [design/stream-applier.md](design/stream-applier.md) — its per-milestone bullets, not
-  its header, are the authority on status.
+- **[#215] Two source nodes the Stream Applier designed but did not build** —
+  `replay-source-timed` (replay by `StreamRecord.t` rather than by index; index-by-tick
+  stays canonical for CI goldens) and `stateGeneratorSource` (R3's consumer: seeded
+  randomness, re-emit the read snapshot so a replay reproduces the feedback). Both belong
+  in `src/nodes/sources/`. The mechanisms they sit on all exist; this was sequencing, not
+  design. **#101 itself is closed** — see the shipped table above.
 
   One thing worth knowing before touching the live loop: **M-D's stated gate, a browser
-  smoke test, does not exist** — this repo has no Playwright or e2e harness. What stands
-  in for it is a jsdom test that mounts the real hook and watches the loop run and stop.
-  AudioContext, MediaPipe and real rAF under load are still unverified, as a no-camera
-  item on #146.
+  smoke test, does not exist** — this repo has no Playwright or e2e harness (#209). What
+  stands in for it is a jsdom test that mounts the real hook and watches the loop run and
+  stop.
+
 - **[#14] React Flow patcher UI** driven by Zod node configs (M6's remaining half).
   **Build is parked**; the open question is scope, not schedule — see #181.
 
@@ -288,7 +294,7 @@ these rather than inside them, so read the status column, not the milestone numb
 | **M5** | Conductor mode: immutable `score` node + `performance` overlay + humanization. | **Decided (#180 → #187, Option A: wire it) and wired.** The `conductor` node (PR 2 of #187) wraps `src/ictus` (PR 1): the beating hand's ictus → an adaptive oscillator → `beat` / `bpm` / `velocityScale` for the `score` node, which is now in the default graph behind the `conductor.enabled` dial (off by default; the built-in demo scale until the score pipeline, PR 3). `transport` / `performance` stay registered for the non-conductor chain. Remaining per the #187 plan: score pipeline, the Conductor tool + scheduler, the orchestra node, meter recognition, the audio pacer. |
 | **M6** | `midi-out` + a React Flow patcher UI + deploy as a tw_platform static app. | partial — deploy done; `midi-out` shipped (#13 / PR #120) and made reachable (#137 / PR #147); the patcher (#14) is open, with its **scope** the actual open question (#181). |
 | **M7** | (optional) Pluggable Python feature service + self-hosted generative service behind the existing node facades. | optional, untouched. |
-| **M8** | **Stream Applier**: pluggable sources + batch-vs-paced execution + state-feedback generators. | in progress — **M-A…M-D shipped** (both callers are Applier configs); M-E two-thirds landed (`defineMergeNode` + event accumulate; timed replay remains); M-F/M-G designed. See [design/stream-applier.md](design/stream-applier.md). |
+| **M8** | **Stream Applier**: pluggable sources + batch-vs-paced execution + state-feedback generators. | **done** — M-A…M-G shipped; #101 closed. Two source nodes split out to #215, the offline render to #146 B9. See [design/stream-applier.md](design/stream-applier.md). |
 
 ### Open engine decisions (recorded; defaults taken)
 

--- a/docs/design/stream-applier.md
+++ b/docs/design/stream-applier.md
@@ -1,21 +1,30 @@
 # Stream Applier — pluggable sources + batch/paced execution
 
-> **Status:** design agreed (2026-07); being built incrementally (M-A…M-G below).
-> **Shipped:** **M-A** (camera-free video source, #102 / PR #105), **M-B** (Clock +
-> speed, #103 / PR #106), and **M-C** (#104 / PR #167 — the `source` slot, the typed
-> `replay-hands` candidate, and `PortSpec.schema` conformance). **M-D is in progress:**
-> its clock half landed with the live loop (#166 / `src/app/engineLoop.ts`, since removed in #189); what
-> **M-D is done** — both callers are Applier configs (`runHeadless` in #184,
-> `useEngine` in #189), and `runEngineLoop` retired with it. **M-E is partly landed**:
-> `defineMergeNode` (R2 composition) is built and the `event`-kind accumulate half came
-> with the Applier's pump; the timestamp-aware `replay-source-timed` remains. M-F and
-> M-G are designed, unstarted.
+> **Status: DELIVERED.** Every requirement R1–R6 is met and the epic (#101) is closed.
+> What the design set out to separate — *where data comes from*, *when the engine
+> advances*, *what happens to the outputs* — is now three independent choices, and both
+> callers are thin configs of one `Applier`.
 >
-> This document is the single source of truth; the ROADMAP and the tracking issues
-> point here. It supersedes ad-hoc source/replay wiring. **The per-milestone bullets
-> under [Incremental build order](#incremental-build-order) are the authority on
-> status** — this header is a summary of them, and when the two disagree the bullets
-> are right.
+> | | shipped in |
+> |---|---|
+> | **M-A** camera-free video source | #102 / PR #105 |
+> | **M-B** `Clock` + speed multiplier | #103 / PR #106 |
+> | **M-C** `source` slot, typed `replay-hands`, `PortSpec.schema` | #104 / PR #167 |
+> | **M-D** the `Applier`; `runHeadless` and `useEngine` both configs of it | PR #184, #189 |
+> | **M-E** `defineMergeNode` (R2) + `event`-kind accumulation | PR #191, #184 |
+> | **M-F** the `StateReader` feedback channel (R3) | PR #192 |
+> | **M-G** boundary (B) enforced; delayed edges + the `delay` node | PR #210, #214 |
+>
+> **Three things are deliberately not built**, each with a home that is not this document:
+> the timestamp-aware `replay-source-timed` and `stateGeneratorSource` (both belong in
+> `src/nodes/sources/`, tracked in #215); the `OfflineAudioContext` render-at-speed action
+> (its value is a listening judgment — #146 B9); and recorder backpressure (folds into
+> #88). None of them block anything that is built.
+>
+> This document remains the single source of truth for **how** the pieces fit. The
+> per-milestone bullets under [Incremental build order](#incremental-build-order) are the
+> authority on what each one actually did — this header summarises them, and when the two
+> disagree the bullets are right.
 
 ## The idea in one line
 


### PR DESCRIPTION
Docs only. Prepares #101 to close.

## The design doc's status header had garbled

Successive edits left it asserting **both** "M-D is in progress" and "M-D is done", with a
dangling clause between them — exactly the drift its own *"the bullets are the authority"*
rule exists to catch, in the very block that states the rule. Rewritten as one table of
what shipped where.

## The ROADMAP stopped at M-D's first half

M-D complete, plus M-E, M-F and M-G, each with what it actually gives you. #101 leaves the
open list.

## The leftovers now have homes — and that is the part that mattered

Closing an epic whose remainders live only inside its own design doc loses them. So before
closing I checked, and `replay-source-timed` / `stateGeneratorSource` were tracked in
exactly one place: a paragraph in `stream-applier.md`. The handoff to another session
existed as a claim in a cross-session message, which is not an artifact anyone can find
later.

They are now **#215**, carrying the design decisions that were already settled — index-by-tick
stays canonical for CI goldens so the timed replay is a separate node rather than a flag;
seeded randomness, never `Math.random`; re-emit the read snapshot so a replay reproduces
the feedback.

The other two were already homed and are named as such:

| leftover | home | why not built |
|---|---|---|
| `OfflineAudioContext` render-at-speed | #146 **B9** | its value is a listening judgment — ears-gated, not unbuilt |
| recorder backpressure | #88 | belongs to recording-v2, not here |

## Verification

1638 tests, typecheck clean. The CLAUDE.md path guard passes, so no doc points at anything
that does not resolve.

I will close #101 with a landing summary once this merges — not before, so the summary
links to a truthful record rather than promising one.

https://claude.ai/code/session_019MqaXSdxoS9hdavMAAMVvu